### PR TITLE
Add custom tag support to FAST

### DIFF
--- a/fast/stages/1-resman/README.md
+++ b/fast/stages/1-resman/README.md
@@ -139,16 +139,23 @@ The first set of default tags cannot be overridden and defines the following key
 
 - `context` to identify parts of the resource hierarchy, with `data`, `gke`, `networking`, `sandbox`, `security` and `teams` values
 - `environment` to identify folders and projects belonging to specific environments, with `development` and `production` values
+- `org-policies` that holds values designed to be used in organization policy conditions, with a single value `allowed-policy-member-domains-all` used to allow all in the Domain Restricted Sharing policy via tag bindings; more values can be added by using the same tag key and specifying new values via the custom variable described below
 - `tenant` for FAST multitenant, with one value for each defined tenant that identifies their specific set of resources
 
 The second set is optional and allows defining a custom tag hierarchy, including IAM bindings that can refer to specific identities, or to the internally defined automation service accounts via their names, like in the following example:
 
 ```hcl
 tags = {
+  my-custom-tag = {
+    values = {
+      eggs = {}
+      spam = {}
+    }
+  }
   org-policies = {
     description = "Tag values used in organization policy conditions."
     values = {
-      drs-allow-all = {
+      allowed-policy-member-domains-all = {
         description = "Allow all in Domain Restricted Sharing."
         iam = {
           "roles/resourcemanager.tagUser" = ["sandbox"]
@@ -248,9 +255,9 @@ Due to its simplicity, this stage lends itself easily to customizations: adding 
 | [locations](variables.tf#L173) | Optional locations for GCS, BigQuery, and logging buckets created here. | <code title="object&#40;&#123;&#10;  bq      &#61; string&#10;  gcs     &#61; string&#10;  logging &#61; string&#10;  pubsub  &#61; list&#40;string&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code title="&#123;&#10;  bq      &#61; &#34;EU&#34;&#10;  gcs     &#61; &#34;EU&#34;&#10;  logging &#61; &#34;global&#34;&#10;  pubsub  &#61; &#91;&#93;&#10;&#125;">&#123;&#8230;&#125;</code> | <code>0-bootstrap</code> |
 | [organization_policy_configs](variables.tf#L201) | Organization policies customization. | <code title="object&#40;&#123;&#10;  allowed_policy_member_domains &#61; list&#40;string&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |  |
 | [outputs_location](variables.tf#L209) | Enable writing provider, tfvars and CI/CD workflow files to local filesystem. Leave null to disable. | <code>string</code> |  | <code>null</code> |  |
-| [tag_names](variables.tf#L226) | Customized names for resource management tags. | <code title="object&#40;&#123;&#10;  context     &#61; string&#10;  environment &#61; string&#10;  tenant      &#61; string&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code title="&#123;&#10;  context     &#61; &#34;context&#34;&#10;  environment &#61; &#34;environment&#34;&#10;  tenant      &#61; &#34;tenant&#34;&#10;&#125;">&#123;&#8230;&#125;</code> |  |
-| [tags](variables.tf#L245) | Custome secure tags by key name. The `iam` attribute behaves like the similarly named one at module level. | <code title="map&#40;object&#40;&#123;&#10;  description &#61; optional&#40;string, &#34;Managed by the Terraform organization module.&#34;&#41;&#10;  iam         &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;  values &#61; optional&#40;map&#40;object&#40;&#123;&#10;    description &#61; optional&#40;string, &#34;Managed by the Terraform organization module.&#34;&#41;&#10;    iam         &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;    id          &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |  |
-| [team_folders](variables.tf#L266) | Team folders to be created. Format is described in a code comment. | <code title="map&#40;object&#40;&#123;&#10;  descriptive_name     &#61; string&#10;  group_iam            &#61; map&#40;list&#40;string&#41;&#41;&#10;  impersonation_groups &#61; list&#40;string&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>null</code> |  |
+| [tag_names](variables.tf#L226) | Customized names for resource management tags. | <code title="object&#40;&#123;&#10;  context      &#61; string&#10;  environment  &#61; string&#10;  org-policies &#61; string&#10;  tenant       &#61; string&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code title="&#123;&#10;  context      &#61; &#34;context&#34;&#10;  environment  &#61; &#34;environment&#34;&#10;  org-policies &#61; &#34;org-policies&#34;&#10;  tenant       &#61; &#34;tenant&#34;&#10;&#125;">&#123;&#8230;&#125;</code> |  |
+| [tags](variables.tf#L247) | Custome secure tags by key name. The `iam` attribute behaves like the similarly named one at module level. | <code title="map&#40;object&#40;&#123;&#10;  description &#61; optional&#40;string, &#34;Managed by the Terraform organization module.&#34;&#41;&#10;  iam         &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;  values &#61; optional&#40;map&#40;object&#40;&#123;&#10;    description &#61; optional&#40;string, &#34;Managed by the Terraform organization module.&#34;&#41;&#10;    iam         &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;    id          &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |  |
+| [team_folders](variables.tf#L268) | Team folders to be created. Format is described in a code comment. | <code title="map&#40;object&#40;&#123;&#10;  descriptive_name     &#61; string&#10;  group_iam            &#61; map&#40;list&#40;string&#41;&#41;&#10;  impersonation_groups &#61; list&#40;string&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>null</code> |  |
 
 ## Outputs
 

--- a/fast/stages/1-resman/README.md
+++ b/fast/stages/1-resman/README.md
@@ -24,6 +24,7 @@ The following diagram is a high level reference of the resources created and man
   - [Variable configuration](#variable-configuration)
   - [Running the stage](#running-the-stage)
 - [Customizations](#customizations)
+  - [Secure tags](#secure-tags)
   - [Team folders](#team-folders)
   - [Organization Policies](#organization-policies)
   - [IAM](#iam)
@@ -127,6 +128,37 @@ terraform apply
 
 ## Customizations
 
+### Secure tags
+
+This stage manages [Secure Tags](https://cloud.google.com/resource-manager/docs/tags/tags-creating-and-managing) at the organization level, via two sets of keys and values:
+
+- a default set of tags used by FAST itself in specific IAM conditions that allow automation service accounts to gain organization-level privileges or specific access to parts of the resource management hierarchy
+- an optional set of user-defined tags that can be used in organization policy or IAM conditions
+
+The first set of default tags cannot be overridden and defines the following keys and values (key names can be changed via the `tag_names` variable):
+
+- `context` to identify parts of the resource hierarchy, with `data`, `gke`, `networking`, `sandbox`, `security` and `teams` values
+- `environment` to identify folders and projects belonging to specific environments, with `development` and `production` values
+- `tenant` for FAST multitenant, with one value for each defined tenant that identifies their specific set of resources
+
+The second set is optional and allows defining a custom tag hierarchy, including IAM bindings that can refer to specific identities, or to the internally defined automation service accounts via their names, like in the following example:
+
+```hcl
+tags = {
+  org-policies = {
+    description = "Tag values used in organization policy conditions."
+    values = {
+      drs-allow-all = {
+        description = "Allow all in Domain Restricted Sharing."
+        iam = {
+          "roles/resourcemanager.tagUser" = ["sandbox"]
+        }
+      }
+    }
+  }
+}
+```
+
 ### Team folders
 
 This stage provides a single built-in customization that offers a minimal (but usable) implementation of the "application" or "business" grouping for resources discussed above. The `team_folders` variable allows you to specify a map of team name and groups, that will result in folders, automation service accounts, and IAM policies applied.
@@ -217,7 +249,8 @@ Due to its simplicity, this stage lends itself easily to customizations: adding 
 | [organization_policy_configs](variables.tf#L201) | Organization policies customization. | <code title="object&#40;&#123;&#10;  allowed_policy_member_domains &#61; list&#40;string&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |  |
 | [outputs_location](variables.tf#L209) | Enable writing provider, tfvars and CI/CD workflow files to local filesystem. Leave null to disable. | <code>string</code> |  | <code>null</code> |  |
 | [tag_names](variables.tf#L226) | Customized names for resource management tags. | <code title="object&#40;&#123;&#10;  context     &#61; string&#10;  environment &#61; string&#10;  tenant      &#61; string&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code title="&#123;&#10;  context     &#61; &#34;context&#34;&#10;  environment &#61; &#34;environment&#34;&#10;  tenant      &#61; &#34;tenant&#34;&#10;&#125;">&#123;&#8230;&#125;</code> |  |
-| [team_folders](variables.tf#L245) | Team folders to be created. Format is described in a code comment. | <code title="map&#40;object&#40;&#123;&#10;  descriptive_name     &#61; string&#10;  group_iam            &#61; map&#40;list&#40;string&#41;&#41;&#10;  impersonation_groups &#61; list&#40;string&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>null</code> |  |
+| [tags](variables.tf#L245) | Custome secure tags by key name. The `iam` attribute behaves like the similarly named one at module level. | <code title="map&#40;object&#40;&#123;&#10;  description &#61; optional&#40;string, &#34;Managed by the Terraform organization module.&#34;&#41;&#10;  iam         &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;  values &#61; optional&#40;map&#40;object&#40;&#123;&#10;    description &#61; optional&#40;string, &#34;Managed by the Terraform organization module.&#34;&#41;&#10;    iam         &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;    id          &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |  |
+| [team_folders](variables.tf#L266) | Team folders to be created. Format is described in a code comment. | <code title="map&#40;object&#40;&#123;&#10;  descriptive_name     &#61; string&#10;  group_iam            &#61; map&#40;list&#40;string&#41;&#41;&#10;  impersonation_groups &#61; list&#40;string&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>null</code> |  |
 
 ## Outputs
 

--- a/fast/stages/1-resman/organization.tf
+++ b/fast/stages/1-resman/organization.tf
@@ -21,12 +21,28 @@ locals {
     [var.organization.customer_id],
     try(local.policy_configs.allowed_policy_member_domains, [])
   )
-
   policy_configs = (
     var.organization_policy_configs == null
     ? {}
     : var.organization_policy_configs
   )
+  tags = {
+    for k, v in var.tags : k => merge(v, {
+      values = {
+        for vk, vv in v.values : vk => merge(vv, {
+          iam = {
+            for rk, rv in vv.iam : rk => [
+              for rm in rv : (
+                contains(keys(local.service_accounts), rm)
+                ? "serviceAccount:${local.service_accounts[rm]}"
+                : rm
+              )
+            ]
+          }
+        })
+      }
+    })
+  }
 }
 
 module "organization" {
@@ -70,7 +86,19 @@ module "organization" {
   org_policies = {
     "iam.allowedPolicyMemberDomains" = {
       rules = [
-        { allow = { values = local.all_drs_domains } }
+        {
+          allow = { values = local.all_drs_domains }
+          condition = {
+            expression = "!resource.matchTag('${var.organization.id}/${var.tag_names.org-policies}', 'allowed-policy-member-domains-all')"
+          }
+        },
+        {
+          allow = { all = true }
+          condition = {
+            expression = "resource.matchTag('${var.organization.id}/${var.tag_names.org-policies}', 'allowed-policy-member-domains-all')"
+            title      = "allow-all"
+          }
+        },
       ]
     }
 
@@ -92,23 +120,7 @@ module "organization" {
   # they are managed authoritatively and will break multitenant stages
 
   tags = merge(
-    {
-      for k, v in var.tags : k => merge(v, {
-        values = {
-          for vk, vv in v.values : vk => merge(vv, {
-            iam = {
-              for rk, rv in vv.iam : rk => [
-                for rm in rv : (
-                  contains(keys(local.service_accounts), rm)
-                  ? "serviceAccount:${local.service_accounts[rm]}"
-                  : rm
-                )
-              ]
-            }
-          })
-        }
-      })
-    },
+    local.tags,
     {
       (var.tag_names.context) = {
         description = "Resource management context."
@@ -128,6 +140,16 @@ module "organization" {
         values = {
           development = null
           production  = null
+        }
+      }
+      (var.tag_names.org-policies) = {
+        description = "Organization policy conditions."
+        iam         = {}
+        values = {
+          allowed-policy-member-domains-all = merge({}, try(
+            local.tags[var.tag_names.org-policies].values.allowed-policy-member-domains-all,
+            {}
+          ))
         }
       }
       (var.tag_names.tenant) = {

--- a/fast/stages/1-resman/variables.tf
+++ b/fast/stages/1-resman/variables.tf
@@ -226,14 +226,16 @@ variable "prefix" {
 variable "tag_names" {
   description = "Customized names for resource management tags."
   type = object({
-    context     = string
-    environment = string
-    tenant      = string
+    context      = string
+    environment  = string
+    org-policies = string
+    tenant       = string
   })
   default = {
-    context     = "context"
-    environment = "environment"
-    tenant      = "tenant"
+    context      = "context"
+    environment  = "environment"
+    org-policies = "org-policies"
+    tenant       = "tenant"
   }
   nullable = false
   validation {

--- a/fast/stages/1-resman/variables.tf
+++ b/fast/stages/1-resman/variables.tf
@@ -242,6 +242,27 @@ variable "tag_names" {
   }
 }
 
+variable "tags" {
+  description = "Custome secure tags by key name. The `iam` attribute behaves like the similarly named one at module level."
+  type = map(object({
+    description = optional(string, "Managed by the Terraform organization module.")
+    iam         = optional(map(list(string)), {})
+    values = optional(map(object({
+      description = optional(string, "Managed by the Terraform organization module.")
+      iam         = optional(map(list(string)), {})
+      id          = optional(string)
+    })), {})
+  }))
+  nullable = false
+  default  = {}
+  validation {
+    condition = alltrue([
+      for k, v in var.tags : v != null
+    ])
+    error_message = "Use an empty map instead of null as value."
+  }
+}
+
 variable "team_folders" {
   description = "Team folders to be created. Format is described in a code comment."
   type = map(object({

--- a/modules/organization/organization-policies.tf
+++ b/modules/organization/organization-policies.tf
@@ -121,5 +121,7 @@ resource "google_org_policy_policy" "default" {
     google_organization_iam_member.additive,
     google_organization_iam_policy.authoritative,
     google_org_policy_custom_constraint.constraint,
+    google_tags_tag_key.default,
+    google_tags_tag_value.default,
   ]
 }

--- a/tests/modules/organization/test_plan_org_policies_modules.py
+++ b/tests/modules/organization/test_plan_org_policies_modules.py
@@ -54,7 +54,7 @@ def test_policy_implementation():
       '-      parent = local.folder.name\n',
       '+      name   = "${var.organization_id}/policies/${k}"\n',
       '+      parent = var.organization_id\n',
-      '@@ -116,0 +117,8 @@\n',
+      '@@ -116,0 +117,10 @@\n',
       '+  depends_on = [\n',
       '+    google_organization_iam_audit_config.config,\n',
       '+    google_organization_iam_binding.authoritative,\n',
@@ -62,5 +62,7 @@ def test_policy_implementation():
       '+    google_organization_iam_member.additive,\n',
       '+    google_organization_iam_policy.authoritative,\n',
       '+    google_org_policy_custom_constraint.constraint,\n',
+      '+    google_tags_tag_key.default,\n',
+      '+    google_tags_tag_value.default,\n',
       '+  ]\n',
   ]


### PR DESCRIPTION
This adds support for a custom tag hierarchy to FAST stage 1, and includes simple aliasing to refer to the internally created IaC service accounts in tag value bindings.

```hcl
tags = {
  org-policies = {
    description = "Tag values used in organization policy conditions."
    values = {
      drs-allow-all = {
        description = "Allow all in Domain Restricted Sharing."
        iam = {
          "roles/resourcemanager.tagUser" = ["sandbox"]
        }
      }
    }
  }
}
```

It also creates a new tag key that forms the base of the hierarchy of tag values for org policy conditions. This has a single default value for "DRS all" but can be extended by using the same tag key name in the custom variable shown above.