### PR TITLE
Allow overriding name in net-vpc subnet factory

### DIFF
--- a/modules/net-vpc/README.md
+++ b/modules/net-vpc/README.md
@@ -306,7 +306,7 @@ module "vpc" {
 
 ### Subnet Factory
 
-The `net-vpc` module includes a subnet factory (see [Resource Factories](../../blueprints/factories/)) for the massive creation of subnets leveraging one configuration file per subnet. The factory also supports proxy-only and PSC subnets via the `purpose` attribute.
+The `net-vpc` module includes a subnet factory (see [Resource Factories](../../blueprints/factories/)) for the massive creation of subnets leveraging one configuration file per subnet. The factory also supports proxy-only and PSC subnets via the `purpose` attribute. The `name` attribute is optional and defaults to the file name, allowing to use the same name for subnets in different regions.
 
 ```hcl
 module "vpc" {
@@ -315,13 +315,21 @@ module "vpc" {
   name        = "my-network"
   data_folder = "config/subnets"
 }
-# tftest modules=1 resources=6 files=subnet-simple,subnet-detailed,subnet-proxy,subnet-psc inventory=factory.yaml
+# tftest modules=1 resources=7 files=subnet-simple,subnet-simple-2,subnet-detailed,subnet-proxy,subnet-psc inventory=factory.yaml
 ```
 
 ```yaml
 # tftest-file id=subnet-simple path=config/subnets/subnet-simple.yaml
+name: simple
 region: europe-west4
 ip_cidr_range: 10.0.1.0/24
+```
+
+```yaml
+# tftest-file id=subnet-simple-2 path=config/subnets/subnet-simple-2.yaml
+name: simple
+region: europe-west8
+ip_cidr_range: 10.0.2.0/24
 ```
 
 ```yaml

--- a/modules/net-vpc/subnets.tf
+++ b/modules/net-vpc/subnets.tf
@@ -22,8 +22,8 @@ locals {
     trimsuffix(basename(f), ".yaml") => yamldecode(file("${var.data_folder}/${f}"))
   }
   _factory_subnets = {
-    for k, v in local._factory_data : "${v.region}/${k}" => {
-      name                  = k
+    for k, v in local._factory_data : "${v.region}/${try(v.name, k)}" => {
+      name                  = try(v.name, k)
       ip_cidr_range         = v.ip_cidr_range
       region                = v.region
       description           = try(v.description, null)

--- a/tests/modules/net_vpc/examples/factory.yaml
+++ b/tests/modules/net_vpc/examples/factory.yaml
@@ -34,14 +34,24 @@ values:
     secondary_ip_range:
     - ip_cidr_range: 192.168.0.0/24
       range_name: secondary-range-a
-  module.vpc.google_compute_subnetwork.subnetwork["europe-west4/subnet-simple"]:
+  module.vpc.google_compute_subnetwork.subnetwork["europe-west4/simple"]:
     description: Terraform-managed.
     ip_cidr_range: 10.0.1.0/24
     log_config: []
-    name: subnet-simple
+    name: simple
     private_ip_google_access: true
     project: my-project
     region: europe-west4
+    role: null
+    secondary_ip_range: []
+  module.vpc.google_compute_subnetwork.subnetwork["europe-west8/simple"]:
+    description: Terraform-managed.
+    ip_cidr_range: 10.0.2.0/24
+    log_config: []
+    name: simple
+    private_ip_google_access: true
+    project: my-project
+    region: europe-west8
     role: null
     secondary_ip_range: []
   module.vpc.google_compute_subnetwork_iam_binding.binding["europe-west1/subnet-detailed.roles/compute.networkUser"]:
@@ -65,5 +75,5 @@ values:
 
 counts:
   google_compute_network: 1
-  google_compute_subnetwork: 4
+  google_compute_subnetwork: 5
   google_compute_subnetwork_iam_binding: 1


### PR DESCRIPTION
This allows using the same name for subnets in different regions, while still using the factory file name as a default if no subnet name has been explicitly set.