### PR TITLE
compute-vm module align attached device_name with disk name, default value of console attach

### DIFF
--- a/modules/compute-vm/main.tf
+++ b/modules/compute-vm/main.tf
@@ -138,7 +138,7 @@ resource "google_compute_instance" "default" {
     for_each = local.attached_disks_zonal
     iterator = config
     content {
-      device_name = config.value.device_name != null ? config.value.device_name : config.value.name
+      device_name = config.value.device_name != null ? config.value.device_name : "${var.name}-${config.value.name}"
       mode        = config.value.options.mode
       source = (
         config.value.source_type == "attach"
@@ -152,7 +152,7 @@ resource "google_compute_instance" "default" {
     for_each = local.attached_disks_regional
     iterator = config
     content {
-      device_name = config.value.device_name != null ? config.value.device_name : config.value.name
+      device_name = config.value.device_name != null ? config.value.device_name : "${var.name}-${config.value.name}"
       mode        = config.value.options.mode
       source = (
         config.value.source_type == "attach"


### PR DESCRIPTION
Align attached device_name with disk name, default value of console attach