### PR TITLE
Fixed issue with missing project reference in Cloud DNS data source 

### DIFF
--- a/modules/dns/main.tf
+++ b/modules/dns/main.tf
@@ -103,8 +103,9 @@ resource "google_dns_managed_zone" "non-public" {
 }
 
 data "google_dns_managed_zone" "public" {
-  count = var.zone_create ? 0 : 1
-  name  = var.name
+  count   = var.zone_create ? 0 : 1
+  project = var.project_id
+  name    = var.name
 }
 
 resource "google_dns_managed_zone" "public" {


### PR DESCRIPTION
Fixed issue with missing project reference in Cloud DNS data source when creating a public zone.

```
│ Error: project: required field is not set
│ 
│   with module.xlb-dns.data.google_dns_managed_zone.public[0],
│   on .terraform/modules/xlb-dns/modules/dns/main.tf line 105, in data "google_dns_managed_zone" "public":
│  105: data "google_dns_managed_zone" "public" {
```