### PR TITLE
Allow multiple CIDR blocks in the ip_range for Apigee Instance

### DIFF
--- a/modules/apigee-x-instance/README.md
+++ b/modules/apigee-x-instance/README.md
@@ -49,12 +49,12 @@ module "apigee-x-instance" {
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
 | [apigee_org_id](variables.tf#L32) | Apigee Organization ID. | <code>string</code> | ✓ |  |
-| [ip_range](variables.tf#L37) | Customer-provided CIDR block of length 22 for the Apigee instance. | <code>string</code> | ✓ |  |
-| [name](variables.tf#L52) | Apigee instance name. | <code>string</code> | ✓ |  |
-| [region](variables.tf#L57) | Compute region. | <code>string</code> | ✓ |  |
+| [name](variables.tf#L49) | Apigee instance name. | <code>string</code> | ✓ |  |
+| [region](variables.tf#L54) | Compute region. | <code>string</code> | ✓ |  |
 | [apigee_envgroups](variables.tf#L17) | Apigee Environment Groups. | <code title="map&#40;object&#40;&#123;&#10;  environments &#61; list&#40;string&#41;&#10;  hostnames    &#61; list&#40;string&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [apigee_environments](variables.tf#L26) | Apigee Environment Names. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
-| [disk_encryption_key](variables.tf#L46) | Customer Managed Encryption Key (CMEK) self link (e.g. `projects/foo/locations/us/keyRings/bar/cryptoKeys/baz`) used for disk and volume encryption (required for PAID Apigee Orgs only). | <code>string</code> |  | <code>null</code> |
+| [disk_encryption_key](variables.tf#L43) | Customer Managed Encryption Key (CMEK) self link (e.g. `projects/foo/locations/us/keyRings/bar/cryptoKeys/baz`) used for disk and volume encryption (required for PAID Apigee Orgs only). | <code>string</code> |  | <code>null</code> |
+| [ip_range](variables.tf#L37) | Customer-provided CIDR blocks of length 22 and 28 for the Apigee instance (e.g. `10.0.0.0/22,10.1.0.0/28`). | <code>string</code> |  | <code>null</code> |
 
 ## Outputs
 

--- a/modules/apigee-x-instance/variables.tf
+++ b/modules/apigee-x-instance/variables.tf
@@ -35,12 +35,9 @@ variable "apigee_org_id" {
 }
 
 variable "ip_range" {
-  description = "Customer-provided CIDR block of length 22 for the Apigee instance."
+  description = "Customer-provided CIDR blocks of length 22 and 28 for the Apigee instance (e.g. `10.0.0.0/22,10.1.0.0/28`)."
   type        = string
-  validation {
-    condition     = try(cidrnetmask(var.ip_range), null) == "255.255.252.0"
-    error_message = "Invalid CIDR block provided; Allowed pattern for ip_range: X.X.X.X/22."
-  }
+  default     = null
 }
 
 variable "disk_encryption_key" {

--- a/tests/modules/apigee_x_instance/fixture/variables.tf
+++ b/tests/modules/apigee_x_instance/fixture/variables.tf
@@ -26,5 +26,5 @@ variable "region" {
 
 variable "ip_range" {
   type    = string
-  default = "10.0.0.0/22"
+  default = "10.0.0.0/22,10.1.0.0/28"
 }

--- a/tests/modules/apigee_x_instance/test_plan.py
+++ b/tests/modules/apigee_x_instance/test_plan.py
@@ -39,6 +39,6 @@ def test_instance(resources):
   instances = [r['values'] for r in resources if r['type']
                == 'google_apigee_instance']
   assert len(instances) == 1
-  assert instances[0]['ip_range'] == '10.0.0.0/22'
+  assert instances[0]['ip_range'] == '10.0.0.0/22,10.1.0.0/28'
   assert instances[0]['name'] == 'my-test-instance'
   assert instances[0]['location'] == 'europe-west1'


### PR DESCRIPTION
The parameters has changed to allow both a /22 for the runtime and a /28 for the master authorized network of an Apigee instance.