### PR TITLE
Add note about TF_PLUGIN_CACHE_DIR

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,9 +71,14 @@ pytest tests/examples
 
 Once everything looks good, add/commit any pending changes then push and open a PR on GitHub. We typically enforce a set of design and style conventions, so please make sure you have familiarized yourself with the following sections and implemented them in your code, to avoid lengthy review cycles.
 
-HINT: if you work on high-latency or low-bandwidth network use `TF_PLUGIN_CACHE_DIR` environment variable to dramatically speed up the tests, for example
+HINT: if you work on high-latency or low-bandwidth network use `TF_PLUGIN_CACHE_DIR` environment variable to dramatically speed up the tests, for example:
 ```bash
 TF_PLUGIN_CACHE_DIR=/tmp/tfcache pytest tests
+```
+
+Or just add into your [terraformrc](https://developer.hashicorp.com/terraform/cli/config/config-file):
+```
+plugin_cache_dir = "$HOME/.terraform.d/plugin-cache"
 ```
 
 ## Developer's handbook

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,11 @@ pytest tests/examples
 
 Once everything looks good, add/commit any pending changes then push and open a PR on GitHub. We typically enforce a set of design and style conventions, so please make sure you have familiarized yourself with the following sections and implemented them in your code, to avoid lengthy review cycles.
 
+HINT: if you work on high-latency or low-bandwidth network use `TF_PLUGIN_CACHE_DIR` environment variable to dramatically speed up the tests, for example
+```bash
+TF_PLUGIN_CACHE_DIR=/tmp/tfcache pytest tests
+```
+
 ## Developer's handbook
 
 Over the years we have assembled a specific set of design principles and style conventions that allow for better readability and make understanding and changing code more predictable.


### PR DESCRIPTION
I noticed that tests on my laptop worked very slow, especially compared to GitHub workflows or my workstation.

For example, on my laptop (connected through medium bandwidth, high latency 3G connection) speedup is 26x :
```bash
pytest tests/blueprints
=============================== 41 passed, 1 warning in 4182.25s (1:09:42) ===============================
```
vs:
```bash
TF_PLUGIN_CACHE_DIR=/tmp/tfcache pytest tests/blueprints
=============================== 41 passed, 1 warning in 159.37s (0:02:39) ===============================

```

On my workstation, the speed up is not so drastic, but stil significant (1.58x faster):
```bash
/usr/bin/time  pytest tests/blueprints
=============================== 41 passed, 1 warning in 315.45s (0:05:15) ===============================
324.84user 75.50system 5:15.75elapsed 126%CPU (0avgtext+0avgdata 153676maxresident)k
0inputs+15606560outputs (17major+1854428minor)pagefaults 0swaps
```
vs:
```bash
TF_PLUGIN_CACHE_DIR=/tmp/tfcache /usr/bin/time pytest tests/blueprints/
=============================== 41 passed, 1 warning in 199.81s (0:03:19) ===============================
270.63user 37.29system 3:20.12elapsed 153%CPU (0avgtext+0avgdata 153336maxresident)k
0inputs+493496outputs (5major+1822243minor)pagefaults 0swaps
```

I think it is at least worth mentioning in the documentation or implementation in `conftest.py`. Any ideas which directory would be the best to use for this purpose?