### PR TITLE
Workaround to mitigate provider issue 9164

### DIFF
--- a/blueprints/data-solutions/data-playground/main.tf
+++ b/blueprints/data-solutions/data-playground/main.tf
@@ -217,6 +217,11 @@ resource "google_notebooks_instance" "playground" {
 
   service_account = module.service-account-notebook.email
 
+  # Remove once terraform-provider-google/issues/9164 is fixed
+  lifecycle {
+    ignore_changes = [disk_encryption, kms_key]
+  }
+
   #TODO Uncomment once terraform-provider-google/issues/9273 is fixed
   # tags = ["ssh"]
   depends_on = [


### PR DESCRIPTION
Implement a 'lifecycle' block on 'google_notebooks_instance' to mitigate [issue 9164 in the Google provider](https://github.com/hashicorp/terraform-provider-google/issues/9164)