### PR TITLE
Add providers to vertex-mlops blueprint

### DIFF
--- a/blueprints/data-solutions/vertex-mlops/providers.tf
+++ b/blueprints/data-solutions/vertex-mlops/providers.tf
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  provider_meta "google" {
+    module_name = "blueprints/terraform/fabric-blueprints:vertex-mlops/v1.0.0"
+  }
+  provider_meta "google-beta" {
+    module_name = "blueprints/terraform/fabric-blueprints:vertex-mlops/v1.0.0"
+  }
+}


### PR DESCRIPTION
Add provider metadata config as agreed with the blueprints team.