### PR TITLE
Support CMEK encryption in logging-bucket module

### DIFF
--- a/modules/logging-bucket/README.md
+++ b/modules/logging-bucket/README.md
@@ -64,11 +64,12 @@ module "bucket-billing-account" {
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
 | [id](variables.tf#L23) | Name of the logging bucket. | <code>string</code> | ✓ |  |
-| [parent](variables.tf#L34) | ID of the parentresource containing the bucket in the format 'project_id' 'folders/folder_id', 'organizations/organization_id' or 'billing_account_id'. | <code>string</code> | ✓ |  |
-| [parent_type](variables.tf#L39) | Parent object type for the bucket (project, folder, organization, billing_account). | <code>string</code> | ✓ |  |
+| [parent](variables.tf#L40) | ID of the parentresource containing the bucket in the format 'project_id' 'folders/folder_id', 'organizations/organization_id' or 'billing_account_id'. | <code>string</code> | ✓ |  |
+| [parent_type](variables.tf#L45) | Parent object type for the bucket (project, folder, organization, billing_account). | <code>string</code> | ✓ |  |
 | [description](variables.tf#L17) | Human-readable description for the logging bucket. | <code>string</code> |  | <code>null</code> |
-| [location](variables.tf#L28) | Location of the bucket. | <code>string</code> |  | <code>&#34;global&#34;</code> |
-| [retention](variables.tf#L44) | Retention time in days for the logging bucket. | <code>number</code> |  | <code>30</code> |
+| [kms_key_name](variables.tf#L28) | To enable CMEK for a project logging bucket, set this field to a valid name. The associated service account requires cloudkms.cryptoKeyEncrypterDecrypter roles assigned for the key. | <code>string</code> |  | <code>null</code> |
+| [location](variables.tf#L34) | Location of the bucket. | <code>string</code> |  | <code>&#34;global&#34;</code> |
+| [retention](variables.tf#L50) | Retention time in days for the logging bucket. | <code>number</code> |  | <code>30</code> |
 
 ## Outputs
 

--- a/modules/logging-bucket/main.tf
+++ b/modules/logging-bucket/main.tf
@@ -21,6 +21,13 @@ resource "google_logging_project_bucket_config" "bucket" {
   retention_days = var.retention
   bucket_id      = var.id
   description    = var.description
+
+  dynamic "cmek_settings" {
+    for_each = var.kms_key_name == null ? [] : [""]
+    content {
+      kms_key_name = var.kms_key_name
+    }
+  }
 }
 
 resource "google_logging_folder_bucket_config" "bucket" {

--- a/modules/logging-bucket/variables.tf
+++ b/modules/logging-bucket/variables.tf
@@ -25,6 +25,12 @@ variable "id" {
   type        = string
 }
 
+variable "kms_key_name" {
+  description = "To enable CMEK for a project logging bucket, set this field to a valid name. The associated service account requires cloudkms.cryptoKeyEncrypterDecrypter roles assigned for the key."
+  type        = string
+  default     = null
+}
+
 variable "location" {
   description = "Location of the bucket."
   type        = string


### PR DESCRIPTION
We have a use case, Local Controls, that requires to configure CMEK with Logging buckets. This commit adds an optional variable to configure CMEK in the `logging-bucket` module. By default the Logging bucket won't use CMEK encryption.

To configure CMEK for Logging buckets it's also required to add the correct permissions to the bucket service account. For more information and a Terraform example, see:

https://cloud.google.com/logging/docs/routing/managed-encryption-storage

https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/logging_project_bucket_config#example-usage