### PR TITLE
Experimental module to derive DNS inbound policy addresses

### DIFF
--- a/modules/__experimental/net-dns-policy-address/README.md
+++ b/modules/__experimental/net-dns-policy-address/README.md
@@ -1,0 +1,35 @@
+# Google Cloud DNS Inbound Policy Addresses
+
+This module allows discovering the addresses reserved in subnets when [DNS Inbound Policies](https://cloud.google.com/dns/docs/policies) are configured.
+
+Since it's currently impossible to fetch those addresses using a GCP data source (see [this issue](https://github.com/hashicorp/terraform-provider-google/issues/3753) for more details), the workaround used here is to derive the authorization token from the Google provider, and do a direct HTTP call to the Compute API.
+
+## Examples
+
+```hcl
+module "dns-policy-addresses" {
+  source          = "./modules/_experimental/net-dns-policy-addresses"
+  project_id      = "myproject"
+  regions = ["europe-west1", "europe-west3"]
+}
+# tftest skip
+```
+
+The output is a map with lists of addresses of type `DNS_RESOLVER` for each region specified in variables.
+
+<!-- BEGIN TFDOC -->
+
+## Variables
+
+| name | description | type | required | default |
+|---|---|:---:|:---:|:---:|
+| [project_id](variables.tf#L17) | Project id. | <code>string</code> | ✓ |  |
+| [regions](variables.tf#L22) | Regions to fetch addresses from. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#34;europe-west1&#34;&#93;</code> |
+
+## Outputs
+
+| name | description | sensitive |
+|---|---|:---:|
+| [addresses](outputs.tf#L24) | DNS inbound policy addresses per region. |  |
+
+<!-- END TFDOC -->

--- a/modules/__experimental/net-dns-policy-address/main.tf
+++ b/modules/__experimental/net-dns-policy-address/main.tf
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  url = format(
+    "https://content-compute.googleapis.com/compute/v1/projects/%s",
+    var.project_id
+  )
+}
+
+data "google_client_config" "current" {
+}
+
+data "http" "addresses" {
+  for_each = toset(var.regions)
+  url      = "${local.url}/regions/${each.key}/addresses?filter=purpose%20%3D%20%22DNS_RESOLVER%22"
+
+  # Optional request headers
+  request_headers = {
+    Authorization = "Bearer ${data.google_client_config.current.access_token}"
+  }
+}

--- a/modules/__experimental/net-dns-policy-address/outputs.tf
+++ b/modules/__experimental/net-dns-policy-address/outputs.tf
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  region_addresses = {
+    for k, v in data.http.addresses : k => try(jsondecode(v.body), {})
+  }
+}
+
+
+output "addresses" {
+  description = "DNS inbound policy addresses per region."
+  value = {
+    for k, v in local.region_addresses : k => [
+      for i in try(v.items, []) : i.address
+    ]
+  }
+}

--- a/modules/__experimental/net-dns-policy-address/variables.tf
+++ b/modules/__experimental/net-dns-policy-address/variables.tf
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "Project id."
+  type        = string
+}
+
+variable "regions" {
+  description = "Regions to fetch addresses from."
+  nullable    = false
+  type        = list(string)
+  default     = ["europe-west1"]
+}


### PR DESCRIPTION
Workaround for [this provider issue](https://github.com/hashicorp/terraform-provider-google/issues/3753).