### PR TITLE
Fix automation gcs location

### DIFF
--- a/fast/stages/00-bootstrap/main.tf
+++ b/fast/stages/00-bootstrap/main.tf
@@ -16,8 +16,8 @@
 
 locals {
   gcs_storage_class = (
-    length(split("-", var.locations.gcs)) > 1
-    ? "MULTI-REGIONAL"
+    length(split("-", var.locations.gcs)) < 2
+    ? "MULTI_REGIONAL"
     : "REGIONAL"
   )
   groups = {

--- a/fast/stages/01-resman/main.tf
+++ b/fast/stages/01-resman/main.tf
@@ -67,8 +67,8 @@ locals {
   }
   custom_roles = coalesce(var.custom_roles, {})
   gcs_storage_class = (
-    length(split("-", var.locations.gcs)) > 1
-    ? "MULTI-REGIONAL"
+    length(split("-", var.locations.gcs)) < 2
+    ? "MULTI_REGIONAL"
     : "REGIONAL"
   )
   groups = {


### PR DESCRIPTION
Currently the creation of gcs buckets fails:
- regional vs. multi_regional condition is inverted
- it's MULTI_REGIONAL (with underscore)