### PR TITLE
Make demo pipeline append into BQ tables

### DIFF
--- a/blueprints/data-solutions/data-platform-foundations/demo/datapipeline_dc_tags.py
+++ b/blueprints/data-solutions/data-platform-foundations/demo/datapipeline_dc_tags.py
@@ -283,7 +283,7 @@ with models.DAG(
           'datasetId': DWH_CURATED_BQ_DATASET,
           'tableId': 'customer_purchase'
         },
-        'writeDisposition':'WRITE_TRUNCATE',
+        'writeDisposition':'WRITE_APPEND',
         "useLegacySql": False
       }
     },
@@ -313,7 +313,7 @@ with models.DAG(
           'datasetId': DWH_CONFIDENTIAL_BQ_DATASET,
           'tableId': 'customer_purchase'
         },
-        'writeDisposition':'WRITE_TRUNCATE',
+        'writeDisposition':'WRITE_APPEND',
         "useLegacySql": False
       }
     },

--- a/blueprints/data-solutions/data-platform-foundations/demo/datapipeline_dc_tags_flex.py
+++ b/blueprints/data-solutions/data-platform-foundations/demo/datapipeline_dc_tags_flex.py
@@ -414,7 +414,7 @@ with models.DAG('data_pipeline_dc_tags_dag_flex',
                     'tableId': 'customer_purchase'
                 },
                 'writeDisposition':
-                'WRITE_TRUNCATE',
+                'WRITE_APPEND',
                 "useLegacySql":
                 False
             }
@@ -449,7 +449,7 @@ with models.DAG('data_pipeline_dc_tags_dag_flex',
                     'tableId': 'customer_purchase'
                 },
                 'writeDisposition':
-                'WRITE_TRUNCATE',
+                'WRITE_APPEND',
                 "useLegacySql":
                 False
             }


### PR DESCRIPTION
Make demo pipeline append into BQ tables instead of truncating. Truncating causes policy tags to be dropped, and therefore leaves sensitive columns without column-level protection.

Fixes https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/issues/1532