### PR TITLE
Make changelog tool slower to work around inconsistencies in API results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 ### BLUEPRINTS
 
+- [[#875](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/pull/875)] **incompatible change:** Refactor GKE nodepool and blueprints ([ludoo](https://github.com/ludoo)) <!-- 2022-10-12 10:59:37+00:00 -->
+- [[#873](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/pull/873)] Fix docker tag command and link to Cloud Shell in WP blueprint ([skalolazka](https://github.com/skalolazka)) <!-- 2022-10-11 12:40:25+00:00 -->
 - [[#870](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/pull/870)] Temporarily revert to Terraform 1.3.1 to support Cloud Shell ([skalolazka](https://github.com/skalolazka)) <!-- 2022-10-10 09:36:41+00:00 -->
 - [[#856](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/pull/856)] Add network firewall metrics to network dashboard ([maunope](https://github.com/maunope)) <!-- 2022-10-10 08:46:22+00:00 -->
 - [[#868](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/pull/868)] **incompatible change:** Refactor GKE module for Terraform 1.3 ([ludoo](https://github.com/ludoo)) <!-- 2022-10-10 07:38:21+00:00 -->
@@ -30,6 +32,7 @@ All notable changes to this project will be documented in this file.
 
 ### FAST
 
+- [[#875](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/pull/875)] **incompatible change:** Refactor GKE nodepool and blueprints ([ludoo](https://github.com/ludoo)) <!-- 2022-10-12 10:59:37+00:00 -->
 - [[#566](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/pull/566)] FAST: Separate network environment  ([sruffilli](https://github.com/sruffilli)) <!-- 2022-10-10 09:50:08+00:00 -->
 - [[#870](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/pull/870)] Temporarily revert to Terraform 1.3.1 to support Cloud Shell ([skalolazka](https://github.com/skalolazka)) <!-- 2022-10-10 09:36:41+00:00 -->
 - [[#868](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/pull/868)] **incompatible change:** Refactor GKE module for Terraform 1.3 ([ludoo](https://github.com/ludoo)) <!-- 2022-10-10 07:38:21+00:00 -->
@@ -45,6 +48,7 @@ All notable changes to this project will be documented in this file.
 
 ### MODULES
 
+- [[#875](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/pull/875)] **incompatible change:** Refactor GKE nodepool and blueprints ([ludoo](https://github.com/ludoo)) <!-- 2022-10-12 10:59:37+00:00 -->
 - [[#870](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/pull/870)] Temporarily revert to Terraform 1.3.1 to support Cloud Shell ([skalolazka](https://github.com/skalolazka)) <!-- 2022-10-10 09:36:41+00:00 -->
 - [[#869](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/pull/869)] Fix optionals for resource_usage_export field in `gke-cluster` ([juliocc](https://github.com/juliocc)) <!-- 2022-10-10 09:04:44+00:00 -->
 - [[#868](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/pull/868)] **incompatible change:** Refactor GKE module for Terraform 1.3 ([ludoo](https://github.com/ludoo)) <!-- 2022-10-10 07:38:21+00:00 -->

--- a/tools/changelog.py
+++ b/tools/changelog.py
@@ -137,6 +137,7 @@ def get_pulls(api):
   'Get all pull requests (GH sometimes forgets pulls with filters).'
   pulls = []
   # this should be done on the fly with sort='updated', direction='desc'
+  # if the API could be trusted (they cannot)
   for p in _paginate(api.pulls.list, base='master', state='closed'):
     try:
       merged_at = iso8601.parse_date(p['merged_at'])

--- a/tools/changelog.py
+++ b/tools/changelog.py
@@ -133,24 +133,33 @@ def get_api(token, owner=ORG, name=REPO):
   return ghapi.all.GhApi(owner=owner, repo=name, token=token)
 
 
-def get_release_pulls(api, releases):
-  'Get and add pull requests for releases.'
-  i = 0
-  for p in _paginate(api.pulls.list, base='master', state='closed',
-                     sort='updated', direction='desc'):
+def get_pulls(api):
+  'Get all pull requests (GH sometimes forgets pulls with filters).'
+  pulls = []
+  # this should be done on the fly with sort='updated', direction='desc'
+  for p in _paginate(api.pulls.list, base='master', state='closed'):
     try:
       merged_at = iso8601.parse_date(p['merged_at'])
     except iso8601.ParseError:
       continue
-    if releases[i].published and merged_at >= releases[i].published:
+    pulls.append(
+        PullRequest(p['number'], p['user']['login'], p['title'], merged_at,
+                    [l['name'] for l in p['labels']]))
+  pulls.sort(key=lambda p: p.merged_at, reverse=True)
+  return pulls
+
+
+def get_release_pulls(api, releases):
+  'Get and add pull requests for releases.'
+  i = 0
+  for p in get_pulls(api):
+    if releases[i].published and p.merged_at >= releases[i].published:
       continue
-    if releases[i].since and merged_at <= releases[i].since:
+    if releases[i].since and p.merged_at <= releases[i].since:
       i += 1
       if i == len(releases):
         break
-    releases[i].pulls.append(
-        PullRequest(p['number'], p['user']['login'], p['title'], merged_at,
-                    [l['name'] for l in p['labels']]))
+    releases[i].pulls.append(p)
   return releases
 
 


### PR DESCRIPTION
The GH API sometimes don't return all pulls when using filters, and/or don't sort them properly. This makes it impossible to process pulls in streaming mode, and forces us to fetch them all and sort later. The tool becomes slower but we avoid updating skipping requests when updating CHANGELOG.