### PR TITLE
Use uniform access on Cloud Functions buckets.

### DIFF
--- a/modules/cloud-function/README.md
+++ b/modules/cloud-function/README.md
@@ -169,7 +169,7 @@ module "cf-http" {
 | [environment_variables](variables.tf#L46) | Cloud function environment variables. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
 | [function_config](variables.tf#L52) | Cloud function configuration. | <code title="object&#40;&#123;&#10;  entry_point &#61; string&#10;  instances   &#61; number&#10;  memory      &#61; number&#10;  runtime     &#61; string&#10;  timeout     &#61; number&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code title="&#123;&#10;  entry_point &#61; &#34;main&#34;&#10;  instances   &#61; 1&#10;  memory      &#61; 256&#10;  runtime     &#61; &#34;python37&#34;&#10;  timeout     &#61; 180&#10;&#125;">&#123;&#8230;&#125;</code> |
 | [iam](variables.tf#L70) | IAM bindings for topic in {ROLE => [MEMBERS]} format. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [ingress_settings](variables.tf#L76) | Control traffic that reaches the cloud function. Allowed values are ALLOW_ALL and ALLOW_INTERNAL_ONLY. | <code>string</code> |  | <code>null</code> |
+| [ingress_settings](variables.tf#L76) | Control traffic that reaches the cloud function. Allowed values are ALLOW_ALL, ALLOW_INTERNAL_AND_GCLB and ALLOW_INTERNAL_ONLY . | <code>string</code> |  | <code>null</code> |
 | [labels](variables.tf#L82) | Resource labels. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
 | [prefix](variables.tf#L93) | Optional prefix used for resource names. | <code>string</code> |  | <code>null</code> |
 | [region](variables.tf#L104) | Region used for all resources. | <code>string</code> |  | <code>&#34;europe-west1&#34;</code> |

--- a/modules/cloud-function/main.tf
+++ b/modules/cloud-function/main.tf
@@ -118,7 +118,10 @@ resource "google_storage_bucket" "bucket" {
     for_each = var.bucket_config.lifecycle_delete_age == null ? [] : [""]
     content {
       action { type = "Delete" }
-      condition { age = var.bucket_config.lifecycle_delete_age }
+      condition {
+        age        = var.bucket_config.lifecycle_delete_age
+        with_state = "ARCHIVED"
+      }
     }
   }
 

--- a/modules/cloud-function/main.tf
+++ b/modules/cloud-function/main.tf
@@ -121,6 +121,13 @@ resource "google_storage_bucket" "bucket" {
       condition { age = var.bucket_config.lifecycle_delete_age }
     }
   }
+
+  dynamic "versioning" {
+    for_each = var.bucket_config.lifecycle_delete_age == null ? [] : [""]
+    content {
+      enabled = true
+    }
+  }
 }
 
 resource "google_storage_bucket_object" "bundle" {

--- a/modules/cloud-function/main.tf
+++ b/modules/cloud-function/main.tf
@@ -103,9 +103,10 @@ resource "google_cloudfunctions_function_iam_binding" "default" {
 }
 
 resource "google_storage_bucket" "bucket" {
-  count   = var.bucket_config == null ? 0 : 1
-  project = var.project_id
-  name    = "${local.prefix}${var.bucket_name}"
+  count                       = var.bucket_config == null ? 0 : 1
+  project                     = var.project_id
+  name                        = "${local.prefix}${var.bucket_name}"
+  uniform_bucket_level_access = true
   location = (
     var.bucket_config.location == null
     ? var.region

--- a/modules/cloud-function/variables.tf
+++ b/modules/cloud-function/variables.tf
@@ -74,7 +74,7 @@ variable "iam" {
 }
 
 variable "ingress_settings" {
-  description = "Control traffic that reaches the cloud function. Allowed values are ALLOW_ALL and ALLOW_INTERNAL_ONLY."
+  description = "Control traffic that reaches the cloud function. Allowed values are ALLOW_ALL, ALLOW_INTERNAL_AND_GCLB and ALLOW_INTERNAL_ONLY ."
   type        = string
   default     = null
 }


### PR DESCRIPTION
There is no way to provide whether to use uniform access level or not other than provide own bucket.

Using uniform access in anyway recommended by GCP approach. If someone has use case, where ACL's are required, then they can provide they own bucket.

This makes life easier for cases, where uniform access is mandated by organization policy.

Apart from that, I've fixed few things around versioning:
* missing activation of versioning
* adding to the lifecycle rule that it affects only non-current versions of objects (otherwise, function will lose it's code after specified time)