### PR TITLE
Fix project factory blueprint and fast stage

### DIFF
--- a/blueprints/factories/project-factory/factory.tf
+++ b/blueprints/factories/project-factory/factory.tf
@@ -28,11 +28,11 @@ locals {
   )
   projects = {
     for k, v in local._data : k => merge(v, {
-      billing_account = coalesce(
+      billing_account = try(coalesce(
         var.data_overrides.billing_account,
         try(v.billing_account, null),
         var.data_defaults.billing_account
-      )
+      ), null)
       contacts = coalesce(
         var.data_overrides.contacts,
         try(v.contacts, null),
@@ -45,6 +45,11 @@ locals {
       metric_scopes = coalesce(
         try(v.metric_scopes, null),
         var.data_defaults.metric_scopes
+      )
+      parent = coalesce(
+        var.data_overrides.parent,
+        try(v.parent, null),
+        var.data_defaults.parent
       )
       prefix = coalesce(
         var.data_overrides.prefix,

--- a/blueprints/factories/project-factory/variables.tf
+++ b/blueprints/factories/project-factory/variables.tf
@@ -21,6 +21,7 @@ variable "data_defaults" {
     contacts                   = optional(map(list(string)), {})
     labels                     = optional(map(string), {})
     metric_scopes              = optional(list(string), [])
+    parent                     = optional(string)
     prefix                     = optional(string)
     service_encryption_key_ids = optional(map(list(string)), {})
     service_perimeter_bridges  = optional(list(string), [])
@@ -65,6 +66,7 @@ variable "data_overrides" {
   type = object({
     billing_account            = optional(string)
     contacts                   = optional(map(list(string)))
+    parent                     = optional(string)
     prefix                     = optional(string)
     service_encryption_key_ids = optional(map(list(string)))
     service_perimeter_bridges  = optional(list(string))

--- a/fast/stages/3-project-factory/dev/data/projects/project.yaml.sample
+++ b/fast/stages/3-project-factory/dev/data/projects/project.yaml.sample
@@ -23,7 +23,7 @@ essential_contacts:
   - team-a-contacts@example.com
 
 # Folder the project will be created as children of
-folder_id: folders/012345678901
+parent: folders/012345678901
 
 # [opt] Authoritative IAM bindings in group => [roles] format
 group_iam:


### PR DESCRIPTION
The PR:
* Adds the variable parent to the recently refactored project factory blueprint, so the value can be correctly passed to the project module
* Modifies the `project.yaml.sample` template file adding the parent key (as opposed to the folder key which seems to map to nothing at the moment)
* Adds the possibility to temporarily set billing id to null in the project_factory blueprint, in order to use project factory internally

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
