### PR TITLE
FAST: allow changing tag names from variables in resman

### DIFF
--- a/fast/stages/01-resman/README.md
+++ b/fast/stages/01-resman/README.md
@@ -183,20 +183,21 @@ Due to its simplicity, this stage lends itself easily to customizations: adding 
 | [groups](variables.tf#L118) | Group names to grant organization-level permissions. | <code>map&#40;string&#41;</code> |  | <code title="&#123;&#10;  gcp-billing-admins      &#61; &#34;gcp-billing-admins&#34;,&#10;  gcp-devops              &#61; &#34;gcp-devops&#34;,&#10;  gcp-network-admins      &#61; &#34;gcp-network-admins&#34;&#10;  gcp-organization-admins &#61; &#34;gcp-organization-admins&#34;&#10;  gcp-security-admins     &#61; &#34;gcp-security-admins&#34;&#10;  gcp-support             &#61; &#34;gcp-support&#34;&#10;&#125;">&#123;&#8230;&#125;</code> | <code>00-bootstrap</code> |
 | [organization_policy_configs](variables.tf#L143) | Organization policies customization. | <code title="object&#40;&#123;&#10;  allowed_policy_member_domains &#61; list&#40;string&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |  |
 | [outputs_location](variables.tf#L151) | Enable writing provider, tfvars and CI/CD workflow files to local filesystem. Leave null to disable | <code>string</code> |  | <code>null</code> |  |
-| [team_folders](variables.tf#L168) | Team folders to be created. Format is described in a code comment. | <code title="map&#40;object&#40;&#123;&#10;  descriptive_name     &#61; string&#10;  group_iam            &#61; map&#40;list&#40;string&#41;&#41;&#10;  impersonation_groups &#61; list&#40;string&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>null</code> |  |
+| [tag_names](variables.tf#L168) | Customized names for resource management tags. | <code title="object&#40;&#123;&#10;  context     &#61; string&#10;  environment &#61; string&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code title="&#123;&#10;  context     &#61; &#34;context&#34;&#10;  environment &#61; &#34;environment&#34;&#10;&#125;">&#123;&#8230;&#125;</code> |  |
+| [team_folders](variables.tf#L185) | Team folders to be created. Format is described in a code comment. | <code title="map&#40;object&#40;&#123;&#10;  descriptive_name     &#61; string&#10;  group_iam            &#61; map&#40;list&#40;string&#41;&#41;&#10;  impersonation_groups &#61; list&#40;string&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>null</code> |  |
 
 ## Outputs
 
 | name | description | sensitive | consumers |
 |---|---|:---:|---|
-| [cicd_repositories](outputs.tf#L156) | WIF configuration for CI/CD repositories. |  |  |
-| [dataplatform](outputs.tf#L168) | Data for the Data Platform stage. |  |  |
-| [networking](outputs.tf#L184) | Data for the networking stage. |  |  |
-| [project_factories](outputs.tf#L193) | Data for the project factories stage. |  |  |
-| [providers](outputs.tf#L209) | Terraform provider files for this stage and dependent stages. | ✓ | <code>02-networking</code> · <code>02-security</code> · <code>03-dataplatform</code> · <code>xx-sandbox</code> · <code>xx-teams</code> |
-| [sandbox](outputs.tf#L216) | Data for the sandbox stage. |  | <code>xx-sandbox</code> |
-| [security](outputs.tf#L226) | Data for the networking stage. |  | <code>02-security</code> |
-| [teams](outputs.tf#L236) | Data for the teams stage. |  |  |
-| [tfvars](outputs.tf#L249) | Terraform variable files for the following stages. | ✓ |  |
+| [cicd_repositories](outputs.tf#L157) | WIF configuration for CI/CD repositories. |  |  |
+| [dataplatform](outputs.tf#L169) | Data for the Data Platform stage. |  |  |
+| [networking](outputs.tf#L185) | Data for the networking stage. |  |  |
+| [project_factories](outputs.tf#L194) | Data for the project factories stage. |  |  |
+| [providers](outputs.tf#L210) | Terraform provider files for this stage and dependent stages. | ✓ | <code>02-networking</code> · <code>02-security</code> · <code>03-dataplatform</code> · <code>xx-sandbox</code> · <code>xx-teams</code> |
+| [sandbox](outputs.tf#L217) | Data for the sandbox stage. |  | <code>xx-sandbox</code> |
+| [security](outputs.tf#L227) | Data for the networking stage. |  | <code>02-security</code> |
+| [teams](outputs.tf#L237) | Data for the teams stage. |  |  |
+| [tfvars](outputs.tf#L250) | Terraform variable files for the following stages. | ✓ |  |
 
 <!-- END TFDOC -->

--- a/fast/stages/01-resman/branch-data-platform.tf
+++ b/fast/stages/01-resman/branch-data-platform.tf
@@ -21,7 +21,9 @@ module "branch-dp-folder" {
   parent = "organizations/${var.organization.id}"
   name   = "Data Platform"
   tag_bindings = {
-    context = try(module.organization.tag_values["context/data"].id, null)
+    context = try(
+      module.organization.tag_values["${var.tag_names.context}/data"].id, null
+    )
   }
 }
 
@@ -39,7 +41,9 @@ module "branch-dp-dev-folder" {
     "roles/resourcemanager.projectCreator" = [module.branch-dp-dev-sa.iam_email]
   }
   tag_bindings = {
-    context = try(module.organization.tag_values["environment/development"].id, null)
+    context = try(
+      module.organization.tag_values["${var.tag_names.environment}/development"].id, null
+    )
   }
 }
 
@@ -57,7 +61,9 @@ module "branch-dp-prod-folder" {
     "roles/resourcemanager.projectCreator" = [module.branch-dp-prod-sa.iam_email]
   }
   tag_bindings = {
-    context = try(module.organization.tag_values["environment/production"].id, null)
+    context = try(
+      module.organization.tag_values["${var.tag_names.environment}/production"].id, null
+    )
   }
 }
 

--- a/fast/stages/01-resman/branch-networking.tf
+++ b/fast/stages/01-resman/branch-networking.tf
@@ -39,7 +39,9 @@ module "branch-network-folder" {
     "roles/compute.xpnAdmin"               = [module.branch-network-sa.iam_email]
   }
   tag_bindings = {
-    context = try(module.organization.tag_values["context/networking"].id, null)
+    context = try(
+      module.organization.tag_values["${var.tag_names.context}/networking"].id, null
+    )
   }
 }
 
@@ -54,7 +56,9 @@ module "branch-network-prod-folder" {
     ]
   }
   tag_bindings = {
-    environment = try(module.organization.tag_values["environment/production"].id, null)
+    environment = try(
+      module.organization.tag_values["${var.tag_names.environment}/production"].id, null
+    )
   }
 }
 
@@ -69,7 +73,9 @@ module "branch-network-dev-folder" {
     ]
   }
   tag_bindings = {
-    environment = try(module.organization.tag_values["environment/development"].id, null)
+    environment = try(
+      module.organization.tag_values["${var.tag_names.environment}/development"].id, null
+    )
   }
 }
 

--- a/fast/stages/01-resman/branch-sandbox.tf
+++ b/fast/stages/01-resman/branch-sandbox.tf
@@ -38,7 +38,9 @@ module "branch-sandbox-folder" {
     }
   }
   tag_bindings = {
-    context = try(module.organization.tag_values["context/sandbox"].id, null)
+    context = try(
+      module.organization.tag_values["${var.tag_names.context}/sandbox"].id, null
+    )
   }
 }
 

--- a/fast/stages/01-resman/branch-security.tf
+++ b/fast/stages/01-resman/branch-security.tf
@@ -40,7 +40,9 @@ module "branch-security-folder" {
     "roles/resourcemanager.projectCreator" = [module.branch-security-sa.iam_email]
   }
   tag_bindings = {
-    context = try(module.organization.tag_values["context/security"].id, null)
+    context = try(
+      module.organization.tag_values["${var.tag_names.context}/security"].id, null
+    )
   }
 }
 

--- a/fast/stages/01-resman/branch-teams.tf
+++ b/fast/stages/01-resman/branch-teams.tf
@@ -21,7 +21,9 @@ module "branch-teams-folder" {
   parent = "organizations/${var.organization.id}"
   name   = "Teams"
   tag_bindings = {
-    context = try(module.organization.tag_values["context/teams"].id, null)
+    context = try(
+      module.organization.tag_values["${var.tag_names.context}/teams"].id, null
+    )
   }
 }
 
@@ -90,7 +92,9 @@ module "branch-teams-team-dev-folder" {
     "roles/resourcemanager.projectCreator" = [module.branch-teams-dev-pf-sa.iam_email]
   }
   tag_bindings = {
-    environment = try(module.organization.tag_values["environment/development"].id, null)
+    environment = try(
+      module.organization.tag_values["${var.tag_names.environment}/development"].id, null
+    )
   }
 }
 
@@ -111,7 +115,9 @@ module "branch-teams-team-prod-folder" {
     "roles/resourcemanager.projectCreator" = [module.branch-teams-prod-pf-sa.iam_email]
   }
   tag_bindings = {
-    environment = try(module.organization.tag_values["environment/production"].id, null)
+    environment = try(
+      module.organization.tag_values["${var.tag_names.environment}/production"].id, null
+    )
   }
 }
 

--- a/fast/stages/01-resman/organization.tf
+++ b/fast/stages/01-resman/organization.tf
@@ -151,7 +151,7 @@ module "organization" {
     # )
   }
   tags = {
-    context = {
+    (var.tag_names.context) = {
       description = "Resource management context."
       iam         = {}
       values = {
@@ -163,7 +163,7 @@ module "organization" {
         teams      = null
       }
     }
-    environment = {
+    (var.tag_names.environment) = {
       description = "Environment definition."
       iam         = {}
       values = {
@@ -190,9 +190,9 @@ resource "google_organization_iam_member" "org_policy_admin" {
     title       = "org_policy_tag_scoped"
     description = "Org policy tag scoped grant for ${each.value.0}/${each.value.1}."
     expression  = <<-END
-    resource.matchTag('${var.organization.id}/context', '${each.value.0}')
+    resource.matchTag('${var.organization.id}/${var.tag_names.context}', '${each.value.0}')
     &&
-    resource.matchTag('${var.organization.id}/environment', '${each.value.1}')
+    resource.matchTag('${var.organization.id}/${var.tag_names.environment}', '${each.value.1}')
     END
   }
 }

--- a/fast/stages/01-resman/outputs.tf
+++ b/fast/stages/01-resman/outputs.tf
@@ -150,6 +150,7 @@ locals {
   tfvars = {
     folder_ids       = local.folder_ids
     service_accounts = local.service_accounts
+    tag_names        = var.tag_names
   }
 }
 

--- a/fast/stages/01-resman/variables.tf
+++ b/fast/stages/01-resman/variables.tf
@@ -165,6 +165,23 @@ variable "prefix" {
   }
 }
 
+variable "tag_names" {
+  description = "Customized names for resource management tags."
+  type = object({
+    context     = string
+    environment = string
+  })
+  default = {
+    context     = "context"
+    environment = "environment"
+  }
+  nullable = false
+  validation {
+    condition     = alltrue([for k, v in var.tag_names : v != null])
+    error_message = "Tag names cannot be null."
+  }
+}
+
 variable "team_folders" {
   description = "Team folders to be created. Format is described in a code comment."
   type = map(object({


### PR DESCRIPTION
This allows changing the names used for secure tags in resource management, to address issues where tags with thosenames already exist.