### PR TITLE
Don't define nor use health checks with SNEGs

### DIFF
--- a/modules/net-ilb-l7/README.md
+++ b/modules/net-ilb-l7/README.md
@@ -326,8 +326,10 @@ module "ilb-l7" {
         group          = "my-neg"
         max_rate       = { per_endpoint = 1 }
       }]
+      health_checks = []
     }
   }
+  health_check_configs = {}
   neg_configs = {
     my-neg = {
       cloudrun = {
@@ -343,7 +345,7 @@ module "ilb-l7" {
     subnetwork = var.subnet.self_link
   }
 }
-# tftest modules=1 resources=6
+# tftest modules=1 resources=5
 ```
 
 ### URL Map


### PR DESCRIPTION
SNEGs don't use health checks and it's an error to add one in their backend services. 'terraform plan' doesn't detect it, only 'apply'.