### PR TITLE
fixed permissions for security stage SA

### DIFF
--- a/fast/stages/1-resman/branch-security.tf
+++ b/fast/stages/1-resman/branch-security.tf
@@ -59,6 +59,11 @@ module "branch-security-sa" {
       try(module.branch-security-sa-cicd.0.iam_email, null)
     ])
   }
+  iam_project_roles = {
+    (var.automation.project_id) = [
+      "roles/serviceusage.serviceUsageConsumer",
+    ]
+  }
   iam_storage_roles = {
     (var.automation.outputs_bucket) = ["roles/storage.objectAdmin"]
   }


### PR DESCRIPTION
it should be able to use automation project
as a quota project, hence it needs `serviceusage.serviceUsageConsumer` role