### PR TITLE
Add missing `write_package` permission

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -24,6 +24,9 @@ on:
         required: true
         type: string
 
+permissions:
+  packages: write
+
 env:
   REGISTRY: ghcr.io
 


### PR DESCRIPTION
Fixes `ERROR: denied: permission_denied: write_package` - this didn't show up on my tests under my org/user, most probably because the GoogleCloudPlatform org has different default workflow permissions set.