### PR TITLE
Multiple Updates in READMEs and wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -808,8 +808,8 @@ All notable changes to this project will be documented in this file.
 - use `xpnServiceAdmin` (custom role) for stage 3 service accounts that need to attach to a shared VPC
 - simplify and standarize ourputs from each stage
 - standarize names of projects, service accounts and buckets
-- swtich to folder-level `xpnAdmin` and `xpnServiceAdmin`
-- moved networking projects to folder matching their enviroments
+- switch to folder-level `xpnAdmin` and `xpnServiceAdmin`
+- moved networking projects to folder matching their environments
 
 ## [13.0.0] - 2022-01-27
 

--- a/blueprints/networking/ha-vpn-over-interconnect/README.md
+++ b/blueprints/networking/ha-vpn-over-interconnect/README.md
@@ -1,6 +1,6 @@
 # HA VPN over Interconnect
 
-This blueprint creates a complete HA VPN over Interconnect setup, which leverages IPSec to encrypt all traffic transiting through purposedly-created VLAN Attachments.
+This blueprint creates a complete HA VPN over Interconnect setup, which leverages IPSec to encrypt all traffic transiting through purposely-created VLAN Attachments.
 
 This blueprint supports Dedicated Interconnect - in case Partner Interconnect is used instead (hence the VLAN Attachments are already created), simply refer to the [net-ipsec-over-interconnect](../../../modules/net-ipsec-over-interconnect/) module documentation.
 

--- a/modules/net-dedicated-vlan-attachment/README.md
+++ b/modules/net-dedicated-vlan-attachment/README.md
@@ -293,7 +293,7 @@ module "example-va-b" {
 | [bandwidth](variables.tf#L23) | The bandwidth assigned to the VLAN attachment (e.g. BPS_10G). | <code>string</code> |  | <code>&#34;BPS_10G&#34;</code> |
 | [bgp_range](variables.tf#L30) | The underlay link-local IP range (in CIDR notation). | <code>string</code> |  | <code>&#34;169.254.128.0&#47;29&#34;</code> |
 | [ipsec_gateway_ip_ranges](variables.tf#L46) | IPSec Gateway IP Ranges. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
-| [mtu](variables.tf#L52) | The MTU associated to the VLAN attachemnt (1440 / 1500). | <code>number</code> |  | <code>1500</code> |
+| [mtu](variables.tf#L52) | The MTU associated to the VLAN attachment (1440 / 1500). | <code>number</code> |  | <code>1500</code> |
 | [vpn_gateways_ip_range](variables.tf#L109) | The IP range (cidr notation) to be used for the GCP VPN gateways. If null IPSec over Interconnect is not enabled. | <code>string</code> |  | <code>null</code> |
 
 <!-- END TFDOC -->

--- a/modules/net-dedicated-vlan-attachment/variables.tf
+++ b/modules/net-dedicated-vlan-attachment/variables.tf
@@ -50,7 +50,7 @@ variable "ipsec_gateway_ip_ranges" {
 }
 
 variable "mtu" {
-  description = "The MTU associated to the VLAN attachemnt (1440 / 1500)."
+  description = "The MTU associated to the VLAN attachment (1440 / 1500)."
   type        = number
   default     = "1500"
 }


### PR DESCRIPTION
Updated wording in CHANGELOG.md
Updated “mtu” variable description in modules/net-dedicated-vlan-attachment/variables.tf
Fixed typo in blueprints/networking/ha-vpn-over-interconnect/README.md
Fixed typo in modules/net-dedicated-vlan-attachment/README.md
