### PR TITLE
Fix FAST audit logs when using pubsub as destination

### DIFF
--- a/fast/stages/00-bootstrap/log-export.tf
+++ b/fast/stages/00-bootstrap/log-export.tf
@@ -59,15 +59,15 @@ module "log-export-gcs" {
 
 module "log-export-logbucket" {
   source      = "../../../modules/logging-bucket"
-  count       = contains(local.log_types, "logging") ? 1 : 0
+  for_each    = toset([for k, v in var.log_sinks : k if v.type == "logging"])
   parent_type = "project"
   parent      = module.log-export-project.project_id
-  id          = "audit-logs-0"
+  id          = "audit-logs-${each.key}"
 }
 
 module "log-export-pubsub" {
   source     = "../../../modules/pubsub"
-  for_each   = toset([for k, v in var.log_sinks : k if v == "pubsub"])
+  for_each   = toset([for k, v in var.log_sinks : k if v.type == "pubsub"])
   project_id = module.log-export-project.project_id
   name       = "audit-logs-${each.key}"
 }

--- a/fast/stages/00-bootstrap/organization.tf
+++ b/fast/stages/00-bootstrap/organization.tf
@@ -110,8 +110,8 @@ locals {
     { for k, v in var.log_sinks : k => module.log-export-gcs.0 if v.type == "storage" },
     # use separate pubsub topics and logging buckets for sinks with
     # destination `pubsub` and `logging`
-    { for k, v in module.log-export-pubsub : k => v },
-    { for k, v in module.log-export-logbucket : k => v }
+    module.log-export-pubsub,
+    module.log-export-logbucket
   )
 }
 

--- a/modules/folder/README.md
+++ b/modules/folder/README.md
@@ -141,7 +141,7 @@ module "folder-sink" {
   logging_sinks = {
     warnings = {
       type             = "storage"
-      destination      = module.gcs.name
+      destination      = module.gcs.id
       filter           = "severity=WARNING"
       include_children = true
       exclusions       = {}

--- a/modules/gcs/README.md
+++ b/modules/gcs/README.md
@@ -135,9 +135,10 @@ module "bucket-gcs-notification" {
 | name | description | sensitive |
 |---|---|:---:|
 | [bucket](outputs.tf#L17) | Bucket resource. |  |
-| [name](outputs.tf#L22) | Bucket name. |  |
-| [notification](outputs.tf#L30) | GCS Notification self link. |  |
-| [topic](outputs.tf#L34) | Topic ID used by GCS. |  |
-| [url](outputs.tf#L38) | Bucket URL. |  |
+| [id](outputs.tf#L28) | Bucket ID (same as name). |  |
+| [name](outputs.tf#L37) | Bucket name. |  |
+| [notification](outputs.tf#L46) | GCS Notification self link. |  |
+| [topic](outputs.tf#L51) | Topic ID used by GCS. |  |
+| [url](outputs.tf#L56) | Bucket URL. |  |
 
 <!-- END TFDOC -->

--- a/modules/gcs/outputs.tf
+++ b/modules/gcs/outputs.tf
@@ -19,6 +19,21 @@ output "bucket" {
   value       = google_storage_bucket.bucket
 }
 
+# We add `id` as an alias to `name` to simplify log sink handling.
+# Since all other log destinations (pubsub, logging-bucket, bigquery)
+# have an id output, it is convenient to have in this module too to
+# handle all log destination as homogeneous objects (i.e. you can
+# assume any valid log destination has an `id` output).
+
+output "id" {
+  description = "Bucket ID (same as name)."
+  value       = "${local.prefix}${lower(var.name)}"
+  depends_on = [
+    google_storage_bucket.bucket,
+    google_storage_bucket_iam_binding.bindings
+  ]
+}
+
 output "name" {
   description = "Bucket name."
   value       = "${local.prefix}${lower(var.name)}"
@@ -27,14 +42,17 @@ output "name" {
     google_storage_bucket_iam_binding.bindings
   ]
 }
+
 output "notification" {
   description = "GCS Notification self link."
   value       = local.notification ? google_storage_notification.notification[0].self_link : null
 }
+
 output "topic" {
   description = "Topic ID used by GCS."
   value       = local.notification ? google_pubsub_topic.topic[0].id : null
 }
+
 output "url" {
   description = "Bucket URL."
   value       = google_storage_bucket.bucket.url

--- a/modules/organization/README.md
+++ b/modules/organization/README.md
@@ -179,7 +179,7 @@ module "org" {
   logging_sinks = {
     warnings = {
       type                 = "storage"
-      destination          = module.gcs.name
+      destination          = module.gcs.id
       filter               = "severity=WARNING"
       include_children     = true
       bq_partitioned_table = null

--- a/modules/project/README.md
+++ b/modules/project/README.md
@@ -221,7 +221,7 @@ module "project-host" {
   logging_sinks = {
     warnings = {
       type          = "storage"
-      destination   = module.gcs.name
+      destination   = module.gcs.id
       filter        = "severity=WARNING"
       iam           = false
       unique_writer = false


### PR DESCRIPTION
- Fix FAST audit logging (stage0) when pubsub is used as destination
- Split each organization-level logging sink of type `logging` to a separate logging bucket.
- Add convenience output `id` to `gcs` module