### PR TITLE
Peering dashboard

### DIFF
--- a/fast/stages/2-networking-a-peering/data/dashboards/vpc_and_vpc_peering_group_quotas.json
+++ b/fast/stages/2-networking-a-peering/data/dashboards/vpc_and_vpc_peering_group_quotas.json
@@ -1,0 +1,253 @@
+{
+  "dashboardFilters": [],
+  "displayName": "VPC & VPC Peering Group Quotas",
+  "labels": {},
+  "mosaicLayout": {
+    "columns": 12,
+    "tiles": [
+      {
+        "height": 4,
+        "widget": {
+          "title": "Internal network (L4) Load Balancers per VPC Peering Group",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "measures": [],
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch compute.googleapis.com/VpcNetwork\n|{ metric\n      compute.googleapis.com/quota/internal_lb_forwarding_rules_per_peering_group/usage\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .max()\n  ; metric\n      compute.googleapis.com/quota/internal_lb_forwarding_rules_per_peering_group/limit\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .min() }\n| ratio\n| value cast_units(val()*100, \"%\")",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "xPos": 6
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Internal network (L4) Load Balancers per VPC",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch compute.googleapis.com/VpcNetwork\n|{ metric\n      compute.googleapis.com/quota/internal_lb_forwarding_rules_per_vpc_network/usage\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .max()\n  ; metric\n      compute.googleapis.com/quota/internal_lb_forwarding_rules_per_vpc_network/limit\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .min() }\n| ratio\n| value cast_units(val()*100, \"%\")",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Internal application (L7) Load Balancers per VPC",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "measures": [],
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch compute.googleapis.com/VpcNetwork\n|{ metric\n      compute.googleapis.com/quota/internal_managed_forwarding_rules_per_vpc_network/usage\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .max()\n  ; metric\n      compute.googleapis.com/quota/internal_managed_forwarding_rules_per_vpc_network/limit\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .min() }\n| ratio\n| value cast_units(val()*100, \"%\")",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "yPos": 4
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Internal application (L7) Load Balancers per VPC Peering Group",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "measures": [],
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch compute.googleapis.com/VpcNetwork\n|{ metric\n      compute.googleapis.com/quota/internal_managed_forwarding_rules_per_peering_group/usage\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .max()\n  ; metric\n      compute.googleapis.com/quota/internal_managed_forwarding_rules_per_peering_group/limit\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .min() }\n| ratio\n| value cast_units(val()*100, \"%\")",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "xPos": 6,
+        "yPos": 4
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Instances per VPC",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch compute.googleapis.com/VpcNetwork\n|{ metric\n      compute.googleapis.com/quota/instances_per_vpc_network/usage\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .max()\n  ; metric\n      compute.googleapis.com/quota/instances_per_vpc_network/limit\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .min() }\n| ratio\n| value cast_units(val()*100, \"%\")  ",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "yPos": 8
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Instances per VPC Peering Group",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch compute.googleapis.com/VpcNetwork\n|{ metric\n      compute.googleapis.com/quota/instances_per_peering_group/usage\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .max()\n  ; metric\n      compute.googleapis.com/quota/instances_per_peering_group/limit\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .min() }\n| ratio\n| value cast_units(val()*100, \"%\")",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "xPos": 6,
+        "yPos": 8
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Subnet ranges per VPC",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch compute.googleapis.com/VpcNetwork\n|{ metric\n      compute.googleapis.com/quota/subnet_ranges_per_vpc_network/usage\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .max()\n  ; metric\n      compute.googleapis.com/quota/subnet_ranges_per_vpc_network/limit\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .min() }\n| ratio\n| value cast_units(val()*100, \"%\")",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "yPos": 12
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Subnet ranges per VPC Peering Group",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch compute.googleapis.com/VpcNetwork\n|{ metric\n      compute.googleapis.com/quota/subnet_ranges_per_peering_group/usage\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .max()\n  ; metric\n      compute.googleapis.com/quota/subnet_ranges_per_peering_group/limit\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .min() }\n| ratio\n| value cast_units(val()*100, \"%\") ",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "xPos": 6,
+        "yPos": 12
+      }
+    ]
+  }
+}

--- a/fast/stages/2-networking-b-vpn/data/dashboards/vpc_and_vpc_peering_group_quotas.json
+++ b/fast/stages/2-networking-b-vpn/data/dashboards/vpc_and_vpc_peering_group_quotas.json
@@ -1,0 +1,253 @@
+{
+  "dashboardFilters": [],
+  "displayName": "VPC & VPC Peering Group Quotas",
+  "labels": {},
+  "mosaicLayout": {
+    "columns": 12,
+    "tiles": [
+      {
+        "height": 4,
+        "widget": {
+          "title": "Internal network (L4) Load Balancers per VPC Peering Group",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "measures": [],
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch compute.googleapis.com/VpcNetwork\n|{ metric\n      compute.googleapis.com/quota/internal_lb_forwarding_rules_per_peering_group/usage\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .max()\n  ; metric\n      compute.googleapis.com/quota/internal_lb_forwarding_rules_per_peering_group/limit\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .min() }\n| ratio\n| value cast_units(val()*100, \"%\")",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "xPos": 6
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Internal network (L4) Load Balancers per VPC",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch compute.googleapis.com/VpcNetwork\n|{ metric\n      compute.googleapis.com/quota/internal_lb_forwarding_rules_per_vpc_network/usage\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .max()\n  ; metric\n      compute.googleapis.com/quota/internal_lb_forwarding_rules_per_vpc_network/limit\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .min() }\n| ratio\n| value cast_units(val()*100, \"%\")",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Internal application (L7) Load Balancers per VPC",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "measures": [],
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch compute.googleapis.com/VpcNetwork\n|{ metric\n      compute.googleapis.com/quota/internal_managed_forwarding_rules_per_vpc_network/usage\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .max()\n  ; metric\n      compute.googleapis.com/quota/internal_managed_forwarding_rules_per_vpc_network/limit\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .min() }\n| ratio\n| value cast_units(val()*100, \"%\")",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "yPos": 4
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Internal application (L7) Load Balancers per VPC Peering Group",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "measures": [],
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch compute.googleapis.com/VpcNetwork\n|{ metric\n      compute.googleapis.com/quota/internal_managed_forwarding_rules_per_peering_group/usage\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .max()\n  ; metric\n      compute.googleapis.com/quota/internal_managed_forwarding_rules_per_peering_group/limit\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .min() }\n| ratio\n| value cast_units(val()*100, \"%\")",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "xPos": 6,
+        "yPos": 4
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Instances per VPC",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch compute.googleapis.com/VpcNetwork\n|{ metric\n      compute.googleapis.com/quota/instances_per_vpc_network/usage\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .max()\n  ; metric\n      compute.googleapis.com/quota/instances_per_vpc_network/limit\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .min() }\n| ratio\n| value cast_units(val()*100, \"%\")  ",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "yPos": 8
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Instances per VPC Peering Group",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch compute.googleapis.com/VpcNetwork\n|{ metric\n      compute.googleapis.com/quota/instances_per_peering_group/usage\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .max()\n  ; metric\n      compute.googleapis.com/quota/instances_per_peering_group/limit\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .min() }\n| ratio\n| value cast_units(val()*100, \"%\")",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "xPos": 6,
+        "yPos": 8
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Subnet ranges per VPC",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch compute.googleapis.com/VpcNetwork\n|{ metric\n      compute.googleapis.com/quota/subnet_ranges_per_vpc_network/usage\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .max()\n  ; metric\n      compute.googleapis.com/quota/subnet_ranges_per_vpc_network/limit\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .min() }\n| ratio\n| value cast_units(val()*100, \"%\")",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "yPos": 12
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Subnet ranges per VPC Peering Group",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch compute.googleapis.com/VpcNetwork\n|{ metric\n      compute.googleapis.com/quota/subnet_ranges_per_peering_group/usage\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .max()\n  ; metric\n      compute.googleapis.com/quota/subnet_ranges_per_peering_group/limit\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .min() }\n| ratio\n| value cast_units(val()*100, \"%\") ",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "xPos": 6,
+        "yPos": 12
+      }
+    ]
+  }
+}

--- a/fast/stages/2-networking-c-nva/data/dashboards/vpc_and_vpc_peering_group_quotas.json
+++ b/fast/stages/2-networking-c-nva/data/dashboards/vpc_and_vpc_peering_group_quotas.json
@@ -1,0 +1,253 @@
+{
+  "dashboardFilters": [],
+  "displayName": "VPC & VPC Peering Group Quotas",
+  "labels": {},
+  "mosaicLayout": {
+    "columns": 12,
+    "tiles": [
+      {
+        "height": 4,
+        "widget": {
+          "title": "Internal network (L4) Load Balancers per VPC Peering Group",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "measures": [],
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch compute.googleapis.com/VpcNetwork\n|{ metric\n      compute.googleapis.com/quota/internal_lb_forwarding_rules_per_peering_group/usage\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .max()\n  ; metric\n      compute.googleapis.com/quota/internal_lb_forwarding_rules_per_peering_group/limit\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .min() }\n| ratio\n| value cast_units(val()*100, \"%\")",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "xPos": 6
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Internal network (L4) Load Balancers per VPC",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch compute.googleapis.com/VpcNetwork\n|{ metric\n      compute.googleapis.com/quota/internal_lb_forwarding_rules_per_vpc_network/usage\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .max()\n  ; metric\n      compute.googleapis.com/quota/internal_lb_forwarding_rules_per_vpc_network/limit\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .min() }\n| ratio\n| value cast_units(val()*100, \"%\")",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Internal application (L7) Load Balancers per VPC",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "measures": [],
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch compute.googleapis.com/VpcNetwork\n|{ metric\n      compute.googleapis.com/quota/internal_managed_forwarding_rules_per_vpc_network/usage\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .max()\n  ; metric\n      compute.googleapis.com/quota/internal_managed_forwarding_rules_per_vpc_network/limit\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .min() }\n| ratio\n| value cast_units(val()*100, \"%\")",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "yPos": 4
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Internal application (L7) Load Balancers per VPC Peering Group",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "measures": [],
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch compute.googleapis.com/VpcNetwork\n|{ metric\n      compute.googleapis.com/quota/internal_managed_forwarding_rules_per_peering_group/usage\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .max()\n  ; metric\n      compute.googleapis.com/quota/internal_managed_forwarding_rules_per_peering_group/limit\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .min() }\n| ratio\n| value cast_units(val()*100, \"%\")",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "xPos": 6,
+        "yPos": 4
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Instances per VPC",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch compute.googleapis.com/VpcNetwork\n|{ metric\n      compute.googleapis.com/quota/instances_per_vpc_network/usage\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .max()\n  ; metric\n      compute.googleapis.com/quota/instances_per_vpc_network/limit\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .min() }\n| ratio\n| value cast_units(val()*100, \"%\")  ",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "yPos": 8
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Instances per VPC Peering Group",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch compute.googleapis.com/VpcNetwork\n|{ metric\n      compute.googleapis.com/quota/instances_per_peering_group/usage\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .max()\n  ; metric\n      compute.googleapis.com/quota/instances_per_peering_group/limit\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .min() }\n| ratio\n| value cast_units(val()*100, \"%\")",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "xPos": 6,
+        "yPos": 8
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Subnet ranges per VPC",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch compute.googleapis.com/VpcNetwork\n|{ metric\n      compute.googleapis.com/quota/subnet_ranges_per_vpc_network/usage\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .max()\n  ; metric\n      compute.googleapis.com/quota/subnet_ranges_per_vpc_network/limit\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .min() }\n| ratio\n| value cast_units(val()*100, \"%\")",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "yPos": 12
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Subnet ranges per VPC Peering Group",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch compute.googleapis.com/VpcNetwork\n|{ metric\n      compute.googleapis.com/quota/subnet_ranges_per_peering_group/usage\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .max()\n  ; metric\n      compute.googleapis.com/quota/subnet_ranges_per_peering_group/limit\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .min() }\n| ratio\n| value cast_units(val()*100, \"%\") ",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "xPos": 6,
+        "yPos": 12
+      }
+    ]
+  }
+}

--- a/fast/stages/2-networking-d-separate-envs/data/dashboards/vpc_and_vpc_peering_group_quotas.json
+++ b/fast/stages/2-networking-d-separate-envs/data/dashboards/vpc_and_vpc_peering_group_quotas.json
@@ -1,0 +1,253 @@
+{
+  "dashboardFilters": [],
+  "displayName": "VPC & VPC Peering Group Quotas",
+  "labels": {},
+  "mosaicLayout": {
+    "columns": 12,
+    "tiles": [
+      {
+        "height": 4,
+        "widget": {
+          "title": "Internal network (L4) Load Balancers per VPC Peering Group",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "measures": [],
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch compute.googleapis.com/VpcNetwork\n|{ metric\n      compute.googleapis.com/quota/internal_lb_forwarding_rules_per_peering_group/usage\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .max()\n  ; metric\n      compute.googleapis.com/quota/internal_lb_forwarding_rules_per_peering_group/limit\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .min() }\n| ratio\n| value cast_units(val()*100, \"%\")",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "xPos": 6
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Internal network (L4) Load Balancers per VPC",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch compute.googleapis.com/VpcNetwork\n|{ metric\n      compute.googleapis.com/quota/internal_lb_forwarding_rules_per_vpc_network/usage\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .max()\n  ; metric\n      compute.googleapis.com/quota/internal_lb_forwarding_rules_per_vpc_network/limit\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .min() }\n| ratio\n| value cast_units(val()*100, \"%\")",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Internal application (L7) Load Balancers per VPC",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "measures": [],
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch compute.googleapis.com/VpcNetwork\n|{ metric\n      compute.googleapis.com/quota/internal_managed_forwarding_rules_per_vpc_network/usage\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .max()\n  ; metric\n      compute.googleapis.com/quota/internal_managed_forwarding_rules_per_vpc_network/limit\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .min() }\n| ratio\n| value cast_units(val()*100, \"%\")",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "yPos": 4
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Internal application (L7) Load Balancers per VPC Peering Group",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "measures": [],
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch compute.googleapis.com/VpcNetwork\n|{ metric\n      compute.googleapis.com/quota/internal_managed_forwarding_rules_per_peering_group/usage\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .max()\n  ; metric\n      compute.googleapis.com/quota/internal_managed_forwarding_rules_per_peering_group/limit\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .min() }\n| ratio\n| value cast_units(val()*100, \"%\")",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "xPos": 6,
+        "yPos": 4
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Instances per VPC",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch compute.googleapis.com/VpcNetwork\n|{ metric\n      compute.googleapis.com/quota/instances_per_vpc_network/usage\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .max()\n  ; metric\n      compute.googleapis.com/quota/instances_per_vpc_network/limit\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .min() }\n| ratio\n| value cast_units(val()*100, \"%\")  ",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "yPos": 8
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Instances per VPC Peering Group",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch compute.googleapis.com/VpcNetwork\n|{ metric\n      compute.googleapis.com/quota/instances_per_peering_group/usage\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .max()\n  ; metric\n      compute.googleapis.com/quota/instances_per_peering_group/limit\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .min() }\n| ratio\n| value cast_units(val()*100, \"%\")",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "xPos": 6,
+        "yPos": 8
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Subnet ranges per VPC",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch compute.googleapis.com/VpcNetwork\n|{ metric\n      compute.googleapis.com/quota/subnet_ranges_per_vpc_network/usage\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .max()\n  ; metric\n      compute.googleapis.com/quota/subnet_ranges_per_vpc_network/limit\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .min() }\n| ratio\n| value cast_units(val()*100, \"%\")",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "yPos": 12
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Subnet ranges per VPC Peering Group",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch compute.googleapis.com/VpcNetwork\n|{ metric\n      compute.googleapis.com/quota/subnet_ranges_per_peering_group/usage\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .max()\n  ; metric\n      compute.googleapis.com/quota/subnet_ranges_per_peering_group/limit\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .min() }\n| ratio\n| value cast_units(val()*100, \"%\") ",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "xPos": 6,
+        "yPos": 12
+      }
+    ]
+  }
+}

--- a/fast/stages/2-networking-e-nva-bgp/data/dashboards/vpc_and_vpc_peering_group_quotas.json
+++ b/fast/stages/2-networking-e-nva-bgp/data/dashboards/vpc_and_vpc_peering_group_quotas.json
@@ -1,0 +1,253 @@
+{
+  "dashboardFilters": [],
+  "displayName": "VPC & VPC Peering Group Quotas",
+  "labels": {},
+  "mosaicLayout": {
+    "columns": 12,
+    "tiles": [
+      {
+        "height": 4,
+        "widget": {
+          "title": "Internal network (L4) Load Balancers per VPC Peering Group",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "measures": [],
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch compute.googleapis.com/VpcNetwork\n|{ metric\n      compute.googleapis.com/quota/internal_lb_forwarding_rules_per_peering_group/usage\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .max()\n  ; metric\n      compute.googleapis.com/quota/internal_lb_forwarding_rules_per_peering_group/limit\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .min() }\n| ratio\n| value cast_units(val()*100, \"%\")",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "xPos": 6
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Internal network (L4) Load Balancers per VPC",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch compute.googleapis.com/VpcNetwork\n|{ metric\n      compute.googleapis.com/quota/internal_lb_forwarding_rules_per_vpc_network/usage\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .max()\n  ; metric\n      compute.googleapis.com/quota/internal_lb_forwarding_rules_per_vpc_network/limit\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .min() }\n| ratio\n| value cast_units(val()*100, \"%\")",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Internal application (L7) Load Balancers per VPC",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "measures": [],
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch compute.googleapis.com/VpcNetwork\n|{ metric\n      compute.googleapis.com/quota/internal_managed_forwarding_rules_per_vpc_network/usage\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .max()\n  ; metric\n      compute.googleapis.com/quota/internal_managed_forwarding_rules_per_vpc_network/limit\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .min() }\n| ratio\n| value cast_units(val()*100, \"%\")",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "yPos": 4
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Internal application (L7) Load Balancers per VPC Peering Group",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "measures": [],
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch compute.googleapis.com/VpcNetwork\n|{ metric\n      compute.googleapis.com/quota/internal_managed_forwarding_rules_per_peering_group/usage\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .max()\n  ; metric\n      compute.googleapis.com/quota/internal_managed_forwarding_rules_per_peering_group/limit\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .min() }\n| ratio\n| value cast_units(val()*100, \"%\")",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "xPos": 6,
+        "yPos": 4
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Instances per VPC",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch compute.googleapis.com/VpcNetwork\n|{ metric\n      compute.googleapis.com/quota/instances_per_vpc_network/usage\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .max()\n  ; metric\n      compute.googleapis.com/quota/instances_per_vpc_network/limit\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .min() }\n| ratio\n| value cast_units(val()*100, \"%\")  ",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "yPos": 8
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Instances per VPC Peering Group",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch compute.googleapis.com/VpcNetwork\n|{ metric\n      compute.googleapis.com/quota/instances_per_peering_group/usage\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .max()\n  ; metric\n      compute.googleapis.com/quota/instances_per_peering_group/limit\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .min() }\n| ratio\n| value cast_units(val()*100, \"%\")",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "xPos": 6,
+        "yPos": 8
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Subnet ranges per VPC",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch compute.googleapis.com/VpcNetwork\n|{ metric\n      compute.googleapis.com/quota/subnet_ranges_per_vpc_network/usage\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .max()\n  ; metric\n      compute.googleapis.com/quota/subnet_ranges_per_vpc_network/limit\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .min() }\n| ratio\n| value cast_units(val()*100, \"%\")",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "yPos": 12
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Subnet ranges per VPC Peering Group",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch compute.googleapis.com/VpcNetwork\n|{ metric\n      compute.googleapis.com/quota/subnet_ranges_per_peering_group/usage\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .max()\n  ; metric\n      compute.googleapis.com/quota/subnet_ranges_per_peering_group/limit\n    | align next_older(1d)\n    | group_by [resource.resource_container, metric.limit_name], .min() }\n| ratio\n| value cast_units(val()*100, \"%\") ",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "xPos": 6,
+        "yPos": 12
+      }
+    ]
+  }
+}

--- a/tests/fast/stages/s2_networking_a_peering/stage.yaml
+++ b/tests/fast/stages/s2_networking_a_peering/stage.yaml
@@ -14,4 +14,4 @@
 
 counts:
   modules: 27
-  resources: 141
+  resources: 142

--- a/tests/fast/stages/s2_networking_b_vpn/stage.yaml
+++ b/tests/fast/stages/s2_networking_b_vpn/stage.yaml
@@ -14,4 +14,4 @@
 
 counts:
   modules: 29
-  resources: 178
+  resources: 179

--- a/tests/fast/stages/s2_networking_c_nva/stage.yaml
+++ b/tests/fast/stages/s2_networking_c_nva/stage.yaml
@@ -14,4 +14,4 @@
 
 counts:
   modules: 41
-  resources: 187
+  resources: 188

--- a/tests/fast/stages/s2_networking_d_separate_envs/stage.yaml
+++ b/tests/fast/stages/s2_networking_d_separate_envs/stage.yaml
@@ -14,4 +14,4 @@
 
 counts:
   modules: 20
-  resources: 160
+  resources: 161

--- a/tests/fast/stages/s2_networking_d_separate_envs/stage.yaml
+++ b/tests/fast/stages/s2_networking_d_separate_envs/stage.yaml
@@ -14,4 +14,4 @@
 
 counts:
   modules: 20
-  resources: 161
+  resources: 162

--- a/tests/fast/stages/s2_networking_e_nva_bgp/stage.yaml
+++ b/tests/fast/stages/s2_networking_e_nva_bgp/stage.yaml
@@ -14,4 +14,4 @@
 
 counts:
   modules: 35
-  resources: 200
+  resources: 201


### PR DESCRIPTION
Adding a monitoring dashboard for key VPC and VPC peering group network quotas that most of our customers care about.

I added this only in the networking-a-peering folder, should I also add it for other networking architecture options in fast?
Should I also add alerting policies when your utilization is above 80% for any of these quotas?