### PR TITLE
data-platform-minimal - 02-processing.tf typo

### DIFF
--- a/blueprints/data-solutions/data-platform-minimal/02-processing.tf
+++ b/blueprints/data-solutions/data-platform-minimal/02-processing.tf
@@ -43,7 +43,7 @@ locals {
   }
   processing_subnet = (
     local.use_shared_vpc
-    ? var.network_config.subnet_self_links.processingestration
+    ? var.network_config.subnet_self_links.processing_transformation
     : module.processing-vpc.0.subnet_self_links["${var.region}/${var.prefix}-processing"]
   )
   processing_vpc = (


### PR DESCRIPTION
error is 
```
│ Error: Unsupported attribute
│ 
│   on ../../../../blueprints/data-solutions/data-platform-minimal/02-processing.tf line 46, in locals:
│   46:     ? var.network_config.subnet_self_links.processingestration
│     ├────────────────
│     │ var.network_config.subnet_self_links is object with 2 attributes
│ 
│ This object does not have an attribute named "processingestration".
╵
```

I'm guessing this should be `processing_transformation` the other option is `processing_composer`