### PR TITLE
Fixed error of inconsistent conditional result types when evaluating …

### DIFF
--- a/modules/net-ipsec-over-interconnect/main.tf
+++ b/modules/net-ipsec-over-interconnect/main.tf
@@ -15,11 +15,6 @@
  */
 
 locals {
-  peer_gateway = (
-    var.peer_gateway_config.create
-    ? try(google_compute_external_vpn_gateway.default[0], null)
-    : var.peer_gateway_config
-  )
   peer_gateway_id = (
     var.peer_gateway_config.create
     ? try(google_compute_external_vpn_gateway.default[0].id, null)

--- a/modules/net-ipsec-over-interconnect/outputs.tf
+++ b/modules/net-ipsec-over-interconnect/outputs.tf
@@ -24,7 +24,7 @@ output "bgp_peers" {
 
 output "external_gateway" {
   description = "External VPN gateway resource."
-  value       = local.peer_gateway
+  value       = try(google_compute_external_vpn_gateway.default[0], null)
 }
 
 output "id" {


### PR DESCRIPTION
…local peer_gateway variable

```
I was getting the following error:

│ Error: Inconsistent conditional result types
│
│   on .terraform/modules/nonprod_hub.ipsec_over_interconnect/modules/net-ipsec-over-interconnect/main.tf line 20, in locals:
│   19:     var.peer_gateway_config.create
│   20:     ? try(google_compute_external_vpn_gateway.default[0], null)
│   21:     : var.peer_gateway_config
│     ├────────────────
│     │ google_compute_external_vpn_gateway.default[0] is object with 9 attributes
│     │ var.peer_gateway_config is object with 5 attributes
│     │ var.peer_gateway_config.create is true
│
│ The true and false result expressions must have consistent types. The 'true' value includes object attribute "interface", which is
│ absent in the 'false' value.
```