### PR TITLE
Fix Gitlab WIF attributes

### DIFF
--- a/fast/stages/00-bootstrap/README.md
+++ b/fast/stages/00-bootstrap/README.md
@@ -349,13 +349,17 @@ The variable maps each provider's `issuer` attribute with the definitions in the
 
 Provider key names are used by the `cicd_repositories` variable to configure authentication for CI/CD repositories, and generally from your Terraform code whenever you need to configure IAM access or impersonation for federated identities.
 
-This is a sample configuration of a GitHub provider, the `attribute_condition` attribute can be set to null if needed:
+This is a sample configuration of a GitHub and a Gitlab provider, `attribute_condition` attribute can use any of the mapped attribute for the provider (refer to the `identity-providers.tf` file for the full list) or set to `null` if needed:
 
 ```hcl
 federated_identity_providers = {
   github-sample = {
     attribute_condition = "attribute.repository_owner==\"my-github-org\""
     issuer              = "github"
+  }
+  gitlab-sample = {
+    attribute_condition = "attribute.namespace_path==\"my-gitlab-org\""
+    issuer              = "gitlab"
   }
 }
 ```

--- a/fast/stages/00-bootstrap/identity-providers.tf
+++ b/fast/stages/00-bootstrap/identity-providers.tf
@@ -38,11 +38,20 @@ locals {
     # https://docs.gitlab.com/ee/ci/cloud_services/index.html#how-it-works
     gitlab = {
       attribute_mapping = {
-        "google.subject"       = "assertion.sub"
-        "attribute.sub"        = "assertion.sub"
-        "attribute.actor"      = "assertion.actor"
-        "attribute.repository" = "assertion.project_path"
-        "attribute.ref"        = "assertion.ref"
+        "google.subject"                  = "assertion.sub"
+        "attribute.sub"                   = "assertion.sub"
+        "attribute.environment"           = "assertion.environment"
+        "attribute.environment_protected" = "assertion.environment_protected"
+        "attribute.namespace_id"          = "assertion.namespace_id"
+        "attribute.namespace_path"        = "assertion.namespace_path"
+        "attribute.pipeline_id"           = "assertion.pipeline_id"
+        "attribute.pipeline_source"       = "assertion.pipeline_source"
+        "attribute.project_id"            = "assertion.project_id"
+        "attribute.project_path"          = "assertion.project_path"
+        "attribute.repository"            = "assertion.project_path"
+        "attribute.ref"                   = "assertion.ref"
+        "attribute.ref_protected"         = "assertion.ref_protected"
+        "attribute.ref_type"              = "assertion.ref_type"
       }
       allowed_audiences = ["https://gitlab.com"]
       issuer_uri        = "https://gitlab.com"


### PR DESCRIPTION
This removes unsupported attributes and adds supported ones to the Gitlab mapping used for Workload Identity Federation pools.

Tested with the following condition:

```hcl
cicd_repositories = {
  bootstrap = {
    branch            = "main"
    identity_provider = "gitlab-ludomagno"
    name              = "ludomagno/fast-test"
    type              = "gitlab"
  }
}
federated_identity_providers = {
  gitlab-ludomagno = {
    attribute_condition = "attribute.namespace_path==\"ludomagno\""
    issuer              = "gitlab"
  }
}
```