### PR TITLE
Fix `repository name must be lowercase` on docker build

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -24,6 +24,9 @@ on:
         required: true
         type: string
 
+env:
+  REGISTRY: ghcr.io
+
 jobs:
   build-push-generic-container-image:
     runs-on: ubuntu-latest
@@ -34,10 +37,14 @@ jobs:
         id: date
         run: echo "::set-output name=date::$(date +'%Y%m%d')"
 
+      - name: Normalise image name
+        run: |
+          echo IMAGE_NAME=$(echo '${{ github.repository_owner }}/${{ inputs.image_name }}' | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
+
       - name: Login to GHCR
         uses: docker/login-action@v2
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
@@ -47,5 +54,5 @@ jobs:
           context: ${{ inputs.docker_context }}
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/${{ inputs.image_name }}:latest
-            ghcr.io/${{ github.repository_owner }}/${{ inputs.image_name }}:${{ steps.date.outputs.date }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.date.outputs.date }}


### PR DESCRIPTION
Fixes `ERROR: invalid tag "ghcr.io/GoogleCloudPlatform/fabric-squid:latest": repository name must be lowercase` because **_GoogleCloudPlatform_** has uppercase letters in it.