### PR TITLE
fix(compute-mig): add mode property to compute_region_autoscaler

### DIFF
--- a/modules/compute-mig/autoscaler.tf
+++ b/modules/compute-mig/autoscaler.tf
@@ -35,6 +35,7 @@ resource "google_compute_autoscaler" "default" {
     max_replicas    = var.autoscaler_config.max_replicas
     min_replicas    = var.autoscaler_config.min_replicas
     cooldown_period = var.autoscaler_config.cooldown_period
+    mode            = var.autoscaler_config.mode
 
     dynamic "scale_down_control" {
       for_each = local.as_scaling.down == null ? [] : [""]

--- a/modules/compute-mig/autoscaler.tf
+++ b/modules/compute-mig/autoscaler.tf
@@ -138,6 +138,7 @@ resource "google_compute_region_autoscaler" "default" {
     max_replicas    = var.autoscaler_config.max_replicas
     min_replicas    = var.autoscaler_config.min_replicas
     cooldown_period = var.autoscaler_config.cooldown_period
+    mode            = var.autoscaler_config.mode
 
     dynamic "scale_down_control" {
       for_each = local.as_scaling.down == null ? [] : [""]


### PR DESCRIPTION
## Description
The `compute-mig` module at `//modules/compute-mig` takes in the `mode` property via the variable `autoscaler_config` but does not propagate it to the `google_compute_autoscaler` and `google_compute_region_autoscaler` resources in `autoscaler.tf`.

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [x] Made sure all relevant tests pass
