### PR TITLE
fix null object exception in bootstrap output when using cloudsource

### DIFF
--- a/fast/stages/0-bootstrap/README.md
+++ b/fast/stages/0-bootstrap/README.md
@@ -529,14 +529,14 @@ The remaining configuration is manual, as it regards the repositories themselves
 
 | name | description | sensitive | consumers |
 |---|---|:---:|---|
-| [automation](outputs.tf#L100) | Automation resources. |  |  |
-| [billing_dataset](outputs.tf#L105) | BigQuery dataset prepared for billing export. |  |  |
-| [cicd_repositories](outputs.tf#L110) | CI/CD repository configurations. |  |  |
-| [custom_roles](outputs.tf#L122) | Organization-level custom roles. |  |  |
-| [federated_identity](outputs.tf#L127) | Workload Identity Federation pool and providers. |  |  |
-| [outputs_bucket](outputs.tf#L137) | GCS bucket where generated output files are stored. |  |  |
-| [project_ids](outputs.tf#L142) | Projects created by this stage. |  |  |
-| [providers](outputs.tf#L152) | Terraform provider files for this stage and dependent stages. | ✓ | <code>stage-01</code> |
-| [service_accounts](outputs.tf#L159) | Automation service accounts created by this stage. |  |  |
-| [tfvars](outputs.tf#L168) | Terraform variable files for the following stages. | ✓ |  |
+| [automation](outputs.tf#L102) | Automation resources. |  |  |
+| [billing_dataset](outputs.tf#L107) | BigQuery dataset prepared for billing export. |  |  |
+| [cicd_repositories](outputs.tf#L112) | CI/CD repository configurations. |  |  |
+| [custom_roles](outputs.tf#L124) | Organization-level custom roles. |  |  |
+| [federated_identity](outputs.tf#L129) | Workload Identity Federation pool and providers. |  |  |
+| [outputs_bucket](outputs.tf#L139) | GCS bucket where generated output files are stored. |  |  |
+| [project_ids](outputs.tf#L144) | Projects created by this stage. |  |  |
+| [providers](outputs.tf#L154) | Terraform provider files for this stage and dependent stages. | ✓ | <code>stage-01</code> |
+| [service_accounts](outputs.tf#L161) | Automation service accounts created by this stage. |  |  |
+| [tfvars](outputs.tf#L170) | Terraform variable files for the following stages. | ✓ |  |
 <!-- END TFDOC -->

--- a/fast/stages/0-bootstrap/outputs.tf
+++ b/fast/stages/0-bootstrap/outputs.tf
@@ -22,7 +22,9 @@ locals {
       "${path.module}/templates/workflow-${v.type}.yaml", {
         # If users give a list of custom audiences we set by default the first element.
         # If no audiences are given, we set https://iam.googleapis.com/{PROVIDER_NAME}
-        audiences = local.cicd_providers[v["identity_provider"]].audiences
+        audiences = try(
+          local.cicd_providers[v["identity_provider"]].audiences, ""
+        )
         identity_provider = try(
           local.cicd_providers[v["identity_provider"]].name, ""
         )


### PR DESCRIPTION
When using Cloud Source repos with FAST, there is no workflow identity federation configuration, so `local.cicd_providers[v["identity_provider"]]` is null. When the bootstrap stage's output module tries to populate the `audience` local, this causes a null object exception.

There may be other ways to address this, but wrapping the call in a try block seemed the most painless to me.