### PR TITLE
Improve tests from documentation

### DIFF
--- a/examples/factories/net-vpc-firewall-yaml/README.md
+++ b/examples/factories/net-vpc-firewall-yaml/README.md
@@ -36,7 +36,7 @@ module "dev-firewall" {
     "./common"
   ]
 }
-# tftest:skip
+# tftest skip
 ```
 
 ### Configuration Structure

--- a/modules/apigee-organization/README.md
+++ b/modules/apigee-organization/README.md
@@ -29,7 +29,7 @@ module "apigee-organization" {
     }
   }
 }
-# tftest:modules=1:resources=6
+# tftest modules=1 resources=6
 ```
 
 ### Apigee X Paid Organization
@@ -69,7 +69,7 @@ module "apigee-organization" {
     }
   }
 }
-# tftest:modules=1:resources=11
+# tftest modules=1 resources=11
 ```
 
 ### Apigee hybrid Organization
@@ -96,7 +96,7 @@ module "apigee-organization" {
     }
   }
 }
-# tftest:modules=1:resources=6
+# tftest modules=1 resources=6
 ```
 <!-- BEGIN TFDOC -->
 

--- a/modules/apigee-x-instance/README.md
+++ b/modules/apigee-x-instance/README.md
@@ -19,7 +19,7 @@ module "apigee-x-instance" {
     "eval2"
   ]
 }
-# tftest:modules=1:resources=3
+# tftest modules=1 resources=3
 ```
 
 ### Apigee X Paid Instance
@@ -40,7 +40,7 @@ module "apigee-x-instance" {
     "test2"
   ]
 }
-# tftest:modules=1:resources=5
+# tftest modules=1 resources=5
 ```
 <!-- BEGIN TFDOC -->
 

--- a/modules/artifact-registry/README.md
+++ b/modules/artifact-registry/README.md
@@ -17,7 +17,7 @@ module "docker_artifact_registry" {
     "roles/artifactregistry.admin" = ["group:cicd@example.com"]
   }
 }
-# tftest:modules=1:resources=2
+# tftest modules=1 resources=2
 ```
 <!-- BEGIN TFDOC -->
 

--- a/modules/bigquery-dataset/README.md
+++ b/modules/bigquery-dataset/README.md
@@ -35,7 +35,7 @@ module "bigquery-dataset" {
     view_1         = "my-project|my-dataset|my-table"
   }
 }
-# tftest:modules=1:resources=5
+# tftest modules=1 resources=5
 ```
 
 ### IAM roles
@@ -51,7 +51,7 @@ module "bigquery-dataset" {
     "roles/bigquery.dataOwner" = ["user:user1@example.org"]
   }
 }
-# tftest:modules=1:resources=2
+# tftest modules=1 resources=2
 ```
 
 roles/bigquery.dataOwner
@@ -71,7 +71,7 @@ module "bigquery-dataset" {
     delete_contents_on_destroy      = false
   }
 }
-# tftest:modules=1:resources=1
+# tftest modules=1 resources=1
 ```
 
 ### Tables and views
@@ -101,7 +101,7 @@ module "bigquery-dataset" {
     }
   }
 }
-# tftest:modules=1:resources=2
+# tftest modules=1 resources=2
 ```
 
 If partitioning is needed, populate the `partitioning` variable using either the `time` or `range` attribute.
@@ -133,7 +133,7 @@ module "bigquery-dataset" {
     }
   }
 }
-# tftest:modules=1:resources=2
+# tftest modules=1 resources=2
 ```
 
 To create views use the `view` variable. If you're querying a table created by the same module `terraform apply` will initially fail and eventually succeed once the underlying table has been created. You can probably also use the module's output in the view's query to create a dependency on the table.
@@ -171,7 +171,7 @@ module "bigquery-dataset" {
   }
 }
 
-# tftest:modules=1:resources=3
+# tftest modules=1 resources=3
 ```
 <!-- BEGIN TFDOC -->
 

--- a/modules/bigtable-instance/README.md
+++ b/modules/bigtable-instance/README.md
@@ -30,7 +30,7 @@ module "bigtable-instance" {
     "roles/bigtable.user" = ["user:viewer@testdomain.com"]
   }
 }
-# tftest:modules=1:resources=4
+# tftest modules=1 resources=4
 ```
 <!-- BEGIN TFDOC -->
 

--- a/modules/billing-budget/README.md
+++ b/modules/billing-budget/README.md
@@ -32,7 +32,7 @@ module "budget" {
     emails     =  ["user@example.com"]
   }
 }
-# tftest:modules=1:resources=2
+# tftest modules=1 resources=2
 ```
 
 ### Pubsub notification
@@ -59,7 +59,7 @@ module "pubsub" {
   name       = "budget-topic"
 }
 
-# tftest:modules=2:resources=2
+# tftest modules=2 resources=2
 ```
 <!-- BEGIN TFDOC -->
 

--- a/modules/cloud-function/README.md
+++ b/modules/cloud-function/README.md
@@ -26,7 +26,7 @@ module "cf-http" {
     excludes    = null
   }
 }
-# tftest:skip
+# tftest skip
 ```
 
 ### PubSub and non-HTTP triggers
@@ -50,7 +50,7 @@ module "cf-http" {
     retry = null
   }
 }
-# tftest:skip
+# tftest skip
 ```
 
 ### Controlling HTTP access
@@ -72,7 +72,7 @@ module "cf-http" {
     "roles/cloudfunctions.invoker" = ["allUsers"]
   }
 }
-# tftest:skip
+# tftest skip
 ```
 
 ### GCS bucket creation
@@ -95,7 +95,7 @@ module "cf-http" {
     excludes    = null
   }
 }
-# tftest:skip
+# tftest skip
 ```
 
 ### Service account management
@@ -115,7 +115,7 @@ module "cf-http" {
   }
   service_account_create = true
 }
-# tftest:skip
+# tftest skip
 ```
 
 To use an externally managed service account, pass its email in `service_account` and leave `service_account_create` to `false` (the default).
@@ -133,7 +133,7 @@ module "cf-http" {
   }
   service_account = local.service_account_email
 }
-# tftest:skip
+# tftest skip
 ```
 
 ### Custom bundle config
@@ -152,7 +152,7 @@ module "cf-http" {
     excludes    = ["__pycache__"]
   }
 }
-# tftest:skip
+# tftest skip
 ```
 <!-- BEGIN TFDOC -->
 

--- a/modules/cloud-identity-group/README.md
+++ b/modules/cloud-identity-group/README.md
@@ -29,7 +29,7 @@ module "group" {
     "service-account@my-gcp-project.iam.gserviceaccount.com"
   ]
 }
-# tftest:modules=1:resources=4
+# tftest modules=1 resources=4
 ```
 <!-- BEGIN TFDOC -->
 

--- a/modules/cloud-run/README.md
+++ b/modules/cloud-run/README.md
@@ -29,7 +29,7 @@ module "cloud_run" {
     volume_mounts = null
   }]
 }
-# tftest:modules=1:resources=1
+# tftest modules=1 resources=1
 ```
 
 ### Environment variables (value read from secret)
@@ -57,7 +57,7 @@ module "cloud_run" {
     volume_mounts = null
   }]
 }
-# tftest:modules=1:resources=1
+# tftest modules=1 resources=1
 ```
 
 ### Secret mounted as volume
@@ -89,7 +89,7 @@ module "cloud_run" {
     }
   ]
 }
-# tftest:modules=1:resources=1
+# tftest modules=1 resources=1
 ```
 
 ### Traffic split
@@ -114,7 +114,7 @@ module "cloud_run" {
     "green" = 75
   }
 }
-# tftest:modules=1:resources=1
+# tftest modules=1 resources=1
 ```
 
 ### Eventarc trigger (Pub/Sub)
@@ -138,7 +138,7 @@ module "cloud_run" {
     "topic2"
   ]
 }
-# tftest:modules=1:resources=3
+# tftest modules=1 resources=3
 ```
 
 ### Eventarc trigger (Audit logs)
@@ -164,7 +164,7 @@ module "cloud_run" {
     }
   ]
 }
-# tftest:modules=1:resources=2
+# tftest modules=1 resources=2
 ```
 
 ### Service account management
@@ -185,7 +185,7 @@ module "cloud_run" {
   }]
   service_account_create = true
 }
-# tftest:modules=1:resources=2
+# tftest modules=1 resources=2
 ```
 
 To use an externally managed service account, pass its email in `service_account` and leave `service_account_create` to `false` (the default).
@@ -204,7 +204,7 @@ module "cloud_run" {
   }]
   service_account = "cloud-run@my-project.iam.gserviceaccount.com"
 }
-# tftest:modules=1:resources=1
+# tftest modules=1 resources=1
 ```
 <!-- BEGIN TFDOC -->
 

--- a/modules/cloudsql-instance/README.md
+++ b/modules/cloudsql-instance/README.md
@@ -37,7 +37,7 @@ module "db" {
   database_version = "POSTGRES_13"
   tier             = "db-g1-small"
 }
-# tftest:modules=3:resources=6
+# tftest modules=3 resources=6
 ```
 
 ## Cross-regional read replica
@@ -57,7 +57,7 @@ module "db" {
     replica2 = "us-central1"
   }
 }
-# tftest:modules=1:resources=3
+# tftest modules=1 resources=3
 ```
 
 ## Custom flags, databases and users
@@ -88,7 +88,7 @@ module "db" {
     user2  = "mypassword"
   }
 }
-# tftest:modules=1:resources=6
+# tftest modules=1 resources=6
 ```
 <!-- BEGIN TFDOC -->
 

--- a/modules/compute-mig/README.md
+++ b/modules/compute-mig/README.md
@@ -49,7 +49,7 @@ module "nginx-mig" {
     name              = "default"
   }
 }
-# tftest:modules=2:resources=2
+# tftest modules=2 resources=2
 ```
 
 ### Multiple versions
@@ -102,7 +102,7 @@ module "nginx-mig" {
     }
   }
 }
-# tftest:modules=2:resources=2
+# tftest modules=2 resources=2
 ```
 
 ### Health check and autohealing policies
@@ -158,7 +158,7 @@ module "nginx-mig" {
     logging = true
   }
 }
-# tftest:modules=2:resources=3
+# tftest modules=2 resources=3
 ```
 
 ### Autoscaling
@@ -212,7 +212,7 @@ module "nginx-mig" {
     metric                            = null
   }
 }
-# tftest:modules=2:resources=3
+# tftest modules=2 resources=3
 ```
 
 ### Update policy
@@ -265,7 +265,7 @@ module "nginx-mig" {
     max_unavailable      = null
   }
 }
-# tftest:modules=2:resources=2
+# tftest modules=2 resources=2
 ```
 
 ### Stateful MIGs - MIG Config
@@ -347,7 +347,7 @@ module "nginx-mig" {
     }
   }
 }
-# tftest:modules=2:resources=3
+# tftest modules=2 resources=3
 
 ```
 
@@ -440,7 +440,7 @@ module "nginx-mig" {
     }
   }
 }
-# tftest:modules=2:resources=4
+# tftest modules=2 resources=4
 
 ```
 <!-- BEGIN TFDOC -->

--- a/modules/compute-vm/README.md
+++ b/modules/compute-vm/README.md
@@ -27,7 +27,7 @@ module "simple-vm-example" {
   }]
   service_account_create = true
 }
-# tftest:modules=1:resources=2
+# tftest modules=1 resources=2
 
 ```
 
@@ -67,7 +67,7 @@ module "simple-vm-example" {
   }]
   service_account_create = true
 }
-# tftest:modules=1:resources=2
+# tftest modules=1 resources=2
 ```
 
 And the same example for an instance template (where not using the full self link of the disk triggers recreation of the template)
@@ -98,7 +98,7 @@ module "simple-vm-example" {
   service_account_create = true
   create_template  = true
 }
-# tftest:modules=1:resources=2
+# tftest modules=1 resources=2
 ```
 
 ### Disk encryption with Cloud KMS
@@ -138,7 +138,7 @@ module "kms-vm-example" {
     kms_key_self_link       = var.kms_key.self_link
   }
 }
-# tftest:modules=1:resources=3
+# tftest modules=1 resources=3
 ```
 
 ### Using Alias IPs
@@ -167,7 +167,7 @@ module "vm-with-alias-ips" {
   }
   service_account_create = true
 }
-# tftest:modules=1:resources=2
+# tftest modules=1 resources=2
 ```
 
 ### Using gVNIC
@@ -219,7 +219,7 @@ module "vm-with-gvnic" {
   }
   service_account_create = true
 }
-# tftest:modules=1:resources=2
+# tftest modules=1 resources=2
 ```
 
 ### Instance template
@@ -255,7 +255,7 @@ module "cos-test" {
   service_account        = "vm-default@my-project.iam.gserviceaccount.com"
   create_template  = true
 }
-# tftest:modules=1:resources=1
+# tftest modules=1 resources=1
 ```
 
 ### Instance group
@@ -290,7 +290,7 @@ module "instance-group" {
   }
   group = { named_ports = {} }
 }
-# tftest:modules=1:resources=2
+# tftest modules=1 resources=2
 ```
 <!-- BEGIN TFDOC -->
 

--- a/modules/container-registry/README.md
+++ b/modules/container-registry/README.md
@@ -13,7 +13,7 @@ module "container_registry" {
     "roles/storage.admin" = ["group:cicd@example.com"]
   }
 }
-# tftest:modules=1:resources=2
+# tftest modules=1 resources=2
 ```
 <!-- BEGIN TFDOC -->
 

--- a/modules/datafusion/README.md
+++ b/modules/datafusion/README.md
@@ -16,7 +16,7 @@ module "datafusion" {
   # TODO: remove the following line
   firewall_create = false
 }
-# tftest:modules=1:resources=3
+# tftest modules=1 resources=3
 ```
 
 ### Externally managed IP allocation
@@ -31,7 +31,7 @@ module "datafusion" {
   ip_allocation_create = false
   ip_allocation        = "10.0.0.0/22"
 }
-# tftest:modules=1:resources=3
+# tftest modules=1 resources=3
 ```
 <!-- BEGIN TFDOC -->
 

--- a/modules/dns/README.md
+++ b/modules/dns/README.md
@@ -20,7 +20,7 @@ module "private-dns" {
     "A localhost" = { type = "A", ttl = 300, records = ["127.0.0.1"] }
   }
 }
-# tftest:modules=1:resources=2
+# tftest modules=1 resources=2
 ```
 
 ### Forwarding Zone
@@ -35,7 +35,7 @@ module "private-dns" {
   client_networks = [var.vpc.self_link]
   forwarders      = { "10.0.1.1" = null, "1.2.3.4" = "private" }
 }
-# tftest:modules=1:resources=1
+# tftest modules=1 resources=1
 ```
 
 ### Peering Zone
@@ -50,7 +50,7 @@ module "private-dns" {
   client_networks = [var.vpc.self_link]
   peer_network    = var.vpc2.self_link
 }
-# tftest:modules=1:resources=1
+# tftest modules=1 resources=1
 ```
 <!-- BEGIN TFDOC -->
 

--- a/modules/endpoints/README.md
+++ b/modules/endpoints/README.md
@@ -18,7 +18,7 @@ module "endpoint" {
     ]
   }
 }
-# tftest:skip
+# tftest skip
 ```
 
 [Here](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/endpoints/getting-started/openapi.yaml) you can find an example of an openapi.yaml file. Once created the endpoint, remember to activate the service at project level.

--- a/modules/folder/README.md
+++ b/modules/folder/README.md
@@ -21,7 +21,7 @@ module "folder" {
     "roles/owner" = ["user:one@example.com"]
   }
 }
-# tftest:modules=1:resources=3
+# tftest modules=1 resources=3
 ```
 
 ### Organization policies
@@ -44,7 +44,7 @@ module "folder" {
     }
   }
 }
-# tftest:modules=1:resources=4
+# tftest modules=1 resources=4
 ```
 
 ### Firewall policy factory
@@ -65,7 +65,7 @@ module "folder" {
     factory-policy = module.folder.firewall_policy_id["factory"]
   }
 }
-# tftest:skip
+# tftest skip
 ```
 
 ```yaml
@@ -174,7 +174,7 @@ module "folder-sink" {
     no-gce-instances = "resource.type=gce_instance"
   }
 }
-# tftest:modules=5:resources=14
+# tftest modules=5 resources=14
 ```
 
 ### Hierarchical firewall policies
@@ -213,7 +213,7 @@ module "folder2" {
     iap-policy = module.folder1.firewall_policy_id["iap-policy"]
   }
 }
-# tftest:modules=2:resources=6
+# tftest modules=2 resources=6
 ```
 <!-- BEGIN TFDOC -->
 

--- a/modules/folders-unit/README.md
+++ b/modules/folders-unit/README.md
@@ -21,7 +21,7 @@ module "folders-unit" {
   }
   service_account_keys  = true
 }
-# tftest:modules=1:resources=37
+# tftest modules=1 resources=37
 ```
 <!-- BEGIN TFDOC -->
 

--- a/modules/gcs/README.md
+++ b/modules/gcs/README.md
@@ -11,7 +11,7 @@ module "bucket" {
     "roles/storage.admin" = ["group:storage@example.com"]
   }
 }
-# tftest:modules=1:resources=2
+# tftest modules=1 resources=2
 ```
 
 ### Example with Cloud KMS
@@ -27,7 +27,7 @@ module "bucket" {
   }
   encryption_key = "my-encryption-key"
 }
-# tftest:modules=1:resources=2
+# tftest modules=1 resources=2
 ```
 
 ### Example with retention policy
@@ -52,7 +52,7 @@ module "bucket" {
     log_object_prefix = null
   }
 }
-# tftest:modules=1:resources=2
+# tftest modules=1 resources=2
 ```
 
 ### Example with lifecycle rule
@@ -86,7 +86,7 @@ module "bucket" {
     }
   }
 }
-# tftest:modules=1:resources=2
+# tftest modules=1 resources=2
 ```
 ### Minimal example with GCS notifications
 ```hcl
@@ -104,7 +104,7 @@ module "bucket-gcs-notification" {
     custom_attributes = {}
   }
 }
-# tftest:modules=1:resources=4
+# tftest modules=1 resources=4
 ```
 <!-- BEGIN TFDOC -->
 

--- a/modules/gke-cluster/README.md
+++ b/modules/gke-cluster/README.md
@@ -30,7 +30,7 @@ module "cluster-1" {
     environment = "dev"
   }
 }
-# tftest:modules=1:resources=1
+# tftest modules=1 resources=1
 ```
 
 ### GKE Cluster with Dataplane V2 enabled
@@ -60,7 +60,7 @@ module "cluster-1" {
     environment = "dev"
   }
 }
-# tftest:modules=1:resources=1
+# tftest modules=1 resources=1
 ```
 <!-- BEGIN TFDOC -->
 

--- a/modules/gke-nodepool/README.md
+++ b/modules/gke-nodepool/README.md
@@ -31,7 +31,7 @@ module "cluster-1-nodepool-1" {
   name                        = "nodepool-1"
   node_service_account_create = true
 }
-# tftest:modules=1:resources=2
+# tftest modules=1 resources=2
 ```
 <!-- BEGIN TFDOC -->
 

--- a/modules/iam-service-account/README.md
+++ b/modules/iam-service-account/README.md
@@ -22,7 +22,7 @@ module "myproject-default-service-accounts" {
     ]
   }
 }
-# tftest:modules=1:resources=5
+# tftest modules=1 resources=5
 ```
 <!-- BEGIN TFDOC -->
 

--- a/modules/kms/README.md
+++ b/modules/kms/README.md
@@ -23,7 +23,7 @@ module "kms" {
   keyring_create = false
   keys           = { key-a = null, key-b = null, key-c = null }
 }
-# tftest:skip
+# tftest skip
 ```
 
 ### Keyring creation and crypto key rotation and IAM roles
@@ -56,7 +56,7 @@ module "kms" {
     key-c = { rotation_period = null, labels = { env = "test" } }
   }
 }
-# tftest:modules=1:resources=9
+# tftest modules=1 resources=9
 ```
 
 ### Crypto key purpose
@@ -77,7 +77,7 @@ module "kms" {
   keyring     = { location = "europe-west1", name = "test" }
   keys        = { key-a = null, key-b = null, key-c = null }
 }
-# tftest:modules=1:resources=4
+# tftest modules=1 resources=4
 ```
 <!-- BEGIN TFDOC -->
 

--- a/modules/logging-bucket/README.md
+++ b/modules/logging-bucket/README.md
@@ -17,7 +17,7 @@ module "bucket" {
   parent      = var.project_id
   id          = "mybucket"
 }
-# tftest:modules=1:resources=1
+# tftest modules=1 resources=1
 ```
 
 
@@ -37,7 +37,7 @@ module "bucket-default" {
   id          = "_Default"
   retention   = 10
 }
-# tftest:modules=2:resources=2
+# tftest modules=2 resources=2
 ```
 <!-- BEGIN TFDOC -->
 

--- a/modules/net-address/README.md
+++ b/modules/net-address/README.md
@@ -16,7 +16,7 @@ module "addresses" {
   }
   global_addresses = ["app-1", "app-2"]
 }
-# tftest:modules=1:resources=4
+# tftest modules=1 resources=4
 ```
 
 ### Internal addresses
@@ -44,7 +44,7 @@ module "addresses" {
     }
   }
 }
-# tftest:modules=1:resources=2
+# tftest modules=1 resources=2
 ```
 
 ### PSA addresses
@@ -61,7 +61,7 @@ module "addresses" {
     }
   }
 }
-# tftest:modules=1:resources=1
+# tftest modules=1 resources=1
 ```
 
 ### PSC addresses
@@ -81,7 +81,7 @@ module "addresses" {
     }
   }
 }
-# tftest:modules=1:resources=2
+# tftest modules=1 resources=2
 ```
 <!-- BEGIN TFDOC -->
 

--- a/modules/net-cloudnat/README.md
+++ b/modules/net-cloudnat/README.md
@@ -12,7 +12,7 @@ module "nat" {
   name           = "default"
   router_network = "my-vpc"
 }
-# tftest:modules=1:resources=2
+# tftest modules=1 resources=2
 ```
 <!-- BEGIN TFDOC -->
 

--- a/modules/net-glb/README.md
+++ b/modules/net-glb/README.md
@@ -26,7 +26,7 @@ module "glb" {
     }
   }
 }
-# tftest:modules=1:resources=4
+# tftest modules=1 resources=4
 ```
 
 ### Group Backend Service Minimal Example
@@ -58,7 +58,7 @@ module "glb" {
     }
   }
 }
-# tftest:modules=1:resources=5
+# tftest modules=1 resources=5
 ```
 
 ### Health Checks For Group Backend Services
@@ -108,7 +108,7 @@ module "glb" {
     }
   }
 }
-# tftest:modules=1:resources=5
+# tftest modules=1 resources=5
 ```
 
 ### Serverless Backends
@@ -154,7 +154,7 @@ resource "google_compute_region_network_endpoint_group" "serverless-neg" {
     service = "my-cloud-run-service"
   }
 }
-# tftest:modules=1:resources=4
+# tftest modules=1 resources=4
 ```
 
 ### Mixing Backends
@@ -211,7 +211,7 @@ module "glb" {
     }
   }
 }
-# tftest:modules=1:resources=7
+# tftest modules=1 resources=7
 ```
 
 ### Url-map
@@ -286,7 +286,7 @@ module "glb" {
     }
   }
 }
-# tftest:modules=1:resources=6
+# tftest modules=1 resources=6
 ```
 
 ### Reserve a static IP address
@@ -320,7 +320,7 @@ module "glb" {
     }
   }
 }
-# tftest:modules=1:resources=6
+# tftest modules=1 resources=6
 ```
 
 ### HTTPS And SSL Certificates
@@ -357,7 +357,7 @@ module "glb" {
     }
   }
 }
-# tftest:modules=1:resources=6
+# tftest modules=1 resources=6
 ```
 
 Otherwise, SSL certificates can be explicitely defined. In this case, they'll need to be referenced from the `target_proxy_https_config.ssl_certificates` variable.
@@ -407,7 +407,7 @@ module "glb" {
     }
   }
 }
-# tftest:modules=1:resources=6
+# tftest modules=1 resources=6
 ```
 
 Using unamanged certificates is also possible. Here is an example:
@@ -479,7 +479,7 @@ resource "tls_self_signed_cert" "self_signed_cert" {
     organization = "My Test Org"
   }
 }
-# tftest:modules=1:resources=6
+# tftest modules=1 resources=6
 ```
 
 ## Components And Files Mapping

--- a/modules/net-ilb/README.md
+++ b/modules/net-ilb/README.md
@@ -43,7 +43,7 @@ module "ilb" {
     type = "http", check = { port = 80 }, config = {}, logging = true
   }
 }
-# tftest:modules=1:resources=4
+# tftest modules=1 resources=4
 ```
 
 ### End to end example
@@ -105,7 +105,7 @@ module "ilb" {
     type = "http", check = { port = 80 }, config = {}, logging = true
   }
 }
-# tftest:modules=3:resources=7
+# tftest modules=3 resources=7
 ```
 <!-- BEGIN TFDOC -->
 

--- a/modules/net-interconnect-attachment-direct/README.md
+++ b/modules/net-interconnect-attachment-direct/README.md
@@ -19,7 +19,7 @@ module "vlan-attachment-1" {
     asn        = 65418
   }
 }
-# tftest:modules=1:resources=4
+# tftest modules=1 resources=4
 ```
 #### Direct Interconnect VLAN attachments to achieve 99.9% SLA setup
 
@@ -101,7 +101,7 @@ module "vlan-attachment-2" {
     candidate_ip_ranges       = ["169.254.63.8/29"]
   }
 }
-# tftest:modules=2:resources=8
+# tftest modules=2 resources=8
 ```
 <!-- BEGIN TFDOC -->
 

--- a/modules/net-vpc-firewall/README.md
+++ b/modules/net-vpc-firewall/README.md
@@ -21,7 +21,7 @@ module "firewall" {
   network              = "my-network"
   admin_ranges         = ["10.0.0.0/8"]
 }
-# tftest:modules=1:resources=4
+# tftest modules=1 resources=4
 ```
 
 ### Custom rules
@@ -48,7 +48,7 @@ module "firewall" {
     }
   }
 }
-# tftest:modules=1:resources=5
+# tftest modules=1 resources=5
 ```
 
 ### No predefined rules
@@ -78,7 +78,7 @@ module "firewall" {
     }
   }
 }
-# tftest:modules=1:resources=1
+# tftest modules=1 resources=1
 ```
 
 
@@ -93,7 +93,7 @@ module "firewall" {
   data_folder        = "config/firewall"
   cidr_template_file = "config/cidr_template.yaml"
 }
-# tftest:skip
+# tftest skip
 ```
 
 ```yaml

--- a/modules/net-vpc-peering/README.md
+++ b/modules/net-vpc-peering/README.md
@@ -18,7 +18,7 @@ module "peering" {
   local_network = "projects/project-1/global/networks/vpc-1"
   peer_network  = "projects/project-1/global/networks/vpc-2"
 }
-# tftest:modules=1:resources=2
+# tftest modules=1 resources=2
 ```
 
 If you need to create more than one peering for the same VPC Network `(A -> B, A -> C)` you use a `depends_on` for second one to keep order of peering creation (It is not currently possible to create more than one peering connection for a VPC Network at the same time).
@@ -38,7 +38,7 @@ module "peering-a-c" {
   peer_network  = "projects/project-c/global/networks/vpc-c"
   depends_on    = [module.peering-a-b]
 }
-# tftest:modules=2:resources=4
+# tftest modules=2 resources=4
 ```
 <!-- BEGIN TFDOC -->
 

--- a/modules/net-vpc/README.md
+++ b/modules/net-vpc/README.md
@@ -31,7 +31,7 @@ module "vpc" {
     }
   ]
 }
-# tftest:modules=1:resources=3
+# tftest modules=1 resources=3
 ```
 
 ### Peering
@@ -69,7 +69,7 @@ module "vpc-spoke-1" {
     import_routes      = true
   }
 }
-# tftest:modules=2:resources=6
+# tftest modules=2 resources=6
 ```
 
 ### Shared VPC
@@ -120,7 +120,7 @@ module "vpc-host" {
     }
   }
 }
-# tftest:modules=1:resources=7
+# tftest modules=1 resources=7
 ```
 
 ### Private Service Networking
@@ -140,7 +140,7 @@ module "vpc" {
   ]
   psn_ranges = ["10.10.0.0/16"]
 }
-# tftest:modules=1:resources=4
+# tftest modules=1 resources=4
 ```
 
 ### DNS Policies
@@ -167,7 +167,7 @@ module "vpc" {
     }
   ]
 }
-# tftest:modules=1:resources=3
+# tftest modules=1 resources=3
 ```
 
 ### Subnet Factory
@@ -181,7 +181,7 @@ module "vpc" {
   name        = "my-network"
   data_folder = "config/subnets"
 }
-# tftest:skip
+# tftest skip
 ```
 
 ```yaml

--- a/modules/net-vpn-dynamic/README.md
+++ b/modules/net-vpn-dynamic/README.md
@@ -36,7 +36,7 @@ module "vpn-dynamic" {
     }
   }
 }
-# tftest:modules=1:resources=10
+# tftest modules=1 resources=10
 ```
 <!-- BEGIN TFDOC -->
 

--- a/modules/net-vpn-ha/README.md
+++ b/modules/net-vpn-ha/README.md
@@ -87,7 +87,7 @@ module "vpn_ha-2" {
     }
   }
 }
-# tftest:modules=2:resources=18
+# tftest modules=2 resources=18
 ```
 
 ### GCP to on-prem
@@ -136,7 +136,7 @@ module "vpn_ha" {
     }
   }
 }
-# tftest:modules=1:resources=10
+# tftest modules=1 resources=10
 ```
 <!-- BEGIN TFDOC -->
 

--- a/modules/net-vpn-static/README.md
+++ b/modules/net-vpn-static/README.md
@@ -29,7 +29,7 @@ module "vpn" {
     }
   }
 }
-# tftest:modules=2:resources=8
+# tftest modules=2 resources=8
 ```
 <!-- BEGIN TFDOC -->
 

--- a/modules/organization/README.md
+++ b/modules/organization/README.md
@@ -32,7 +32,7 @@ module "org" {
     }
   }
 }
-# tftest:modules=1:resources=6
+# tftest modules=1 resources=6
 ```
 
 ## IAM
@@ -83,7 +83,7 @@ module "org" {
     iap_policy = "iap-policy"
   }
 }
-# tftest:modules=1:resources=3
+# tftest modules=1 resources=3
 ```
 
 ### Firewall policy factory
@@ -103,7 +103,7 @@ module "org" {
     factory-policy = module.org.firewall_policy_id["factory"]
   }
 }
-# tftest:skip
+# tftest skip
 ```
 
 ```yaml
@@ -216,7 +216,7 @@ module "org" {
     no-gce-instances = "resource.type=gce_instance"
   }
 }
-# tftest:modules=5:resources=13
+# tftest modules=5 resources=13
 ```
 
 ## Custom Roles
@@ -233,7 +233,7 @@ module "org" {
     (module.org.custom_role_id.myRole) = ["user:me@example.com"]
   }
 }
-# tftest:modules=1:resources=2
+# tftest modules=1 resources=2
 ```
 <!-- BEGIN TFDOC -->
 

--- a/modules/project/README.md
+++ b/modules/project/README.md
@@ -25,7 +25,7 @@ module "project" {
     ]
   }
 }
-# tftest:modules=1:resources=4
+# tftest modules=1 resources=4
 ```
 
 ### Minimal example with IAM additive roles
@@ -41,7 +41,7 @@ module "project" {
     "roles/owner"                = ["group:three@example.org"],
   }
 }
-# tftest:modules=1:resources=5
+# tftest modules=1 resources=5
 ```
 
 ### Organization policies
@@ -70,7 +70,7 @@ module "project" {
     }
   }
 }
-# tftest:modules=1:resources=6
+# tftest modules=1 resources=6
 ```
 
 ## Logging Sinks
@@ -146,7 +146,7 @@ module "project-host" {
     no-gce-instances = "resource.type=gce_instance"
   }
 }
-# tftest:modules=5:resources=12
+# tftest modules=5 resources=12
 ```
 
 ## Cloud KMS encryption keys
@@ -171,7 +171,7 @@ module "project" {
     ]
   }
 }
-# tftest:modules=1:resources=7
+# tftest modules=1 resources=7
 ```
 
 <!-- TFDOC OPTS files:1 -->

--- a/modules/pubsub/README.md
+++ b/modules/pubsub/README.md
@@ -17,7 +17,7 @@ module "pubsub" {
     "roles/pubsub.subscriber" = ["user:user1@example.com"]
   }
 }
-# tftest:modules=1:resources=3
+# tftest modules=1 resources=3
 ```
 
 ### Subscriptions
@@ -42,7 +42,7 @@ module "pubsub" {
     }
   }
 }
-# tftest:modules=1:resources=3
+# tftest modules=1 resources=3
 ```
 
 ### Push subscriptions
@@ -65,7 +65,7 @@ module "pubsub" {
     }
   }
 }
-# tftest:modules=1:resources=2
+# tftest modules=1 resources=2
 ```
 
 ### Subscriptions with IAM
@@ -85,7 +85,7 @@ module "pubsub" {
     }
   }
 }
-# tftest:modules=1:resources=3
+# tftest modules=1 resources=3
 ```
 <!-- BEGIN TFDOC -->
 

--- a/modules/secret-manager/README.md
+++ b/modules/secret-manager/README.md
@@ -21,7 +21,7 @@ module "secret-manager" {
     test-manual = ["europe-west1", "europe-west4"]
   }
 }
-# tftest:modules=1:resources=2
+# tftest modules=1 resources=2
 ```
 
 ### Secret IAM bindings
@@ -45,7 +45,7 @@ module "secret-manager" {
     }
   }
 }
-# tftest:modules=1:resources=4
+# tftest modules=1 resources=4
 ```
 
 ### Secret versions
@@ -70,7 +70,7 @@ module "secret-manager" {
     }
   }
 }
-# tftest:modules=1:resources=5
+# tftest modules=1 resources=5
 ```
 <!-- BEGIN TFDOC -->
 

--- a/modules/service-directory/README.md
+++ b/modules/service-directory/README.md
@@ -21,7 +21,7 @@ module "service-directory" {
     ]
   }
 }
-# tftest:modules=1:resources=2
+# tftest modules=1 resources=2
 ```
 
 ### Services with IAM and endpoints
@@ -50,7 +50,7 @@ module "service-directory" {
     "one/second" = { address = "127.0.0.2", port = 80, metadata = {} }
   }
 }
-# tftest:modules=1:resources=5
+# tftest modules=1 resources=5
 ```
 
 ### DNS based zone
@@ -85,7 +85,7 @@ module "dns-sd" {
   client_networks             = [var.vpc.self_link]
   service_directory_namespace = module.service-directory.id
 }
-# tftest:modules=2:resources=5
+# tftest modules=2 resources=5
 ```
 <!-- BEGIN TFDOC -->
 

--- a/modules/source-repository/README.md
+++ b/modules/source-repository/README.md
@@ -16,7 +16,7 @@ module "repo" {
     "roles/source.reader" = ["user:foo@example.com"]
   }
 }
-# tftest:modules=1:resources=2
+# tftest modules=1 resources=2
 ```
 <!-- BEGIN TFDOC -->
 

--- a/modules/vpc-sc/README.md
+++ b/modules/vpc-sc/README.md
@@ -17,7 +17,7 @@ module "test" {
   source        = "./modules/vpc-sc"
   access_policy = "accessPolicies/12345678"
 }
-# tftest:modules=0:resources=0
+# tftest modules=0 resources=0
 ```
 
 If you need the module to create the policy for you, use the `access_policy_create` variable, and set `access_policy` to `null`:
@@ -31,7 +31,7 @@ module "test" {
     title  = "vpcsc-policy"
   }
 }
-# tftest:modules=1:resources=1
+# tftest modules=1 resources=1
 ```
 
 ### Access levels
@@ -62,7 +62,7 @@ module "test" {
     }
   }
 }
-# tftest:modules=1:resources=2
+# tftest modules=1 resources=2
 ```
 
 ### Service perimeters
@@ -96,7 +96,7 @@ module "test" {
     }
   }
 }
-# tftest:modules=1:resources=2
+# tftest modules=1 resources=2
 ```
 
 #### Regular type
@@ -139,7 +139,7 @@ module "test" {
     }
   }
 }
-# tftest:modules=1:resources=3
+# tftest modules=1 resources=3
 ```
 
 ## Notes

--- a/tests/doc_examples/conftest.py
+++ b/tests/doc_examples/conftest.py
@@ -34,6 +34,7 @@ def pytest_generate_tests(metafunc):
         continue
       doc = marko.parse(readme.read_text())
       index = 0
+      last_header = None
       for child in doc.children:
         if isinstance(child, marko.block.FencedCode) and child.lang == 'hcl':
           index += 1
@@ -41,6 +42,12 @@ def pytest_generate_tests(metafunc):
           if 'tftest skip' in code:
             continue
           examples.append(code)
-          ids.append(f'{module.stem}:example{index}')
+          name = f'{module.stem}:{last_header}'
+          if index > 1:
+            name += f' {index}'
+          ids.append(name)
+        elif isinstance(child, marko.block.Heading):
+          last_header = child.children[0].children
+          index = 0
 
     metafunc.parametrize('example', examples, ids=ids)

--- a/tests/doc_examples/conftest.py
+++ b/tests/doc_examples/conftest.py
@@ -38,7 +38,7 @@ def pytest_generate_tests(metafunc):
         if isinstance(child, marko.block.FencedCode) and child.lang == 'hcl':
           index += 1
           code = child.children[0].children
-          if 'tftest:skip' in code:
+          if 'tftest skip' in code:
             continue
           examples.append(code)
           ids.append(f'{module.stem}:example{index}')

--- a/tests/doc_examples/test_plan.py
+++ b/tests/doc_examples/test_plan.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 
 BASE_PATH = Path(__file__).parent
-EXPECTED_RESOURCES_RE = re.compile(r'# tftest:modules=(\d+):resources=(\d+)')
+EXPECTED_RESOURCES_RE = re.compile(r'# tftest modules=(\d+) resources=(\d+)')
 
 
 def test_example(example_plan_runner, tmp_path, example):


### PR DESCRIPTION
- Use meaningful names to tests derived from examples.
- Use space as token separator