### PR TITLE
clusters improvement #1

### DIFF
--- a/fast/stages/03-gke-multitenant/prod/gke-clusters.tf
+++ b/fast/stages/03-gke-multitenant/prod/gke-clusters.tf
@@ -26,8 +26,8 @@ locals {
 module "gke-cluster" {
   source                   = "../../../../modules/gke-cluster"
   for_each                 = local.clusters
-  project_id               = module.gke-project-0.project_id
   name                     = each.key
+  project_id               = each.value.project_id
   description              = each.value.description
   location                 = each.value.location
   network                  = each.value.net.vpc

--- a/fast/stages/03-gke-multitenant/prod/gke-nodepools.tf
+++ b/fast/stages/03-gke-multitenant/prod/gke-nodepools.tf
@@ -34,7 +34,7 @@ module "gke_1_nodepool" {
   project_id         = module.gke-project-0.project_id
   cluster_name       = module.gke-cluster[each.value.cluster].name
   location           = module.gke-cluster[each.value.cluster].location
-  initial_node_count = each.value.node_count
+  initial_node_count = each.value.initial_node_count 
   node_machine_type  = each.value.node_type
   # TODO(jccb): can we use spot instances here?
   node_preemptible = each.value.preemptible

--- a/fast/stages/03-gke-multitenant/prod/main.tf
+++ b/fast/stages/03-gke-multitenant/prod/main.tf
@@ -69,7 +69,7 @@ module "gke-project-0" {
 module "gke-project-1" {
   source          = "../../../../modules/project"
   billing_account = var.billing_account_id
-  name            = "${var.environment}-gke-clusters-2j"
+  name            = "${var.environment}-gke-clusters-1"
   parent          = var.folder_id
   prefix          = var.prefix
   labels          = local.labels

--- a/fast/stages/03-gke-multitenant/prod/variables.tf
+++ b/fast/stages/03-gke-multitenant/prod/variables.tf
@@ -68,6 +68,7 @@ variable "clusters" {
       memory_min = number
       memory_max = number
     })
+    project_id = string
     description = string
     dns_domain  = string
     labels      = map(string)

--- a/fast/stages/03-gke-multitenant/prod/variables.tf
+++ b/fast/stages/03-gke-multitenant/prod/variables.tf
@@ -160,9 +160,3 @@ variable "vpc_host_project" {
   description = "Host project for the shared VPC."
   type        = string
 }
-
-variable "shared_vpc_self_link" {
-  # tfdoc:variable:source 02-networking
-  description = "Host project for the shared VPC."
-  type        = string
-}

--- a/fast/stages/03-gke-multitenant/prod/variables.tf
+++ b/fast/stages/03-gke-multitenant/prod/variables.tf
@@ -160,3 +160,9 @@ variable "vpc_host_project" {
   description = "Host project for the shared VPC."
   type        = string
 }
+
+variable "shared_vpc_self_link" {
+  # tfdoc:variable:source 02-networking
+  description = "Host project for the shared VPC."
+  type        = string
+}

--- a/fast/stages/03-gke-multitenant/prod/variables.tf
+++ b/fast/stages/03-gke-multitenant/prod/variables.tf
@@ -139,6 +139,7 @@ variable "nodepools" {
   type = map(map(object({
     node_count = number
     node_type  = string
+    initial_node_count = number
     overrides = object({
       image_type        = string
       max_pods_per_node = number


### PR DESCRIPTION
- decouple initial_node_count from node_count (cannot be set at the same time) 
- using project_id as a parameters for the clusters variable to being able to place clusters into different projects