### PR TITLE
Fix issue with GKE cluster notifications topic & static output for pubsub module

### DIFF
--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -406,9 +406,11 @@ resource "google_compute_network_peering_routes_config" "gke_master" {
 
 resource "google_pubsub_topic" "notifications" {
   count = (
-    try(var.enable_features.upgrade_notifications.topic_id, null) == null ? 0 : 1
+    try(var.enable_features.upgrade_notifications, null) != null &&
+    try(var.enable_features.upgrade_notifications.topic_id, null) == null ? 1 : 0
   )
-  name = "gke-pubsub-notifications"
+  project = var.project_id
+  name    = "gke-pubsub-notifications"
   labels = {
     content = "gke-notifications"
   }

--- a/modules/pubsub/README.md
+++ b/modules/pubsub/README.md
@@ -169,10 +169,10 @@ module "pubsub" {
 | name | description | sensitive |
 |---|---|:---:|
 | [id](outputs.tf#L17) | Topic id. |  |
-| [schema](outputs.tf#L25) | Schema resource. |  |
-| [schema_id](outputs.tf#L30) | Schema resource id. |  |
-| [subscription_id](outputs.tf#L35) | Subscription ids. |  |
-| [subscriptions](outputs.tf#L45) | Subscription resources. |  |
-| [topic](outputs.tf#L53) | Topic resource. |  |
+| [schema](outputs.tf#L26) | Schema resource. |  |
+| [schema_id](outputs.tf#L31) | Schema resource id. |  |
+| [subscription_id](outputs.tf#L36) | Subscription ids. |  |
+| [subscriptions](outputs.tf#L46) | Subscription resources. |  |
+| [topic](outputs.tf#L54) | Topic resource. |  |
 
 <!-- END TFDOC -->

--- a/modules/pubsub/main.tf
+++ b/modules/pubsub/main.tf
@@ -33,6 +33,7 @@ locals {
       options = try(v.options, v, null) == null ? var.defaults : v.options
     }
   }
+  topic_id_static = "projects/${var.project_id}/topics/${var.name}"
 }
 
 resource "google_pubsub_schema" "default" {

--- a/modules/pubsub/outputs.tf
+++ b/modules/pubsub/outputs.tf
@@ -16,8 +16,9 @@
 
 output "id" {
   description = "Topic id."
-  value       = google_pubsub_topic.default.id
+  value       = local.topic_id_static
   depends_on = [
+    google_pubsub_topic.default,
     google_pubsub_topic_iam_binding.default
   ]
 }


### PR DESCRIPTION
- Fix issue with GKE cluster notifications topic creation logic.
- Output static topic ID from `pubsub` module.