### PR TITLE
merge labels from data_merges in project factory

### DIFF
--- a/blueprints/factories/project-factory/main.tf
+++ b/blueprints/factories/project-factory/main.tf
@@ -33,11 +33,13 @@ module "projects" {
   iam                     = try(each.value.iam, {})
   iam_bindings            = try(each.value.iam_bindings, {})
   iam_bindings_additive   = try(each.value.iam_bindings_additive, {})
-  labels                  = each.value.labels
-  lien_reason             = try(each.value.lien_reason, null)
-  logging_data_access     = try(each.value.logging_data_access, {})
-  logging_exclusions      = try(each.value.logging_exclusions, {})
-  logging_sinks           = try(each.value.logging_sinks, {})
+  labels = merge(
+    each.value.labels, var.data_merges.labels
+  )
+  lien_reason         = try(each.value.lien_reason, null)
+  logging_data_access = try(each.value.logging_data_access, {})
+  logging_exclusions  = try(each.value.logging_exclusions, {})
+  logging_sinks       = try(each.value.logging_sinks, {})
   metric_scopes = distinct(concat(
     each.value.metric_scopes, var.data_merges.metric_scopes
   ))

--- a/tests/blueprints/factories/project_factory/examples/example.yaml
+++ b/tests/blueprints/factories/project_factory/examples/example.yaml
@@ -33,6 +33,7 @@ values:
     folder_id: "12345678"
     labels:
       app: app-1
+      environment: test
       team: foo
     name: test-pf-prj-app-1
     org_id: null
@@ -64,6 +65,7 @@ values:
     folder_id: "12345678"
     labels:
       app: app-1
+      environment: test
       team: foo
     name: test-pf-prj-app-2
     org_id: null


### PR DESCRIPTION
<!-- Put a description of what this PR is for here -->

The `labels` key in `data_merges` in the **project-factory** blueprint was the only one not being merged.

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [x] Made sure all relevant tests pass
