### PR TITLE
Update net-vpc module to use beta provider for shared vpc resources.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - support service dependencies for crypto key bindings in project module
 - refactor project module in multiple files
 - add support for per-file option overrides to tfdoc
+- the `net-vpc` and `project` modules now use the beta provider for shared VPC-related resources
 
 ## [12.0.0] - 2022-01-11
 

--- a/modules/net-vpc/main.tf
+++ b/modules/net-vpc/main.tf
@@ -153,12 +153,14 @@ resource "google_compute_network_peering" "remote" {
 }
 
 resource "google_compute_shared_vpc_host_project" "shared_vpc_host" {
+  provider   = google-beta
   count      = var.shared_vpc_host ? 1 : 0
   project    = var.project_id
   depends_on = [local.network]
 }
 
 resource "google_compute_shared_vpc_service_project" "service_projects" {
+  provider = google-beta
   for_each = (
     var.shared_vpc_host && var.shared_vpc_service_projects != null
     ? toset(var.shared_vpc_service_projects)


### PR DESCRIPTION
This aligns the `net-vpc` module with the changes introduced in #499 