### PR TITLE
Added daily tagging GitHub Action

### DIFF
--- a/.github/workflows/daily-tag.yml
+++ b/.github/workflows/daily-tag.yml
@@ -1,0 +1,47 @@
+
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: |
+  Create daily release tags
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron:  '0 2 * * *'
+
+permissions:
+  contents: write
+
+jobs:
+  daily-tag:
+    name: "Create tag on master if there was activity in last 24 hours"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: "Check changes and tag"
+        run: |
+          CHANGES=$(git log --since="1 day ago" --name-only --pretty=format: )
+
+          if [ "x$CHANGES" != "x" ] ; then
+            TAG="daily-$(date +%Y.%m.%d)"
+            git tag $TAG
+            git push origin $TAG
+
+            echo "Created new tag: $TAG"
+          else
+            echo "No changes in last 24 hours"
+          fi
+          


### PR DESCRIPTION
Creates new tags in format `daily_2021.10.21`, but only if there were any action in the master in the last day.