### PR TITLE
revert net-nva specific output files

### DIFF
--- a/fast/stages/01-resman/outputs.tf
+++ b/fast/stages/01-resman/outputs.tf
@@ -25,11 +25,6 @@ locals {
       name   = "networking"
       sa     = module.branch-network-sa.email
     })
-    "02-networking-nva" = templatefile("${path.module}/../../assets/templates/providers.tpl", {
-      bucket = module.branch-network-gcs.name
-      name   = "networking-nva"
-      sa     = module.branch-network-sa.email
-    })
     "02-security" = templatefile("${path.module}/../../assets/templates/providers.tpl", {
       bucket = module.branch-security-gcs.name
       name   = "security"
@@ -53,10 +48,6 @@ locals {
   }
   tfvars = {
     "02-networking" = jsonencode({
-      folder_id          = module.branch-network-folder.id
-      project_factory_sa = local._project_factory_sas
-    })
-    "02-networkin-nva" = jsonencode({
       folder_id          = module.branch-network-folder.id
       project_factory_sa = local._project_factory_sas
     })


### PR DESCRIPTION
There's no need to have different output files for the different net stages. This contradicts our statement that we have interfaces between stages, and the utput files are identical and just bad copy/paste.