### PR TITLE
Fix net-firewall-policy factory name and action

### DIFF
--- a/modules/net-firewall-policy/factory.tf
+++ b/modules/net-firewall-policy/factory.tf
@@ -26,10 +26,10 @@ locals {
   )
   factory_egress_rules = {
     for k, v in local._factory_egress_rules : "egress/${k}" => {
-      action                  = "deny"
       direction               = "EGRESS"
       name                    = k
       priority                = v.priority
+      action                  = lookup(v, "action", "deny")
       description             = lookup(v, "description", null)
       disabled                = lookup(v, "disabled", false)
       enable_logging          = lookup(v, "enable_logging", null)
@@ -70,10 +70,10 @@ locals {
   }
   factory_ingress_rules = {
     for k, v in local._factory_ingress_rules : "ingress/${k}" => {
-      action                  = "allow"
       direction               = "INGRESS"
       name                    = k
       priority                = v.priority
+      action                  = lookup(v, "action", "deny")
       description             = lookup(v, "description", null)
       disabled                = lookup(v, "disabled", false)
       enable_logging          = lookup(v, "enable_logging", null)

--- a/modules/net-firewall-policy/factory.tf
+++ b/modules/net-firewall-policy/factory.tf
@@ -28,6 +28,7 @@ locals {
     for k, v in local._factory_egress_rules : "egress/${k}" => {
       action                  = "deny"
       direction               = "EGRESS"
+      name                    = k
       priority                = v.priority
       description             = lookup(v, "description", null)
       disabled                = lookup(v, "disabled", false)
@@ -71,6 +72,7 @@ locals {
     for k, v in local._factory_ingress_rules : "ingress/${k}" => {
       action                  = "allow"
       direction               = "INGRESS"
+      name                    = k
       priority                = v.priority
       description             = lookup(v, "description", null)
       disabled                = lookup(v, "disabled", false)

--- a/modules/net-firewall-policy/factory.tf
+++ b/modules/net-firewall-policy/factory.tf
@@ -73,7 +73,7 @@ locals {
       direction               = "INGRESS"
       name                    = k
       priority                = v.priority
-      action                  = lookup(v, "action", "deny")
+      action                  = lookup(v, "action", "allow")
       description             = lookup(v, "description", null)
       disabled                = lookup(v, "disabled", false)
       enable_logging          = lookup(v, "enable_logging", null)


### PR DESCRIPTION
Currently the net-firewall-policy module factory implementation doesn't enable customisation of the rule action, nor does it `plan` correctly due to a missing name attribute.

Customisable action - the action for egress and ingress rules generated using the factory is hardcoded to "deny" and "allow" respectively. The previous `net-vpc-firewall-policy` module allowed customisation but set deny egress and allow ingress by default, which has been replicated in this PR rather than requiring an explicit action which the HFW set up in the `folder` module required.

Missing attribute - while the rules passed via `.tfvars` have a name/direction appended in `main.tf` the factory rules do not. As the direction for factory rules is assigned in `factory.tf`, this PR adds the name there too.

```
│ Error: Unsupported attribute
│
│   on .terraform/modules/firewall-policy/net-global.tf line 43, in resource "google_compute_network_firewall_policy_rule" "net-global":
│   43:   rule_name               = local.rules[each.key].name
│     ├────────────────
│     │ each.key is "egress/internet-deny"
│     │ local.rules is object with 4 attributes
│
│ This object does not have an attribute named "name"
```