### PR TITLE
Include cloudbuild API in project module

### DIFF
--- a/blueprints/data-solutions/data-platform-foundations/README.md
+++ b/blueprints/data-solutions/data-platform-foundations/README.md
@@ -219,7 +219,7 @@ module "data-platform" {
   prefix              = "myprefix"
 }
 
-# tftest modules=39 resources=286
+# tftest modules=39 resources=287
 ```
 
 ## Customizations

--- a/modules/project/service-accounts.tf
+++ b/modules/project/service-accounts.tf
@@ -75,7 +75,8 @@ locals {
     "gkehub.googleapis.com",
     "pubsub.googleapis.com",
     "secretmanager.googleapis.com",
-    "sqladmin.googleapis.com"
+    "sqladmin.googleapis.com",
+    "cloudbuild.googleapis.com",
   ]
   service_accounts_cmek_service_keys = distinct(flatten([
     for s in keys(var.service_encryption_key_ids) : [

--- a/tests/blueprints/apigee/bigquery-analytics/basic.yaml
+++ b/tests/blueprints/apigee/bigquery-analytics/basic.yaml
@@ -14,4 +14,4 @@
 
 counts:
   modules: 9
-  resources: 60
+  resources: 61

--- a/tests/blueprints/cloud_operations/asset_inventory_feed_remediation/test_plan.py
+++ b/tests/blueprints/cloud_operations/asset_inventory_feed_remediation/test_plan.py
@@ -16,4 +16,4 @@ def test_resources(e2e_plan_runner):
   "Test that plan works and the numbers of resources is as expected."
   modules, resources = e2e_plan_runner()
   assert len(modules) == 6
-  assert len(resources) == 18
+  assert len(resources) == 19

--- a/tests/blueprints/cloud_operations/scheduled_asset_inventory_export_bq/test_plan.py
+++ b/tests/blueprints/cloud_operations/scheduled_asset_inventory_export_bq/test_plan.py
@@ -16,4 +16,4 @@ def test_resources(e2e_plan_runner):
   "Test that plan works and the numbers of resources is as expected."
   modules, resources = e2e_plan_runner()
   assert len(modules) == 7
-  assert len(resources) == 29
+  assert len(resources) == 30

--- a/tests/blueprints/cloud_operations/unmanaged_instances_healthcheck/test_plan.py
+++ b/tests/blueprints/cloud_operations/unmanaged_instances_healthcheck/test_plan.py
@@ -16,4 +16,4 @@ def test_resources(e2e_plan_runner):
   "Test that plan works and the numbers of resources is as expected."
   modules, resources = e2e_plan_runner()
   assert len(modules) == 10
-  assert len(resources) == 31
+  assert len(resources) == 32

--- a/tests/blueprints/data_solutions/data_platform_foundations/test_plan.py
+++ b/tests/blueprints/data_solutions/data_platform_foundations/test_plan.py
@@ -22,4 +22,4 @@ def test_resources(e2e_plan_runner):
   "Test that plan works and the numbers of resources is as expected."
   modules, resources = e2e_plan_runner(FIXTURES_DIR)
   assert len(modules) == 38
-  assert len(resources) == 285
+  assert len(resources) == 286

--- a/tests/blueprints/gke/binauthz/test_plan.py
+++ b/tests/blueprints/gke/binauthz/test_plan.py
@@ -16,4 +16,4 @@ def test_resources(e2e_plan_runner):
   "Test that plan works and the numbers of resources is as expected."
   modules, resources = e2e_plan_runner()
   assert len(modules) == 13
-  assert len(resources) == 43
+  assert len(resources) == 44

--- a/tests/blueprints/networking/private_cloud_function_from_onprem/test_plan.py
+++ b/tests/blueprints/networking/private_cloud_function_from_onprem/test_plan.py
@@ -16,4 +16,4 @@ def test_resources(e2e_plan_runner):
   "Test that plan works and the numbers of resources is as expected."
   modules, resources = e2e_plan_runner()
   assert len(modules) == 10
-  assert len(resources) == 38
+  assert len(resources) == 39

--- a/tests/blueprints/serverless/api_gateway/test_plan.py
+++ b/tests/blueprints/serverless/api_gateway/test_plan.py
@@ -16,4 +16,4 @@ def test_resources(e2e_plan_runner):
   "Test that plan works and the numbers of resources is as expected."
   modules, resources = e2e_plan_runner()
   assert len(modules) == 7
-  assert len(resources) == 31
+  assert len(resources) == 32

--- a/tests/fast/stages/s00_bootstrap/simple.yaml
+++ b/tests/fast/stages/s00_bootstrap/simple.yaml
@@ -24,7 +24,7 @@ counts:
   google_project_iam_binding: 9
   google_project_iam_member: 1
   google_project_service: 29
-  google_project_service_identity: 2
+  google_project_service_identity: 3
   google_service_account: 3
   google_service_account_iam_binding: 3
   google_storage_bucket: 4


### PR DESCRIPTION
This PR enables the `cloudbuild.googleapis.com` on the project modules, which is needed in order to be able to have the cloudbuild service account created automatically on projects.