### PR TITLE
Firewall Validator fix target_service_accounts ref

### DIFF
--- a/blueprints/networking/decentralized-firewall/validator/firewallSchema.yaml
+++ b/blueprints/networking/decentralized-firewall/validator/firewallSchema.yaml
@@ -25,7 +25,7 @@ rule:
   source_tags: list(networktag(), max=30, required=False)
   target_tags: list(networktag(), max=70, required=False)
   source_service_accounts: list(serviceaccount(), max=10, required=False)
-  target_service_account: list(serviceaccount(), max=10, required=False)
+  target_service_accounts: list(serviceaccount(), max=10, required=False)
 ---
 trafficSpec:
   ports: list(networkports())

--- a/blueprints/networking/decentralized-firewall/validator/firewallSchemaAutoApprove.yaml
+++ b/blueprints/networking/decentralized-firewall/validator/firewallSchemaAutoApprove.yaml
@@ -23,7 +23,7 @@ ingress:
   source_tags: list(networktag(), max=30, required=False)
   target_tags: list(networktag(), max=70, required=False)
   source_service_accounts: list(serviceaccount(), max=10, required=False)
-  target_service_account: list(serviceaccount(), max=10, required=False)
+  target_service_accounts: list(serviceaccount(), max=10, required=False)
 ---
 egress:
   disabled: bool(required=False)
@@ -35,7 +35,7 @@ egress:
   source_tags: list(networktag(), max=30, required=False)
   target_tags: list(networktag(), max=70, required=False)
   source_service_accounts: list(serviceaccount(), max=10, required=False)
-  target_service_account: list(serviceaccount(), max=10, required=False)
+  target_service_accounts: list(serviceaccount(), max=10, required=False)
 ---
 trafficSpec:
   ports: list()


### PR DESCRIPTION
The Firewall Validator schema configuration contains a field `target_service_account`. This should be updated to `target_service_accounts` to match the `google_compute_firewall` Terraform resource argument:

https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall#target_service_accounts