### PR TITLE
Update ncc-spoke-ra module to explicity request ncc hub id when referencing existing hubs

### DIFF
--- a/modules/ncc-spoke-ra/README.md
+++ b/modules/ncc-spoke-ra/README.md
@@ -132,7 +132,7 @@ module "spoke-ra" {
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [hub](variables.tf#L23) | The name of the NCC hub to create or the id for an existing hub to use. | <code title="object&#40;&#123;&#10;  create      &#61; optional&#40;bool, false&#41;&#10;  description &#61; optional&#40;string&#41;&#10;  id          &#61; optional&#40;string&#41;&#10;  name        &#61; optional&#40;string&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
+| [hub](variables.tf#L23) | The NCC hub. You should either provide an existing hub id or a hub name if create is true. | <code title="object&#40;&#123;&#10;  create      &#61; optional&#40;bool, false&#41;&#10;  description &#61; optional&#40;string&#41;&#10;  id          &#61; optional&#40;string&#41;&#10;  name        &#61; optional&#40;string&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
 | [name](variables.tf#L37) | The name of the NCC spoke. | <code>string</code> | ✓ |  |
 | [project_id](variables.tf#L42) | The ID of the project where the NCC hub & spokes will be created. | <code>string</code> | ✓ |  |
 | [region](variables.tf#L47) | Region where the spoke is located. | <code>string</code> | ✓ |  |

--- a/modules/ncc-spoke-ra/README.md
+++ b/modules/ncc-spoke-ra/README.md
@@ -132,13 +132,13 @@ module "spoke-ra" {
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [hub](variables.tf#L23) | The id of the NCC hub to create or use. | <code title="object&#40;&#123;&#10;  create      &#61; optional&#40;bool, false&#41;&#10;  description &#61; optional&#40;string&#41;&#10;  id        &#61; string&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
-| [name](variables.tf#L32) | The name of the NCC spoke. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L37) | The ID of the project where the NCC hub & spokes will be created. | <code>string</code> | ✓ |  |
-| [region](variables.tf#L42) | Region where the spoke is located. | <code>string</code> | ✓ |  |
-| [router_appliances](variables.tf#L47) | List of router appliances this spoke is associated with. | <code title="list&#40;object&#40;&#123;&#10;  internal_ip  &#61; string&#10;  vm_self_link &#61; string&#10;&#125;&#41;&#41;">list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> | ✓ |  |
-| [router_config](variables.tf#L55) | Configuration of the Cloud Router. | <code title="object&#40;&#123;&#10;  asn &#61; number&#10;  custom_advertise &#61; optional&#40;object&#40;&#123;&#10;    all_subnets &#61; bool&#10;    ip_ranges   &#61; map&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;  ip_interface0   &#61; string&#10;  ip_interface1   &#61; string&#10;  keepalive       &#61; optional&#40;number&#41;&#10;  peer_asn        &#61; number&#10;  routes_priority &#61; optional&#40;number, 100&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
-| [vpc_config](variables.tf#L71) | Network and subnetwork for the CR interfaces. | <code title="object&#40;&#123;&#10;  network_name     &#61; string&#10;  subnet_self_link &#61; string&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
+| [hub](variables.tf#L23) | The name of the NCC hub to create or the id for an existing hub to use. | <code title="object&#40;&#123;&#10;  create      &#61; optional&#40;bool, false&#41;&#10;  description &#61; optional&#40;string&#41;&#10;  id          &#61; optional&#40;string&#41;&#10;  name        &#61; optional&#40;string&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
+| [name](variables.tf#L37) | The name of the NCC spoke. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L42) | The ID of the project where the NCC hub & spokes will be created. | <code>string</code> | ✓ |  |
+| [region](variables.tf#L47) | Region where the spoke is located. | <code>string</code> | ✓ |  |
+| [router_appliances](variables.tf#L52) | List of router appliances this spoke is associated with. | <code title="list&#40;object&#40;&#123;&#10;  internal_ip  &#61; string&#10;  vm_self_link &#61; string&#10;&#125;&#41;&#41;">list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> | ✓ |  |
+| [router_config](variables.tf#L60) | Configuration of the Cloud Router. | <code title="object&#40;&#123;&#10;  asn &#61; number&#10;  custom_advertise &#61; optional&#40;object&#40;&#123;&#10;    all_subnets &#61; bool&#10;    ip_ranges   &#61; map&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;  ip_interface0   &#61; string&#10;  ip_interface1   &#61; string&#10;  keepalive       &#61; optional&#40;number&#41;&#10;  peer_asn        &#61; number&#10;  routes_priority &#61; optional&#40;number, 100&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
+| [vpc_config](variables.tf#L76) | Network and subnetwork for the CR interfaces. | <code title="object&#40;&#123;&#10;  network_name     &#61; string&#10;  subnet_self_link &#61; string&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
 | [data_transfer](variables.tf#L17) | Site-to-site data transfer feature, available only in some regions. | <code>bool</code> |  | <code>false</code> |
 
 ## Outputs

--- a/modules/ncc-spoke-ra/README.md
+++ b/modules/ncc-spoke-ra/README.md
@@ -40,7 +40,7 @@ module "spoke-ra" {
 ```hcl
 module "spoke-ra-a" {
   source     = "./fabric/modules/ncc-spoke-ra"
-  hub        = { name = "ncc-hub" }
+  hub        = { id = "projects/my-project/locations/global/hubs/ncc-hub" }
   name       = "spoke-ra-a"
   project_id = "my-project"
   region     = "europe-west1"
@@ -64,7 +64,7 @@ module "spoke-ra-a" {
 
 module "spoke-ra-b" {
   source     = "./fabric/modules/ncc-spoke-ra"
-  hub        = { name = "ncc-hub" }
+  hub        = { id = "projects/my-project/locations/global/hubs/ncc-hub" }
   name       = "spoke-ra-b"
   project_id = "my-project"
   region     = "europe-west3"
@@ -93,7 +93,7 @@ module "spoke-ra-b" {
 ```hcl
 module "spoke-ra" {
   source     = "./fabric/modules/ncc-spoke-ra"
-  hub        = { name = "ncc-hub" }
+  hub        = { id = "projects/my-project/locations/global/hubs/ncc-hub" }
   name       = "spoke-ra"
   project_id = "my-project"
   region     = "europe-west1"
@@ -132,7 +132,7 @@ module "spoke-ra" {
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [hub](variables.tf#L23) | The name of the NCC hub to create or use. | <code title="object&#40;&#123;&#10;  create      &#61; optional&#40;bool, false&#41;&#10;  description &#61; optional&#40;string&#41;&#10;  name        &#61; string&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
+| [hub](variables.tf#L23) | The id of the NCC hub to create or use. | <code title="object&#40;&#123;&#10;  create      &#61; optional&#40;bool, false&#41;&#10;  description &#61; optional&#40;string&#41;&#10;  id        &#61; string&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
 | [name](variables.tf#L32) | The name of the NCC spoke. | <code>string</code> | ✓ |  |
 | [project_id](variables.tf#L37) | The ID of the project where the NCC hub & spokes will be created. | <code>string</code> | ✓ |  |
 | [region](variables.tf#L42) | Region where the spoke is located. | <code>string</code> | ✓ |  |

--- a/modules/ncc-spoke-ra/main.tf
+++ b/modules/ncc-spoke-ra/main.tf
@@ -35,7 +35,7 @@ resource "google_network_connectivity_hub" "hub" {
 
 resource "google_network_connectivity_spoke" "spoke-ra" {
   project  = var.project_id
-  hub      = try(google_network_connectivity_hub.hub[0].name, var.hub.name)
+  hub      = try(google_network_connectivity_hub.hub[0].id, var.hub.id)
   location = var.region
   name     = var.name
   linked_router_appliance_instances {

--- a/modules/ncc-spoke-ra/variables.tf
+++ b/modules/ncc-spoke-ra/variables.tf
@@ -21,7 +21,7 @@ variable "data_transfer" {
 }
 
 variable "hub" {
-  description = "The name of the NCC hub to create or the id for an existing hub to use."
+  description = "The NCC hub. You should either provide an existing hub id or a hub name if create is true."
   type = object({
     create      = optional(bool, false)
     description = optional(string)

--- a/modules/ncc-spoke-ra/variables.tf
+++ b/modules/ncc-spoke-ra/variables.tf
@@ -29,7 +29,7 @@ variable "hub" {
     name        = optional(string)
   })
   validation {
-    condition     = var.hub.create && var.hub.name != null || !var.hub.create && var.hub.id != null
+    condition     = var.hub.create && var.hub.name != null || var.hub.create == false && var.hub.id != null
     error_message = "Name is required for configuring new ncc hub while referencing existing hub requires id."
   }
 }

--- a/modules/ncc-spoke-ra/variables.tf
+++ b/modules/ncc-spoke-ra/variables.tf
@@ -21,12 +21,17 @@ variable "data_transfer" {
 }
 
 variable "hub" {
-  description = "The name of the NCC hub to create or use."
+  description = "The name of the NCC hub to create or the id for an existing hub to use."
   type = object({
     create      = optional(bool, false)
     description = optional(string)
-    name        = string
+    id          = optional(string)
+    name        = optional(string)
   })
+  validation {
+    condition     = var.hub.create && var.hub.name != null || !var.hub.create && var.hub.id != null
+    error_message = "Name is required for configuring new ncc hub while referencing existing hub requires id."
+  }
 }
 
 variable "name" {


### PR DESCRIPTION
Modified module input variable to deal with ncc hub creation (passing the name of the hub to create) as well as referencing existing hub via id (instead of the name). Only specifying the name of the hub (even if in the same project) led to strange terraform behaviour (name of the hub being interpreted as the project id somehow), at least in the latest version of the provider.