### PR TITLE
Bump provider version to 4.80.0

### DIFF
--- a/blueprints/apigee/bigquery-analytics/versions.tf
+++ b/blueprints/apigee/bigquery-analytics/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/blueprints/apigee/network-patterns/nb-glb-psc-neg-sb-psc-ilbl7-hybrid-neg/versions.tf
+++ b/blueprints/apigee/network-patterns/nb-glb-psc-neg-sb-psc-ilbl7-hybrid-neg/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/blueprints/cloud-operations/adfs/versions.tf
+++ b/blueprints/cloud-operations/adfs/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/blueprints/cloud-operations/asset-inventory-feed-remediation/versions.tf
+++ b/blueprints/cloud-operations/asset-inventory-feed-remediation/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/blueprints/cloud-operations/dns-fine-grained-iam/versions.tf
+++ b/blueprints/cloud-operations/dns-fine-grained-iam/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/blueprints/cloud-operations/dns-shared-vpc/versions.tf
+++ b/blueprints/cloud-operations/dns-shared-vpc/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/blueprints/cloud-operations/iam-delegated-role-grants/versions.tf
+++ b/blueprints/cloud-operations/iam-delegated-role-grants/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/blueprints/cloud-operations/onprem-sa-key-management/versions.tf
+++ b/blueprints/cloud-operations/onprem-sa-key-management/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/blueprints/cloud-operations/packer-image-builder/versions.tf
+++ b/blueprints/cloud-operations/packer-image-builder/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/blueprints/cloud-operations/quota-monitoring/versions.tf
+++ b/blueprints/cloud-operations/quota-monitoring/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/blueprints/cloud-operations/scheduled-asset-inventory-export-bq/versions.tf
+++ b/blueprints/cloud-operations/scheduled-asset-inventory-export-bq/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/blueprints/data-solutions/bq-ml/versions.tf
+++ b/blueprints/data-solutions/bq-ml/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/blueprints/data-solutions/cmek-via-centralized-kms/versions.tf
+++ b/blueprints/data-solutions/cmek-via-centralized-kms/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/blueprints/data-solutions/data-playground/versions.tf
+++ b/blueprints/data-solutions/data-playground/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/blueprints/data-solutions/gcs-to-bq-with-least-privileges/versions.tf
+++ b/blueprints/data-solutions/gcs-to-bq-with-least-privileges/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/blueprints/factories/net-vpc-firewall-yaml/versions.tf
+++ b/blueprints/factories/net-vpc-firewall-yaml/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/blueprints/networking/__need_fixing/nginx-reverse-proxy-cluster/versions.tf
+++ b/blueprints/networking/__need_fixing/nginx-reverse-proxy-cluster/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/blueprints/networking/__need_fixing/onprem-google-access-dns/versions.tf
+++ b/blueprints/networking/__need_fixing/onprem-google-access-dns/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/blueprints/networking/decentralized-firewall/versions.tf
+++ b/blueprints/networking/decentralized-firewall/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/blueprints/networking/filtering-proxy-psc/versions.tf
+++ b/blueprints/networking/filtering-proxy-psc/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/blueprints/networking/filtering-proxy/versions.tf
+++ b/blueprints/networking/filtering-proxy/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/blueprints/networking/hub-and-spoke-peering/versions.tf
+++ b/blueprints/networking/hub-and-spoke-peering/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/blueprints/networking/hub-and-spoke-vpn/versions.tf
+++ b/blueprints/networking/hub-and-spoke-vpn/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/blueprints/networking/ilb-next-hop/versions.tf
+++ b/blueprints/networking/ilb-next-hop/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/blueprints/networking/private-cloud-function-from-onprem/versions.tf
+++ b/blueprints/networking/private-cloud-function-from-onprem/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/blueprints/networking/shared-vpc-gke/versions.tf
+++ b/blueprints/networking/shared-vpc-gke/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/blueprints/third-party-solutions/openshift/tf/versions.tf
+++ b/blueprints/third-party-solutions/openshift/tf/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/default-versions.tf
+++ b/default-versions.tf
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/__experimental/net-neg/versions.tf
+++ b/modules/__experimental/net-neg/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/alloydb-instance/versions.tf
+++ b/modules/alloydb-instance/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/api-gateway/versions.tf
+++ b/modules/api-gateway/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/apigee/versions.tf
+++ b/modules/apigee/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/artifact-registry/versions.tf
+++ b/modules/artifact-registry/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/bigquery-dataset/versions.tf
+++ b/modules/bigquery-dataset/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/bigtable-instance/versions.tf
+++ b/modules/bigtable-instance/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/billing-budget/versions.tf
+++ b/modules/billing-budget/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/binauthz/versions.tf
+++ b/modules/binauthz/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/__need_fixing/onprem/versions.tf
+++ b/modules/cloud-config-container/__need_fixing/onprem/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/coredns/versions.tf
+++ b/modules/cloud-config-container/coredns/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/cos-generic-metadata/versions.tf
+++ b/modules/cloud-config-container/cos-generic-metadata/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/envoy-traffic-director/versions.tf
+++ b/modules/cloud-config-container/envoy-traffic-director/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/mysql/versions.tf
+++ b/modules/cloud-config-container/mysql/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/nginx-tls/versions.tf
+++ b/modules/cloud-config-container/nginx-tls/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/nginx/versions.tf
+++ b/modules/cloud-config-container/nginx/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/simple-nva/versions.tf
+++ b/modules/cloud-config-container/simple-nva/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/squid/versions.tf
+++ b/modules/cloud-config-container/squid/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/cloud-function-v1/versions.tf
+++ b/modules/cloud-function-v1/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/cloud-function-v2/versions.tf
+++ b/modules/cloud-function-v2/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/cloud-identity-group/versions.tf
+++ b/modules/cloud-identity-group/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/cloud-run/versions.tf
+++ b/modules/cloud-run/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/cloudsql-instance/versions.tf
+++ b/modules/cloudsql-instance/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/compute-mig/versions.tf
+++ b/modules/compute-mig/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/compute-vm/versions.tf
+++ b/modules/compute-vm/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/container-registry/versions.tf
+++ b/modules/container-registry/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/data-catalog-policy-tag/versions.tf
+++ b/modules/data-catalog-policy-tag/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/datafusion/versions.tf
+++ b/modules/datafusion/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/dataplex-datascan/versions.tf
+++ b/modules/dataplex-datascan/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/dataplex/versions.tf
+++ b/modules/dataplex/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/dataproc/versions.tf
+++ b/modules/dataproc/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/dns-response-policy/versions.tf
+++ b/modules/dns-response-policy/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/dns/versions.tf
+++ b/modules/dns/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/endpoints/versions.tf
+++ b/modules/endpoints/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/folder/versions.tf
+++ b/modules/folder/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/gcs/versions.tf
+++ b/modules/gcs/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/gcve-private-cloud/versions.tf
+++ b/modules/gcve-private-cloud/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/gke-cluster-autopilot/versions.tf
+++ b/modules/gke-cluster-autopilot/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/gke-cluster-standard/versions.tf
+++ b/modules/gke-cluster-standard/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/gke-hub/versions.tf
+++ b/modules/gke-hub/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/gke-nodepool/versions.tf
+++ b/modules/gke-nodepool/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/iam-service-account/versions.tf
+++ b/modules/iam-service-account/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/kms/versions.tf
+++ b/modules/kms/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/logging-bucket/versions.tf
+++ b/modules/logging-bucket/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/ncc-spoke-ra/versions.tf
+++ b/modules/ncc-spoke-ra/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/net-address/versions.tf
+++ b/modules/net-address/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/net-cloudnat/versions.tf
+++ b/modules/net-cloudnat/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/net-firewall-policy/versions.tf
+++ b/modules/net-firewall-policy/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/net-ipsec-over-interconnect/versions.tf
+++ b/modules/net-ipsec-over-interconnect/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/net-lb-app-ext/versions.tf
+++ b/modules/net-lb-app-ext/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/net-lb-app-int/versions.tf
+++ b/modules/net-lb-app-int/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/net-lb-ext/versions.tf
+++ b/modules/net-lb-ext/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/net-lb-int/versions.tf
+++ b/modules/net-lb-int/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/net-lb-proxy-int/versions.tf
+++ b/modules/net-lb-proxy-int/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/net-swp/versions.tf
+++ b/modules/net-swp/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/net-vlan-attachment/versions.tf
+++ b/modules/net-vlan-attachment/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/net-vpc-firewall/versions.tf
+++ b/modules/net-vpc-firewall/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/net-vpc-peering/versions.tf
+++ b/modules/net-vpc-peering/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/net-vpc/versions.tf
+++ b/modules/net-vpc/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/net-vpn-dynamic/versions.tf
+++ b/modules/net-vpn-dynamic/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/net-vpn-ha/versions.tf
+++ b/modules/net-vpn-ha/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/net-vpn-static/versions.tf
+++ b/modules/net-vpn-static/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/organization/versions.tf
+++ b/modules/organization/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/project/versions.tf
+++ b/modules/project/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/projects-data-source/versions.tf
+++ b/modules/projects-data-source/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/pubsub/versions.tf
+++ b/modules/pubsub/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/secret-manager/versions.tf
+++ b/modules/secret-manager/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/service-directory/versions.tf
+++ b/modules/service-directory/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/source-repository/versions.tf
+++ b/modules/source-repository/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/modules/vpc-sc/versions.tf
+++ b/modules/vpc-sc/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.76.0" # tftest
+      version = ">= 4.80.0" # tftest
     }
   }
 }

--- a/tests/modules/billing_budget/examples/email.yaml
+++ b/tests/modules/billing_budget/examples/email.yaml
@@ -31,6 +31,7 @@ values:
       projects:
       - projects/123456789000
       - projects/123456789111
+      resource_ancestors: null
     display_name: $100 budget
     threshold_rules:
     - spend_basis: CURRENT_SPEND

--- a/tests/modules/billing_budget/examples/pubsub.yaml
+++ b/tests/modules/billing_budget/examples/pubsub.yaml
@@ -28,6 +28,7 @@ values:
       credit_types_treatment: INCLUDE_ALL_CREDITS
       custom_period: []
       projects: null
+      resource_ancestors: null
     display_name: previous period budget
     threshold_rules:
     - spend_basis: CURRENT_SPEND

--- a/tests/modules/cloudsql_instance/examples/insights.yaml
+++ b/tests/modules/cloudsql_instance/examples/insights.yaml
@@ -44,6 +44,7 @@ values:
         enable_private_path_for_google_cloud_services: null
         ipv4_enabled: false
         private_network: projects/xxx/global/networks/aaa
+        psc_config: []
         require_ssl: null
       maintenance_window: []
       password_validation_policy: []

--- a/tests/modules/cloudsql_instance/examples/public-ip.yaml
+++ b/tests/modules/cloudsql_instance/examples/public-ip.yaml
@@ -50,6 +50,7 @@ values:
         enable_private_path_for_google_cloud_services: null
         ipv4_enabled: true
         private_network: projects/xxx/global/networks/aaa
+        psc_config: []
         require_ssl: null
       maintenance_window: []
       password_validation_policy: []
@@ -83,6 +84,7 @@ values:
         authorized_networks: []
         enable_private_path_for_google_cloud_services: null
         ipv4_enabled: true
+        psc_config: []
         private_network: projects/xxx/global/networks/aaa
         require_ssl: null
       maintenance_window: []

--- a/tests/modules/cloudsql_instance/examples/simple.yaml
+++ b/tests/modules/cloudsql_instance/examples/simple.yaml
@@ -39,6 +39,7 @@ values:
         authorized_networks: []
         enable_private_path_for_google_cloud_services: null
         ipv4_enabled: false
+        psc_config: []
         require_ssl: null
       maintenance_window: []
       password_validation_policy: []

--- a/tests/modules/compute_vm/examples/independent-boot-disk.yaml
+++ b/tests/modules/compute_vm/examples/independent-boot-disk.yaml
@@ -60,6 +60,7 @@ values:
     scheduling:
     - automatic_restart: true
       instance_termination_action: null
+      local_ssd_recovery_timeout: []
       maintenance_interval: null
       max_run_duration: []
       min_node_cpus: null

--- a/tests/modules/compute_vm/examples/simple.yaml
+++ b/tests/modules/compute_vm/examples/simple.yaml
@@ -48,6 +48,7 @@ values:
     scheduling:
     - automatic_restart: true
       instance_termination_action: null
+      local_ssd_recovery_timeout: []
       maintenance_interval: null
       max_run_duration: []
       min_node_cpus: null

--- a/tests/modules/compute_vm/examples/spot.yaml
+++ b/tests/modules/compute_vm/examples/spot.yaml
@@ -20,6 +20,7 @@ values:
     - automatic_restart: false
       instance_termination_action: STOP
       maintenance_interval: null
+      local_ssd_recovery_timeout: []
       max_run_duration: []
       min_node_cpus: null
       node_affinities: []

--- a/tests/modules/dataplex_datascan/datascan_test_inputs.yaml
+++ b/tests/modules/dataplex_datascan/datascan_test_inputs.yaml
@@ -18,9 +18,12 @@ values:
       resource: //bigquery.googleapis.com/projects/bigquery-public-data/datasets/austin_bikeshare/tables/bikeshare_stations
     data_profile_spec: []
     data_quality_spec:
-    - row_filter: station_id > 1000
+    - post_scan_actions: []
+      row_filter: station_id > 1000
       rules:
       - column: address
+        name: null
+        description: null
         dimension: VALIDITY
         ignore_null: null
         non_null_expectation:
@@ -34,6 +37,8 @@ values:
         threshold: 0.99
         uniqueness_expectation: []
       - column: council_district
+        name: null
+        description: null
         dimension: VALIDITY
         ignore_null: true
         non_null_expectation: []
@@ -50,6 +55,8 @@ values:
         threshold: 0.9
         uniqueness_expectation: []
       - column: council_district
+        name: null
+        description: null
         dimension: VALIDITY
         ignore_null: null
         non_null_expectation: []
@@ -66,6 +73,8 @@ values:
         threshold: 0.8
         uniqueness_expectation: []
       - column: power_type
+        name: null
+        description: null
         dimension: VALIDITY
         ignore_null: false
         non_null_expectation: []
@@ -79,6 +88,8 @@ values:
         threshold: null
         uniqueness_expectation: []
       - column: property_type
+        name: null
+        description: null
         dimension: VALIDITY
         ignore_null: false
         non_null_expectation: []
@@ -94,6 +105,8 @@ values:
         threshold: null
         uniqueness_expectation: []
       - column: address
+        name: null
+        description: null
         dimension: UNIQUENESS
         ignore_null: null
         non_null_expectation: []
@@ -107,6 +120,8 @@ values:
         uniqueness_expectation:
         - {}
       - column: number_of_docks
+        name: null
+        description: null
         dimension: VALIDITY
         ignore_null: null
         non_null_expectation: []
@@ -124,6 +139,8 @@ values:
         threshold: null
         uniqueness_expectation: []
       - column: footprint_length
+        name: null
+        description: null
         dimension: VALIDITY
         ignore_null: null
         non_null_expectation: []
@@ -137,6 +154,8 @@ values:
         threshold: null
         uniqueness_expectation: []
       - column: null
+        name: null
+        description: null
         dimension: VALIDITY
         ignore_null: null
         non_null_expectation: []

--- a/tests/modules/dataplex_datascan/examples/datascan_cron.yaml
+++ b/tests/modules/dataplex_datascan/examples/datascan_cron.yaml
@@ -17,7 +17,10 @@ values:
     - entity: null
       resource: //bigquery.googleapis.com/projects/bigquery-public-data/datasets/austin_bikeshare/tables/bikeshare_stations
     data_profile_spec:
-    - row_filter: null
+    - exclude_fields: []
+      include_fields: []
+      post_scan_actions: []
+      row_filter: null
       sampling_percent: null
     data_quality_spec: []
     data_scan_id: test-datascan

--- a/tests/modules/dataplex_datascan/examples/datascan_dq.yaml
+++ b/tests/modules/dataplex_datascan/examples/datascan_dq.yaml
@@ -18,9 +18,12 @@ values:
       resource: //bigquery.googleapis.com/projects/bigquery-public-data/datasets/austin_bikeshare/tables/bikeshare_stations
     data_profile_spec: []
     data_quality_spec:
-    - row_filter: station_id > 1000
+    - post_scan_actions: []
+      row_filter: station_id > 1000
       rules:
       - column: address
+        name: null
+        description: null
         dimension: VALIDITY
         ignore_null: null
         non_null_expectation:
@@ -34,6 +37,8 @@ values:
         threshold: 0.99
         uniqueness_expectation: []
       - column: council_district
+        name: null
+        description: null
         dimension: VALIDITY
         ignore_null: true
         non_null_expectation: []
@@ -50,6 +55,8 @@ values:
         threshold: 0.9
         uniqueness_expectation: []
       - column: council_district
+        name: null
+        description: null
         dimension: VALIDITY
         ignore_null: null
         non_null_expectation: []
@@ -66,6 +73,8 @@ values:
         threshold: 0.8
         uniqueness_expectation: []
       - column: power_type
+        name: null
+        description: null
         dimension: VALIDITY
         ignore_null: false
         non_null_expectation: []
@@ -79,6 +88,8 @@ values:
         threshold: null
         uniqueness_expectation: []
       - column: property_type
+        name: null
+        description: null
         dimension: VALIDITY
         ignore_null: false
         non_null_expectation: []
@@ -94,6 +105,8 @@ values:
         threshold: null
         uniqueness_expectation: []
       - column: address
+        name: null
+        description: null
         dimension: UNIQUENESS
         ignore_null: null
         non_null_expectation: []
@@ -107,6 +120,8 @@ values:
         uniqueness_expectation:
         - {}
       - column: number_of_docks
+        name: null
+        description: null
         dimension: VALIDITY
         ignore_null: null
         non_null_expectation: []
@@ -124,6 +139,8 @@ values:
         threshold: null
         uniqueness_expectation: []
       - column: footprint_length
+        name: null
+        description: null
         dimension: VALIDITY
         ignore_null: null
         non_null_expectation: []
@@ -137,6 +154,8 @@ values:
         threshold: null
         uniqueness_expectation: []
       - column: null
+        name: null
+        description: null
         dimension: VALIDITY
         ignore_null: null
         non_null_expectation: []

--- a/tests/modules/dataplex_datascan/examples/datascan_entity.yaml
+++ b/tests/modules/dataplex_datascan/examples/datascan_entity.yaml
@@ -17,7 +17,10 @@ values:
     - entity: projects/<project_number>/locations/<locationId>/lakes/<lakeId>/zones/<zoneId>/entities/<entityId>
       resource: null
     data_profile_spec:
-    - row_filter: null
+    - exclude_fields: []
+      include_fields: []
+      post_scan_actions: []
+      row_filter: null
       sampling_percent: null
     data_quality_spec: []
     data_scan_id: test-datascan

--- a/tests/modules/dataplex_datascan/examples/datascan_iam.yaml
+++ b/tests/modules/dataplex_datascan/examples/datascan_iam.yaml
@@ -18,7 +18,10 @@ values:
     - entity: null
       resource: //bigquery.googleapis.com/projects/bigquery-public-data/datasets/austin_bikeshare/tables/bikeshare_stations
     data_profile_spec:
-    - row_filter: null
+    - exclude_fields: []
+      include_fields: []
+      post_scan_actions: []
+      row_filter: null
       sampling_percent: null
     data_quality_spec: []
     data_scan_id: test-datascan

--- a/tests/modules/dataplex_datascan/examples/datascan_profiling.yaml
+++ b/tests/modules/dataplex_datascan/examples/datascan_profiling.yaml
@@ -17,7 +17,10 @@ values:
     - entity: null
       resource: //bigquery.googleapis.com/projects/bigquery-public-data/datasets/austin_bikeshare/tables/bikeshare_stations
     data_profile_spec:
-    - row_filter: station_id > 1000
+    - exclude_fields: []
+      include_fields: []
+      post_scan_actions: []
+      row_filter: station_id > 1000
       sampling_percent: 100
     data_quality_spec: []
     data_scan_id: test-datascan

--- a/tests/modules/gke_cluster_autopilot/examples/dns.yaml
+++ b/tests/modules/gke_cluster_autopilot/examples/dns.yaml
@@ -14,10 +14,7 @@
 
 values:
   module.cluster-1.google_container_cluster.cluster:
-    dns_config:
-    - cluster_dns: CLOUD_DNS
-      cluster_dns_domain: gke.local
-      cluster_dns_scope: CLUSTER_SCOPE
+    dns_config: []
 
 counts:
   google_container_cluster: 1

--- a/tests/modules/net_address/examples/internal.yaml
+++ b/tests/modules/net_address/examples/internal.yaml
@@ -18,7 +18,6 @@ values:
     labels: null
     name: ilb-1
     network: null
-    prefix_length: null
     project: project-id
     purpose: SHARED_LOADBALANCER_VIP
     region: region
@@ -29,7 +28,6 @@ values:
     labels: null
     name: ilb-2
     network: null
-    prefix_length: null
     project: project-id
     region: region
     subnetwork: subnet_self_link

--- a/tests/modules/net_address/examples/psc.yaml
+++ b/tests/modules/net_address/examples/psc.yaml
@@ -17,7 +17,6 @@ values:
     address_type: INTERNAL
     name: one
     network: projects/xxx/global/networks/aaa
-    prefix_length: null
     project: project-id
     purpose: PRIVATE_SERVICE_CONNECT
   module.addresses.google_compute_global_address.psc["two"]:
@@ -25,7 +24,6 @@ values:
     address_type: INTERNAL
     name: two
     network: projects/xxx/global/networks/aaa
-    prefix_length: null
     project: project-id
     purpose: PRIVATE_SERVICE_CONNECT
 


### PR DESCRIPTION
Bump provider to version 4.80.0 to avoid permadiffs with GKE Autopilot (see #1602)

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [x] Made sure all relevant tests pass
