### PR TITLE
Update ipprefix_by_netmask.sh

### DIFF
--- a/modules/cloud-config-container/simple-nva/files/ipprefix_by_netmask.sh
+++ b/modules/cloud-config-container/simple-nva/files/ipprefix_by_netmask.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # https://stackoverflow.com/questions/50413579/bash-convert-netmask-in-cidr-notation
-c=0 x=0$(printf '%o' $${1//./ })
+c=0 x=0$(printf '%o' ${1//./ })
 while [ $x -gt 0 ]; do
   let c+=$((x % 2)) 'x>>=1'
 done


### PR DESCRIPTION
When code was moved from terraform template to separate file, "$$" (used to print $ on a tf template) was wrongly left behind. This fixes the bug.