### PR TITLE
match readme groups with variables file

### DIFF
--- a/blueprints/data-solutions/shielded-folder/README.md
+++ b/blueprints/data-solutions/shielded-folder/README.md
@@ -45,8 +45,8 @@ User groups provide a stable frame of reference that allows decoupling the final
 
 We use groups to control access to resources:
 
-- `data-engineers`: They handle and run workloads on the `workload` subfolder. They have editor access to all resources in the `workload` folder in order to troubleshoot possible issues within the workload. This team can also impersonate any service account in the workload folder.
-- `data-security`: They handle security configurations for the shielded folder. They have owner access to the `audit-log` and `sec-core` projects.
+- `gcp-data-engineers`: They handle and run workloads on the `workload` subfolder. They have editor access to all resources in the `workload` folder in order to troubleshoot possible issues within the workload. This team can also impersonate any service account in the workload folder.
+- `gcp-data-security`: They handle security configurations for the shielded folder. They have owner access to the `audit-log` and `sec-core` projects.
 
 ## Encryption
 


### PR DESCRIPTION
I faced error during my deployment even though I created `data-engineers group`. Then I found out that variables file uses `gcp-data-engineers` as default. The same is valid for `data-security`.

reference lines in `variables.tf`:
https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/261ad646a821851fb4c1e42d26fefa41e8aa371f/blueprints/data-solutions/shielded-folder/variables.tf#L68

https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/261ad646a821851fb4c1e42d26fefa41e8aa371f/blueprints/data-solutions/shielded-folder/variables.tf#L69