### PR TITLE
Secret manager flag sensitive output

### DIFF
--- a/modules/secret-manager/README.md
+++ b/modules/secret-manager/README.md
@@ -91,7 +91,7 @@ module "secret-manager" {
 | [ids](outputs.tf#L17) | Secret ids keyed by secret_ids (names). |  |
 | [secrets](outputs.tf#L24) | Secret resources. |  |
 | [version_ids](outputs.tf#L29) | Version ids keyed by secret name : version name. |  |
-| [versions](outputs.tf#L36) | Secret versions. | Yes |
+| [versions](outputs.tf#L36) | Secret versions. | ✓ |
 
 <!-- END TFDOC -->
 ## Requirements

--- a/modules/secret-manager/README.md
+++ b/modules/secret-manager/README.md
@@ -91,7 +91,7 @@ module "secret-manager" {
 | [ids](outputs.tf#L17) | Secret ids keyed by secret_ids (names). |  |
 | [secrets](outputs.tf#L24) | Secret resources. |  |
 | [version_ids](outputs.tf#L29) | Version ids keyed by secret name : version name. |  |
-| [versions](outputs.tf#L36) | Secret versions. |  |
+| [versions](outputs.tf#L36) | Secret versions. | Yes |
 
 <!-- END TFDOC -->
 ## Requirements

--- a/modules/secret-manager/outputs.tf
+++ b/modules/secret-manager/outputs.tf
@@ -36,4 +36,5 @@ output "version_ids" {
 output "versions" {
   description = "Secret versions."
   value       = google_secret_manager_secret_version.default
+  sensitive   = true
 }


### PR DESCRIPTION
Secret manager module output (versions) contains sensitive value and without that flag, terraform init and plan throws error. I have added the sensitive flag for that output in that module.  