### PR TITLE
Improvements to NCC-RA spoke module.

### DIFF
--- a/modules/ncc-spoke-ra/README.md
+++ b/modules/ncc-spoke-ra/README.md
@@ -23,8 +23,8 @@ module "spoke-ra" {
   ]
   router_config = {
     asn           = 65000
-    ip_interface1 = "10.0.0.14"
-    ip_interface2 = "10.0.0.15"
+    ip_interface0 = "10.0.0.14"
+    ip_interface1 = "10.0.0.15"
     peer_asn      = 65001
   }
   vpc_config = {
@@ -52,8 +52,8 @@ module "spoke-ra-a" {
   ]
   router_config = {
     asn           = 65000
-    ip_interface1 = "10.0.0.14"
-    ip_interface2 = "10.0.0.15"
+    ip_interface0 = "10.0.0.14"
+    ip_interface1 = "10.0.0.15"
     peer_asn      = 65001
   }
   vpc_config = {
@@ -76,8 +76,8 @@ module "spoke-ra-b" {
   ]
   router_config = {
     asn           = 65000
-    ip_interface1 = "10.0.0.14"
-    ip_interface2 = "10.0.0.15"
+    ip_interface0 = "10.0.0.14"
+    ip_interface1 = "10.0.0.15"
     peer_asn      = 65002
   }
   vpc_config = {
@@ -115,8 +115,8 @@ module "spoke-ra" {
         "10.10.0.0/24" = "peered-vpc"
       }
     }
-    ip_interface1 = "10.0.0.14"
-    ip_interface2 = "10.0.0.15"
+    ip_interface0 = "10.0.0.14"
+    ip_interface1 = "10.0.0.15"
     peer_asn      = 65001
   }
   vpc_config = {
@@ -137,8 +137,8 @@ module "spoke-ra" {
 | [project_id](variables.tf#L37) | The ID of the project where the NCC hub & spokes will be created. | <code>string</code> | ✓ |  |
 | [region](variables.tf#L42) | Region where the spoke is located. | <code>string</code> | ✓ |  |
 | [router_appliances](variables.tf#L47) | List of router appliances this spoke is associated with. | <code title="list&#40;object&#40;&#123;&#10;  internal_ip  &#61; string&#10;  vm_self_link &#61; string&#10;&#125;&#41;&#41;">list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> | ✓ |  |
-| [router_config](variables.tf#L55) | Configuration of the Cloud Router. | <code title="object&#40;&#123;&#10;  asn &#61; number&#10;  custom_advertise &#61; optional&#40;object&#40;&#123;&#10;    all_subnets &#61; bool&#10;    ip_ranges   &#61; map&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;  ip_interface1 &#61; string&#10;  ip_interface2 &#61; string&#10;  keepalive     &#61; optional&#40;number&#41;&#10;  peer_asn      &#61; number&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
-| [vpc_config](variables.tf#L70) | Network and subnetwork for the CR interfaces. | <code title="object&#40;&#123;&#10;  network_name     &#61; string&#10;  subnet_self_link &#61; string&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
+| [router_config](variables.tf#L55) | Configuration of the Cloud Router. | <code title="object&#40;&#123;&#10;  asn &#61; number&#10;  custom_advertise &#61; optional&#40;object&#40;&#123;&#10;    all_subnets &#61; bool&#10;    ip_ranges   &#61; map&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;  ip_interface0   &#61; string&#10;  ip_interface1   &#61; string&#10;  keepalive       &#61; optional&#40;number&#41;&#10;  peer_asn        &#61; number&#10;  routes_priority &#61; optional&#40;number, 100&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
+| [vpc_config](variables.tf#L71) | Network and subnetwork for the CR interfaces. | <code title="object&#40;&#123;&#10;  network_name     &#61; string&#10;  subnet_self_link &#61; string&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
 | [data_transfer](variables.tf#L17) | Site-to-site data transfer feature, available only in some regions. | <code>bool</code> |  | <code>false</code> |
 
 ## Outputs

--- a/modules/ncc-spoke-ra/main.tf
+++ b/modules/ncc-spoke-ra/main.tf
@@ -75,48 +75,50 @@ resource "google_compute_router" "cr" {
   }
 }
 
-resource "google_compute_router_interface" "intf1" {
+resource "google_compute_router_interface" "intf_0" {
   project            = var.project_id
-  name               = "intf1"
+  name               = "${google_compute_router.cr.name}-intf0"
   router             = google_compute_router.cr.name
   region             = var.region
   subnetwork         = var.vpc_config.subnet_self_link
-  private_ip_address = var.router_config.ip_interface1
+  private_ip_address = var.router_config.ip_interface0
 }
 
-resource "google_compute_router_interface" "intf2" {
+resource "google_compute_router_interface" "intf_1" {
   project             = var.project_id
-  name                = "intf2"
+  name                = "${google_compute_router.cr.name}-intf1"
   router              = google_compute_router.cr.name
   region              = var.region
   subnetwork          = var.vpc_config.subnet_self_link
-  private_ip_address  = var.router_config.ip_interface2
-  redundant_interface = google_compute_router_interface.intf1.name
+  private_ip_address  = var.router_config.ip_interface1
+  redundant_interface = google_compute_router_interface.intf_0.name
 }
 
-resource "google_compute_router_peer" "peer1" {
+resource "google_compute_router_peer" "peer_0" {
   for_each = {
     for idx, entry in local.spoke_vms : idx => entry
   }
   project                   = var.project_id
-  name                      = "peer1-${each.value.vm_name}"
+  name                      = "${google_compute_router.cr.name}-${each.value.vm_name}-peer1"
   router                    = google_compute_router.cr.name
   region                    = var.region
-  interface                 = google_compute_router_interface.intf1.name
+  advertised_route_priority = var.router_config.routes_priority
+  interface                 = google_compute_router_interface.intf_0.name
   peer_asn                  = var.router_config.peer_asn
   peer_ip_address           = each.value.ip
   router_appliance_instance = each.value.vm
 }
 
-resource "google_compute_router_peer" "peer2" {
+resource "google_compute_router_peer" "peer_1" {
   for_each = {
     for idx, entry in local.spoke_vms : idx => entry
   }
   project                   = var.project_id
-  name                      = "peer2-${each.value.vm_name}"
+  name                      = "${google_compute_router.cr.name}-${each.value.vm_name}-peer2"
   router                    = google_compute_router.cr.name
   region                    = var.region
-  interface                 = google_compute_router_interface.intf2.name
+  advertised_route_priority = var.router_config.routes_priority
+  interface                 = google_compute_router_interface.intf_1.name
   peer_asn                  = var.router_config.peer_asn
   peer_ip_address           = each.value.ip
   router_appliance_instance = each.value.vm

--- a/modules/ncc-spoke-ra/variables.tf
+++ b/modules/ncc-spoke-ra/variables.tf
@@ -60,10 +60,11 @@ variable "router_config" {
       all_subnets = bool
       ip_ranges   = map(string)
     }))
-    ip_interface1 = string
-    ip_interface2 = string
-    keepalive     = optional(number)
-    peer_asn      = number
+    ip_interface0   = string
+    ip_interface1   = string
+    keepalive       = optional(number)
+    peer_asn        = number
+    routes_priority = optional(number, 100)
   })
 }
 


### PR DESCRIPTION
* Users can now set route priorities
* Prefixes all GCP names with a prefix so the module can be instantiated multiple times in the same project
* Calls the variables and add suffixes 0 and 1 (instead of 1 and 2) to interfaces and peers to reflect the GCP nomenclature