### PR TITLE
Replace `set-output` with env variable and remove single quotes on labels

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -36,13 +36,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Get current date
-        id: date
-        run: echo "::set-output name=date::$(date +'%Y%m%d')"
+      - name: Set image version
+        run: echo IMAGE_VERSION=$(date +'%Y%m%d') >> $GITHUB_ENV
 
       - name: Normalise image name
-        run: |
-          echo IMAGE_NAME=$(echo '${{ github.repository_owner }}/${{ inputs.image_name }}' | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
+        run: echo IMAGE_NAME=$(echo '${{ github.repository_owner }}/${{ inputs.image_name }}' | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
 
       - name: Login to GHCR
         uses: docker/login-action@v2
@@ -58,11 +56,11 @@ jobs:
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.date.outputs.date }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_VERSION }}
           labels: |
-            org.opencontainers.image.licenses='Apache-2.0'
-            org.opencontainers.image.revision='${{ github.sha }}'
-            org.opencontainers.image.source='${{ github.server_url }}/${{ github.repository }}'
-            org.opencontainers.image.title='${{ inputs.image_name }}'
-            org.opencontainers.image.vendor='Google LLC'
-            org.opencontainers.image.version='${{ steps.date.outputs.date }}'
+            org.opencontainers.image.licenses=Apache-2.0
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.title=${{ inputs.image_name }}
+            org.opencontainers.image.vendor=Google LLC
+            org.opencontainers.image.version=${{ env.IMAGE_VERSION }}


### PR DESCRIPTION
Fixes the following warning:

> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
