### PR TITLE
Fixed type in readme for FAST stages

### DIFF
--- a/fast/stages/README.md
+++ b/fast/stages/README.md
@@ -44,7 +44,7 @@ Implemented via separate stages that configure separate FAST-enabled  hierarchie
 ## Environment-level resources (3)
 
 - [Project Factory](3-project-factory/dev/)  
-  YAML-based fatory to create and configure application or team-level projects. Configuration includes VPC-level settings for Shared VPC, service-level configuration for CMEK encryption via centralized keys, and service account creation for workloads and applications. This stage is meant to be used once per environment.
+  YAML-based factory to create and configure application or team-level projects. Configuration includes VPC-level settings for Shared VPC, service-level configuration for CMEK encryption via centralized keys, and service account creation for workloads and applications. This stage is meant to be used once per environment.
 - [Data Platform](3-data-platform/dev/)
 - [GKE Multitenant](3-gke-multitenant/dev/)
 - GCE Migration (in development)


### PR DESCRIPTION
Fixed typo from "fatory" to "factory" in readme.