### PR TITLE
Use labels var in cloud-run module

### DIFF
--- a/modules/cloud-run/main.tf
+++ b/modules/cloud-run/main.tf
@@ -259,6 +259,7 @@ resource "google_cloud_run_service" "service" {
 
   metadata {
     annotations = local.annotations
+    labels      = var.labels
   }
 
   dynamic "traffic" {


### PR DESCRIPTION
Currently, the labels var is defined but not used, it is my understanding that this var should be used in the metadata main block of the `google_cloud_run_service` resource