### PR TITLE
Project factory support for Serverless VPC Access connector permissions

### DIFF
--- a/blueprints/factories/project-factory/README.md
+++ b/blueprints/factories/project-factory/README.md
@@ -76,7 +76,7 @@ module "projects" {
   service_identities_iam = try(each.value.service_identities_iam, {})
   vpc                    = try(each.value.vpc, null)
 }
-# tftest modules=7 resources=36 inventory=example.yaml
+# tftest modules=7 resources=38 inventory=example.yaml
 ```
 
 ### Projects configuration
@@ -218,6 +218,12 @@ vpc:
     europe-west1/prod-default-ew1:
       - user:foobar@example.com
       - serviceAccount:service-account1@my-project.iam.gserviceaccount.com
+
+  # [opt] Grants "roles/vpcaccess.user" to the enabled service agents
+  serverless_connector_iam:
+    enable_cloud_run_agent: true
+    enable_cloud_functions_agent: false
+    enable_app_engine_standard_agent: false
 ```
 <!-- BEGIN TFDOC -->
 
@@ -248,7 +254,7 @@ vpc:
 | [service_identities_iam](variables.tf#L184) | Custom IAM settings for service identities in service => [role] format. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [service_identities_iam_additive](variables.tf#L191) | Custom additive IAM settings for service identities in service => [role] format. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [services](variables.tf#L198) | Services to be enabled for the project. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
-| [vpc](variables.tf#L205) | VPC configuration for the project. | <code title="object&#40;&#123;&#10;  host_project &#61; string&#10;  gke_setup &#61; object&#40;&#123;&#10;    enable_security_admin     &#61; bool&#10;    enable_host_service_agent &#61; bool&#10;  &#125;&#41;&#10;  subnets_iam &#61; map&#40;list&#40;string&#41;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [vpc](variables.tf#L205) | VPC configuration for the project. | <code title="object&#40;&#123;&#10;  host_project &#61; string&#10;  gke_setup &#61; object&#40;&#123;&#10;    enable_security_admin     &#61; bool&#10;    enable_host_service_agent &#61; bool&#10;  &#125;&#41;&#10;  subnets_iam &#61; map&#40;list&#40;string&#41;&#41;&#10;  serverless_connector_iam &#61; object&#40;&#123;&#10;    enable_cloud_run_agent           &#61; bool&#10;    enable_cloud_functions_agent     &#61; bool&#10;    enable_app_engine_standard_agent &#61; bool&#10;  &#125;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
 
 ## Outputs
 

--- a/blueprints/factories/project-factory/sample-data/projects/project.yaml
+++ b/blueprints/factories/project-factory/sample-data/projects/project.yaml
@@ -105,3 +105,9 @@ vpc:
     europe-west1/dev-default-ew1:
       - user:foobar@example.com
       - serviceAccount:my-service-account
+
+  # [opt] Grants "roles/vpcaccess.user" to the enabled service agents
+  serverless_connector_iam:
+    enable_cloud_run_agent: true
+    enable_cloud_functions_agent: false
+    enable_app_engine_standard_agent: true

--- a/blueprints/factories/project-factory/variables.tf
+++ b/blueprints/factories/project-factory/variables.tf
@@ -211,6 +211,11 @@ variable "vpc" {
       enable_host_service_agent = bool
     })
     subnets_iam = map(list(string))
+    serverless_connector_iam = object({
+      enable_cloud_run_agent           = bool
+      enable_cloud_functions_agent     = bool
+      enable_app_engine_standard_agent = bool
+    })
   })
   default = null
 }

--- a/tests/blueprints/factories/project_factory/examples/example.yaml
+++ b/tests/blueprints/factories/project_factory/examples/example.yaml
@@ -170,6 +170,14 @@ values:
     condition: []
     project: fast-dev-net-spoke-0
     role: roles/compute.securityAdmin
+  module.projects["project"].module.project.google_project_iam_member.shared_vpc_host_robots["roles/vpcaccess.user:cloudrun"]:
+    condition: []
+    project: fast-dev-net-spoke-0
+    role: roles/vpcaccess.user
+  module.projects["project"].module.project.google_project_iam_member.shared_vpc_host_robots["roles/vpcaccess.user:appenginestandard"]:
+    condition: []
+    project: fast-dev-net-spoke-0
+    role: roles/vpcaccess.user
   module.projects["project"].module.project.google_kms_crypto_key_iam_member.service_identity_cmek["compute.key1"]:
     condition: []
     crypto_key_id: key1
@@ -245,7 +253,7 @@ counts:
   google_org_policy_policy: 3
   google_project: 1
   google_project_iam_binding: 3
-  google_project_iam_member: 2
+  google_project_iam_member: 4
   google_project_service: 8
   google_service_account: 2
   google_storage_project_service_account: 1

--- a/tests/fast/stages/s3_project_factory/data/projects/project.yaml
+++ b/tests/fast/stages/s3_project_factory/data/projects/project.yaml
@@ -109,3 +109,9 @@ vpc:
     europe-west1/prod-default-ew1:
       - user:foobar@example.com
       - serviceAccount:service-account1
+
+  # [opt] Grants "roles/vpcaccess.user" to the enabled service agents
+  serverless_connector_iam:
+    enable_cloud_run_agent: false 
+    enable_cloud_functions_agent: false
+    enable_app_engine_standard_agent: true


### PR DESCRIPTION
Proposed project-factory update to support enabling access for Cloud Run, Cloud Functions and App Engine service agents to use Serverless VPC Access connectors that are deployed in a shared vpc host project. 

Relates to issue https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/issues/1517

