### PR TITLE
simple-nva: add ability to parse BGP configs as strings.

### DIFF
--- a/modules/cloud-config-container/simple-nva/README.md
+++ b/modules/cloud-config-container/simple-nva/README.md
@@ -144,7 +144,7 @@ module "vm" {
 | [cloud_config](variables.tf#L17) | Cloud config template path. If null default will be used. | <code>string</code> |  | <code>null</code> |
 | [enable_health_checks](variables.tf#L23) | Configures routing to enable responses to health check probes. | <code>bool</code> |  | <code>false</code> |
 | [files](variables.tf#L29) | Map of extra files to create on the instance, path as key. Owner and permissions will use defaults if null. | <code title="map&#40;object&#40;&#123;&#10;  content     &#61; string&#10;  owner       &#61; string&#10;  permissions &#61; string&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [frr_config](variables.tf#L39) | FRR configuration for container running on the NVA. | <code title="object&#40;&#123;&#10;  daemons_enabled &#61; optional&#40;list&#40;string&#41;&#41;&#10;  config_file     &#61; string&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [frr_config](variables.tf#L39) | FRR configuration for container running on the NVA. | <code title="object&#40;&#123;&#10;  config          &#61; string&#10;  daemons_enabled &#61; optional&#40;list&#40;string&#41;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
 | [optional_run_cmds](variables.tf#L84) | Optional Cloud Init run commands to execute. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
 
 ## Outputs

--- a/modules/cloud-config-container/simple-nva/README.md
+++ b/modules/cloud-config-container/simple-nva/README.md
@@ -144,7 +144,7 @@ module "vm" {
 | [cloud_config](variables.tf#L17) | Cloud config template path. If null default will be used. | <code>string</code> |  | <code>null</code> |
 | [enable_health_checks](variables.tf#L23) | Configures routing to enable responses to health check probes. | <code>bool</code> |  | <code>false</code> |
 | [files](variables.tf#L29) | Map of extra files to create on the instance, path as key. Owner and permissions will use defaults if null. | <code title="map&#40;object&#40;&#123;&#10;  content     &#61; string&#10;  owner       &#61; string&#10;  permissions &#61; string&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [frr_config](variables.tf#L39) | FRR configuration for container running on the NVA. | <code title="object&#40;&#123;&#10;  config          &#61; string&#10;  daemons_enabled &#61; optional&#40;list&#40;string&#41;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [frr_config](variables.tf#L39) | FRR configuration for container running on the NVA. | <code title="object&#40;&#123;&#10;  config_file     &#61; string&#10;  daemons_enabled &#61; optional&#40;list&#40;string&#41;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
 | [optional_run_cmds](variables.tf#L84) | Optional Cloud Init run commands to execute. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
 
 ## Outputs

--- a/modules/cloud-config-container/simple-nva/main.tf
+++ b/modules/cloud-config-container/simple-nva/main.tf
@@ -41,7 +41,8 @@ locals {
         permissions = "0744"
       }
       "/etc/frr/frr.conf" = {
-        content     = file(var.frr_config.config_file)
+        # content can either be the path to the config file or the config string
+        content     = try(file(var.frr_config.config_file), var.frr_config.config_file)
         owner       = "root"
         permissions = "0744"
       }

--- a/modules/cloud-config-container/simple-nva/variables.tf
+++ b/modules/cloud-config-container/simple-nva/variables.tf
@@ -39,8 +39,8 @@ variable "files" {
 variable "frr_config" {
   description = "FRR configuration for container running on the NVA."
   type = object({
+    config          = string
     daemons_enabled = optional(list(string))
-    config_file     = string
   })
   default = null
   validation {

--- a/modules/cloud-config-container/simple-nva/variables.tf
+++ b/modules/cloud-config-container/simple-nva/variables.tf
@@ -39,7 +39,7 @@ variable "files" {
 variable "frr_config" {
   description = "FRR configuration for container running on the NVA."
   type = object({
-    config          = string
+    config_file     = string
     daemons_enabled = optional(list(string))
   })
   default = null


### PR DESCRIPTION
Users can now pass FRR BGP configs as strings and not just as paths to existing files. This is useful if templatefile is used in the caller module.