### PR TITLE
Allow multiple dns records with the same name and type

### DIFF
--- a/modules/dns/main.tf
+++ b/modules/dns/main.tf
@@ -16,8 +16,8 @@
 
 locals {
   recordsets = var.recordsets == null ? {} : {
-    for record in var.recordsets :
-    join("/", [record.name, record.type]) => record
+    for idx, record in var.recordsets :
+    join("/", [idx, record.name, record.type]) => record
   }
   zone = (
     var.zone_create


### PR DESCRIPTION
This Pull Request is for allowing multiple records with the same name and type.


## Problem:

It is not possible to add records that contain the same name and type, for example:

```hcl
module "dns-example" {
  source        = "./modules/dns"
  project_id  = "myproject"
  name        = "my-domain"
  domain      = "mydomain.com."
  dnssec_config = {
    state = "on"
  }
  zone_create = true
  type        = "public"
  recordsets = [
    {
      name    = "@",
      type    = "MX",
      ttl     = 900,
      records = ["1 ASPMX.L.GOOGLE.COM"]
    },
    {
      name    = "@",
      type    = "MX",
      ttl     = 900,
      records = ["5 ALT1.ASPMX.L.GOOGLE.COM"]
    }
 ]   
}
```

This will fail with the following error: 

```
│   18:   recordsets = var.recordsets == null ? *** : ***
│   19:     for record in var.recordsets :
│   20:     join("/", [record.name, record.type]) => record
│   21:   ***
│     ├────────────────
│     │ record.name is "@"
│     │ record.type is "TXT"
│ 
│ Two different items produced the key "@/TXT" in this 'for' expression. If
│ duplicates are expected, use the ellipsis (...) after the value expression
│ to enable grouping by key.
```

## Solution

My solution was to add an index as part of the key the recordset map. Since the key is not used, only the values, adding the idx won't break the code.