### PR TITLE
Add gc_policy to Bigtable module, bump provider versions to 4.47

### DIFF
--- a/blueprints/cloud-operations/adfs/versions.tf
+++ b/blueprints/cloud-operations/adfs/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/blueprints/cloud-operations/apigee/versions.tf
+++ b/blueprints/cloud-operations/apigee/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/blueprints/cloud-operations/asset-inventory-feed-remediation/versions.tf
+++ b/blueprints/cloud-operations/asset-inventory-feed-remediation/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/blueprints/cloud-operations/dns-fine-grained-iam/versions.tf
+++ b/blueprints/cloud-operations/dns-fine-grained-iam/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/blueprints/cloud-operations/dns-shared-vpc/versions.tf
+++ b/blueprints/cloud-operations/dns-shared-vpc/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/blueprints/cloud-operations/iam-delegated-role-grants/versions.tf
+++ b/blueprints/cloud-operations/iam-delegated-role-grants/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/blueprints/cloud-operations/onprem-sa-key-management/versions.tf
+++ b/blueprints/cloud-operations/onprem-sa-key-management/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/blueprints/cloud-operations/packer-image-builder/versions.tf
+++ b/blueprints/cloud-operations/packer-image-builder/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/blueprints/cloud-operations/quota-monitoring/versions.tf
+++ b/blueprints/cloud-operations/quota-monitoring/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/blueprints/cloud-operations/scheduled-asset-inventory-export-bq/versions.tf
+++ b/blueprints/cloud-operations/scheduled-asset-inventory-export-bq/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/blueprints/cloud-operations/terraform-enterprise-wif/tfc-workflow-using-wif/tfc-oidc/versions.tf
+++ b/blueprints/cloud-operations/terraform-enterprise-wif/tfc-workflow-using-wif/tfc-oidc/versions.tf
@@ -14,4 +14,16 @@
 
 terraform {
   required_version = ">= 1.3.1"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 4.47.0" # tftest
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 4.47.0" # tftest
+    }
+  }
 }
+
+

--- a/blueprints/data-solutions/cmek-via-centralized-kms/versions.tf
+++ b/blueprints/data-solutions/cmek-via-centralized-kms/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/blueprints/data-solutions/data-playground/versions.tf
+++ b/blueprints/data-solutions/data-playground/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/blueprints/data-solutions/gcs-to-bq-with-least-privileges/versions.tf
+++ b/blueprints/data-solutions/gcs-to-bq-with-least-privileges/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/blueprints/factories/net-vpc-firewall-yaml/versions.tf
+++ b/blueprints/factories/net-vpc-firewall-yaml/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/blueprints/networking/__need_fixing/nginx-reverse-proxy-cluster/versions.tf
+++ b/blueprints/networking/__need_fixing/nginx-reverse-proxy-cluster/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/blueprints/networking/__need_fixing/onprem-google-access-dns/versions.tf
+++ b/blueprints/networking/__need_fixing/onprem-google-access-dns/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/blueprints/networking/decentralized-firewall/versions.tf
+++ b/blueprints/networking/decentralized-firewall/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/blueprints/networking/filtering-proxy-psc/versions.tf
+++ b/blueprints/networking/filtering-proxy-psc/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/blueprints/networking/filtering-proxy/versions.tf
+++ b/blueprints/networking/filtering-proxy/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/blueprints/networking/hub-and-spoke-peering/versions.tf
+++ b/blueprints/networking/hub-and-spoke-peering/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/blueprints/networking/hub-and-spoke-vpn/versions.tf
+++ b/blueprints/networking/hub-and-spoke-vpn/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/blueprints/networking/ilb-next-hop/versions.tf
+++ b/blueprints/networking/ilb-next-hop/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/blueprints/networking/private-cloud-function-from-onprem/versions.tf
+++ b/blueprints/networking/private-cloud-function-from-onprem/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/blueprints/networking/shared-vpc-gke/versions.tf
+++ b/blueprints/networking/shared-vpc-gke/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/blueprints/third-party-solutions/openshift/tf/versions.tf
+++ b/blueprints/third-party-solutions/openshift/tf/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/default-versions.tf
+++ b/default-versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/__experimental/net-neg/versions.tf
+++ b/modules/__experimental/net-neg/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/api-gateway/versions.tf
+++ b/modules/api-gateway/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/apigee/versions.tf
+++ b/modules/apigee/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/artifact-registry/versions.tf
+++ b/modules/artifact-registry/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/bigquery-dataset/versions.tf
+++ b/modules/bigquery-dataset/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/bigtable-instance/README.md
+++ b/modules/bigtable-instance/README.md
@@ -185,19 +185,19 @@ module "bigtable-instance" {
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [name](variables.tf#L69) | The name of the Cloud Bigtable instance. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L80) | Id of the project where datasets will be created. | <code>string</code> | ✓ |  |
-| [zone](variables.tf#L110) | The zone to create the Cloud Bigtable cluster in. | <code>string</code> | ✓ |  |
+| [name](variables.tf#L68) | The name of the Cloud Bigtable instance. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L79) | Id of the project where datasets will be created. | <code>string</code> | ✓ |  |
+| [zone](variables.tf#L109) | The zone to create the Cloud Bigtable cluster in. | <code>string</code> | ✓ |  |
 | [autoscaling_config](variables.tf#L17) | Settings for autoscaling of the instance. If you set this variable, the variable num_nodes is ignored. | <code title="object&#40;&#123;&#10;  min_nodes      &#61; number&#10;  max_nodes      &#61; number&#10;  cpu_target     &#61; number&#10;  storage_target &#61; optional&#40;number, null&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
 | [cluster_id](variables.tf#L28) | The ID of the Cloud Bigtable cluster. | <code>string</code> |  | <code>&#34;europe-west1&#34;</code> |
 | [default_gc_policy](variables.tf#L34) | Default garbage collection policy, to be applied to all column families and all tables. Can be override in the tables variable for specific column families. | <code title="object&#40;&#123;&#10;  deletion_policy &#61; optional&#40;string&#41;&#10;  gc_rules        &#61; optional&#40;string&#41;&#10;  mode            &#61; optional&#40;string&#41;&#10;  max_age         &#61; optional&#40;string&#41;&#10;  max_version     &#61; optional&#40;string&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
 | [deletion_protection](variables.tf#L46) | Whether or not to allow Terraform to destroy the instance. Unless this field is set to false in Terraform state, a terraform destroy or terraform apply that would delete the instance will fail. | <code></code> |  | <code>true</code> |
 | [display_name](variables.tf#L51) | The human-readable display name of the Bigtable instance. | <code></code> |  | <code>null</code> |
-| [iam](variables.tf#L57) | IAM bindings for topic in {ROLE => [MEMBERS]} format. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [instance_type](variables.tf#L63) | (deprecated) The instance type to create. One of 'DEVELOPMENT' or 'PRODUCTION'. | <code>string</code> |  | <code>null</code> |
-| [num_nodes](variables.tf#L74) | The number of nodes in your Cloud Bigtable cluster. This value is ignored if you are using autoscaling. | <code>number</code> |  | <code>1</code> |
-| [storage_type](variables.tf#L85) | The storage type to use. | <code>string</code> |  | <code>&#34;SSD&#34;</code> |
-| [tables](variables.tf#L91) | Tables to be created in the BigTable instance. | <code title="map&#40;object&#40;&#123;&#10;  split_keys &#61; optional&#40;list&#40;string&#41;, &#91;&#93;&#41;&#10;  column_families &#61; optional&#40;map&#40;object&#40;&#10;    &#123;&#10;      gc_policy &#61; optional&#40;object&#40;&#123;&#10;        deletion_policy &#61; optional&#40;string&#41;&#10;        gc_rules        &#61; optional&#40;string&#41;&#10;        mode            &#61; optional&#40;string&#41;&#10;        max_age         &#61; optional&#40;string&#41;&#10;        max_version     &#61; optional&#40;string&#41;&#10;      &#125;&#41;, null&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [iam](variables.tf#L56) | IAM bindings for topic in {ROLE => [MEMBERS]} format. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [instance_type](variables.tf#L62) | (deprecated) The instance type to create. One of 'DEVELOPMENT' or 'PRODUCTION'. | <code>string</code> |  | <code>null</code> |
+| [num_nodes](variables.tf#L73) | The number of nodes in your Cloud Bigtable cluster. This value is ignored if you are using autoscaling. | <code>number</code> |  | <code>1</code> |
+| [storage_type](variables.tf#L84) | The storage type to use. | <code>string</code> |  | <code>&#34;SSD&#34;</code> |
+| [tables](variables.tf#L90) | Tables to be created in the BigTable instance. | <code title="map&#40;object&#40;&#123;&#10;  split_keys &#61; optional&#40;list&#40;string&#41;, &#91;&#93;&#41;&#10;  column_families &#61; optional&#40;map&#40;object&#40;&#10;    &#123;&#10;      gc_policy &#61; optional&#40;object&#40;&#123;&#10;        deletion_policy &#61; optional&#40;string&#41;&#10;        gc_rules        &#61; optional&#40;string&#41;&#10;        mode            &#61; optional&#40;string&#41;&#10;        max_age         &#61; optional&#40;string&#41;&#10;        max_version     &#61; optional&#40;string&#41;&#10;      &#125;&#41;, null&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 
 ## Outputs
 

--- a/modules/bigtable-instance/README.md
+++ b/modules/bigtable-instance/README.md
@@ -4,7 +4,6 @@ This module allows managing a single BigTable instance, including access configu
 
 ## TODO
 
-- [ ] support bigtable_gc_policy
 - [ ] support bigtable_app_profile
 - [ ] support cluster replicas
 - [ ] support IAM for tables
@@ -47,11 +46,75 @@ module "bigtable-instance" {
   tables = {
     test1 = {},
     test2 = {
-      split_keys      = ["a", "b", "c"]
-      column_families = ["cf1", "cf2", "cf3"]
+      split_keys = ["a", "b", "c"]
+      column_families = {
+        cf1 = {}
+        cf2 = {}
+        cf3 = {}
+      }
     }
     test3 = {
-      column_families = ["cf1"]
+      column_families = {
+        cf1 = {}
+      }
+    }
+  }
+}
+# tftest modules=1 resources=4
+```
+
+### Instance with garbage collection policy
+
+```hcl
+
+module "bigtable-instance" {
+  source     = "./fabric/modules/bigtable-instance"
+  project_id = "my-project"
+  name       = "instance"
+  cluster_id = "instance"
+  zone       = "europe-west1-b"
+  tables = {
+    test1 = {
+      column_families = {
+        cf1 = {
+          gc_policy = {
+            deletion_policy = "ABANDON"
+            max_age         = "18h"
+          }
+        }
+        cf2 = {}
+      }
+    }
+  }
+}
+# tftest modules=1 resources=3
+```
+
+### Instance with default garbage collection policy
+
+The default garbage collection policy is applied to any column family that does
+not specify a `gc_policy`. If a column family specifies a `gc_policy`, the
+default garbage collection policy is ignored for that column family.
+
+```hcl
+
+module "bigtable-instance" {
+  source     = "./fabric/modules/bigtable-instance"
+  project_id = "my-project"
+  name       = "instance"
+  cluster_id = "instance"
+  zone       = "europe-west1-b"
+  default_gc_policy = {
+    deletion_policy = "ABANDON"
+    max_age         = "18h"
+    max_version     = 7
+  }
+  tables = {
+    test1 = {
+      column_families = {
+        cf1 = {}
+        cf2 = {}
+      }
     }
   }
 }
@@ -122,18 +185,19 @@ module "bigtable-instance" {
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [name](variables.tf#L56) | The name of the Cloud Bigtable instance. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L67) | Id of the project where datasets will be created. | <code>string</code> | ✓ |  |
-| [zone](variables.tf#L88) | The zone to create the Cloud Bigtable cluster in. | <code>string</code> | ✓ |  |
-| [autoscaling_config](variables.tf#L17) | Settings for autoscaling of the instance. If you set this variable, the variable num_nodes is ignored. | <code title="object&#40;&#123;&#10;  min_nodes      &#61; number&#10;  max_nodes      &#61; number&#10;  cpu_target     &#61; number,&#10;  storage_target &#61; optional&#40;number, null&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [name](variables.tf#L69) | The name of the Cloud Bigtable instance. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L80) | Id of the project where datasets will be created. | <code>string</code> | ✓ |  |
+| [zone](variables.tf#L110) | The zone to create the Cloud Bigtable cluster in. | <code>string</code> | ✓ |  |
+| [autoscaling_config](variables.tf#L17) | Settings for autoscaling of the instance. If you set this variable, the variable num_nodes is ignored. | <code title="object&#40;&#123;&#10;  min_nodes      &#61; number&#10;  max_nodes      &#61; number&#10;  cpu_target     &#61; number&#10;  storage_target &#61; optional&#40;number, null&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
 | [cluster_id](variables.tf#L28) | The ID of the Cloud Bigtable cluster. | <code>string</code> |  | <code>&#34;europe-west1&#34;</code> |
-| [deletion_protection](variables.tf#L34) | Whether or not to allow Terraform to destroy the instance. Unless this field is set to false in Terraform state, a terraform destroy or terraform apply that would delete the instance will fail. | <code></code> |  | <code>true</code> |
-| [display_name](variables.tf#L39) | The human-readable display name of the Bigtable instance. | <code></code> |  | <code>null</code> |
-| [iam](variables.tf#L44) | IAM bindings for topic in {ROLE => [MEMBERS]} format. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [instance_type](variables.tf#L50) | (deprecated) The instance type to create. One of 'DEVELOPMENT' or 'PRODUCTION'. | <code>string</code> |  | <code>null</code> |
-| [num_nodes](variables.tf#L61) | The number of nodes in your Cloud Bigtable cluster. This value is ignored if you are using autoscaling. | <code>number</code> |  | <code>1</code> |
-| [storage_type](variables.tf#L72) | The storage type to use. | <code>string</code> |  | <code>&#34;SSD&#34;</code> |
-| [tables](variables.tf#L78) | Tables to be created in the BigTable instance. | <code title="map&#40;object&#40;&#123;&#10;  split_keys      &#61; optional&#40;list&#40;string&#41;, &#91;&#93;&#41;&#10;  column_families &#61; optional&#40;list&#40;string&#41;, &#91;&#93;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [default_gc_policy](variables.tf#L34) | Default garbage collection policy, to be applied to all column families and all tables. Can be override in the tables variable for specific column families. | <code title="object&#40;&#123;&#10;  deletion_policy &#61; optional&#40;string&#41;&#10;  gc_rules        &#61; optional&#40;string&#41;&#10;  mode            &#61; optional&#40;string&#41;&#10;  max_age         &#61; optional&#40;string&#41;&#10;  max_version     &#61; optional&#40;string&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [deletion_protection](variables.tf#L46) | Whether or not to allow Terraform to destroy the instance. Unless this field is set to false in Terraform state, a terraform destroy or terraform apply that would delete the instance will fail. | <code></code> |  | <code>true</code> |
+| [display_name](variables.tf#L51) | The human-readable display name of the Bigtable instance. | <code></code> |  | <code>null</code> |
+| [iam](variables.tf#L57) | IAM bindings for topic in {ROLE => [MEMBERS]} format. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [instance_type](variables.tf#L63) | (deprecated) The instance type to create. One of 'DEVELOPMENT' or 'PRODUCTION'. | <code>string</code> |  | <code>null</code> |
+| [num_nodes](variables.tf#L74) | The number of nodes in your Cloud Bigtable cluster. This value is ignored if you are using autoscaling. | <code>number</code> |  | <code>1</code> |
+| [storage_type](variables.tf#L85) | The storage type to use. | <code>string</code> |  | <code>&#34;SSD&#34;</code> |
+| [tables](variables.tf#L91) | Tables to be created in the BigTable instance. | <code title="map&#40;object&#40;&#123;&#10;  split_keys &#61; optional&#40;list&#40;string&#41;, &#91;&#93;&#41;&#10;  column_families &#61; optional&#40;map&#40;object&#40;&#10;    &#123;&#10;      gc_policy &#61; optional&#40;object&#40;&#123;&#10;        deletion_policy &#61; optional&#40;string&#41;&#10;        gc_rules        &#61; optional&#40;string&#41;&#10;        mode            &#61; optional&#40;string&#41;&#10;        max_age         &#61; optional&#40;string&#41;&#10;        max_version     &#61; optional&#40;string&#41;&#10;      &#125;&#41;, null&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 
 ## Outputs
 

--- a/modules/bigtable-instance/main.tf
+++ b/modules/bigtable-instance/main.tf
@@ -16,6 +16,15 @@
 
 locals {
   num_nodes = var.autoscaling_config == null ? var.num_nodes : null
+  gc_pairs = flatten([
+    for table, table_obj in var.tables : [
+      for cf, cf_obj in table_obj.column_families : {
+        table         = table
+        column_family = cf
+        gc_policy     = cf_obj.gc_policy == null ? var.default_gc_policy : cf_obj.gc_policy
+      }
+    ]
+  ])
 }
 
 resource "google_bigtable_instance" "default" {
@@ -61,7 +70,34 @@ resource "google_bigtable_table" "default" {
     for_each = each.value.column_families
 
     content {
-      family = column_family.value
+      family = column_family.key
+    }
+  }
+}
+
+resource "google_bigtable_gc_policy" "default" {
+  for_each = { for k, v in local.gc_pairs : k => v if v.gc_policy != null }
+
+  table         = each.value.table
+  column_family = each.value.column_family
+  instance_name = google_bigtable_instance.default.name
+  project       = var.project_id
+
+  gc_rules        = try(each.value.gc_policy.gc_rules, null)
+  mode            = try(each.value.gc_policy.mode, null)
+  deletion_policy = try(each.value.gc_policy.deletion_policy, null)
+
+  dynamic "max_age" {
+    for_each = try(each.value.gc_policy.max_age, null) != null ? [""] : []
+    content {
+      duration = each.value.gc_policy.max_age
+    }
+  }
+
+  dynamic "max_version" {
+    for_each = try(each.value.gc_policy.max_version, null) != null ? [""] : []
+    content {
+      number = each.value.gc_policy.max_version
     }
   }
 }

--- a/modules/bigtable-instance/variables.tf
+++ b/modules/bigtable-instance/variables.tf
@@ -19,7 +19,7 @@ variable "autoscaling_config" {
   type = object({
     min_nodes      = number
     max_nodes      = number
-    cpu_target     = number,
+    cpu_target     = number
     storage_target = optional(number, null)
   })
   default = null
@@ -31,6 +31,18 @@ variable "cluster_id" {
   default     = "europe-west1"
 }
 
+variable "default_gc_policy" {
+  description = "Default garbage collection policy, to be applied to all column families and all tables. Can be override in the tables variable for specific column families."
+  type = object({
+    deletion_policy = optional(string)
+    gc_rules        = optional(string)
+    mode            = optional(string)
+    max_age         = optional(string)
+    max_version     = optional(string)
+  })
+  default = null
+}
+
 variable "deletion_protection" {
   description = "Whether or not to allow Terraform to destroy the instance. Unless this field is set to false in Terraform state, a terraform destroy or terraform apply that would delete the instance will fail."
   default     = true
@@ -40,6 +52,7 @@ variable "display_name" {
   description = "The human-readable display name of the Bigtable instance."
   default     = null
 }
+
 
 variable "iam" {
   description = "IAM bindings for topic in {ROLE => [MEMBERS]} format."
@@ -79,8 +92,17 @@ variable "tables" {
   description = "Tables to be created in the BigTable instance."
   nullable    = false
   type = map(object({
-    split_keys      = optional(list(string), [])
-    column_families = optional(list(string), [])
+    split_keys = optional(list(string), [])
+    column_families = optional(map(object(
+      {
+        gc_policy = optional(object({
+          deletion_policy = optional(string)
+          gc_rules        = optional(string)
+          mode            = optional(string)
+          max_age         = optional(string)
+          max_version     = optional(string)
+        }), null)
+    })), {})
   }))
   default = {}
 }

--- a/modules/bigtable-instance/variables.tf
+++ b/modules/bigtable-instance/variables.tf
@@ -53,7 +53,6 @@ variable "display_name" {
   default     = null
 }
 
-
 variable "iam" {
   description = "IAM bindings for topic in {ROLE => [MEMBERS]} format."
   type        = map(list(string))

--- a/modules/bigtable-instance/versions.tf
+++ b/modules/bigtable-instance/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/billing-budget/versions.tf
+++ b/modules/billing-budget/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/binauthz/versions.tf
+++ b/modules/binauthz/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/__need_fixing/onprem/versions.tf
+++ b/modules/cloud-config-container/__need_fixing/onprem/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/coredns/versions.tf
+++ b/modules/cloud-config-container/coredns/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/cos-generic-metadata/versions.tf
+++ b/modules/cloud-config-container/cos-generic-metadata/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/envoy-traffic-director/versions.tf
+++ b/modules/cloud-config-container/envoy-traffic-director/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/mysql/versions.tf
+++ b/modules/cloud-config-container/mysql/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/nginx-tls/versions.tf
+++ b/modules/cloud-config-container/nginx-tls/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/nginx/versions.tf
+++ b/modules/cloud-config-container/nginx/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/simple-nva/versions.tf
+++ b/modules/cloud-config-container/simple-nva/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/squid/versions.tf
+++ b/modules/cloud-config-container/squid/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/cloud-function/versions.tf
+++ b/modules/cloud-function/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/cloud-identity-group/versions.tf
+++ b/modules/cloud-identity-group/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/cloud-run/versions.tf
+++ b/modules/cloud-run/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/cloudsql-instance/versions.tf
+++ b/modules/cloudsql-instance/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/compute-mig/versions.tf
+++ b/modules/compute-mig/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/compute-vm/versions.tf
+++ b/modules/compute-vm/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/container-registry/versions.tf
+++ b/modules/container-registry/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/data-catalog-policy-tag/versions.tf
+++ b/modules/data-catalog-policy-tag/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/datafusion/versions.tf
+++ b/modules/datafusion/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/dns/versions.tf
+++ b/modules/dns/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/endpoints/versions.tf
+++ b/modules/endpoints/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/folder/versions.tf
+++ b/modules/folder/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/gcs/versions.tf
+++ b/modules/gcs/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/gke-cluster/versions.tf
+++ b/modules/gke-cluster/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/gke-hub/versions.tf
+++ b/modules/gke-hub/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/gke-nodepool/versions.tf
+++ b/modules/gke-nodepool/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/iam-service-account/versions.tf
+++ b/modules/iam-service-account/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/kms/versions.tf
+++ b/modules/kms/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/logging-bucket/versions.tf
+++ b/modules/logging-bucket/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/net-address/versions.tf
+++ b/modules/net-address/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/net-cloudnat/versions.tf
+++ b/modules/net-cloudnat/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/net-glb/versions.tf
+++ b/modules/net-glb/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/net-ilb-l7/versions.tf
+++ b/modules/net-ilb-l7/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/net-ilb/versions.tf
+++ b/modules/net-ilb/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/net-interconnect-attachment-direct/versions.tf
+++ b/modules/net-interconnect-attachment-direct/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/net-vpc-firewall/versions.tf
+++ b/modules/net-vpc-firewall/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/net-vpc-peering/versions.tf
+++ b/modules/net-vpc-peering/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/net-vpc/README.md
+++ b/modules/net-vpc/README.md
@@ -76,8 +76,8 @@ module "vpc-spoke-1" {
 locals {
   service_project_1 = {
     project_id                     = "project1"
-    gke_service_account            = "gke"
-    cloud_services_service_account = "cloudsvc"
+    gke_service_account            = "serviceAccount:gke"
+    cloud_services_service_account = "serviceAccount:cloudsvc"
   }
   service_project_2 = {
     project_id = "project2"

--- a/modules/net-vpc/versions.tf
+++ b/modules/net-vpc/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/net-vpn-dynamic/versions.tf
+++ b/modules/net-vpn-dynamic/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/net-vpn-ha/versions.tf
+++ b/modules/net-vpn-ha/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/net-vpn-static/versions.tf
+++ b/modules/net-vpn-static/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/organization/versions.tf
+++ b/modules/organization/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/project/versions.tf
+++ b/modules/project/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/projects-data-source/versions.tf
+++ b/modules/projects-data-source/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/pubsub/versions.tf
+++ b/modules/pubsub/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/secret-manager/versions.tf
+++ b/modules/secret-manager/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/service-directory/versions.tf
+++ b/modules/service-directory/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/source-repository/versions.tf
+++ b/modules/source-repository/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/modules/vpc-sc/versions.tf
+++ b/modules/vpc-sc/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.40.0" # tftest
+      version = ">= 4.47.0" # tftest
     }
   }
 }

--- a/tests/modules/logging_bucket/test_plan.py
+++ b/tests/modules/logging_bucket/test_plan.py
@@ -22,6 +22,7 @@ def test_project_logging_bucket(plan_runner):
   assert resource["type"] == "google_logging_project_bucket_config"
   assert resource["values"] == {
       "bucket_id": "mybucket",
+      "cmek_settings": [],
       "project": "myproject",
       "location": "global",
       "retention_days": 30,
@@ -39,6 +40,7 @@ def test_folder_logging_bucket(plan_runner):
   assert resource["type"] == "google_logging_folder_bucket_config"
   assert resource["values"] == {
       "bucket_id": "mybucket",
+      "cmek_settings": [],
       "folder": "folders/0123456789",
       "location": "global",
       "retention_days": 30,
@@ -56,6 +58,7 @@ def test_organization_logging_bucket(plan_runner):
   assert resource["type"] == "google_logging_organization_bucket_config"
   assert resource["values"] == {
       "bucket_id": "mybucket",
+      "cmek_settings": [],
       "organization": "organizations/0123456789",
       "location": "global",
       "retention_days": 30,
@@ -73,6 +76,7 @@ def test_billing_account_logging_bucket(plan_runner):
   assert resource["type"] == "google_logging_billing_account_bucket_config"
   assert resource["values"] == {
       "bucket_id": "mybucket",
+      "cmek_settings": [],
       "billing_account": "0123456789",
       "location": "global",
       "retention_days": 30,


### PR DESCRIPTION
Column families have now a new property, to specify the garbage collection policy. A new option also allows to set a default policy if none is specified.

This changes the previous syntax for column families, that was necessary since the policy is column-family specific. The new syntax makes it easier to specify a policy per column family.

I had to update the default version of the Google TF provider to 4.47, in order to match the latest options available for `google_bigtable_gc_policy` resources.