### PR TITLE
feat(blueprints): get audience from tfc environment variable

### DIFF
--- a/blueprints/cloud-operations/terraform-enterprise-wif/tfc-workflow-using-wif/README.md
+++ b/blueprints/cloud-operations/terraform-enterprise-wif/tfc-workflow-using-wif/README.md
@@ -13,6 +13,5 @@ The codebase provisions the following list of resources:
 |---|---|:---:|:---:|:---:|
 | [impersonate_service_account_email](variables.tf#L16) | Service account to be impersonated by workload identity. | <code>string</code> | ✓ |  |
 | [project_id](variables.tf#L21) | GCP project ID. | <code>string</code> | ✓ |  |
-| [workload_identity_pool_provider_id](variables.tf#L26) | GCP workload identity pool provider ID. | <code>string</code> | ✓ |  |
 
 <!-- END TFDOC -->

--- a/blueprints/cloud-operations/terraform-enterprise-wif/tfc-workflow-using-wif/terraform.auto.tfvars.template
+++ b/blueprints/cloud-operations/terraform-enterprise-wif/tfc-workflow-using-wif/terraform.auto.tfvars.template
@@ -13,5 +13,4 @@
 # limitations under the License.
 
 project_id                         = "tfe-oidc-workflow"
-workload_identity_pool_provider_id = "projects/683987109094/locations/global/workloadIdentityPools/tfe-pool/providers/tfe-provider"
 impersonate_service_account_email  = "sa-tfe@tfe-oidc-workflow2.iam.gserviceaccount.com"

--- a/blueprints/cloud-operations/terraform-enterprise-wif/tfc-workflow-using-wif/tfc-oidc/README.md
+++ b/blueprints/cloud-operations/terraform-enterprise-wif/tfc-workflow-using-wif/tfc-oidc/README.md
@@ -5,9 +5,8 @@ This is a helper module to prepare GCP Credentials from Terraform Enterprise wor
 ## Example
 ```hcl
 module "tfe_oidc" {
-  source = "./tfe_oidc"
+  source = "./tfc-oidc"
 
-  workload_identity_pool_provider_id = "projects/683987109094/locations/global/workloadIdentityPools/tfe-pool/providers/tfe-provider"
   impersonate_service_account_email  = "tfe-test@tfe-test-wif.iam.gserviceaccount.com"
 }
 
@@ -28,7 +27,6 @@ provider "google-beta" {
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
 | [impersonate_service_account_email](variables.tf#L17) | Service account to be impersonated by workload identity federation. | <code>string</code> | ✓ |  |
-| [workload_identity_pool_provider_id](variables.tf#L28) | GCP workload identity pool provider ID. | <code>string</code> | ✓ |  |
 | [tmp_oidc_token_path](variables.tf#L22) | Name of the temporary file where TFC OIDC token will be stored to authentificate terraform provider google. | <code>string</code> |  | <code>&#34;.oidc_token&#34;</code> |
 
 ## Outputs

--- a/blueprints/cloud-operations/terraform-enterprise-wif/tfc-workflow-using-wif/tfc-oidc/get_audience.sh
+++ b/blueprints/cloud-operations/terraform-enterprise-wif/tfc-workflow-using-wif/tfc-oidc/get_audience.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,13 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Exit if any of the intermediate steps fail
+set -e
 
-module "tfe_oidc" {
-  source = "./tfc-oidc"
-
-  impersonate_service_account_email = var.impersonate_service_account_email
+cat <<EOF
+{
+  "audience": "$TFC_WORKLOAD_IDENTITY_AUDIENCE"
 }
-
-provider "google" {
-  credentials = module.tfe_oidc.credentials
-}
+EOF

--- a/blueprints/cloud-operations/terraform-enterprise-wif/tfc-workflow-using-wif/tfc-oidc/main.tf
+++ b/blueprints/cloud-operations/terraform-enterprise-wif/tfc-workflow-using-wif/tfc-oidc/main.tf
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-locals {
-  audience = "//iam.googleapis.com/${var.workload_identity_pool_provider_id}"
-}
-
 data "external" "oidc_token_file" {
   program = ["bash", "${path.module}/write_token.sh", "${var.tmp_oidc_token_path}"]
+}
+
+data "external" "workload_identity_pool" {
+  program = ["bash", "${path.module}/get_audience.sh"]
 }

--- a/blueprints/cloud-operations/terraform-enterprise-wif/tfc-workflow-using-wif/tfc-oidc/outputs.tf
+++ b/blueprints/cloud-operations/terraform-enterprise-wif/tfc-workflow-using-wif/tfc-oidc/outputs.tf
@@ -18,7 +18,7 @@ output "credentials" {
   description = "Credentials in format to pass the to gcp provider."
   value = jsonencode({
     "type" : "external_account",
-    "audience" : "${local.audience}",
+    "audience" : data.external.workload_identity_pool.result.audience,
     "subject_token_type" : "urn:ietf:params:oauth:token-type:jwt",
     "token_url" : "https://sts.googleapis.com/v1/token",
     "credential_source" : data.external.oidc_token_file.result

--- a/blueprints/cloud-operations/terraform-enterprise-wif/tfc-workflow-using-wif/tfc-oidc/variables.tf
+++ b/blueprints/cloud-operations/terraform-enterprise-wif/tfc-workflow-using-wif/tfc-oidc/variables.tf
@@ -24,8 +24,3 @@ variable "tmp_oidc_token_path" {
   type        = string
   default     = ".oidc_token"
 }
-
-variable "workload_identity_pool_provider_id" {
-  description = "GCP workload identity pool provider ID."
-  type        = string
-}

--- a/blueprints/cloud-operations/terraform-enterprise-wif/tfc-workflow-using-wif/variables.tf
+++ b/blueprints/cloud-operations/terraform-enterprise-wif/tfc-workflow-using-wif/variables.tf
@@ -22,8 +22,3 @@ variable "project_id" {
   description = "GCP project ID."
   type        = string
 }
-
-variable "workload_identity_pool_provider_id" {
-  description = "GCP workload identity pool provider ID."
-  type        = string
-}


### PR DESCRIPTION
# Subject

This PR is about using Workload Identity Federation with Terraform Cloud.

# Description

I propose this change because the **audience** in Terraform Cloud / Enterprise is already defined by the user in the `TFC_WORKLOAD_IDENTITY_AUDIENCE` environment variable for the workspace. So you can avoid to define it in the Terraform code as variable.

I take this opportunity to also correct a typo error in the documentation.

Thank you for the sample code, it helped me a lot to understand how to use Workload Identity Federation with Terraform Cloud.

Have a nice day ! 👋