### PR TITLE
FAST: fixes to GitHub workflow and 02/net outputs

### DIFF
--- a/fast/assets/templates/workflow-github.yaml
+++ b/fast/assets/templates/workflow-github.yaml
@@ -99,15 +99,17 @@ jobs:
         name: Terraform plan
         continue-on-error: true
         run: |
+          set -o pipefail
           echo -e "## Plan Output\n\n\`\`\`hcl" >> $$GITHUB_STEP_SUMMARY
           terraform plan -input=false -out ../plan.out -no-color |tee -a $$GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $$GITHUB_STEP_SUMMARY
 
       - id: tf-apply
-        if: github.event.pull_request.merged == true
+        if: github.event.pull_request.merged == true && success()
         name: Terraform apply
         continue-on-error: true
         run: |
+          set -o pipefail
           echo -e "## Apply Output\n\n\`\`\`hcl" >> $$GITHUB_STEP_SUMMARY
           terraform apply -input=false -auto-approve -no-color ../plan.out |tee -a $$GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $$GITHUB_STEP_SUMMARY
@@ -117,7 +119,7 @@ jobs:
         uses: actions/github-script@v6
         if: github.event_name == 'pull_request'
         env:
-          PLAN: terraform\n$${{ steps.tf-plan.outputs.stdout }}
+          PLAN: $${{ steps.tf-plan.outputs.stdout }}\n$${{ steps.tf-plan.outputs.stderr }}
         with:
           script: |
             const output = `### Terraform Initialization \`$${{ steps.tf-init.outcome }}\`
@@ -153,4 +155,12 @@ jobs:
               body: output
             })
 
-      # jq -j -r '.resource_changes[] | (.change.actions | join(",")), " ", .address, "\n" ' foo.json
+      - id: check-outcome
+        name: Check on failures
+        if: steps.tf-plan.outcome != 'success'
+        run: |
+          echo -e "## Plan Output\n\n\`\`\`hcl" > $$GITHUB_STEP_SUMMARY
+          echo "$${{ steps.tf-plan.outputs.stdout }}" >> $$GITHUB_STEP_SUMMARY
+          echo "$${{ steps.tf-plan.outputs.stderr }}" >> $$GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $$GITHUB_STEP_SUMMARY
+          exit 1

--- a/fast/assets/templates/workflow-github.yaml
+++ b/fast/assets/templates/workflow-github.yaml
@@ -99,20 +99,14 @@ jobs:
         name: Terraform plan
         continue-on-error: true
         run: |
-          set -o pipefail
-          echo -e "## Plan Output\n\n\`\`\`hcl" >> $$GITHUB_STEP_SUMMARY
-          terraform plan -input=false -out ../plan.out -no-color |tee -a $$GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $$GITHUB_STEP_SUMMARY
+          terraform plan -input=false -out ../plan.out -no-color
 
       - id: tf-apply
         if: github.event.pull_request.merged == true && success()
         name: Terraform apply
         continue-on-error: true
         run: |
-          set -o pipefail
-          echo -e "## Apply Output\n\n\`\`\`hcl" >> $$GITHUB_STEP_SUMMARY
-          terraform apply -input=false -auto-approve -no-color ../plan.out |tee -a $$GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $$GITHUB_STEP_SUMMARY
+          terraform apply -input=false -auto-approve -no-color ../plan.out
 
       - id: pr-comment
         name: Post comment to Pull Request
@@ -181,7 +175,12 @@ jobs:
               body: output
             })
 
-      - id: check-outcome
-        name: Check on failures
+      - id: check-plan
+        name: Check plan failure
         if: steps.tf-plan.outcome != 'success'
+        run: exit 1
+
+      - id: check-apply
+        name: Check apply failure
+        if: github.event.pull_request.merged == true && steps.tf-apply.outcome != 'success'
         run: exit 1

--- a/fast/assets/templates/workflow-github.yaml
+++ b/fast/assets/templates/workflow-github.yaml
@@ -116,6 +116,7 @@ jobs:
 
       - id: pr-comment
         name: Post comment to Pull Request
+        continue-on-error: true
         uses: actions/github-script@v6
         if: github.event_name == 'pull_request'
         env:
@@ -155,12 +156,32 @@ jobs:
               body: output
             })
 
+      - id: pr-short-comment
+        name: Post comment to Pull Request
+        uses: actions/github-script@v6
+        if: github.event_name == 'pull_request' && steps.pr-comment.outcome != 'success'
+        with:
+          script: |
+            const output = `### Terraform Initialization \`$${{ steps.tf-init.outcome }}\`
+
+            ### Terraform Validation \`$${{ steps.tf-validate.outcome }}\`
+
+            ### Terraform Plan \`$${{ steps.tf-plan.outcome }}\`
+
+            Plan output is in the action log.
+
+            ### Terraform Apply \`$${{ steps.tf-apply.outcome }}\`
+
+            *Pusher: @$${{ github.actor }}, Action: \`$${{ github.event_name }}\`, Working Directory: \`$${{ env.tf_actions_working_dir }}\`, Workflow: \`$${{ github.workflow }}\`*`;
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            })
+
       - id: check-outcome
         name: Check on failures
         if: steps.tf-plan.outcome != 'success'
-        run: |
-          echo -e "## Plan Output\n\n\`\`\`hcl" > $$GITHUB_STEP_SUMMARY
-          echo "$${{ steps.tf-plan.outputs.stdout }}" >> $$GITHUB_STEP_SUMMARY
-          echo "$${{ steps.tf-plan.outputs.stderr }}" >> $$GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $$GITHUB_STEP_SUMMARY
-          exit 1
+        run: exit 1

--- a/fast/stages/02-networking-nva/outputs.tf
+++ b/fast/stages/02-networking-nva/outputs.tf
@@ -43,7 +43,7 @@ locals {
 resource "local_file" "tfvars" {
   for_each        = var.outputs_location == null ? {} : { 1 = 1 }
   file_permission = "0644"
-  filename        = "${pathexpand(var.outputs_location)}/tfvars/02-networking.auto.tfvars.json"
+  filename        = "${try(pathexpand(var.outputs_location), "")}/tfvars/02-networking.auto.tfvars.json"
   content         = jsonencode(local.tfvars)
 }
 

--- a/fast/stages/02-networking-peering/outputs.tf
+++ b/fast/stages/02-networking-peering/outputs.tf
@@ -48,7 +48,7 @@ locals {
 resource "local_file" "tfvars" {
   for_each        = var.outputs_location == null ? {} : { 1 = 1 }
   file_permission = "0644"
-  filename        = "${pathexpand(var.outputs_location)}/tfvars/02-networking.auto.tfvars.json"
+  filename        = "${try(pathexpand(var.outputs_location), "")}/tfvars/02-networking.auto.tfvars.json"
   content         = jsonencode(local.tfvars)
 }
 

--- a/fast/stages/02-networking-separate-envs/outputs.tf
+++ b/fast/stages/02-networking-separate-envs/outputs.tf
@@ -44,7 +44,7 @@ locals {
 resource "local_file" "tfvars" {
   for_each        = var.outputs_location == null ? {} : { 1 = 1 }
   file_permission = "0644"
-  filename        = "${pathexpand(var.outputs_location)}/tfvars/02-networking.auto.tfvars.json"
+  filename        = "${try(pathexpand(var.outputs_location), "")}/tfvars/02-networking.auto.tfvars.json"
   content         = jsonencode(local.tfvars)
 }
 

--- a/fast/stages/02-networking-vpn/outputs.tf
+++ b/fast/stages/02-networking-vpn/outputs.tf
@@ -48,7 +48,7 @@ locals {
 resource "local_file" "tfvars" {
   for_each        = var.outputs_location == null ? {} : { 1 = 1 }
   file_permission = "0644"
-  filename        = "${pathexpand(var.outputs_location)}/tfvars/02-networking.auto.tfvars.json"
+  filename        = "${try(pathexpand(var.outputs_location), "")}/tfvars/02-networking.auto.tfvars.json"
   content         = jsonencode(local.tfvars)
 }
 


### PR DESCRIPTION
This fixes a few things in the GitHub workflow

- include plan stderr in PR comment
- remove the code to post to the action status page, as that too has a message length limit
- additional step to error workflow if plan or apply fails, needed since the plan and apply steps have `continue-on-error: true` to allow the PR comment step to always run
- set `continue-on-error: true` on the step that posts the PR comment, and add a second step that posts a shorter comment which omits plan standard output in case of failure due to comment length

It also fixes file outputs for the networking stages, which raise an error if the `outputs_location` variable is not set.