### PR TITLE
Allow to not use any health check

### DIFF
--- a/modules/net-ilb-l7/backend-service.tf
+++ b/modules/net-ilb-l7/backend-service.tf
@@ -46,7 +46,7 @@ resource "google_compute_region_backend_service" "default" {
   description                     = var.description
   affinity_cookie_ttl_sec         = each.value.affinity_cookie_ttl_sec
   connection_draining_timeout_sec = each.value.connection_draining_timeout_sec
-  health_checks = [
+  health_checks = length(each.value.health_checks) == 0 ? null : [
     for k in each.value.health_checks : lookup(local.hc_ids, k, k)
   ] # not for internet / serverless NEGs
   locality_lb_policy    = each.value.locality_lb_policy


### PR DESCRIPTION
Internet and serverless NEGs (Cloud Run) don't use them and it's an error to add one in their backend services.