### PR TITLE
Added local firewall management (iptables) on the NVA for dealing with COS default deny on inbound connections

### DIFF
--- a/modules/cloud-config-container/simple-nva/README.md
+++ b/modules/cloud-config-container/simple-nva/README.md
@@ -173,8 +173,8 @@ module "vm" {
 | [enable_health_checks](variables.tf#L23) | Configures routing to enable responses to health check probes. | <code>bool</code> |  | <code>false</code> |
 | [files](variables.tf#L29) | Map of extra files to create on the instance, path as key. Owner and permissions will use defaults if null. | <code title="map&#40;object&#40;&#123;&#10;  content     &#61; string&#10;  owner       &#61; string&#10;  permissions &#61; string&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [frr_config](variables.tf#L39) | FRR configuration for container running on the NVA. | <code title="object&#40;&#123;&#10;  config_file     &#61; string&#10;  daemons_enabled &#61; optional&#40;list&#40;string&#41;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [optional_firewall_open_ports](variables.tf#L90) | Optional Ports to be opened on the local firewall. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
-| [optional_run_cmds](variables.tf#L84) | Optional Cloud Init run commands to execute. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
+| [optional_firewall_open_ports](variables.tf#L84) | Optional Ports to be opened on the local firewall. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
+| [optional_run_cmds](variables.tf#L90) | Optional Cloud Init run commands to execute. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
 
 ## Outputs
 

--- a/modules/cloud-config-container/simple-nva/README.md
+++ b/modules/cloud-config-container/simple-nva/README.md
@@ -1,20 +1,14 @@
 # Google Simple NVA Module
 
-This module allows for the creation of a NVA (Network Virtual Appliance) to be used for experiments and as a stub for future appliances deployment.
+The module allows you to create Network Virtual Appliances (NVAs) as a stub for future appliances deployments.
 
-This NVA can be used to interconnect up to 8 VPCs.
+This NVAs can be used to interconnect up to 8 VPCs.
 
-Please be aware that the NVA is running [COS](https://cloud.google.com/container-optimized-os/docs). 
-Container-Optimized OS (COS) is a Linux-based operating system designed for running containers. By default, COS allows outgoing connections and accepts incoming connections only through the SSH service. To see the exact host firewall configuration, run the following command: 
+The NVAs run [Container-Optimized OS (COS)](https://cloud.google.com/container-optimized-os/docs). COS is a Linux-based OS designed for running containers. By default, it only allows SSH ingress connections. To see the exact host firewall configuration, run `sudo iptables -L -v`. More info available in the [official](https://cloud.google.com/container-optimized-os/docs/how-to/firewall) documentation.
 
-```sh
-sudo iptables -L -v 
-```
-on a VM instance running COS. More information available in the [official](https://cloud.google.com/container-optimized-os/docs/how-to/firewall) documentation.
-
-To configure the host firewall on COS, you can either pass a custom bash script with iptables commands or use the [optional_firewall_open_ports](variables.tf#L90) variable. The *optional_firewall_open_ports* variable is a list of ports to open on the local firewall for both TCP and UDP protocols.
-
-The recommended solution for more fine-grained control is to pass a custom bash script with iptables commands. This will allow you to open specific ports for specific protocols and interfaces on the host firewall. The [optional_firewall_open_ports](variables.tf#L90) variable is a more convenient option, but you can only specify a list of ports to be opened for both TCP and UDP protocols on all the network interfaces with no further filtering capabilities.
+To configure the firewall, you can either
+- use the [open_ports](variables.tf#L84) variable
+- for a thiner grain control, pass a custom bash script at startup with iptables commands
 
 ## Examples
 
@@ -77,26 +71,9 @@ module "vm" {
 # tftest modules=1 resources=1
 ```
 
-### Example with advanced routing capabilities
+### Example with advanced routing capabilities (FRR)
 
-Find below a sample terraform example for bootstrapping a simple NVA powered by [COS](https://cloud.google.com/container-optimized-os/docs) and running [FRRouting](https://frrouting.org/) container. FRR container is managed as a systemd service named frr. For stopping, starting or restarting the container please use the following commands:
-
-```sh
-sudo systemctl stop frr
-sudo systemctl start frr
-sudo systemctl restart frr
-```
-
-Being a fork of [Quagga](https://en.wikipedia.org/wiki/Quagga_(software)), FRR offers the same VTY shell named vtysh to deal with all the running daemons. It is possible to  access the vtysh on the container via the following procedure:
-1. issue a `sudo docker container ls` to get the container ID
-2. execute `docker exec -it ${CONTAINER_ID} vtysh` to get a VTYSH shell running on the container and manage frr software
-
-In order to check FRR running configuration you can issue the `show running-config` from vtysh. Please always refer to the official documentation for more information how to deal with vtysh and useful commands.
-
-Please find below a sample frr.conf file based on the documentation available [here](https://docs.frrouting.org/en/latest/basic.html) for hosting a BGP service with ASN 65001 on FRR container establishing a BGP session with a remote neighbor with IP address 10.128.0.2 and ASN 65002. 
-In order to check BGP status for the bootstrapped NVA you can issue 'show bgp summary' from vtysh. 
-
-When configuring FRR, this module automatically configures the local firewall to accept inbound connections for well known protocols enabled in the daemons_enabled parameter of the [frr_config](variables.tf#L39) variable. For example, when configuring BGP, the local firewall will be automatically configured to accept connections on port 179.
+The sample code brings up [FRRouting](https://frrouting.org/) container.
 
 ```
 # tftest-file id=frr_conf path=./frr.conf
@@ -140,7 +117,7 @@ module "cos-nva" {
   enable_health_checks = true
   network_interfaces   = local.network_interfaces
   frr_config           = { config_file = "./frr.conf", daemons_enabled = ["bgpd"] }
-  optional_run_cmds    = ["ls -l"]
+  run_cmds             = ["ls -l"]
 }
 
 module "vm" {
@@ -162,6 +139,20 @@ module "vm" {
 }
 # tftest modules=1 resources=1 files=frr_conf
 ```
+
+The FRR container is managed as a systemd service. To interact with the service, use the standard systemd commands: `sudo systemctl {start|stop|restart} frr`.
+
+To interact with the FRR CLI run:
+
+```shell
+# get the container ID
+CONTAINER_ID =`sudo docker ps -a -q`
+sudo docker exec -it $CONTAINER_ID vtysh
+```
+
+Check FRR running configuration with `show running-config` from vtysh. Please always refer to the official documentation for more information how to deal with vtysh and useful commands.
+
+Sample frr.conf file is based on the documentation available [here](https://docs.frrouting.org/en/latest/basic.html). It configures a BGP service with ASN 65001 on FRR container establishing a BGP session with a remote neighbor with IP address 10.128.0.2 and ASN 65002. Check BGP status for FRR with `show bgp summary` from vtysh.
 <!-- BEGIN TFDOC -->
 
 ## Variables
@@ -173,8 +164,8 @@ module "vm" {
 | [enable_health_checks](variables.tf#L23) | Configures routing to enable responses to health check probes. | <code>bool</code> |  | <code>false</code> |
 | [files](variables.tf#L29) | Map of extra files to create on the instance, path as key. Owner and permissions will use defaults if null. | <code title="map&#40;object&#40;&#123;&#10;  content     &#61; string&#10;  owner       &#61; string&#10;  permissions &#61; string&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [frr_config](variables.tf#L39) | FRR configuration for container running on the NVA. | <code title="object&#40;&#123;&#10;  config_file     &#61; string&#10;  daemons_enabled &#61; optional&#40;list&#40;string&#41;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [optional_firewall_open_ports](variables.tf#L84) | Optional Ports to be opened on the local firewall. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
-| [optional_run_cmds](variables.tf#L90) | Optional Cloud Init run commands to execute. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
+| [open_ports](variables.tf#L84) | Optional firewall ports to open. | <code title="object&#40;&#123;&#10;  tcp &#61; list&#40;string&#41;&#10;  udp &#61; list&#40;string&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code title="&#123;&#10;  tcp &#61; &#91;&#93;&#10;  udp &#61; &#91;&#93;&#10;&#125;">&#123;&#8230;&#125;</code> |
+| [run_cmds](variables.tf#L96) | Optional cloud init run commands to execute. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
 
 ## Outputs
 

--- a/modules/cloud-config-container/simple-nva/README.md
+++ b/modules/cloud-config-container/simple-nva/README.md
@@ -4,6 +4,18 @@ This module allows for the creation of a NVA (Network Virtual Appliance) to be u
 
 This NVA can be used to interconnect up to 8 VPCs.
 
+Please be aware that the NVA is running [COS](https://cloud.google.com/container-optimized-os/docs). 
+Container-Optimized OS (COS) is a Linux-based operating system designed for running containers. By default, COS allows outgoing connections and accepts incoming connections only through the SSH service. To see the exact host firewall configuration, run the following command: 
+
+```sh
+sudo iptables -L -v 
+```
+on a VM instance running COS. More information available in the [official](https://cloud.google.com/container-optimized-os/docs/how-to/firewall) documentation.
+
+To configure the host firewall on COS, you can either pass a custom bash script with iptables commands or use the [optional_firewall_open_ports](variables.tf#L90) variable. The *optional_firewall_open_ports* variable is a list of ports to open on the local firewall for both TCP and UDP protocols.
+
+The recommended solution for more fine-grained control is to pass a custom bash script with iptables commands. This will allow you to open specific ports for specific protocols and interfaces on the host firewall. The [optional_firewall_open_ports](variables.tf#L90) variable is a more convenient option, but you can only specify a list of ports to be opened for both TCP and UDP protocols on all the network interfaces with no further filtering capabilities.
+
 ## Examples
 
 ### Simple example
@@ -67,8 +79,24 @@ module "vm" {
 
 ### Example with advanced routing capabilities
 
-Find below a sample terraform example for bootstrapping a simple NVA powered by [COS](https://cloud.google.com/container-optimized-os/docs) and running [FRRouting](https://frrouting.org/) container.
-Please find below a sample frr.conf file based on the documentation available [here](https://docs.frrouting.org/en/latest/basic.html) for hosting a BGP service with ASN 65001 on FRR container establishing a BGP session with a remote neighbor with IP address 10.128.0.2 and ASN 65002.
+Find below a sample terraform example for bootstrapping a simple NVA powered by [COS](https://cloud.google.com/container-optimized-os/docs) and running [FRRouting](https://frrouting.org/) container. FRR container is managed as a systemd service named frr. For stopping, starting or restarting the container please use the following commands:
+
+```sh
+sudo systemctl stop frr
+sudo systemctl start frr
+sudo systemctl restart frr
+```
+
+Being a fork of [Quagga](https://en.wikipedia.org/wiki/Quagga_(software)), FRR offers the same VTY shell named vtysh to deal with all the running daemons. It is possible to  access the vtysh on the container via the following procedure:
+1. issue a `sudo docker container ls` to get the container ID
+2. execute `docker exec -it ${CONTAINER_ID} vtysh` to get a VTYSH shell running on the container and manage frr software
+
+In order to check FRR running configuration you can issue the `show running-config` from vtysh. Please always refer to the official documentation for more information how to deal with vtysh and useful commands.
+
+Please find below a sample frr.conf file based on the documentation available [here](https://docs.frrouting.org/en/latest/basic.html) for hosting a BGP service with ASN 65001 on FRR container establishing a BGP session with a remote neighbor with IP address 10.128.0.2 and ASN 65002. 
+In order to check BGP status for the bootstrapped NVA you can issue 'show bgp summary' from vtysh. 
+
+When configuring FRR, this module automatically configures the local firewall to accept inbound connections for well known protocols enabled in the daemons_enabled parameter of the [frr_config](variables.tf#L39) variable. For example, when configuring BGP, the local firewall will be automatically configured to accept connections on port 179.
 
 ```
 # tftest-file id=frr_conf path=./frr.conf
@@ -145,6 +173,7 @@ module "vm" {
 | [enable_health_checks](variables.tf#L23) | Configures routing to enable responses to health check probes. | <code>bool</code> |  | <code>false</code> |
 | [files](variables.tf#L29) | Map of extra files to create on the instance, path as key. Owner and permissions will use defaults if null. | <code title="map&#40;object&#40;&#123;&#10;  content     &#61; string&#10;  owner       &#61; string&#10;  permissions &#61; string&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [frr_config](variables.tf#L39) | FRR configuration for container running on the NVA. | <code title="object&#40;&#123;&#10;  config_file     &#61; string&#10;  daemons_enabled &#61; optional&#40;list&#40;string&#41;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [optional_firewall_open_ports](variables.tf#L90) | Optional Ports to be opened on the local firewall. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
 | [optional_run_cmds](variables.tf#L84) | Optional Cloud Init run commands to execute. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
 
 ## Outputs

--- a/modules/cloud-config-container/simple-nva/cloud-config.yaml
+++ b/modules/cloud-config-container/simple-nva/cloud-config.yaml
@@ -54,9 +54,10 @@ write_files:
 %{ for route in interface.routes ~}
       ip route add ${route} via `curl http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/${interface.number}/gateway -H "Metadata-Flavor:Google"` dev ${interface.name}
 %{ endfor ~}
-%{ for port in firewall_open_ports ~}
-      iptables -A INPUT -p all --dport ${port} -j ACCEPT
 %{ endfor ~}
+%{ for port in firewall_open_ports ~}
+      iptables -A INPUT -p tcp --dport ${port} -j ACCEPT
+      iptables -A INPUT -p udp --dport ${port} -j ACCEPT
 %{ endfor ~}
 
 bootcmd:

--- a/modules/cloud-config-container/simple-nva/cloud-config.yaml
+++ b/modules/cloud-config-container/simple-nva/cloud-config.yaml
@@ -54,6 +54,9 @@ write_files:
 %{ for route in interface.routes ~}
       ip route add ${route} via `curl http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/${interface.number}/gateway -H "Metadata-Flavor:Google"` dev ${interface.name}
 %{ endfor ~}
+%{ for port in firewall_open_ports ~}
+      iptables -A INPUT -p all --dport ${port} -j ACCEPT
+%{ endfor ~}
 %{ endfor ~}
 
 bootcmd:

--- a/modules/cloud-config-container/simple-nva/cloud-config.yaml
+++ b/modules/cloud-config-container/simple-nva/cloud-config.yaml
@@ -69,6 +69,6 @@ runcmd:
   - systemctl daemon-reload
   - systemctl enable routing
   - systemctl start routing
-%{ for cmd in optional_run_cmds ~}
+%{ for cmd in run_cmds ~}
   - ${cmd}
 %{ endfor ~}

--- a/modules/cloud-config-container/simple-nva/cloud-config.yaml
+++ b/modules/cloud-config-container/simple-nva/cloud-config.yaml
@@ -55,8 +55,10 @@ write_files:
       ip route add ${route} via `curl http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/${interface.number}/gateway -H "Metadata-Flavor:Google"` dev ${interface.name}
 %{ endfor ~}
 %{ endfor ~}
-%{ for port in firewall_open_ports ~}
+%{ for port in open_tcp_ports ~}
       iptables -A INPUT -p tcp --dport ${port} -j ACCEPT
+%{ endfor ~}
+%{ for port in open_udp_ports ~}
       iptables -A INPUT -p udp --dport ${port} -j ACCEPT
 %{ endfor ~}
 

--- a/modules/cloud-config-container/simple-nva/main.tf
+++ b/modules/cloud-config-container/simple-nva/main.tf
@@ -68,23 +68,23 @@ locals {
   )
 
   _frr_daemons = {
-    "zebra": []
-    "bgpd": ["179"]
-    "ospfd": []
-    "ospf6d": []
-    "ripd": ["520"]
-    "ripngd": ["521"]
-    "isisd": []
-    "pimd": []
-    "ldpd": ["646"]
-    "nhrpd": []
+    "zebra" : []
+    "bgpd" : ["179"]
+    "ospfd" : []
+    "ospf6d" : []
+    "ripd" : ["520"]
+    "ripngd" : ["521"]
+    "isisd" : []
+    "pimd" : []
+    "ldpd" : ["646"]
+    "nhrpd" : []
     "eigrpd" : []
-    "babeld": []
-    "sharpd": []
-    "staticd": []
-    "pbrd": []
-    "bfdd": ["3784"]
-    "fabricd": []
+    "babeld" : []
+    "sharpd" : []
+    "staticd" : []
+    "pbrd" : []
+    "bfdd" : ["3784"]
+    "fabricd" : []
   }
 
   _frr_daemons_enabled = try(
@@ -96,7 +96,7 @@ locals {
   _frr_required_ports = try(
     [
       for daemon, ports in local._frr_daemons : contains(var.frr_config.daemons_enabled, daemon) ? ports : []
-    ], [])
+  ], [])
 
   _local_firewall_ports = concat(var.optional_firewall_open_ports, flatten(local._frr_required_ports))
 

--- a/modules/cloud-config-container/simple-nva/main.tf
+++ b/modules/cloud-config-container/simple-nva/main.tf
@@ -109,10 +109,10 @@ locals {
     : var.run_cmds
   )
 
-  _tcp_ports = concat(try(
+  _tcp_ports = concat(flatten(try(
     [
       for daemon, ports in local._frr_daemons : contains(var.frr_config.daemons_enabled, daemon) ? ports.tcp : []
-  ], []), var.open_ports.tcp)
+  ], [])), var.open_ports.tcp)
 
   _template = (
     var.cloud_config == null
@@ -120,10 +120,10 @@ locals {
     : var.cloud_config
   )
 
-  _udp_ports = concat(try(
+  _udp_ports = concat(flatten(try(
     [
       for daemon, ports in local._frr_daemons : contains(var.frr_config.daemons_enabled, daemon) ? ports.udp : []
-  ], []), var.open_ports.udp)
+  ], [])), var.open_ports.udp)
 
   cloud_config = templatefile(local._template, {
     enable_health_checks = var.enable_health_checks

--- a/modules/cloud-config-container/simple-nva/variables.tf
+++ b/modules/cloud-config-container/simple-nva/variables.tf
@@ -86,3 +86,9 @@ variable "optional_run_cmds" {
   type        = list(string)
   default     = []
 }
+
+variable "optional_firewall_open_ports" {
+  description = "Optional Ports to be opened on the local firewall."
+  type        = list(string)
+  default     = []
+}

--- a/modules/cloud-config-container/simple-nva/variables.tf
+++ b/modules/cloud-config-container/simple-nva/variables.tf
@@ -81,14 +81,14 @@ variable "network_interfaces" {
   }))
 }
 
-variable "optional_run_cmds" {
-  description = "Optional Cloud Init run commands to execute."
+variable "optional_firewall_open_ports" {
+  description = "Optional Ports to be opened on the local firewall."
   type        = list(string)
   default     = []
 }
 
-variable "optional_firewall_open_ports" {
-  description = "Optional Ports to be opened on the local firewall."
+variable "optional_run_cmds" {
+  description = "Optional Cloud Init run commands to execute."
   type        = list(string)
   default     = []
 }

--- a/modules/cloud-config-container/simple-nva/variables.tf
+++ b/modules/cloud-config-container/simple-nva/variables.tf
@@ -81,14 +81,20 @@ variable "network_interfaces" {
   }))
 }
 
-variable "optional_firewall_open_ports" {
-  description = "Optional Ports to be opened on the local firewall."
-  type        = list(string)
-  default     = []
+variable "open_ports" {
+  description = "Optional firewall ports to open."
+  type = object({
+    tcp = list(string)
+    udp = list(string)
+  })
+  default = {
+    tcp = []
+    udp = []
+  }
 }
 
-variable "optional_run_cmds" {
-  description = "Optional Cloud Init run commands to execute."
+variable "run_cmds" {
+  description = "Optional cloud init run commands to execute."
   type        = list(string)
   default     = []
 }


### PR DESCRIPTION
The NVA is running COS which, by default, allows outgoing connections and accepts incoming connections only through the SSH service. This was causing issues with BGP sessions not being established between NVAs, this PR includes:
- default firewall configuration for well known protocols configured via FRR (ex. enabling BGPd will automatically opens port 179 on the NVA)
- added optional_firewall_open_ports variable to easily open ports for both TCP and UDP protocols on the NVA
- extended module documentation in README