### PR TITLE
The role roles/run.invoker cannot be granted at the cloud function v2…

### DIFF
--- a/modules/cloud-function-v2/main.tf
+++ b/modules/cloud-function-v2/main.tf
@@ -24,18 +24,6 @@ locals {
       : null
     )
   )
-  _iam_run_invoker_members = concat(
-    lookup(var.iam, "roles/run.invoker", []),
-    var.trigger_config == null ? [] :
-    var.trigger_config.service_account_create ? ["serviceAccount:${local.trigger_service_account_email}"] : []
-  )
-  iam = merge(
-    var.iam,
-    length(local._iam_run_invoker_members) == 0 ? {} :
-    {
-      "roles/run.invoker" : local._iam_run_invoker_members
-    },
-  )
   prefix = var.prefix == null ? "" : "${var.prefix}-"
   service_account_email = (
     var.service_account_create
@@ -155,7 +143,7 @@ resource "google_cloudfunctions2_function" "function" {
 }
 
 resource "google_cloudfunctions2_function_iam_binding" "default" {
-  for_each       = local.iam
+  for_each       = var.iam
   project        = var.project_id
   location       = google_cloudfunctions2_function.function.location
   cloud_function = google_cloudfunctions2_function.function.name


### PR DESCRIPTION
When you try to apply it at the function level you get the following error:

│
│   with module.apigee_x["int"].module.instance_status_reporter_function[0].google_cloudfunctions2_function_iam_binding.default["roles/run.invoker"],
│   on .terraform/modules/apigee_x.instance_status_reporter_function/modules/cloud-function-v2/main.tf line 157, in resource "google_cloudfunctions2_function_iam_binding" "default":
│  157: resource "google_cloudfunctions2_function_iam_binding" "default" {
│
╵
╷
│ Error: Error applying IAM policy for cloudfunctions2 function "projects/apim-apigee-x-dev-0/locations/europe-west3/functions/instance-monitor": Error setting IAM policy for cloudfunctions2 function "projects/apim-apigee-x-dev-0/locations/europe-west3/functions/instance-monitor": googleapi: Error 400: Invalid argument: 'An invalid argument was specified. Please check the fields and try again.'
│ Details:
│ [
│   {
│     "@type": "type.googleapis.com/google.rpc.DebugInfo",
│     "detail": "generic::invalid_argument: Role roles/run.invoker is not supported for this resource.",
│     "stackEntries": [