### PR TITLE
[revert(revert(patch))] Remove unused ASN numbers for CloudNAT in FAST

### DIFF
--- a/fast/stages/2-networking-a-peering/landing.tf
+++ b/fast/stages/2-networking-a-peering/landing.tf
@@ -84,5 +84,4 @@ module "landing-nat-primary" {
   router_create  = true
   router_name    = "prod-nat-${local.region_shortnames[var.regions.primary]}"
   router_network = module.landing-vpc.name
-  router_asn     = 4200001024
 }

--- a/fast/stages/2-networking-a-peering/spoke-dev.tf
+++ b/fast/stages/2-networking-a-peering/spoke-dev.tf
@@ -80,7 +80,6 @@ module "dev-spoke-cloudnat" {
   name           = "dev-nat-${local.region_shortnames[each.value]}"
   router_create  = true
   router_network = module.dev-spoke-vpc.name
-  router_asn     = 4200001024
   logging_filter = "ERRORS_ONLY"
 }
 

--- a/fast/stages/2-networking-a-peering/spoke-prod.tf
+++ b/fast/stages/2-networking-a-peering/spoke-prod.tf
@@ -79,7 +79,6 @@ module "prod-spoke-cloudnat" {
   name           = "prod-nat-${local.region_shortnames[each.value]}"
   router_create  = true
   router_network = module.prod-spoke-vpc.name
-  router_asn     = 4200001024
   logging_filter = "ERRORS_ONLY"
 }
 

--- a/fast/stages/2-networking-b-vpn/landing.tf
+++ b/fast/stages/2-networking-b-vpn/landing.tf
@@ -84,5 +84,4 @@ module "landing-nat-primary" {
   router_create  = true
   router_name    = "prod-nat-${local.region_shortnames[var.regions.primary]}"
   router_network = module.landing-vpc.name
-  router_asn     = 4200001024
 }

--- a/fast/stages/2-networking-b-vpn/spoke-dev.tf
+++ b/fast/stages/2-networking-b-vpn/spoke-dev.tf
@@ -80,7 +80,6 @@ module "dev-spoke-cloudnat" {
   name           = "dev-nat-${local.region_shortnames[each.value]}"
   router_create  = true
   router_network = module.dev-spoke-vpc.name
-  router_asn     = 4200001024
   logging_filter = "ERRORS_ONLY"
 }
 

--- a/fast/stages/2-networking-b-vpn/spoke-prod.tf
+++ b/fast/stages/2-networking-b-vpn/spoke-prod.tf
@@ -79,7 +79,6 @@ module "prod-spoke-cloudnat" {
   name           = "prod-nat-${local.region_shortnames[each.value]}"
   router_create  = true
   router_network = module.prod-spoke-vpc.name
-  router_asn     = 4200001024
   logging_filter = "ERRORS_ONLY"
 }
 

--- a/fast/stages/2-networking-c-nva/landing.tf
+++ b/fast/stages/2-networking-c-nva/landing.tf
@@ -85,7 +85,6 @@ module "landing-nat-primary" {
   router_create  = true
   router_name    = "prod-nat-${local.region_shortnames[var.regions.primary]}"
   router_network = module.landing-untrusted-vpc.name
-  router_asn     = 4200001024
 }
 
 moved {
@@ -101,7 +100,6 @@ module "landing-nat-secondary" {
   router_create  = true
   router_name    = "prod-nat-${local.region_shortnames[var.regions.secondary]}"
   router_network = module.landing-untrusted-vpc.name
-  router_asn     = 4200001024
 }
 
 # Trusted VPC

--- a/fast/stages/2-networking-d-separate-envs/spoke-dev.tf
+++ b/fast/stages/2-networking-d-separate-envs/spoke-dev.tf
@@ -80,7 +80,6 @@ module "dev-spoke-cloudnat" {
   name           = "dev-nat-${local.region_shortnames[each.value]}"
   router_create  = true
   router_network = module.dev-spoke-vpc.name
-  router_asn     = 4200001024
   logging_filter = "ERRORS_ONLY"
 }
 

--- a/fast/stages/2-networking-d-separate-envs/spoke-prod.tf
+++ b/fast/stages/2-networking-d-separate-envs/spoke-prod.tf
@@ -79,7 +79,6 @@ module "prod-spoke-cloudnat" {
   name           = "prod-nat-${local.region_shortnames[each.value]}"
   router_create  = true
   router_network = module.prod-spoke-vpc.name
-  router_asn     = 4200001024
   logging_filter = "ERRORS_ONLY"
 }
 

--- a/fast/stages/2-networking-e-nva-bgp/landing.tf
+++ b/fast/stages/2-networking-e-nva-bgp/landing.tf
@@ -86,7 +86,6 @@ module "landing-nat-primary" {
   router_create  = true
   router_name    = "prod-nat-${local.region_shortnames[var.regions.primary]}"
   router_network = module.landing-untrusted-vpc.name
-  router_asn     = 4200001024
 }
 
 moved {
@@ -102,7 +101,6 @@ module "landing-nat-secondary" {
   router_create  = true
   router_name    = "prod-nat-${local.region_shortnames[var.regions.secondary]}"
   router_network = module.landing-untrusted-vpc.name
-  router_asn     = 4200001024
 }
 
 # Trusted VPC


### PR DESCRIPTION
**Step 2 of "using correctly ASN in FAST"**

After talking with @juliocc it seems long AS numbers may not be ingested properly if applied from a 32 bit system, so it would be better to avoid them.

On the other hand, a default ASN number is not really needed for Cloud NAT.

As a result

* with a [previous patch](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/pull/1633) we moved to optional the cloud nat module ASN (not required by APIs)
* with THIS patch, we revert (again!) the FAST ASN patch --> meaning, we will no longer specify ASNs in FAST