### PR TITLE
Fix Workload Identity for ASM in GKE hub module

### DIFF
--- a/modules/gke-hub/main.tf
+++ b/modules/gke-hub/main.tf
@@ -41,12 +41,12 @@ resource "google_gke_hub_membership" "default" {
   membership_id = each.key
   endpoint {
     gke_cluster {
-      resource_link = each.value
+      resource_link = "//container.googleapis.com/${each.value}"
     }
   }
   dynamic "authority" {
     for_each = (
-      contains(var.workload_identity_clusters, each.key) ? {} : { 1 = 1 }
+      contains(var.workload_identity_clusters, each.key) ? { 1 = 1 } : {}
     )
     content {
       issuer = "https://container.googleapis.com/v1/${var.clusters[each.key]}"

--- a/tests/modules/gke_hub/test_plan.py
+++ b/tests/modules/gke_hub/test_plan.py
@@ -74,7 +74,7 @@ def test_configmanagement_setup(resources):
     membership_key = f'module.hub.google_gke_hub_membership.default["{cluster}"]'
     membership = resources[membership_key]
     link = membership['endpoint'][0]['gke_cluster'][0]['resource_link']
-    assert link == f'projects/myproject/locations/europe-west1-b/clusters/{cluster}'
+    assert link == f'//container.googleapis.com/projects/myproject/locations/europe-west1-b/clusters/{cluster}'
 
     fm_key = f'module.hub.google_gke_hub_feature_membership.default["{cluster}"]'
     fm = resources[fm_key]


### PR DESCRIPTION
Two fixes:

- the cluster [should be in the form of  "//container.googleapis.com/CLUSTER_RESOURCE_NAME" ](https://cloud.google.com/anthos/fleet-management/docs/register/gke?hl=it#register_your_cluster) - I don't think this is particularly relevant, but it's such a small change
- the condition on when to create the authority seemed to be inverted (it should be created if contains is true, but written that way I think it doesn't create it when contains is true)