### PR TITLE
Fix docker tag command and link to Cloud Shell in WP blueprint

### DIFF
--- a/blueprints/third-party-solutions/wordpress/cloudrun/README.md
+++ b/blueprints/third-party-solutions/wordpress/cloudrun/README.md
@@ -36,7 +36,10 @@ If `project_create` is left to null, the identity performing the deployment need
 
 If you want to deploy from your Cloud Shell, click on the image below, sign in if required and when the prompt appears, click on “confirm”.
 
-[<p align="center"> <img alt="Open Cloudshell" width = "300px" src="images/button.png" /> </p>](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2FGoogleCloudPlatform%2Fcloud-foundation-fabric&cloudshell_print=cloud-shell-readme.txt&cloudshell_working_dir=blueprints%2Fthird-party-solutions%2Fwordpress)
+[<p align="center"> <img alt="Open Cloudshell" width = "300px" src="images/button.png" /> </p>](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2FGoogleCloudPlatform%2Fcloud-foundation-fabric&cloudshell_print=cloud-shell-readme.txt&cloudshell_working_dir=blueprints%2Fthird-party-solutions%2Fwordpress
+
+https://shell.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2FGoogleCloudPlatform%2Fcloud-foundation-fabric&cloudshell_workspace=blueprints%2Fthird-party-solutions%2Fwordpress%2Fcloudrun
+)
 
 Otherwise, in your console of choice:
 ``` {shell}
@@ -56,7 +59,7 @@ Make sure that the Google Container Registry API is enabled and run the followin
 
 ``` {shell}
 docker pull bitnami/wordpress:6.0.2
-docker tag bitnami/wordpress gcr.io/MY_PROJECT/wordpress
+docker tag bitnami/wordpress:6.0.2 gcr.io/MY_PROJECT/wordpress
 docker push gcr.io/MY_PROJECT/wordpress
 ```
 


### PR DESCRIPTION
1. "docker tag" has to include the Docker image version
2. The link to Cloud Shell was not working