### PR TITLE
Switch dns policies to GA provider

### DIFF
--- a/modules/dns-response-policy/main.tf
+++ b/modules/dns-response-policy/main.tf
@@ -34,7 +34,6 @@ locals {
 }
 
 resource "google_dns_response_policy" "default" {
-  provider             = google-beta
   count                = var.policy_create ? 1 : 0
   project              = var.project_id
   response_policy_name = var.name
@@ -53,7 +52,6 @@ resource "google_dns_response_policy" "default" {
 }
 
 resource "google_dns_response_policy_rule" "default" {
-  provider        = google-beta
   for_each        = merge(local.factory_rules, var.rules)
   project         = var.project_id
   response_policy = local.policy_name


### PR DESCRIPTION
DNS policies moved to GA with v 75.0.0 of the provider [1][2]

[1] https://github.com/hashicorp/terraform-provider-google/pull/15146
[2] https://github.com/hashicorp/terraform-provider-google/blob/main/CHANGELOG.md#4750-july-24-2023