### PR TITLE
fix apigee PAYG env node config dynamic block

### DIFF
--- a/modules/apigee/main.tf
+++ b/modules/apigee/main.tf
@@ -47,8 +47,8 @@ resource "google_apigee_environment" "environments" {
   dynamic "node_config" {
     for_each = try(each.value.node_config, null) != null ? [""] : []
     content {
-      min_node_count = node_config.min_node_count
-      max_node_count = node_config.max_node_count
+      min_node_count = each.value.node_config.min_node_count
+      max_node_count = each.value.node_config.max_node_count
     }
   }
   org_id = local.org_id

--- a/tests/modules/apigee/fixture/test.env_only.tfvars
+++ b/tests/modules/apigee/fixture/test.env_only.tfvars
@@ -4,5 +4,9 @@ environments = {
     display_name = "APIs test"
     description  = "APIs Test"
     envgroups    = ["test"]
+    node_config = {
+      min_node_count = 2
+      max_node_count = 5
+    }
   }
 }


### PR DESCRIPTION
Fixed attribute reference issues for the `node_config` dynamic block.
Added test case for Apigee PAYG Environment Node Config.

Changes committed:
- modified:   `modules/apigee/main.tf`
- modified:   `tests/modules/apigee/fixture/test.env_only.tfvars`