### PR TITLE
strongSwan: switch base image to debian-slim

### DIFF
--- a/modules/cloud-config-container/onprem/docker-images/strongswan/Dockerfile
+++ b/modules/cloud-config-container/onprem/docker-images/strongswan/Dockerfile
@@ -12,10 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:latest
+FROM debian:bullseye-slim
 
-RUN set -xe \
-  && apk add --no-cache strongswan bash sudo
+ENV STRONGSWAN_VERSION=5.9
+
+RUN apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y sudo iptables procps strongswan=${STRONGSWAN_VERSION}* \
+  && rm -rf /var/lib/apt/lists/*
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod 0755 /entrypoint.sh

--- a/modules/cloud-config-container/onprem/docker-images/strongswan/entrypoint.sh
+++ b/modules/cloud-config-container/onprem/docker-images/strongswan/entrypoint.sh
@@ -22,7 +22,7 @@ _stop_ipsec() {
   echo "Shutting down strongSwan/ipsec..."
   ipsec stop
 }
-trap _stop_ipsec SIGTERM
+trap _stop_ipsec TERM
 
 # Making the containter to work as a default gateway for LAN_NETWORKS
 iptables -t nat -A POSTROUTING -s ${LAN_NETWORKS} -o ${VPN_DEVICE} -m policy --dir out --pol ipsec -j ACCEPT


### PR DESCRIPTION
This PR changes the base image from alpine to debian-slim for better compliance. Please note: I did NOT test the complete setup. I stopped when I could build the image and run it successfully via `docker run --rm -it --cap-add=NET_ADMIN --privileged strongswan`.