### PR TITLE
Fix compute-vm:CloudKMS test for provider>=4.54.0

### DIFF
--- a/blueprints/apigee/bigquery-analytics/versions.tf
+++ b/blueprints/apigee/bigquery-analytics/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/blueprints/apigee/network-patterns/nb-glb-psc-neg-sb-psc-ilbl7-hybrid-neg/versions.tf
+++ b/blueprints/apigee/network-patterns/nb-glb-psc-neg-sb-psc-ilbl7-hybrid-neg/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/blueprints/cloud-operations/adfs/versions.tf
+++ b/blueprints/cloud-operations/adfs/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/blueprints/cloud-operations/asset-inventory-feed-remediation/versions.tf
+++ b/blueprints/cloud-operations/asset-inventory-feed-remediation/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/blueprints/cloud-operations/dns-fine-grained-iam/versions.tf
+++ b/blueprints/cloud-operations/dns-fine-grained-iam/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/blueprints/cloud-operations/dns-shared-vpc/versions.tf
+++ b/blueprints/cloud-operations/dns-shared-vpc/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/blueprints/cloud-operations/iam-delegated-role-grants/versions.tf
+++ b/blueprints/cloud-operations/iam-delegated-role-grants/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/blueprints/cloud-operations/onprem-sa-key-management/versions.tf
+++ b/blueprints/cloud-operations/onprem-sa-key-management/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/blueprints/cloud-operations/packer-image-builder/versions.tf
+++ b/blueprints/cloud-operations/packer-image-builder/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/blueprints/cloud-operations/quota-monitoring/versions.tf
+++ b/blueprints/cloud-operations/quota-monitoring/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/blueprints/cloud-operations/scheduled-asset-inventory-export-bq/versions.tf
+++ b/blueprints/cloud-operations/scheduled-asset-inventory-export-bq/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/blueprints/data-solutions/cmek-via-centralized-kms/versions.tf
+++ b/blueprints/data-solutions/cmek-via-centralized-kms/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/blueprints/data-solutions/data-playground/versions.tf
+++ b/blueprints/data-solutions/data-playground/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/blueprints/data-solutions/gcs-to-bq-with-least-privileges/versions.tf
+++ b/blueprints/data-solutions/gcs-to-bq-with-least-privileges/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/blueprints/factories/net-vpc-firewall-yaml/versions.tf
+++ b/blueprints/factories/net-vpc-firewall-yaml/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/blueprints/networking/__need_fixing/nginx-reverse-proxy-cluster/versions.tf
+++ b/blueprints/networking/__need_fixing/nginx-reverse-proxy-cluster/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/blueprints/networking/__need_fixing/onprem-google-access-dns/versions.tf
+++ b/blueprints/networking/__need_fixing/onprem-google-access-dns/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/blueprints/networking/decentralized-firewall/versions.tf
+++ b/blueprints/networking/decentralized-firewall/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/blueprints/networking/filtering-proxy-psc/versions.tf
+++ b/blueprints/networking/filtering-proxy-psc/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/blueprints/networking/filtering-proxy/versions.tf
+++ b/blueprints/networking/filtering-proxy/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/blueprints/networking/hub-and-spoke-peering/versions.tf
+++ b/blueprints/networking/hub-and-spoke-peering/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/blueprints/networking/hub-and-spoke-vpn/versions.tf
+++ b/blueprints/networking/hub-and-spoke-vpn/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/blueprints/networking/ilb-next-hop/versions.tf
+++ b/blueprints/networking/ilb-next-hop/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/blueprints/networking/private-cloud-function-from-onprem/versions.tf
+++ b/blueprints/networking/private-cloud-function-from-onprem/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/blueprints/networking/shared-vpc-gke/versions.tf
+++ b/blueprints/networking/shared-vpc-gke/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/blueprints/third-party-solutions/openshift/tf/versions.tf
+++ b/blueprints/third-party-solutions/openshift/tf/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/default-versions.tf
+++ b/default-versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/__experimental/net-neg/versions.tf
+++ b/modules/__experimental/net-neg/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/api-gateway/versions.tf
+++ b/modules/api-gateway/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/apigee/versions.tf
+++ b/modules/apigee/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/artifact-registry/versions.tf
+++ b/modules/artifact-registry/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/bigquery-dataset/versions.tf
+++ b/modules/bigquery-dataset/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/bigtable-instance/versions.tf
+++ b/modules/bigtable-instance/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/billing-budget/versions.tf
+++ b/modules/billing-budget/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/binauthz/versions.tf
+++ b/modules/binauthz/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/__need_fixing/onprem/versions.tf
+++ b/modules/cloud-config-container/__need_fixing/onprem/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/coredns/versions.tf
+++ b/modules/cloud-config-container/coredns/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/cos-generic-metadata/versions.tf
+++ b/modules/cloud-config-container/cos-generic-metadata/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/envoy-traffic-director/versions.tf
+++ b/modules/cloud-config-container/envoy-traffic-director/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/mysql/versions.tf
+++ b/modules/cloud-config-container/mysql/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/nginx-tls/versions.tf
+++ b/modules/cloud-config-container/nginx-tls/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/nginx/versions.tf
+++ b/modules/cloud-config-container/nginx/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/simple-nva/versions.tf
+++ b/modules/cloud-config-container/simple-nva/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/squid/versions.tf
+++ b/modules/cloud-config-container/squid/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/cloud-function/versions.tf
+++ b/modules/cloud-function/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/cloud-identity-group/versions.tf
+++ b/modules/cloud-identity-group/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/cloud-run/versions.tf
+++ b/modules/cloud-run/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/cloudsql-instance/versions.tf
+++ b/modules/cloudsql-instance/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/compute-mig/versions.tf
+++ b/modules/compute-mig/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/compute-vm/versions.tf
+++ b/modules/compute-vm/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/container-registry/versions.tf
+++ b/modules/container-registry/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/data-catalog-policy-tag/versions.tf
+++ b/modules/data-catalog-policy-tag/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/datafusion/versions.tf
+++ b/modules/datafusion/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/dataproc/versions.tf
+++ b/modules/dataproc/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/dns/versions.tf
+++ b/modules/dns/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/endpoints/versions.tf
+++ b/modules/endpoints/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/folder/versions.tf
+++ b/modules/folder/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/gcs/versions.tf
+++ b/modules/gcs/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/gke-cluster/versions.tf
+++ b/modules/gke-cluster/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/gke-hub/versions.tf
+++ b/modules/gke-hub/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/gke-nodepool/versions.tf
+++ b/modules/gke-nodepool/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/iam-service-account/versions.tf
+++ b/modules/iam-service-account/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/kms/versions.tf
+++ b/modules/kms/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/logging-bucket/versions.tf
+++ b/modules/logging-bucket/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/net-address/versions.tf
+++ b/modules/net-address/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/net-cloudnat/versions.tf
+++ b/modules/net-cloudnat/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/net-glb/versions.tf
+++ b/modules/net-glb/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/net-ilb-l7/versions.tf
+++ b/modules/net-ilb-l7/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/net-ilb/versions.tf
+++ b/modules/net-ilb/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/net-interconnect-attachment-direct/versions.tf
+++ b/modules/net-interconnect-attachment-direct/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/net-vpc-firewall/versions.tf
+++ b/modules/net-vpc-firewall/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/net-vpc-peering/versions.tf
+++ b/modules/net-vpc-peering/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/net-vpc/versions.tf
+++ b/modules/net-vpc/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/net-vpn-dynamic/versions.tf
+++ b/modules/net-vpn-dynamic/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/net-vpn-ha/versions.tf
+++ b/modules/net-vpn-ha/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/net-vpn-static/versions.tf
+++ b/modules/net-vpn-static/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/organization/versions.tf
+++ b/modules/organization/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/project/versions.tf
+++ b/modules/project/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/projects-data-source/versions.tf
+++ b/modules/projects-data-source/versions.tf
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/pubsub/versions.tf
+++ b/modules/pubsub/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/secret-manager/versions.tf
+++ b/modules/secret-manager/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/service-directory/versions.tf
+++ b/modules/service-directory/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/source-repository/versions.tf
+++ b/modules/source-repository/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/modules/vpc-sc/versions.tf
+++ b/modules/vpc-sc/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.50.0" # tftest
+      version = ">= 4.55.0" # tftest
     }
   }
 }

--- a/tests/modules/compute_vm/examples/cmek.yaml
+++ b/tests/modules/compute_vm/examples/cmek.yaml
@@ -18,6 +18,7 @@ values:
     - kms_key_self_link: kms_key_self_link
       kms_key_service_account: null
       raw_key: null
+      rsa_encrypted_key: null
     labels:
       disk_name: attached-disk
       disk_type: pd-balanced


### PR DESCRIPTION
* TF provider >= 4.54.0 now returns `rsa_encrypted_key` for `google_compute_disk.disks["attached-disk"]` (see hashicorp/terraform-provider-google#4448)
* Add this field to expected model to fix test assertion failure
* Update required TF provider to 4.55.0 (latest) since the assertion will now fail with <4.54.0, which do not return `rsa_encrypted_key`
  * Updated the whole repo on advice from @ludoo

Please sanity-check me that bumping the TF provider version is the right thing to do, and that I have done it appropriately.

The exact test in question is `tests/examples/test_plan.py::test_example[modules/compute-vm:Disk encryption with Cloud KMS]`. Aassertion copied below, for reference - line-breaks added for clarity:
```
AssertionError: disk_encryption_key at module.kms-vm-example.google_compute_disk.disks["attached-disk"] failed.

Got
`[{'kms_key_self_link': 'kms_key_self_link', 'kms_key_service_account': None, 'raw_key': None, 'rsa_encrypted_key': None}]`,

expected
`[{'kms_key_self_link': 'kms_key_self_link', 'kms_key_service_account': None, 'raw_key': None}]`
```