### PR TITLE
Apigee instance doc examples

### DIFF
--- a/modules/apigee/README.md
+++ b/modules/apigee/README.md
@@ -1,6 +1,6 @@
 # Apigee
 
-This module simplifies the creation of a Apigee resources (organization, environment groups, environment group attachments, environments, instances and instance attachments). 
+This module simplifies the creation of a Apigee resources (organization, environment groups, environment group attachments, environments, instances and instance attachments).
 
 ## Example
 
@@ -44,10 +44,10 @@ module "apigee" {
       environments      = ["apis-test"]
       psa_ip_cidr_range = "10.0.4.0/22"
     }
-    instance-prod-ew1 = {
-      region            = "europe-west1"
+    instance-prod-ew3 = {
+      region            = "europe-west3"
       environments      = ["apis-prod"]
-      psa_ip_cidr_range = "10.0.4.0/22"
+      psa_ip_cidr_range = "10.0.5.0/22"
     }
   }
 }

--- a/tests/modules/apigee/fixture/test.all.tfvars
+++ b/tests/modules/apigee/fixture/test.all.tfvars
@@ -33,9 +33,9 @@ instances = {
     environments      = ["apis-test"]
     psa_ip_cidr_range = "10.0.4.0/22"
   }
-  instance-prod-ew1 = {
-    region            = "europe-west1"
+  instance-prod-ew3 = {
+    region            = "europe-west3"
     environments      = ["apis-prod"]
-    psa_ip_cidr_range = "10.0.4.0/22"
+    psa_ip_cidr_range = "10.0.5.0/22"
   }
 }


### PR DESCRIPTION
Small change in the instance examples:
* An apigee org can only have 1 instance per region
* Every instance needs a /22 so they can't use the same cidr