### PR TITLE
fixup(project-factory): Use the correct KMS Service Agents attribute …

### DIFF
--- a/blueprints/factories/project-factory/README.md
+++ b/blueprints/factories/project-factory/README.md
@@ -67,7 +67,7 @@ module "projects" {
   folder_id              = each.value.folder_id
   group_iam              = try(each.value.group_iam, {})
   iam                    = try(each.value.iam, {})
-  kms_service_agents     = try(each.value.kms, {})
+  kms_service_agents     = try(each.value.kms_service_agents, {})
   labels                 = try(each.value.labels, {})
   org_policies           = try(each.value.org_policies, {})
   prefix                 = each.value.prefix

--- a/blueprints/factories/project-factory/README.md
+++ b/blueprints/factories/project-factory/README.md
@@ -76,7 +76,7 @@ module "projects" {
   service_identities_iam = try(each.value.service_identities_iam, {})
   vpc                    = try(each.value.vpc, null)
 }
-# tftest modules=7 resources=30 inventory=example.yaml
+# tftest modules=7 resources=34 inventory=example.yaml
 ```
 
 ### Projects configuration

--- a/fast/stages/3-project-factory/dev/main.tf
+++ b/fast/stages/3-project-factory/dev/main.tf
@@ -44,7 +44,7 @@ module "projects" {
   folder_id              = try(each.value.folder_id, local.defaults.folder_id)
   group_iam              = try(each.value.group_iam, {})
   iam                    = try(each.value.iam, {})
-  kms_service_agents     = try(each.value.kms, {})
+  kms_service_agents     = try(each.value.kms_service_agents, {})
   labels                 = try(each.value.labels, {})
   org_policies           = try(each.value.org_policies, null)
   prefix                 = var.prefix

--- a/tests/blueprints/factories/project_factory/examples/example.yaml
+++ b/tests/blueprints/factories/project_factory/examples/example.yaml
@@ -249,3 +249,4 @@ counts:
   google_project_service: 8
   google_service_account: 2
   google_storage_project_service_account: 1
+  google_kms_crypto_key_iam_member: 4

--- a/tests/blueprints/factories/project_factory/examples/example.yaml
+++ b/tests/blueprints/factories/project_factory/examples/example.yaml
@@ -170,6 +170,22 @@ values:
     condition: []
     project: fast-dev-net-spoke-0
     role: roles/compute.securityAdmin
+  module.projects["project"].module.project.google_kms_crypto_key_iam_member.service_identity_cmek["compute.key1"]:
+    condition: []
+    crypto_key_id: key1
+    role: roles/cloudkms.cryptoKeyEncrypterDecrypter
+  module.projects["project"].module.project.google_kms_crypto_key_iam_member.service_identity_cmek["compute.key2"]:
+    condition: []
+    crypto_key_id: key2
+    role: roles/cloudkms.cryptoKeyEncrypterDecrypter
+  module.projects["project"].module.project.google_kms_crypto_key_iam_member.service_identity_cmek["storage.key1"]:
+    condition: []
+    crypto_key_id: key1
+    role: roles/cloudkms.cryptoKeyEncrypterDecrypter
+  module.projects["project"].module.project.google_kms_crypto_key_iam_member.service_identity_cmek["storage.key2"]:
+    condition: []
+    crypto_key_id: key2
+    role: roles/cloudkms.cryptoKeyEncrypterDecrypter
   module.projects["project"].module.project.google_project_service.project_services["billingbudgets.googleapis.com"]:
     disable_dependent_services: false
     disable_on_destroy: false


### PR DESCRIPTION
## Intent

To fix a bug affecting the `project-factory` blueprint that was preventing the `kms_service_agents`  entries in `**/*.yaml` from being propagated into the project blueprint module.

## Problem

The file `fast/stages/3-project-factory/dev/main.tf` seems to expect the YAML key to be named `kms` instead of `kms_service_agents`. The key lookup for that attribute is wrapped in a `try()` clause which causes the naming mismatch to go unnoticed because the execution always falls back to the `{}` default value and, thus, any values for `kms_service_agents` are being discarded.

## Solution
To update the `fast/stages/3-project-factory/dev/main.tf` and `README.md` files to use the correct attribute name for KMS Service Agents configurations.