### PR TITLE
Revert "Remove unused ASN numbers from CloudNAT to avoid provider errors"

### DIFF
--- a/fast/stages/2-networking-a-peering/landing.tf
+++ b/fast/stages/2-networking-a-peering/landing.tf
@@ -84,4 +84,5 @@ module "landing-nat-primary" {
   router_create  = true
   router_name    = "prod-nat-${local.region_shortnames[var.regions.primary]}"
   router_network = module.landing-vpc.name
+  router_asn     = 4200001024
 }

--- a/fast/stages/2-networking-a-peering/spoke-dev.tf
+++ b/fast/stages/2-networking-a-peering/spoke-dev.tf
@@ -80,6 +80,7 @@ module "dev-spoke-cloudnat" {
   name           = "dev-nat-${local.region_shortnames[each.value]}"
   router_create  = true
   router_network = module.dev-spoke-vpc.name
+  router_asn     = 4200001024
   logging_filter = "ERRORS_ONLY"
 }
 

--- a/fast/stages/2-networking-a-peering/spoke-prod.tf
+++ b/fast/stages/2-networking-a-peering/spoke-prod.tf
@@ -79,6 +79,7 @@ module "prod-spoke-cloudnat" {
   name           = "prod-nat-${local.region_shortnames[each.value]}"
   router_create  = true
   router_network = module.prod-spoke-vpc.name
+  router_asn     = 4200001024
   logging_filter = "ERRORS_ONLY"
 }
 

--- a/fast/stages/2-networking-b-vpn/landing.tf
+++ b/fast/stages/2-networking-b-vpn/landing.tf
@@ -84,4 +84,5 @@ module "landing-nat-primary" {
   router_create  = true
   router_name    = "prod-nat-${local.region_shortnames[var.regions.primary]}"
   router_network = module.landing-vpc.name
+  router_asn     = 4200001024
 }

--- a/fast/stages/2-networking-b-vpn/spoke-dev.tf
+++ b/fast/stages/2-networking-b-vpn/spoke-dev.tf
@@ -80,6 +80,7 @@ module "dev-spoke-cloudnat" {
   name           = "dev-nat-${local.region_shortnames[each.value]}"
   router_create  = true
   router_network = module.dev-spoke-vpc.name
+  router_asn     = 4200001024
   logging_filter = "ERRORS_ONLY"
 }
 

--- a/fast/stages/2-networking-b-vpn/spoke-prod.tf
+++ b/fast/stages/2-networking-b-vpn/spoke-prod.tf
@@ -79,6 +79,7 @@ module "prod-spoke-cloudnat" {
   name           = "prod-nat-${local.region_shortnames[each.value]}"
   router_create  = true
   router_network = module.prod-spoke-vpc.name
+  router_asn     = 4200001024
   logging_filter = "ERRORS_ONLY"
 }
 

--- a/fast/stages/2-networking-c-nva/landing.tf
+++ b/fast/stages/2-networking-c-nva/landing.tf
@@ -85,6 +85,7 @@ module "landing-nat-primary" {
   router_create  = true
   router_name    = "prod-nat-${local.region_shortnames[var.regions.primary]}"
   router_network = module.landing-untrusted-vpc.name
+  router_asn     = 4200001024
 }
 
 moved {
@@ -100,6 +101,7 @@ module "landing-nat-secondary" {
   router_create  = true
   router_name    = "prod-nat-${local.region_shortnames[var.regions.secondary]}"
   router_network = module.landing-untrusted-vpc.name
+  router_asn     = 4200001024
 }
 
 # Trusted VPC

--- a/fast/stages/2-networking-d-separate-envs/spoke-dev.tf
+++ b/fast/stages/2-networking-d-separate-envs/spoke-dev.tf
@@ -80,6 +80,7 @@ module "dev-spoke-cloudnat" {
   name           = "dev-nat-${local.region_shortnames[each.value]}"
   router_create  = true
   router_network = module.dev-spoke-vpc.name
+  router_asn     = 4200001024
   logging_filter = "ERRORS_ONLY"
 }
 

--- a/fast/stages/2-networking-d-separate-envs/spoke-prod.tf
+++ b/fast/stages/2-networking-d-separate-envs/spoke-prod.tf
@@ -79,6 +79,7 @@ module "prod-spoke-cloudnat" {
   name           = "prod-nat-${local.region_shortnames[each.value]}"
   router_create  = true
   router_network = module.prod-spoke-vpc.name
+  router_asn     = 4200001024
   logging_filter = "ERRORS_ONLY"
 }
 

--- a/fast/stages/2-networking-e-nva-bgp/landing.tf
+++ b/fast/stages/2-networking-e-nva-bgp/landing.tf
@@ -86,6 +86,7 @@ module "landing-nat-primary" {
   router_create  = true
   router_name    = "prod-nat-${local.region_shortnames[var.regions.primary]}"
   router_network = module.landing-untrusted-vpc.name
+  router_asn     = 4200001024
 }
 
 moved {
@@ -101,6 +102,7 @@ module "landing-nat-secondary" {
   router_create  = true
   router_name    = "prod-nat-${local.region_shortnames[var.regions.secondary]}"
   router_network = module.landing-untrusted-vpc.name
+  router_asn     = 4200001024
 }
 
 # Trusted VPC


### PR DESCRIPTION
Turns out that ASN is everything but useless.

* the net-cloudnat module sets `router_asn` to `64514` by default, if not manually set.
* `64514` goes in conflict with other router asn numbers set in different FAST stages (i.e. `2-networking-e-bgp`), causing errors

I tried to reproduce what a user reported before (below):

```
Error: Attribute must be a whole number, got 4.200001024e+09│ │   with module.prod-spoke-cloudnat["europe-west1"].google_compute_router.router[0],│   on ../../../modules/net-cloudnat/[main.tf](http://main.tf/) line 32, in resource "google_compute_router" "router":│   32:     asn = var.router_asn│ ╵╷│

Error: Attribute must be a whole number, got 4.200001024e+09│ │   with module.dev-spoke-cloudnat["europe-west1"].google_compute_router.router[0],│   on ../../../modules/net-cloudnat/[main.tf](http://main.tf/) line 32, in resource "google_compute_router" "router":│   32:     asn = var.router_asn│
```

Anyway, it doesn't seem to be reproducible.
I also checked the APIs and the ASN 4200001024 should be definitely allowed.

**I propose to revert this to fix the `networking-e` stage immediately**. We may otherwise consider to use lower private ASN but not conflicting with ASN numbers used in FAST already (i.e. `65534`?)