### PR TITLE
IAP for Cloud Run GA

### DIFF
--- a/blueprints/serverless/cloud-run-explore/README.md
+++ b/blueprints/serverless/cloud-run-explore/README.md
@@ -214,5 +214,5 @@ module "test" {
   }
 }
 
-# tftest modules=4 resources=17
+# tftest modules=4 resources=18
 ```

--- a/blueprints/serverless/cloud-run-explore/main.tf
+++ b/blueprints/serverless/cloud-run-explore/main.tf
@@ -15,7 +15,8 @@
  */
 
 locals {
-  gclb_create = var.custom_domain == null ? false : true
+  gclb_create  = var.custom_domain == null ? false : true
+  iap_sa_email = try(google_project_service_identity.iap_sa[0].email, "")
 }
 
 module "project" {
@@ -50,7 +51,7 @@ module "cloud_run" {
   }
   iam = {
     "roles/run.invoker" = (local.gclb_create && var.iap.enabled
-      ? ["serviceAccount:${google_project_service_identity.iap_sa[0].email}"]
+      ? ["serviceAccount:${local.iap_sa_email}"]
       : ["allUsers"]
     )
   }


### PR DESCRIPTION
Now that IAP for Cloud Run is GA, the IAP service agent needs to be provisioned and granted access to invoke Cloud Run.
Fixes #1321