### PR TITLE
Add Autopilot Support for cluster_autoscaling Configuration in GKE Module

### DIFF
--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -146,9 +146,9 @@ resource "google_container_cluster" "cluster" {
         for_each = var.cluster_autoscaling.auto_provisioning_defaults != null ? [""] : []
         content {
           boot_disk_kms_key = var.cluster_autoscaling.auto_provisioning_defaults.boot_disk_kms_key != null ? var.cluster_autoscaling.auto_provisioning_defaults.boot_disk_kms_key : null
-          image_type = var.cluster_autoscaling.auto_provisioning_defaults.image_type != null ? var.cluster_autoscaling.auto_provisioning_defaults.image_type : null
-          oauth_scopes = var.cluster_autoscaling.auto_provisioning_defaults.oauth_scopes != null ? var.cluster_autoscaling.auto_provisioning_defaults.oauth_scopes : null
-          service_account = var.cluster_autoscaling.auto_provisioning_defaults.service_account != null ? var.cluster_autoscaling.auto_provisioning_defaults.service_account : null
+          image_type        = var.cluster_autoscaling.auto_provisioning_defaults.image_type != null ? var.cluster_autoscaling.auto_provisioning_defaults.image_type : null
+          oauth_scopes      = var.cluster_autoscaling.auto_provisioning_defaults.oauth_scopes != null ? var.cluster_autoscaling.auto_provisioning_defaults.oauth_scopes : null
+          service_account   = var.cluster_autoscaling.auto_provisioning_defaults.service_account != null ? var.cluster_autoscaling.auto_provisioning_defaults.service_account : null
         }
       }
       dynamic "resource_limits" {

--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -140,7 +140,17 @@ resource "google_container_cluster" "cluster" {
   dynamic "cluster_autoscaling" {
     for_each = var.cluster_autoscaling == null ? [] : [""]
     content {
-      enabled = true
+      enabled = var.enable_features.autopilot ? null : true
+
+      dynamic "auto_provisioning_defaults" {
+        for_each = var.cluster_autoscaling.auto_provisioning_defaults != null ? [""] : []
+        content {
+          boot_disk_kms_key = var.cluster_autoscaling.auto_provisioning_defaults.boot_disk_kms_key != null ? var.cluster_autoscaling.auto_provisioning_defaults.boot_disk_kms_key : null
+          image_type = var.cluster_autoscaling.auto_provisioning_defaults.image_type != null ? var.cluster_autoscaling.auto_provisioning_defaults.image_type : null
+          oauth_scopes = var.cluster_autoscaling.auto_provisioning_defaults.oauth_scopes != null ? var.cluster_autoscaling.auto_provisioning_defaults.oauth_scopes : null
+          service_account = var.cluster_autoscaling.auto_provisioning_defaults.service_account != null ? var.cluster_autoscaling.auto_provisioning_defaults.service_account : null
+        }
+      }
       dynamic "resource_limits" {
         for_each = var.cluster_autoscaling.cpu_limits != null ? [""] : []
         content {

--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -145,10 +145,10 @@ resource "google_container_cluster" "cluster" {
       dynamic "auto_provisioning_defaults" {
         for_each = var.cluster_autoscaling.auto_provisioning_defaults != null ? [""] : []
         content {
-          boot_disk_kms_key = var.cluster_autoscaling.auto_provisioning_defaults.boot_disk_kms_key != null ? var.cluster_autoscaling.auto_provisioning_defaults.boot_disk_kms_key : null
-          image_type        = var.cluster_autoscaling.auto_provisioning_defaults.image_type != null ? var.cluster_autoscaling.auto_provisioning_defaults.image_type : null
-          oauth_scopes      = var.cluster_autoscaling.auto_provisioning_defaults.oauth_scopes != null ? var.cluster_autoscaling.auto_provisioning_defaults.oauth_scopes : null
-          service_account   = var.cluster_autoscaling.auto_provisioning_defaults.service_account != null ? var.cluster_autoscaling.auto_provisioning_defaults.service_account : null
+          boot_disk_kms_key = var.cluster_autoscaling.auto_provisioning_defaults.boot_disk_kms_key
+          image_type        = var.cluster_autoscaling.auto_provisioning_defaults.image_type
+          oauth_scopes      = var.cluster_autoscaling.auto_provisioning_defaults.oauth_scopes
+          service_account   = var.cluster_autoscaling.auto_provisioning_defaults.service_account
         }
       }
       dynamic "resource_limits" {


### PR DESCRIPTION
Add support for the cluster_autoscaling configuration block in the gke-cluster module when autopilot = true.

Previously this would fail because the enabled parameter could not be set with autoscaling enabled. Changed to set enabled = null and added support for the auto_provisioning_defaults configuration, primarily to allow for specification of a non-default service account