### PR TITLE
Add ip_range variable to apigee-x-instance module

### DIFF
--- a/modules/apigee-x-instance/README.md
+++ b/modules/apigee-x-instance/README.md
@@ -11,7 +11,7 @@ module "apigee-x-instance" {
   source             = "./modules/apigee-x-instance"
   name               = "my-us-instance"
   region             = "us-central1"
-  cidr_mask          = 22
+  ip_range           = "10.0.0.0/22"
 
   apigee_org_id      = "my-project"
   apigee_environments = [
@@ -29,7 +29,7 @@ module "apigee-x-instance" {
   source              = "./modules/apigee-x-instance"
   name                = "my-us-instance"
   region              = "us-central1"
-  cidr_mask           = 16
+  ip_range            = "10.0.0.0/22"
   disk_encryption_key = "my-disk-key"
 
   apigee_org_id       = "my-project"
@@ -49,7 +49,7 @@ module "apigee-x-instance" {
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
 | [apigee_org_id](variables.tf#L32) | Apigee Organization ID. | <code>string</code> | ✓ |  |
-| [cidr_mask](variables.tf#L37) | CIDR mask for the Apigee instance. | <code>number</code> | ✓ |  |
+| [ip_range](variables.tf#L37) | Customer-provided CIDR block of length 22 for the Apigee instance. | <code>string</code> | ✓ |  |
 | [name](variables.tf#L52) | Apigee instance name. | <code>string</code> | ✓ |  |
 | [region](variables.tf#L57) | Compute region. | <code>string</code> | ✓ |  |
 | [apigee_envgroups](variables.tf#L17) | Apigee Environment Groups. | <code title="map&#40;object&#40;&#123;&#10;  environments &#61; list&#40;string&#41;&#10;  hostnames    &#61; list&#40;string&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |

--- a/modules/apigee-x-instance/main.tf
+++ b/modules/apigee-x-instance/main.tf
@@ -18,7 +18,7 @@ resource "google_apigee_instance" "apigee_instance" {
   org_id                   = var.apigee_org_id
   name                     = var.name
   location                 = var.region
-  peering_cidr_range       = "SLASH_${var.cidr_mask}"
+  ip_range                 = var.ip_range
   disk_encryption_key_name = var.disk_encryption_key
 }
 


### PR DESCRIPTION
Recently `ip_range` field was added to [google_apigee_instance](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/apigee_instance) Terraform resource.

This is in regards to the new `ipRange` field being added to [organizations.instance](https://cloud.google.com/apigee/docs/reference/apis/apigee/rest/v1/organizations.instances#Instance) API. The `peeringCidrRange` field is being deprecated.

So need to update the **apigee-x-instance** module to be in line with these updates to Apigee X API. Henceforth, `ip_range` variable can be made mandatory for this module and `cidr_range` variable can be removed.