### PR TITLE
fixing to move without output_location

### DIFF
--- a/fast/stages/01-resman/outputs-files.tf
+++ b/fast/stages/01-resman/outputs-files.tf
@@ -31,7 +31,7 @@ resource "local_file" "tfvars" {
 }
 
 resource "local_file" "workflows" {
-  for_each        = local.cicd_workflows
+  for_each        = var.outputs_location == null ? {} : local.cicd_workflows
   file_permission = "0644"
   filename        = "${pathexpand(var.outputs_location)}/workflows/${replace(each.key, "_", "-")}-workflow.yaml"
   content         = each.value


### PR DESCRIPTION
01-resman failed when outpus_location was not specified. In case of using Cloud Build with SoureRepo for runninc terraform commands, outputs_location is unnecessary but the line 36 fails due to the null value. Need to have null check at the beginning.