### PR TITLE
Certificate renewal through terraform 

### DIFF
--- a/modules/net-ilb-l7/main.tf
+++ b/modules/net-ilb-l7/main.tf
@@ -88,6 +88,10 @@ resource "google_compute_region_ssl_certificate" "default" {
   name        = "${var.name}-${each.key}"
   certificate = each.value.certificate
   private_key = each.value.private_key
+  
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "google_compute_region_target_http_proxy" "default" {

--- a/modules/net-ilb-l7/main.tf
+++ b/modules/net-ilb-l7/main.tf
@@ -88,7 +88,7 @@ resource "google_compute_region_ssl_certificate" "default" {
   name        = "${var.name}-${each.key}"
   certificate = each.value.certificate
   private_key = each.value.private_key
-  
+
   lifecycle {
     create_before_destroy = true
   }


### PR DESCRIPTION
When renewing the certificate by updating the variable file, GCP will not let you update because it will try to delete the old certificate is been used by the target proxy. Updating lifecycle  with create_before_destroy will allow the certificate and attach to the proxy and then delete the old certificate.