### PR TITLE
FAST - added missing format argument in branch-pf-dev-sa-cicd

### DIFF
--- a/fast/stages/01-resman/cicd-project-factory.tf
+++ b/fast/stages/01-resman/cicd-project-factory.tf
@@ -122,10 +122,12 @@ module "branch-pf-dev-sa-cicd" {
         each.value.branch == null
         ? format(
           local.identity_providers[each.value.identity_provider].principalset_tpl,
+          var.automation.federated_identity_pool,
           each.value.name
         )
         : format(
           local.identity_providers[each.value.identity_provider].principal_tpl,
+          var.automation.federated_identity_pool,
           each.value.name,
           each.value.branch
         )


### PR DESCRIPTION
In the module branch-pf-dev-sa-cicd, the calls to the "format" function were missing the argument var.automation.federated_identity_pool.