### PR TITLE
Manage billing.creator role authoritatively in FAST bootstrap.

### DIFF
--- a/fast/stages/0-bootstrap/organization.tf
+++ b/fast/stages/0-bootstrap/organization.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ locals {
   # organization authoritative IAM bindings, in an easy to edit format before
   # they are combined with var.iam a bit further in locals
   _iam = {
+    "roles/billing.creator" = []
     "roles/browser" = [
       "domain:${var.organization.domain}"
     ]

--- a/tests/fast/stages/s0_bootstrap/simple.yaml
+++ b/tests/fast/stages/s0_bootstrap/simple.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@ counts:
   google_bigquery_dataset: 1
   google_bigquery_default_service_account: 3
   google_logging_organization_sink: 2
-  google_organization_iam_binding: 19
+  google_organization_iam_binding: 20
   google_organization_iam_custom_role: 3
   google_organization_iam_member: 16
   google_project: 3


### PR DESCRIPTION
By default new orgs grant billing.creator and
resourcemanager.projectCreator to the whole domain[1]. This PR makes FAST remove the former binding during the bootstrap (the latter is already managed by FAST).

Fixes #1220

[1] https://cloud.google.com/resource-manager/docs/default-access-control