### PR TITLE
Add aiplatform robot service account

### DIFF
--- a/modules/project/service-accounts.tf
+++ b/modules/project/service-accounts.tf
@@ -25,6 +25,7 @@ locals {
     "dataflow" : ["dataflow", "compute"]
   }
   _service_accounts_robot_services = {
+    aiplatform        = "service-%s@gcp-sa-aiplatform"
     apigee            = "service-%s@gcp-sa-apigee"
     artifactregistry  = "service-%s@gcp-sa-artifactregistry"
     bq                = "bq-%s@bigquery-encryption"


### PR DESCRIPTION
In this PR we add the aiplatform robot service account to the `Project` module. This is needed to support CMEK encryption on aiplatform components.