### PR TITLE
Fix memory/cpu typo in gke cluster module

### DIFF
--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -142,7 +142,7 @@ resource "google_container_cluster" "cluster" {
       dynamic "resource_limits" {
         for_each = var.cluster_autoscaling.mem_limits != null ? [""] : []
         content {
-          resource_type = "cpu"
+          resource_type = "memory"
           minimum       = var.cluster_autoscaling.mem_limits.min
           maximum       = var.cluster_autoscaling.mem_limits.max
         }


### PR DESCRIPTION
Resolves:

```
> terraform  apply  /var/tmp/1000/terraform/26c67a5d-6df1-48ef-b802-69c0ae4a0209.tfplan
module.cluster.google_container_cluster.cluster: Creating...
╷
│ Error: googleapi: Error 400: Duplicate resource: cpu., badRequest
│ 
│   with module.cluster.google_container_cluster.cluster,
│   on fabric/modules/gke-cluster/main.tf line 17, in resource "google_container_cluster" "cluster":
│   17: resource "google_container_cluster" "cluster" {
│ 
╵
```