### PR TITLE
Add documentation about JIT-ed service accounts

### DIFF
--- a/modules/project/README.md
+++ b/modules/project/README.md
@@ -139,9 +139,10 @@ module "project" {
 ```
 
 ### Service identities requiring manual IAM grants
-The module will create service identities at the time of the creation of the project instead creation of them at the time of first use. 
-This allows granting these service identities roles in other projects which is usually necessary in Shared VPC context.  
-You can grant those roles using following construct:
+
+The module will create service identities at project creation instead of creating of them at the time of first use. This allows granting these service identities roles in other projects, something which is usually necessary in a Shared VPC context.  
+
+You can grant roles to service identities using the following construct:
 
 ```hcl
 module "project" {

--- a/modules/project/README.md
+++ b/modules/project/README.md
@@ -138,6 +138,38 @@ module "project" {
 # tftest modules=1 resources=2
 ```
 
+### Service identities requiring manual IAM grants
+The module will create service identities at the time of the creation of the project instead creation of them at the time of first use. 
+This allows granting these service identities roles in other projects which is usually necessary in Shared VPC context.  
+You can grant those roles using following construct:
+
+```hcl
+module "project" {
+  source = "./fabric/modules/project"
+  name   = "project-example"
+  iam = {
+    "roles/apigee.serviceAgent" = [
+      "serviceAccount:${module.project.service_accounts.robots.apigee}"
+    ]
+  }
+}
+# tftest modules=1 resources=2
+```
+
+This table lists all affected services and roles that you need to grant to service identities
+
+| service | service identity | role |
+|---|---|---|
+| apigee.googleapis.com | apigee | roles/apigee.serviceAgent |
+| artifactregistry.googleapis.com | artifactregistry | roles/artifactregistry.serviceAgent |
+| cloudasset.googleapis.com | cloudasset | roles/cloudasset.serviceAgent |
+| cloudbuild.googleapis.com | cloudbuild | roles/cloudbuild.builds.builder |
+| gkehub.googleapis.com | fleet | roles/gkehub.serviceAgent |
+| multiclusteringress.googleapis.com | multicluster-ingress | roles/multiclusteringress.serviceAgent |
+| pubsub.googleapis.com | pubsub | roles/pubsub.serviceAgent |
+| sqladmin.googleapis.com | sqladmin | roles/cloudsql.serviceAgent |
+
+
 ## Shared VPC
 
 The module allows managing Shared VPC status for both hosts and service projects, and includes a simple way of assigning Shared VPC roles to service identities.

--- a/modules/project/service-accounts.tf
+++ b/modules/project/service-accounts.tf
@@ -70,16 +70,19 @@ locals {
       gke-mcs-importer = "${local.project.project_id}.svc.id.goog[gke-mcs/gke-mcs-importer]"
     }
   )
+  # JIT-ed service accounts are created without default roles granted, these needs to be assigned manually to them
+  # Roles can be found here: https://cloud.google.com/iam/docs/service-agents
+  # Remember to update "Service identities requiring manual IAM grants" in README.md when updating this list
   service_accounts_jit_services = [
-    "apigee.googleapis.com",
-    "artifactregistry.googleapis.com",
-    "cloudasset.googleapis.com",
-    "gkehub.googleapis.com",
-    "multiclusteringress.googleapis.com",
-    "pubsub.googleapis.com",
-    "secretmanager.googleapis.com",
-    "sqladmin.googleapis.com",
-    "cloudbuild.googleapis.com",
+    "apigee.googleapis.com",              # grant roles/apigee.serviceAgent to apigee
+    "artifactregistry.googleapis.com",    # grant roles/artifactregistry.serviceAgent to artifactregistry
+    "cloudasset.googleapis.com",          # grant roles/cloudasset.serviceAgent to cloudasset
+    "cloudbuild.googleapis.com",          # grant roles/cloudbuild.builds.builder to cloudbuild
+    "gkehub.googleapis.com",              # grant roles/gkehub.serviceAgent to fleet
+    "multiclusteringress.googleapis.com", # grant roles/multiclusteringress.serviceAgent to multicluster-ingress
+    "pubsub.googleapis.com",              # grant roles/pubsub.serviceAgent to pubsub
+    "secretmanager.googleapis.com",       # no grants needed
+    "sqladmin.googleapis.com",            # grant roles/cloudsql.serviceAgent to sqladmin (TODO: verify)
   ]
   service_accounts_cmek_service_keys = distinct(flatten([
     for s in keys(var.service_encryption_key_ids) : [


### PR DESCRIPTION
Provide explicit documentation when and which service identities require manual IAM grants.