### PR TITLE
Simplify linting output in workflow

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -53,17 +53,17 @@ jobs:
       - name: Check documentation
         id: documentation-fabric
         run: |
-          python3 tools/check_documentation.py --show-diffs modules fast blueprints
+          python3 tools/check_documentation.py --show-diffs --no-show-summary modules fast blueprints
 
       - name: Check documentation links
         id: documentation-links-fabric
         run: |
-          python3 tools/check_links.py .
+          python3 tools/check_links.py --no-show-summary .
 
       - name: Check name length (fast)
         id: name-length-fast
         run: |
-          python3 tools/check_names.py --prefix-length=10 fast/stages
+          python3 tools/check_names.py --prefix-length=10 --failed-only fast/stages
 
       - name: Check python formatting
         id: yapf
@@ -76,4 +76,4 @@ jobs:
       - name: Check blueprint metadata
         id: metadata
         run: |
-          python tools/validate_metadata.py -v blueprints
+          python tools/validate_metadata.py -v --failed-only blueprints

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -669,6 +669,8 @@ Options:
   --help                          Show this message and exit.
 ```
 
+As a convenience, we provide a script that runs the same set of checks as our GitHub workflow. Before submitting a PR, run `tools/lint.sh` and fix any errors. You can use the tools described above to find out more about the failures.
+
 The test workflow runs test suites in parallel. Refer to the next section for more details on running and writing tests.
 
 ## Using and writing tests

--- a/tools/check_links.py
+++ b/tools/check_links.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -77,20 +77,24 @@ def check_docs(dir_name, external=False):
 @click.argument('dirs', type=str, nargs=-1)
 @click.option('-e', '--external', is_flag=True, default=False,
               help='Whether to test external links.')
-def main(dirs, external):
+@click.option('--show-summary/--no-show-summary', default=True)
+def main(dirs, external, show_summary=True):
   'Checks links in Markdown files contained in dirs.'
   errors = []
   for dir_name in dirs:
-    print(f'----- {dir_name} -----')
+    if show_summary:
+      print(f'----- {dir_name} -----')
     for doc in check_docs(dir_name, external):
       state = '✓' if all(l.valid for l in doc.links) else '✗'
-      print(f'[{state}] {doc.relpath} ({len(doc.links)})')
+      if show_summary:
+        print(f'[{state}] {doc.relpath} ({len(doc.links)})')
       if state == '✗':
         error = [f'{dir_name}/{doc.relpath}']
         for l in doc.links:
           if not l.valid:
             error.append(f'  - {l.dest}')
-            print(f'  {l.dest}')
+            if show_summary:
+              print(f'  {l.dest}')
         errors.append('\n'.join(error))
   if errors:
     raise SystemExit('Errors found:\n{}'.format('\n'.join(errors)))

--- a/tools/check_names.py
+++ b/tools/check_names.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -72,7 +72,8 @@ def get_names(dir_name):
 @click.command()
 @click.argument('dirs', type=str, nargs=-1)
 @click.option('--prefix-length', default=7, type=int)
-def main(dirs, prefix_length=None):
+@click.option('--failed-only', is_flag=True, default=False)
+def main(dirs, prefix_length=None, failed_only=False):
   'Parse names in dirs.'
   import json
   logging.basicConfig(level=logging.INFO)
@@ -87,18 +88,21 @@ def main(dirs, prefix_length=None):
   errors = []
   for name in names:
     name_length = name.length + prefix_length
+    do_print = True
     if name_length >= MOD_LIMITS[name.source]:
       flag = "✗"
       errors += [f"{name.source}:{name.name}:{name_length}"]
     else:
       flag = "✓"
+      do_print = not failed_only
 
-    print(f"[{flag}] {name.source.ljust(source_just)} "
-          f"{name.name.ljust(name_just)} "
-          f"{name.value.ljust(value_just)} "
-          f"({name_length})")
-  if errors:
-    raise ValueError(errors)
+    if do_print:
+      print(f"[{flag}] {name.source.ljust(source_just)} "
+            f"{name.name.ljust(name_just)} "
+            f"{name.value.ljust(value_just)} "
+            f"({name_length})")
+
+  return 0 if not errors else 1
 
 
 if __name__ == '__main__':

--- a/tools/validate_metadata.py
+++ b/tools/validate_metadata.py
@@ -59,7 +59,8 @@ def _validate(path: Path, validator) -> ValidationResult:
 @click.argument('dirs', type=click.Path(exists=True, file_okay=False), nargs=-1)
 @click.option('-v', '--verbose', is_flag=True, default=False,
               help='Print additional validation details.')
-def main(dirs: list[str], verbose: bool) -> int:
+@click.option('--failed-only', is_flag=True, default=False)
+def main(dirs: list[str], verbose: bool, failed_only=False) -> int:
   instances = set()
   for dir_name in dirs:
     instances |= set(Path(dir_name).glob("**/metadata.yaml"))
@@ -72,7 +73,8 @@ def main(dirs: list[str], verbose: bool) -> int:
   for instance in instances:
     result = _validate(instance, validator)
     if result.state == State.OK:
-      print(f'[✓] {instance}')
+      if not failed_only:
+        print(f'[✓] {instance}')
     else:
       print(f'[✗] {instance}')
       failed_files[instance] = result.errors


### PR DESCRIPTION
- Only print liniting failures in GH workflows
- Provide a user-friend script (tools/lint.sh) to run all checks in one go

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
