### PR TITLE
modules/project: Borrows random_proj id from project-factory

### DIFF
--- a/modules/project/outputs.tf
+++ b/modules/project/outputs.tf
@@ -48,7 +48,7 @@ output "number" {
 
 output "project_id" {
   description = "Project id."
-  value       = "${local.prefix}${var.name}"
+  value       = local.project.project_id
   depends_on = [
     google_project.project,
     data.google_project.project,

--- a/modules/project/variables.tf
+++ b/modules/project/variables.tf
@@ -221,3 +221,9 @@ variable "shared_vpc_service_config" {
     host_project = ""
   }
 }
+
+variable "random_project_id" {
+  description = "Adds a suffix of 4 random characters to the `project_id`"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Cloud-foundation-fabric doesn't currently have a way to inject a random suffix for project-ids, which makes it hard if you're prototyping and need to tear something down. 
This borrows the implementation from project-factory to give folks the option to use a "random project id" which just adds a random suffix to project names with the same format as exists. Updated the outputs to find this value also. 