### PR TITLE
FAST: env DNS zones moved to spoke projects

### DIFF
--- a/examples/factories/project-factory/main.tf
+++ b/examples/factories/project-factory/main.tf
@@ -139,7 +139,7 @@ module "billing-alert" {
 module "dns" {
   source          = "../../../modules/dns"
   for_each        = toset(var.dns_zones)
-  project_id      = module.project.project_id
+  project_id      = coalesce(local.vpc.host_project, module.project.project_id)
   type            = "private"
   name            = each.value
   domain          = "${each.value}.${var.defaults.environment_dns_zone}"

--- a/fast/stages/02-networking-nva/data/firewall-rules/dev/rules.yaml
+++ b/fast/stages/02-networking-nva/data/firewall-rules/dev/rules.yaml
@@ -5,7 +5,8 @@ ingress-allow-composer-nodes:
   direction: INGRESS
   action: allow
   sources: []
-  ranges: []
+  ranges:
+    - 0.0.0.0/0
   targets:
     - composer-worker
   use_service_accounts: false
@@ -18,7 +19,8 @@ ingress-allow-dataflow-load:
   direction: INGRESS
   action: allow
   sources: []
-  ranges: []
+  ranges:
+    - 0.0.0.0/0
   targets:
     - dataflow
   use_service_accounts: false

--- a/fast/stages/02-networking-nva/dns-dev.tf
+++ b/fast/stages/02-networking-nva/dns-dev.tf
@@ -24,7 +24,7 @@ module "dev-dns-private-zone" {
   type            = "private"
   name            = "dev-gcp-example-com"
   domain          = "dev.gcp.example.com."
-  client_networks = [module.dev-spoke-vpc.self_link]
+  client_networks = [module.landing-trusted-vpc.self_link, module.landing-untrusted-vpc.self_link]
   recordsets = {
     "A localhost" = { type = "A", ttl = 300, records = ["127.0.0.1"] }
   }

--- a/fast/stages/02-networking-nva/dns-dev.tf
+++ b/fast/stages/02-networking-nva/dns-dev.tf
@@ -20,7 +20,7 @@
 
 module "dev-dns-private-zone" {
   source          = "../../../modules/dns"
-  project_id      = module.landing-project.project_id
+  project_id      = module.dev-spoke-project.project_id
   type            = "private"
   name            = "dev-gcp-example-com"
   domain          = "dev.gcp.example.com."

--- a/fast/stages/02-networking-nva/dns-landing.tf
+++ b/fast/stages/02-networking-nva/dns-landing.tf
@@ -59,34 +59,6 @@ module "gcp-example-dns-private-zone" {
   }
 }
 
-# GCP-specific DNS zones peered to the environment spoke that holds the config
-
-module "prod-gcp-example-dns-peering" {
-  source     = "../../../modules/dns"
-  project_id = module.landing-project.project_id
-  type       = "peering"
-  name       = "prod-root-dns-peering"
-  domain     = "prod.gcp.example.com."
-  client_networks = [
-    module.landing-untrusted-vpc.self_link,
-    module.landing-trusted-vpc.self_link
-  ]
-  peer_network = module.prod-spoke-vpc.self_link
-}
-
-module "dev-gcp-example-dns-peering" {
-  source     = "../../../modules/dns"
-  project_id = module.landing-project.project_id
-  type       = "peering"
-  name       = "dev-root-dns-peering"
-  domain     = "dev.gcp.example.com."
-  client_networks = [
-    module.landing-untrusted-vpc.self_link,
-    module.landing-trusted-vpc.self_link
-  ]
-  peer_network = module.dev-spoke-vpc.self_link
-}
-
 # Google API zone to trigger Private Access
 
 module "googleapis-private-zone" {

--- a/fast/stages/02-networking-nva/dns-prod.tf
+++ b/fast/stages/02-networking-nva/dns-prod.tf
@@ -24,7 +24,7 @@ module "prod-dns-private-zone" {
   type            = "private"
   name            = "prod-gcp-example-com"
   domain          = "prod.gcp.example.com."
-  client_networks = [module.prod-spoke-vpc.self_link]
+  client_networks = [module.landing-trusted-vpc.self_link, module.landing-untrusted-vpc.self_link]
   recordsets = {
     "A localhost" = { type = "A", ttl = 300, records = ["127.0.0.1"] }
   }

--- a/fast/stages/02-networking-nva/dns-prod.tf
+++ b/fast/stages/02-networking-nva/dns-prod.tf
@@ -20,7 +20,7 @@
 
 module "prod-dns-private-zone" {
   source          = "../../../modules/dns"
-  project_id      = module.landing-project.project_id
+  project_id      = module.prod-spoke-project.project_id
   type            = "private"
   name            = "prod-gcp-example-com"
   domain          = "prod.gcp.example.com."

--- a/fast/stages/02-networking-nva/test-resources.tf
+++ b/fast/stages/02-networking-nva/test-resources.tf
@@ -130,33 +130,33 @@
 
 # Dev spoke
 
-# module "test-vm-dev-ew1-0" {
-#   source     = "../../../modules/compute-vm"
-#   project_id = module.dev-spoke-project.project_id
-#   zone       = "europe-west1-b"
-#   name       = "test-vm-dev-ew1-0"
-#   network_interfaces = [{
-#     network = module.dev-spoke-vpc.self_link
-#     # change the subnet name to match the values you are actually using
-#     subnetwork = module.dev-spoke-vpc.subnet_self_links["europe-west1/dev-default-ew1"]
-#     alias_ips  = {}
-#     nat        = false
-#     addresses  = null
-#   }]
-#   tags                   = ["ew1", "ssh"]
-#   service_account_create = true
-#   boot_disk = {
-#     image = "projects/debian-cloud/global/images/family/debian-10"
-#     type  = "pd-balanced"
-#     size  = 10
-#   }
-#   metadata = {
-#     startup-script = <<EOF
-#       apt update
-#       apt install iputils-ping bind9-dnsutils
-#     EOF
-#   }
-# }
+module "test-vm-dev-ew1-0" {
+  source     = "../../../modules/compute-vm"
+  project_id = module.dev-spoke-project.project_id
+  zone       = "europe-west1-b"
+  name       = "test-vm-dev-ew1-0"
+  network_interfaces = [{
+    network = module.dev-spoke-vpc.self_link
+    # change the subnet name to match the values you are actually using
+    subnetwork = module.dev-spoke-vpc.subnet_self_links["europe-west1/dev-default-ew1"]
+    alias_ips  = {}
+    nat        = false
+    addresses  = null
+  }]
+  tags                   = ["ew1", "ssh"]
+  service_account_create = true
+  boot_disk = {
+    image = "projects/debian-cloud/global/images/family/debian-10"
+    type  = "pd-balanced"
+    size  = 10
+  }
+  metadata = {
+    startup-script = <<EOF
+      apt update
+      apt install iputils-ping bind9-dnsutils
+    EOF
+  }
+}
 
 # module "test-vm-dev-ew4-0" {
 #   source     = "../../../modules/compute-vm"

--- a/fast/stages/02-networking-vpn/dns-dev.tf
+++ b/fast/stages/02-networking-vpn/dns-dev.tf
@@ -20,7 +20,7 @@
 
 module "dev-dns-private-zone" {
   source          = "../../../modules/dns"
-  project_id      = module.landing-project.project_id
+  project_id      = module.dev-spoke-project.project_id
   type            = "private"
   name            = "dev-gcp-example-com"
   domain          = "dev.gcp.example.com."

--- a/fast/stages/02-networking-vpn/dns-dev.tf
+++ b/fast/stages/02-networking-vpn/dns-dev.tf
@@ -24,7 +24,7 @@ module "dev-dns-private-zone" {
   type            = "private"
   name            = "dev-gcp-example-com"
   domain          = "dev.gcp.example.com."
-  client_networks = [module.dev-spoke-vpc.self_link]
+  client_networks = [module.landing-vpc.self_link]
   recordsets = {
     "A localhost" = { type = "A", ttl = 300, records = ["127.0.0.1"] }
   }

--- a/fast/stages/02-networking-vpn/dns-landing.tf
+++ b/fast/stages/02-networking-vpn/dns-landing.tf
@@ -50,28 +50,6 @@ module "gcp-example-dns-private-zone" {
   }
 }
 
-# GCP-specific DNS zones peered to the environment spoke that holds the config
-
-module "prod-gcp-example-dns-peering" {
-  source          = "../../../modules/dns"
-  project_id      = module.landing-project.project_id
-  type            = "peering"
-  name            = "prod-root-dns-peering"
-  domain          = "prod.gcp.example.com."
-  client_networks = [module.landing-vpc.self_link]
-  peer_network    = module.prod-spoke-vpc.self_link
-}
-
-module "dev-gcp-example-dns-peering" {
-  source          = "../../../modules/dns"
-  project_id      = module.landing-project.project_id
-  type            = "peering"
-  name            = "dev-root-dns-peering"
-  domain          = "dev.gcp.example.com."
-  client_networks = [module.landing-vpc.self_link]
-  peer_network    = module.dev-spoke-vpc.self_link
-}
-
 # Google API zone to trigger Private Access
 
 module "googleapis-private-zone" {

--- a/fast/stages/02-networking-vpn/dns-prod.tf
+++ b/fast/stages/02-networking-vpn/dns-prod.tf
@@ -24,7 +24,7 @@ module "prod-dns-private-zone" {
   type            = "private"
   name            = "prod-gcp-example-com"
   domain          = "prod.gcp.example.com."
-  client_networks = [module.prod-spoke-vpc.self_link]
+  client_networks = [module.landing-vpc.self_link]
   recordsets = {
     "A localhost" = { type = "A", ttl = 300, records = ["127.0.0.1"] }
   }

--- a/fast/stages/02-networking-vpn/dns-prod.tf
+++ b/fast/stages/02-networking-vpn/dns-prod.tf
@@ -20,7 +20,7 @@
 
 module "prod-dns-private-zone" {
   source          = "../../../modules/dns"
-  project_id      = module.landing-project.project_id
+  project_id      = module.prod-spoke-project.project_id
   type            = "private"
   name            = "prod-gcp-example-com"
   domain          = "prod.gcp.example.com."


### PR DESCRIPTION
NVA (landing) pinging dev:

```
ext_sruffilli_google_com@nva-ew1-0rpz:~$ ping localhost.dev.gcp.example.com
PING localhost.dev.gcp.example.com (127.0.0.1) 56(84) bytes of data.
64 bytes from localhost (127.0.0.1): icmp_seq=1 ttl=64 time=0.028 ms
```