### PR TITLE
Add ability to add KMS encryption to google_compute_instance_template

### DIFF
--- a/modules/compute-vm/main.tf
+++ b/modules/compute-vm/main.tf
@@ -314,6 +314,13 @@ resource "google_compute_instance_template" "default" {
     }
   }
 
+  dynamic "disk_encryption_key" {
+    for_each = var.encryption != null ? [""] : []
+    content {
+      kms_key_self_link = var.encryption.kms_key_self_link != null ? var.encryption.kms_key_self_link : null
+    }
+  }
+
   dynamic "network_interface" {
     for_each = var.network_interfaces
     iterator = config


### PR DESCRIPTION
Adding `disk_encryption_key` block to `google_compute_instance_template`

This is already possible when creating a single instance, but adding to compute instance template as well.

ref: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_template#disk_encryption_key