### PR TITLE
Allow additive IAM grants by robots name

### DIFF
--- a/modules/project/README.md
+++ b/modules/project/README.md
@@ -138,6 +138,29 @@ module "project" {
 # tftest modules=1 resources=2
 ```
 
+### Using shortcodes for Service Identities in additive IAM
+Most Service Identities contains project number in their e-mail address and this prevents additive IAM to work, as these values are not known at moment of execution of `terraform plan` (its not an issue for authoritative IAM). To refer current project Service Identities you may use shortcodes for Service Identities similarly as for `service_identity_iam` when configuring Shared VPC.
+
+```hcl
+module "project" {
+  source = "./fabric/modules/project"
+  name   = "project-example"
+
+  services = [
+    "run.googleapis.com",
+    "container.googleapis.com",
+  ]
+
+  iam_additive = {
+    "roles/editor"                         = ["cloudservices"]
+    "roles/vpcaccess.user"                 = ["cloudrun"]
+    "roles/container.hostServiceAgentUser" = ["container-engine"]
+  }
+}
+# tftest modules=1 resources=6
+```
+
+
 ### Service identities requiring manual IAM grants
 
 The module will create service identities at project creation instead of creating of them at the time of first use. This allows granting these service identities roles in other projects, something which is usually necessary in a Shared VPC context.  

--- a/modules/project/iam.tf
+++ b/modules/project/iam.tf
@@ -47,7 +47,18 @@ locals {
   }
   iam_additive = {
     for pair in concat(local._iam_additive_pairs, local._iam_additive_member_pairs) :
-    "${pair.role}-${pair.member}" => pair
+    "${pair.role}-${pair.member}" => {
+      role = pair.role
+      member = (
+        pair.member == "cloudservices"
+        ? "serviceAccount:${local.service_account_cloud_services}"
+        : pair.member == "default-compute"
+        ? "serviceAccount:${local.service_accounts_default.compute}"
+        : pair.member == "default-gae"
+        ? "serviceAccount:${local.service_accounts_default.gae}"
+        : try("serviceAccount:${local.service_accounts_robots[pair.member]}", pair.member)
+      )
+    }
   }
 }
 

--- a/tests/modules/project/examples/iam-additive-members.yaml
+++ b/tests/modules/project/examples/iam-additive-members.yaml
@@ -17,17 +17,14 @@ values:
     project_id: project-example
   module.project.google_project_iam_member.additive["roles/editor-user:two@example.org"]:
     condition: []
-    member: user:two@example.org
     project: project-example
     role: roles/editor
   module.project.google_project_iam_member.additive["roles/owner-user:one@example.org"]:
     condition: []
-    member: user:one@example.org
     project: project-example
     role: roles/owner
   module.project.google_project_iam_member.additive["roles/owner-user:two@example.org"]:
     condition: []
-    member: user:two@example.org
     project: project-example
     role: roles/owner
 

--- a/tests/modules/project/examples/iam-additive.yaml
+++ b/tests/modules/project/examples/iam-additive.yaml
@@ -16,22 +16,18 @@ values:
   module.project.google_project.project[0]: {}
   module.project.google_project_iam_member.additive["roles/owner-group:three@example.org"]:
     condition: []
-    member: group:three@example.org
     project: project-example
     role: roles/owner
   module.project.google_project_iam_member.additive["roles/storage.objectAdmin-group:two@example.org"]:
     condition: []
-    member: group:two@example.org
     project: project-example
     role: roles/storage.objectAdmin
   module.project.google_project_iam_member.additive["roles/viewer-group:one@example.org"]:
     condition: []
-    member: group:one@example.org
     project: project-example
     role: roles/viewer
   module.project.google_project_iam_member.additive["roles/viewer-group:two@xample.org"]:
     condition: []
-    member: group:two@xample.org
     project: project-example
     role: roles/viewer
 


### PR DESCRIPTION
Allow robots names in additive IAM grants.

Regrettably all member names will be known after apply, hence changes in the tests.