### PR TITLE
add service_attachment to Apigee instance outputs

### DIFF
--- a/modules/apigee-x-instance/README.md
+++ b/modules/apigee-x-instance/README.md
@@ -64,5 +64,6 @@ module "apigee-x-instance" {
 | [id](outputs.tf#L22) | Apigee instance ID. |  |
 | [instance](outputs.tf#L27) | Apigee instance. |  |
 | [port](outputs.tf#L32) | Port number of the internal endpoint of the Apigee instance. |  |
+| [service_attachment](outputs.tf#L37) | Resource name of the service attachment created for this Apigee instance. |  |
 
 <!-- END TFDOC -->

--- a/modules/apigee-x-instance/outputs.tf
+++ b/modules/apigee-x-instance/outputs.tf
@@ -33,3 +33,8 @@ output "port" {
   description = "Port number of the internal endpoint of the Apigee instance."
   value       = google_apigee_instance.apigee_instance.port
 }
+
+output "service_attachment" {
+  description = "Resource name of the service attachment created for this Apigee instance."
+  value       = google_apigee_instance.apigee_instance.service_attachment
+}


### PR DESCRIPTION
The Apigee instance resource [now](https://github.com/hashicorp/terraform-provider-google/releases/tag/v4.20.0) includes a service attachment that we should output explicitly on the module.