### PR TITLE
Add missing description field

### DIFF
--- a/modules/cloud-identity-group/main.tf
+++ b/modules/cloud-identity-group/main.tf
@@ -17,6 +17,7 @@
 resource "google_cloud_identity_group" "group" {
   display_name = var.display_name
   parent       = var.customer_id
+  description  = var.description
 
   group_key {
     id = var.name


### PR DESCRIPTION
Important so we can flag these groups are TF managed and must not be manually updated.