### PR TITLE
[Fix] Add explicit dependency between CR peers and NCC RA spoke creation

### DIFF
--- a/modules/ncc-spoke-ra/main.tf
+++ b/modules/ncc-spoke-ra/main.tf
@@ -107,6 +107,10 @@ resource "google_compute_router_peer" "peer_0" {
   peer_asn                  = var.router_config.peer_asn
   peer_ip_address           = each.value.ip
   router_appliance_instance = each.value.vm
+
+  depends_on = [
+    google_network_connectivity_spoke.spoke-ra
+  ]
 }
 
 resource "google_compute_router_peer" "peer_1" {
@@ -122,4 +126,8 @@ resource "google_compute_router_peer" "peer_1" {
   peer_asn                  = var.router_config.peer_asn
   peer_ip_address           = each.value.ip
   router_appliance_instance = each.value.vm
+
+  depends_on = [
+    google_network_connectivity_spoke.spoke-ra
+  ]
 }


### PR DESCRIPTION
Currently CR peers may be created before the NCC-RA spoke is created (so before the VM is attached to an NCC spoke).
This errors out because we can't reference a VM as a peer before it gets added to an NCC spoke.

Adding an explicit dependency between the CR peer and the NCC RA spoke.

[tried to add an IMPLICIT dependency but makes the code much more complex and unreadable]