### PR TITLE
adding meshconfig.googleapis.com to JIT list.

### DIFF
--- a/modules/gke-hub/README.md
+++ b/modules/gke-hub/README.md
@@ -314,7 +314,7 @@ module "hub" {
   ]
 }
 
-# tftest modules=8 resources=31
+# tftest modules=8 resources=32
 ```
 <!-- BEGIN TFDOC -->
 

--- a/modules/project/README.md
+++ b/modules/project/README.md
@@ -189,6 +189,7 @@ This table lists all affected services and roles that you need to grant to servi
 | cloudasset.googleapis.com | cloudasset | roles/cloudasset.serviceAgent |
 | cloudbuild.googleapis.com | cloudbuild | roles/cloudbuild.builds.builder |
 | gkehub.googleapis.com | fleet | roles/gkehub.serviceAgent |
+| meshconfig.googleapis.com | servicemesh | roles/anthosservicemesh.serviceAgent |
 | multiclusteringress.googleapis.com | multicluster-ingress | roles/multiclusteringress.serviceAgent |
 | pubsub.googleapis.com | pubsub | roles/pubsub.serviceAgent |
 | sqladmin.googleapis.com | sqladmin | roles/cloudsql.serviceAgent |

--- a/modules/project/service-accounts.tf
+++ b/modules/project/service-accounts.tf
@@ -50,6 +50,7 @@ locals {
     notebooks                = "service-%s@gcp-sa-notebooks"
     pubsub                   = "service-%s@gcp-sa-pubsub"
     secretmanager            = "service-%s@gcp-sa-secretmanager"
+    servicemesh              = "service-%s@gcp-sa-servicemesh"
     sql                      = "service-%s@gcp-sa-cloud-sql"
     sqladmin                 = "service-%s@gcp-sa-cloud-sql"
     storage                  = "service-%s@gs-project-accounts"
@@ -81,6 +82,7 @@ locals {
     "gkehub.googleapis.com",              # grant roles/gkehub.serviceAgent to fleet
     "multiclusteringress.googleapis.com", # grant roles/multiclusteringress.serviceAgent to multicluster-ingress
     "pubsub.googleapis.com",              # grant roles/pubsub.serviceAgent to pubsub
+    "meshconfig.googleapis.com",         # grant meshconfig.googleapis.com to meshconfig
     "secretmanager.googleapis.com",       # no grants needed
     "sqladmin.googleapis.com",            # grant roles/cloudsql.serviceAgent to sqladmin (TODO: verify)
   ]

--- a/modules/project/service-accounts.tf
+++ b/modules/project/service-accounts.tf
@@ -82,7 +82,7 @@ locals {
     "gkehub.googleapis.com",              # grant roles/gkehub.serviceAgent to fleet
     "multiclusteringress.googleapis.com", # grant roles/multiclusteringress.serviceAgent to multicluster-ingress
     "pubsub.googleapis.com",              # grant roles/pubsub.serviceAgent to pubsub
-    "meshconfig.googleapis.com",         # grant meshconfig.googleapis.com to meshconfig
+    "meshconfig.googleapis.com",          # grant roles/anthosservicemesh.serviceAgent to meshconfig
     "secretmanager.googleapis.com",       # no grants needed
     "sqladmin.googleapis.com",            # grant roles/cloudsql.serviceAgent to sqladmin (TODO: verify)
   ]


### PR DESCRIPTION
To provision ASM managed you [need to give permission to ASM service accounts](https://cloud.google.com/service-mesh/docs/managed/provision-managed-anthos-service-mesh#register_clusters_to_a_fleet)  on the project. Adding it to JIT list.