### PR TITLE
Add Zonal DNS Only org policy

### DIFF
--- a/fast/stages/01-resman/organization.tf
+++ b/fast/stages/01-resman/organization.tf
@@ -87,6 +87,7 @@ module "organization" {
     "constraints/compute.requireOsLogin"                          = true
     "constraints/compute.restrictXpnProjectLienRemoval"           = true
     "constraints/compute.skipDefaultNetworkCreation"              = true
+    "constraints/compute.setNewProjectDefaultToZonalDNSOnly"      = true
     "constraints/iam.automaticIamGrantsForDefaultServiceAccounts" = true
     "constraints/iam.disableServiceAccountKeyCreation"            = true
     "constraints/iam.disableServiceAccountKeyUpload"              = true


### PR DESCRIPTION
This is a safe and sane org policy that should be recommended for most customers to prevent them from accidentally configuring internal dns in a way that has reduced availability
https://cloud.google.com/compute/docs/internal-dns#enforce_dns_by_policy