### PR TITLE
Inconsistent conditional result types error in net-vpc module

### DIFF
--- a/modules/net-vpc/subnets.tf
+++ b/modules/net-vpc/subnets.tf
@@ -17,8 +17,8 @@
 # tfdoc:file:description Subnet resources.
 
 locals {
-  _factory_data = var.data_folder == null ? tomap({}) : {
-    for f in fileset(var.data_folder, "**/*.yaml") :
+  _factory_data = {
+    for f in try(fileset(var.data_folder, "**/*.yaml"), []) :
     trimsuffix(basename(f), ".yaml") => yamldecode(file("${var.data_folder}/${f}"))
   }
   _factory_subnets = {


### PR DESCRIPTION
The conditional statement, with tomap({}) will cause the following error under terraform 1.4.5

Error: Inconsistent conditional result types
│ 
│   on ../../../modules/net-vpc/subnets.tf line 20, in locals:
│   20:   _factory_data = var.data_folder == null ? tomap({}) : {
│   21:     for f in fileset(var.data_folder, "**/*.yaml") :
│   22:     trimsuffix(basename(f), ".yaml") => yamldecode(file("${var.data_folder}/${f}"))
│   23:   }
│     ├────────────────
│     │ var.data_folder is "data/subnets/common"
│ 
│ The false result value has the wrong type: element types must all match for conversion to map.