### PR TITLE
Fix renamed argument to project factory module

### DIFF
--- a/fast/stages/03-project-factory/prod/README.md
+++ b/fast/stages/03-project-factory/prod/README.md
@@ -108,11 +108,12 @@ terraform apply
 | name | description | type | required | default | producer |
 |---|---|:---:|:---:|:---:|:---:|
 | [billing_account_id](variables.tf#L19) | Billing account id. | <code>string</code> | ✓ |  | <code>00-bootstrap</code> |
+| [prefix](variables.tf#L44) | Prefix used for resources that need unique names. | <code>string</code> | ✓ |  | <code>00-bootstrap</code> |
 | [data_dir](variables.tf#L25) | Relative path for the folder storing configuration data. | <code>string</code> |  | <code>&#34;data&#47;projects&#34;</code> |  |
 | [defaults_file](variables.tf#L38) | Relative path for the file storing the project factory configuration. | <code>string</code> |  | <code>&#34;data&#47;defaults.yaml&#34;</code> |  |
 | [environment_dns_zone](variables.tf#L31) | DNS zone suffix for environment. | <code>string</code> |  | <code>null</code> | <code>02-networking</code> |
-| [shared_vpc_self_link](variables.tf#L44) | Self link for the shared VPC. | <code>string</code> |  | <code>null</code> | <code>02-networking</code> |
-| [vpc_host_project](variables.tf#L51) | Host project for the shared VPC. | <code>string</code> |  | <code>null</code> | <code>02-networking</code> |
+| [shared_vpc_self_link](variables.tf#L50) | Self link for the shared VPC. | <code>string</code> |  | <code>null</code> | <code>02-networking</code> |
+| [vpc_host_project](variables.tf#L57) | Host project for the shared VPC. | <code>string</code> |  | <code>null</code> | <code>02-networking</code> |
 
 ## Outputs
 

--- a/fast/stages/03-project-factory/prod/main.tf
+++ b/fast/stages/03-project-factory/prod/main.tf
@@ -33,24 +33,24 @@ locals {
 }
 
 module "projects" {
-  source             = "../../../../examples/factories/project-factory"
-  for_each           = local.projects
-  defaults           = local.defaults
-  project_id         = each.key
-  billing_account_id = try(each.value.billing_account_id, null)
-  billing_alert      = try(each.value.billing_alert, null)
-  dns_zones          = try(each.value.dns_zones, [])
-  essential_contacts = try(each.value.essential_contacts, [])
-  folder_id          = each.value.folder_id
-  group_iam          = try(each.value.group_iam, {})
-  iam                = try(each.value.iam, {})
-  kms_service_agents = try(each.value.kms, {})
-  labels             = try(each.value.labels, {})
-  org_policies       = try(each.value.org_policies, null)
-  service_accounts   = try(each.value.service_accounts, {})
-  services           = try(each.value.services, [])
-  services_iam       = try(each.value.services_iam, {})
-  vpc                = try(each.value.vpc, null)
+  source                 = "../../../../examples/factories/project-factory"
+  for_each               = local.projects
+  defaults               = local.defaults
+  project_id             = each.key
+  billing_account_id     = try(each.value.billing_account_id, null)
+  billing_alert          = try(each.value.billing_alert, null)
+  dns_zones              = try(each.value.dns_zones, [])
+  essential_contacts     = try(each.value.essential_contacts, [])
+  folder_id              = each.value.folder_id
+  group_iam              = try(each.value.group_iam, {})
+  iam                    = try(each.value.iam, {})
+  kms_service_agents     = try(each.value.kms, {})
+  labels                 = try(each.value.labels, {})
+  org_policies           = try(each.value.org_policies, null)
+  service_accounts       = try(each.value.service_accounts, {})
+  services               = try(each.value.services, [])
+  service_identities_iam = try(each.value.services_iam, {})
+  vpc                    = try(each.value.vpc, null)
 }
 
 

--- a/fast/stages/03-project-factory/prod/main.tf
+++ b/fast/stages/03-project-factory/prod/main.tf
@@ -47,6 +47,7 @@ module "projects" {
   kms_service_agents     = try(each.value.kms, {})
   labels                 = try(each.value.labels, {})
   org_policies           = try(each.value.org_policies, null)
+  prefix                 = var.prefix
   service_accounts       = try(each.value.service_accounts, {})
   services               = try(each.value.services, [])
   service_identities_iam = try(each.value.services_iam, {})

--- a/fast/stages/03-project-factory/prod/variables.tf
+++ b/fast/stages/03-project-factory/prod/variables.tf
@@ -41,6 +41,12 @@ variable "defaults_file" {
   default     = "data/defaults.yaml"
 }
 
+variable "prefix" {
+  # tfdoc:variable:source 00-bootstrap
+  description = "Prefix used for resources that need unique names."
+  type        = string
+}
+
 variable "shared_vpc_self_link" {
   # tfdoc:variable:source 02-networking
   description = "Self link for the shared VPC."


### PR DESCRIPTION
FAST PF was not applying after the latest changes to the factory.

Also, are we intentionally not using prefix in the FAST PF? Projects names are just using the filename of the yaml.