### PR TITLE
cloud-functions v2 - fix reference to bucket_name

### DIFF
--- a/modules/cloud-function/main.tf
+++ b/modules/cloud-function/main.tf
@@ -141,7 +141,7 @@ resource "google_cloudfunctions2_function" "function" {
     environment_variables = var.environment_variables
     source {
       storage_source {
-        bucket = google_storage_bucket.bucket[0].name
+        bucket = local.bucket
         object = google_storage_bucket_object.bundle.name
       }
     }

--- a/tests/modules/cloud_function_v2/__init__.py
+++ b/tests/modules/cloud_function_v2/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/modules/cloud_function_v2/fixture/bundle/main.py
+++ b/tests/modules/cloud_function_v2/fixture/bundle/main.py
@@ -1,0 +1,13 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/modules/cloud_function_v2/fixture/main.tf
+++ b/tests/modules/cloud_function_v2/fixture/main.tf
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module "test" {
+  source      = "../../../../modules/cloud-function"
+  project_id  = "my-project"
+  name        = "test"
+  bucket_name = var.bucket_name
+  v2          = true
+  bundle_config = {
+    source_dir  = "bundle"
+    output_path = "bundle.zip"
+    excludes    = null
+  }
+  iam = {
+    "roles/cloudfunctions.invoker" = ["allUsers"]
+  }
+}

--- a/tests/modules/cloud_function_v2/fixture/variables.tf
+++ b/tests/modules/cloud_function_v2/fixture/variables.tf
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "bucket_name" {
+  type    = string
+  default = "test"
+}

--- a/tests/modules/cloud_function_v2/test_plan.py
+++ b/tests/modules/cloud_function_v2/test_plan.py
@@ -1,0 +1,34 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+
+@pytest.fixture
+def resources(plan_runner):
+  _, resources = plan_runner()
+  return resources
+
+
+def test_resource_count(resources):
+  "Test number of resources created."
+  assert len(resources) == 3
+
+
+def test_iam(resources):
+  "Test IAM binding resources."
+  bindings = [r['values'] for r in resources if r['type']
+              == 'google_cloudfunctions_function_iam_binding']
+  assert len(bindings) == 1
+  assert bindings[0]['role'] == 'roles/cloudfunctions.invoker'


### PR DESCRIPTION
Use local variable for storage source as it is done for v1 functions.

When bucket_name is provided on input of the module then creation of v2 function fails with an error:
```
╷
│ Error: Invalid index
│ 
│   on .terraform/modules/[...]/modules/cloud-function/main.tf line 144, in resource "google_cloudfunctions2_function" "function":
│  144:         bucket = google_storage_bucket.bucket[0].name
│     ├────────────────
│     │ google_storage_bucket.bucket is empty tuple
│ 
│ The given key does not identify an element in this collection value: the collection has no elements.
```

These changes fixes this error.

Copied tests from v1 functions to ensure that v2 function is working properly.