### PR TITLE
nginx-tls: only use hostname part for TLS certificate

### DIFF
--- a/modules/cloud-config-container/nginx-tls/files/customize.sh
+++ b/modules/cloud-config-container/nginx-tls/files/customize.sh
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-HOSTNAME=$(curl -s -H "Metadata-Flavor: Google" http://metadata/computeMetadata/v1/instance/hostname)
-openssl req -new -newkey rsa:4096 -days 365 -nodes -x509 -subj /CN=$HOSTNAME/ -keyout /etc/ssl/self-signed.key  -out /etc/ssl/self-signed.crt
+FQDN=$(curl -s -H "Metadata-Flavor: Google" http://metadata/computeMetadata/v1/instance/hostname)
+HOSTNAME=$(echo $FQDN | cut -d"." -f1)
+openssl req -new -newkey rsa:4096 -days 365 -nodes -x509 -subj /CN=$HOSTNAME/ -addext "subjectAltName = DNS:$FQDN" -keyout /etc/ssl/self-signed.key -out /etc/ssl/self-signed.crt
 sed -i "s/HOSTNAME/${HOSTNAME}/" /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
The limitation for cert request is 64 characters in Common Name field:
```
problems making Certificate Request
140473219843520:error:0D07A097:asn1 encoding routines:ASN1_mbstring_ncopy:string too long:crypto/asn1/a_mbstr.c:107:maxsize=64
```

This also puts the FQDN into `subjectAltName`, so we keep compatibility.
