### PR TITLE
Expose allow_net_admin feature in gke-cluster-autopilot module

### DIFF
--- a/modules/gke-cluster-autopilot/main.tf
+++ b/modules/gke-cluster-autopilot/main.tf
@@ -32,6 +32,7 @@ resource "google_container_cluster" "cluster" {
   initial_node_count       = 1
 
   enable_autopilot = true
+  allow_net_admin = var.allow_net_admin
 
   addons_config {
     http_load_balancing {

--- a/modules/gke-cluster-autopilot/main.tf
+++ b/modules/gke-cluster-autopilot/main.tf
@@ -32,7 +32,7 @@ resource "google_container_cluster" "cluster" {
   initial_node_count       = 1
 
   enable_autopilot = true
-  allow_net_admin = var.allow_net_admin
+  allow_net_admin  = var.allow_net_admin
 
   addons_config {
     http_load_balancing {

--- a/modules/gke-cluster-autopilot/variables.tf
+++ b/modules/gke-cluster-autopilot/variables.tf
@@ -211,3 +211,9 @@ variable "vpc_config" {
   })
   nullable = false
 }
+
+variable "allow_net_admin" {
+  description = "Enable NET_ADMIN feature on autopilot cluster."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Raised in this issue #1571 

Summary of changes
- Added allow_net_admin variable to gke-cluster-autopilot.