### PR TITLE
[#1661] Make FAST stage 1 resman tf destroy more reliable

### DIFF
--- a/fast/stages/1-resman/outputs.tf
+++ b/fast/stages/1-resman/outputs.tf
@@ -223,9 +223,9 @@ locals {
   tfvars = {
     folder_ids       = local.folder_ids
     service_accounts = local.service_accounts
-    tag_keys         = { for k, v in module.organization.tag_keys : k => v.id }
+    tag_keys         = { for k, v in try(module.organization.tag_keys, {}) : k => v.id }
     tag_names        = var.tag_names
-    tag_values       = { for k, v in module.organization.tag_values : k => v.id }
+    tag_values       = { for k, v in try(module.organization.tag_values, {}) : k => v.id }
   }
 }
 


### PR DESCRIPTION
It sometimes happens that when the FAST stage 1 TF destroy process breaks half way through, we get some errors on outputs:

```
Error: Unsupported attribute
│
│   on outputs.tf line 226, in locals:
│  226:     tag_keys         = { for k, v in module.organization.tag_keys : k => v.id }
│     ├────────────────
│     │ module.organization is object with 8 attributes
│
│ This object does not have an attribute named "tag_keys".
╵
╷
│ Error: Unsupported attribute
│
│   on outputs.tf line 228, in locals:
│  228:     tag_values       = { for k, v in module.organization.tag_values : k => v.id }
│     ├────────────────
│     │ module.organization is object with 8 attributes
│
│ This object does not have an attribute named "tag_values".
```

While the real cause is still unknown, this patch tries to address the problem tactically, adding some try statements where needed.

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
