### PR TITLE
Bump TF version in all workflow templates to coincide with module requirements

### DIFF
--- a/fast/assets/templates/workflow-github.yaml
+++ b/fast/assets/templates/workflow-github.yaml
@@ -30,7 +30,7 @@ env:
   SSH_AUTH_SOCK: /tmp/ssh_agent.sock
   TF_PROVIDERS_FILE: ${tf_providers_file}
   TF_VAR_FILES: ${tf_var_files == [] ? "''" : join("\n    ", tf_var_files)}
-  TF_VERSION: 1.3.2
+  TF_VERSION: 1.4.4
 
 jobs:
   fast-pr:

--- a/fast/assets/templates/workflow-sourcerepo.yaml
+++ b/fast/assets/templates/workflow-sourcerepo.yaml
@@ -95,4 +95,4 @@ substitutions:
   _FAST_OUTPUTS_BUCKET: ${outputs_bucket}
   _TF_PROVIDERS_FILE: ${tf_providers_file}
   _TF_VAR_FILES: ${tf_var_files == [] ? "''" : join("\n    ", tf_var_files)}
-  _TF_VERSION: 1.3.2
+  _TF_VERSION: 1.4.4

--- a/fast/stages-multitenant/0-bootstrap-tenant/templates/workflow-github.yaml
+++ b/fast/stages-multitenant/0-bootstrap-tenant/templates/workflow-github.yaml
@@ -32,7 +32,7 @@ env:
   TF_PROVIDERS_FILE: ${tf_providers_file}
   %{~ endif ~}
   TF_VAR_FILES: ${tf_var_files == [] ? "''" : join("\n    ", tf_var_files)}
-  TF_VERSION: 1.3.2
+  TF_VERSION: 1.4.4
 
 jobs:
   fast-pr:

--- a/fast/stages-multitenant/0-bootstrap-tenant/templates/workflow-sourcerepo.yaml
+++ b/fast/stages-multitenant/0-bootstrap-tenant/templates/workflow-sourcerepo.yaml
@@ -97,4 +97,4 @@ substitutions:
   _FAST_OUTPUTS_BUCKET: ${outputs_bucket}
   _TF_PROVIDERS_FILE: ${tf_providers_file}
   _TF_VAR_FILES: ${tf_var_files == [] ? "''" : join("\n    ", tf_var_files)}
-  _TF_VERSION: 1.3.2
+  _TF_VERSION: 1.4.4

--- a/fast/stages-multitenant/1-resman-tenant/templates/workflow-github.yaml
+++ b/fast/stages-multitenant/1-resman-tenant/templates/workflow-github.yaml
@@ -30,7 +30,7 @@ env:
   SSH_AUTH_SOCK: /tmp/ssh_agent.sock
   TF_PROVIDERS_FILE: ${tf_providers_file}
   TF_VAR_FILES: ${tf_var_files == [] ? "''" : join("\n    ", tf_var_files)}
-  TF_VERSION: 1.3.2
+  TF_VERSION: 1.4.4
 
 jobs:
   fast-pr:

--- a/fast/stages-multitenant/1-resman-tenant/templates/workflow-sourcerepo.yaml
+++ b/fast/stages-multitenant/1-resman-tenant/templates/workflow-sourcerepo.yaml
@@ -95,4 +95,4 @@ substitutions:
   _FAST_OUTPUTS_BUCKET: ${outputs_bucket}
   _TF_PROVIDERS_FILE: ${tf_providers_file}
   _TF_VAR_FILES: ${tf_var_files == [] ? "''" : join("\n    ", tf_var_files)}
-  _TF_VERSION: 1.3.2
+  _TF_VERSION: 1.4.4

--- a/fast/stages/0-bootstrap/templates/workflow-sourcerepo.yaml
+++ b/fast/stages/0-bootstrap/templates/workflow-sourcerepo.yaml
@@ -95,4 +95,4 @@ substitutions:
   _FAST_OUTPUTS_BUCKET: ${outputs_bucket}
   _TF_PROVIDERS_FILE: ${tf_providers_file}
   _TF_VAR_FILES: ${tf_var_files == [] ? "''" : join("\n    ", tf_var_files)}
-  _TF_VERSION: 1.3.2
+  _TF_VERSION: 1.4.4

--- a/fast/stages/1-resman/templates/workflow-github.yaml
+++ b/fast/stages/1-resman/templates/workflow-github.yaml
@@ -30,7 +30,7 @@ env:
   SSH_AUTH_SOCK: /tmp/ssh_agent.sock
   TF_PROVIDERS_FILE: ${tf_providers_file}
   TF_VAR_FILES: ${tf_var_files == [] ? "''" : join("\n    ", tf_var_files)}
-  TF_VERSION: 1.3.2
+  TF_VERSION: 1.4.4
 
 jobs:
   fast-pr:

--- a/fast/stages/1-resman/templates/workflow-sourcerepo.yaml
+++ b/fast/stages/1-resman/templates/workflow-sourcerepo.yaml
@@ -95,4 +95,4 @@ substitutions:
   _FAST_OUTPUTS_BUCKET: ${outputs_bucket}
   _TF_PROVIDERS_FILE: ${tf_providers_file}
   _TF_VAR_FILES: ${tf_var_files == [] ? "''" : join("\n    ", tf_var_files)}
-  _TF_VERSION: 1.3.2
+  _TF_VERSION: 1.4.4


### PR DESCRIPTION
Bootstrap was bumped in #1414

my networking repo GH action was failing 
![image](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/assets/4869891/d2bf2421-c470-445a-a603-05ffcae0bb72)
