### PR TITLE
Update labeler.yml

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -15,12 +15,12 @@
 'on:blueprints':
   - blueprints/**/*
 'on:documentation':
-  - '**/*.md'
-  - assets/**/*
-  - tests/**/*
+  - README.md
+  - */README.md
 'on:FAST':
   - fast/**/*
 'on:modules':
   - modules/**/*
 'on:tools':
   - tools/**/*
+  - .github/**/*


### PR DESCRIPTION
The `on:documentation` tag only needs to check top-level READMEs, or it will be assigned every time a variable or output changes.