### PR TITLE
Support manager role in cloud identity group module

### DIFF
--- a/modules/cloud-identity-group/README.md
+++ b/modules/cloud-identity-group/README.md
@@ -7,11 +7,10 @@ To use this module you must either run terraform as a user that has the Groups A
 
 Please note that the underlying terraform resources only allow the creation of groups with members that are part of the organization. If you want to create memberships for identities outside your own organization, you have to manually allow members outside your organization in the Cloud Identity admin console.
 
-As of version 3.50 of the GCP Terraform provider two operations are not working:
+As of version 4.34 of the GCP Terraform provider one operation is not working:
 - removing a group that has at least one OWNER managed by terraform ([bug](https://github.com/hashicorp/terraform-provider-google/issues/7617))
-- removing a role from an existing membership ([bug](https://github.com/hashicorp/terraform-provider-google/issues/7616))
 
-Until those two bugs are fixed, this module will only support the creation of MEMBER memberships.
+Until that bug is fixed, this module will only support the creation of MEMBER and MANAGER memberships.
 
 ## Examples
 
@@ -31,6 +30,26 @@ module "group" {
 }
 # tftest modules=1 resources=4
 ```
+
+### Group with managers
+```hcl
+module "group" {
+  source       = "./modules/cloud-identity-group"
+  customer_id  = "customers/C01234567"
+  name         = "mygroup2@example.com"
+  display_name = "My group name 2"
+  description  = "My group 2 Description"
+  members = [
+    "user1@example.com",
+    "user2@example.com",
+    "service-account@my-gcp-project.iam.gserviceaccount.com"
+  ]
+  managers = [
+    "user3@example.com"
+  ]  
+}
+# tftest modules=1 resources=5
+```
 <!-- BEGIN TFDOC -->
 
 ## Variables
@@ -39,9 +58,10 @@ module "group" {
 |---|---|:---:|:---:|:---:|
 | [customer_id](variables.tf#L17) | Directory customer ID in the form customers/C0xxxxxxx. | <code>string</code> | ✓ |  |
 | [display_name](variables.tf#L32) | Group display name. | <code>string</code> | ✓ |  |
-| [name](variables.tf#L43) | Group ID (usually an email). | <code>string</code> | ✓ |  |
+| [name](variables.tf#L49) | Group ID (usually an email). | <code>string</code> | ✓ |  |
 | [description](variables.tf#L26) | Group description. | <code>string</code> |  | <code>null</code> |
-| [members](variables.tf#L37) | List of group members. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
+| [managers](variables.tf#L37) | List of group managers. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
+| [members](variables.tf#L43) | List of group members. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
 
 ## Outputs
 

--- a/modules/cloud-identity-group/main.tf
+++ b/modules/cloud-identity-group/main.tf
@@ -36,17 +36,18 @@ resource "google_cloud_identity_group" "group" {
 #   roles { name = "MANAGER" }
 # }
 
-# resource "google_cloud_identity_group_membership" "managers" {
-#   group    = google_cloud_identity_group.group.id
-#   for_each = toset(var.managers)
-#   preferred_member_key { id = each.key }
-#   roles { name = "MEMBER" }
-#   roles { name = "MANAGER" }
-# }
+resource "google_cloud_identity_group_membership" "managers" {
+  group    = google_cloud_identity_group.group.id
+  for_each = toset(var.managers)
+  preferred_member_key { id = each.key }
+  roles { name = "MEMBER" }
+  roles { name = "MANAGER" }
+}
 
 resource "google_cloud_identity_group_membership" "members" {
   group    = google_cloud_identity_group.group.id
   for_each = toset(var.members)
   preferred_member_key { id = each.key }
   roles { name = "MEMBER" }
+  depends_on = [google_cloud_identity_group_membership.managers]
 }

--- a/modules/cloud-identity-group/variables.tf
+++ b/modules/cloud-identity-group/variables.tf
@@ -34,6 +34,12 @@ variable "display_name" {
   type        = string
 }
 
+variable "managers" {
+  description = "List of group managers."
+  type        = list(string)
+  default     = []
+}
+
 variable "members" {
   description = "List of group members."
   type        = list(string)
@@ -47,12 +53,6 @@ variable "name" {
 
 # variable "owners" {
 #   description = "List of group owners."
-#   type        = list(string)
-#   default     = []
-# }
-
-# variable "managers" {
-#   description = "List of group managers."
 #   type        = list(string)
 #   default     = []
 # }

--- a/tests/modules/cloud_identity_group/fixture/main.tf
+++ b/tests/modules/cloud_identity_group/fixture/main.tf
@@ -20,5 +20,6 @@ module "test" {
   display_name = var.display_name
   description  = var.description
   customer_id  = var.customer_id
+  managers     = var.managers
   members      = var.members
 }

--- a/tests/modules/cloud_identity_group/fixture/variables.tf
+++ b/tests/modules/cloud_identity_group/fixture/variables.tf
@@ -34,6 +34,11 @@ variable "customer_id" {
   default = "customers/C01234567"
 }
 
+variable "managers" {
+  type    = list(string)
+  default = []
+}
+
 variable "members" {
   type    = list(string)
   default = []


### PR DESCRIPTION
Add support for MANAGERS role.
Associated bug is fixed: https://github.com/hashicorp/terraform-provider-google/issues/7616