### PR TITLE
data-platform-minimal - correct typo

### DIFF
--- a/blueprints/data-solutions/data-platform-minimal/02-processing.tf
+++ b/blueprints/data-solutions/data-platform-minimal/02-processing.tf
@@ -102,7 +102,7 @@ module "processing-project" {
         "composer"
       ]
       "roles/container.hostServiceAgentUser" = [
-        "container-egine"
+        "container-engine"
       ]
     }
   }


### PR DESCRIPTION
`container-egine` errors

```
│ Error: Invalid index
│ 
│   on ../../../../modules/project/shared-vpc.tf line 74, in resource "google_project_iam_member" "shared_vpc_host_robots":
│   74:     : "serviceAccount:${local.service_accounts_robots[each.value.service]}"
│     ├────────────────
│     │ each.value.service is "container-egine"
│     │ local.service_accounts_robots is object with 177 attributes
│ 
│ The given key does not identify an element in this collection value.
```