### PR TITLE
Avoid sa overlap when sa_auto_create  is used in multiple clusters

### DIFF
--- a/modules/gke-nodepool/main.tf
+++ b/modules/gke-nodepool/main.tf
@@ -69,10 +69,14 @@ locals {
   node_taints = concat(local.temp_node_pools_taints, local.win_node_pools_taint)
 }
 
+resource "random_id" "sa" {
+  byte_length = 4
+}
+
 resource "google_service_account" "service_account" {
   count        = var.node_service_account_create ? 1 : 0
   project      = var.project_id
-  account_id   = "tf-gke-${var.name}"
+  account_id   = "tf-gke-${var.name}-${random_id.sa.hex}"
   display_name = "Terraform GKE ${var.cluster_name} ${var.name}."
 }
 


### PR DESCRIPTION
gke_nodepools has to option to autocreate the associated service account. In the case where two clusters in the same project with two nodepools with the same name are created, the name of sa of the first cluster is in conflict with the second and prevent the second nodepool to be created.