### PR TITLE
[gcs2bq] Fix data_eng_principals logging role.

### DIFF
--- a/examples/data-solutions/gcs-to-bq-with-least-privileges/main.tf
+++ b/examples/data-solutions/gcs-to-bq-with-least-privileges/main.tf
@@ -44,6 +44,7 @@ locals {
       module.service-account-df.iam_email
     ]
     # common roles
+    "roles/logging.admin" = var.data_eng_principals
     "roles/logging.logWriter" = [
       module.service-account-bq.iam_email,
       module.service-account-landing.iam_email,

--- a/tests/examples/data_solutions/gcs_to_bq_with_least_privileges/test_plan.py
+++ b/tests/examples/data_solutions/gcs_to_bq_with_least_privileges/test_plan.py
@@ -24,4 +24,4 @@ def test_resources(e2e_plan_runner):
   "Test that plan works and the numbers of resources is as expected."
   modules, resources = e2e_plan_runner(FIXTURES_DIR)
   assert len(modules) == 11
-  assert len(resources) == 46
+  assert len(resources) == 47


### PR DESCRIPTION
Fix data_eng_principals logging role on `gcs-to-bq-with-least-privileges` data example.