### PR TITLE
FAST: add instructions for billing export to stage 0 README

### DIFF
--- a/fast/stages/00-bootstrap/README.md
+++ b/fast/stages/00-bootstrap/README.md
@@ -54,6 +54,9 @@ For same-organization billing, we configure a custom organization role that can 
 
 For details on configuring the different billing account modes, refer to the [How to run this stage](#how-to-run-this-stage) section below.
 
+> Because of limitations of API availability, Manual steps have to followed to enable Billing export within billing project to BigQuery dataset billing_export which will be created as part of the 00-bootstrap stage. Process to share billing data outligned here - [Billing export](https://cloud.google.com/billing/docs/how-to/export-data-bigquery-setup#enable-bq-export)
+
+
 ### Organization-level logging
 
 We create organization-level log sinks early in the bootstrap process to ensure a proper audit trail is in place from the very beginning.  By default, we provide log filters to capture [Cloud Audit Logs](https://cloud.google.com/logging/docs/audit) and [VPC Service Controls violations](https://cloud.google.com/vpc-service-controls/docs/troubleshooting#vpc-sc-errors) into a Bigquery dataset in the top-level audit project.

--- a/fast/stages/00-bootstrap/README.md
+++ b/fast/stages/00-bootstrap/README.md
@@ -54,8 +54,7 @@ For same-organization billing, we configure a custom organization role that can 
 
 For details on configuring the different billing account modes, refer to the [How to run this stage](#how-to-run-this-stage) section below.
 
-> Because of limitations of API availability, Manual steps have to followed to enable Billing export within billing project to BigQuery dataset billing_export which will be created as part of the 00-bootstrap stage. Process to share billing data outligned here - [Billing export](https://cloud.google.com/billing/docs/how-to/export-data-bigquery-setup#enable-bq-export)
-
+Because of limitations of API availability, manual steps have to be followed to enable billing export within billing project to BigQuery dataset `billing_export` which will be created as part of the bootstrap stage. THe process to share billing data [is outlined here](https://cloud.google.com/billing/docs/how-to/export-data-bigquery-setup#enable-bq-export).
 
 ### Organization-level logging
 


### PR DESCRIPTION
Because of the billing API limitations, Though BigQuery dataset will be created within billing project, it will be empty.  BigQuery export have to be manually enabled in order for the data to be populated within the dataset. Since the Readme doesn't capture this, a note and reference link was added.