### PR TITLE
fix(compute-mig): add correct type optionality for metrics in autosca…

### DIFF
--- a/modules/compute-mig/README.md
+++ b/modules/compute-mig/README.md
@@ -7,17 +7,17 @@ This module can be coupled with the [`compute-vm`](../compute-vm) module which c
 Stateful disks can be created directly, as shown in the last example below.
 
 <!-- BEGIN TOC -->
-- [Examples](#examples)
-  - [Simple Example](#simple-example)
-  - [Multiple Versions](#multiple-versions)
-  - [Health Check and Autohealing Policies](#health-check-and-autohealing-policies)
-  - [Autoscaling](#autoscaling)
-  - [Update Policy](#update-policy)
-  - [Stateful MIGs - MIG Config](#stateful-migs-mig-config)
-  - [Stateful MIGs - Instance Config](#stateful-migs-instance-config)
-- [Files](#files)
-- [Variables](#variables)
-- [Outputs](#outputs)
+- [GCE Managed Instance Group module](#gce-managed-instance-group-module)
+  - [Examples](#examples)
+    - [Simple Example](#simple-example)
+    - [Multiple Versions](#multiple-versions)
+    - [Health Check and Autohealing Policies](#health-check-and-autohealing-policies)
+    - [Autoscaling](#autoscaling)
+    - [Update Policy](#update-policy)
+    - [Stateful MIGs - MIG Config](#stateful-migs---mig-config)
+    - [Stateful MIGs - Instance Config](#stateful-migs---instance-config)
+  - [Variables](#variables)
+  - [Outputs](#outputs)
 <!-- END TOC -->
 
 ## Examples
@@ -390,17 +390,6 @@ module "nginx-mig" {
 # tftest modules=2 resources=3 inventory=stateful.yaml
 ```
 <!-- BEGIN TFDOC -->
-## Files
-
-| name | description | resources |
-|---|---|---|
-| [autoscaler.tf](./autoscaler.tf) | Autoscaler resource. | <code>google_compute_autoscaler</code> · <code>google_compute_region_autoscaler</code> |
-| [health-check.tf](./health-check.tf) | Health check resource. | <code>google_compute_health_check</code> |
-| [main.tf](./main.tf) | Module-level locals and resources. | <code>google_compute_instance_group_manager</code> · <code>google_compute_region_instance_group_manager</code> |
-| [outputs.tf](./outputs.tf) | Module outputs. |  |
-| [stateful-config.tf](./stateful-config.tf) | Instance-level stateful configuration resources. | <code>google_compute_per_instance_config</code> · <code>google_compute_region_per_instance_config</code> |
-| [variables.tf](./variables.tf) | Module variables. |  |
-| [versions.tf](./versions.tf) | Version pins. |  |
 
 ## Variables
 

--- a/modules/compute-mig/README.md
+++ b/modules/compute-mig/README.md
@@ -15,7 +15,6 @@ Stateful disks can be created directly, as shown in the last example below.
   - [Update Policy](#update-policy)
   - [Stateful MIGs - MIG Config](#stateful-migs-mig-config)
   - [Stateful MIGs - Instance Config](#stateful-migs-instance-config)
-- [Files](#files)
 - [Variables](#variables)
 - [Outputs](#outputs)
 <!-- END TOC -->
@@ -390,18 +389,6 @@ module "nginx-mig" {
 # tftest modules=2 resources=3 inventory=stateful.yaml
 ```
 <!-- BEGIN TFDOC -->
-## Files
-
-| name | description | resources |
-|---|---|---|
-| [autoscaler.tf](./autoscaler.tf) | Autoscaler resource. | <code>google_compute_autoscaler</code> · <code>google_compute_region_autoscaler</code> |
-| [health-check.tf](./health-check.tf) | Health check resource. | <code>google_compute_health_check</code> |
-| [main.tf](./main.tf) | Module-level locals and resources. | <code>google_compute_instance_group_manager</code> · <code>google_compute_region_instance_group_manager</code> |
-| [outputs.tf](./outputs.tf) | Module outputs. |  |
-| [stateful-config.tf](./stateful-config.tf) | Instance-level stateful configuration resources. | <code>google_compute_per_instance_config</code> · <code>google_compute_region_per_instance_config</code> |
-| [variables.tf](./variables.tf) | Module variables. |  |
-| [versions.tf](./versions.tf) | Version pins. |  |
-
 ## Variables
 
 | name | description | type | required | default |

--- a/modules/compute-mig/README.md
+++ b/modules/compute-mig/README.md
@@ -7,17 +7,17 @@ This module can be coupled with the [`compute-vm`](../compute-vm) module which c
 Stateful disks can be created directly, as shown in the last example below.
 
 <!-- BEGIN TOC -->
-- [GCE Managed Instance Group module](#gce-managed-instance-group-module)
-  - [Examples](#examples)
-    - [Simple Example](#simple-example)
-    - [Multiple Versions](#multiple-versions)
-    - [Health Check and Autohealing Policies](#health-check-and-autohealing-policies)
-    - [Autoscaling](#autoscaling)
-    - [Update Policy](#update-policy)
-    - [Stateful MIGs - MIG Config](#stateful-migs---mig-config)
-    - [Stateful MIGs - Instance Config](#stateful-migs---instance-config)
-  - [Variables](#variables)
-  - [Outputs](#outputs)
+- [Examples](#examples)
+  - [Simple Example](#simple-example)
+  - [Multiple Versions](#multiple-versions)
+  - [Health Check and Autohealing Policies](#health-check-and-autohealing-policies)
+  - [Autoscaling](#autoscaling)
+  - [Update Policy](#update-policy)
+  - [Stateful MIGs - MIG Config](#stateful-migs-mig-config)
+  - [Stateful MIGs - Instance Config](#stateful-migs-instance-config)
+- [Files](#files)
+- [Variables](#variables)
+- [Outputs](#outputs)
 <!-- END TOC -->
 
 ## Examples
@@ -390,6 +390,17 @@ module "nginx-mig" {
 # tftest modules=2 resources=3 inventory=stateful.yaml
 ```
 <!-- BEGIN TFDOC -->
+## Files
+
+| name | description | resources |
+|---|---|---|
+| [autoscaler.tf](./autoscaler.tf) | Autoscaler resource. | <code>google_compute_autoscaler</code> · <code>google_compute_region_autoscaler</code> |
+| [health-check.tf](./health-check.tf) | Health check resource. | <code>google_compute_health_check</code> |
+| [main.tf](./main.tf) | Module-level locals and resources. | <code>google_compute_instance_group_manager</code> · <code>google_compute_region_instance_group_manager</code> |
+| [outputs.tf](./outputs.tf) | Module outputs. |  |
+| [stateful-config.tf](./stateful-config.tf) | Instance-level stateful configuration resources. | <code>google_compute_per_instance_config</code> · <code>google_compute_region_per_instance_config</code> |
+| [variables.tf](./variables.tf) | Module variables. |  |
+| [versions.tf](./versions.tf) | Version pins. |  |
 
 ## Variables
 

--- a/modules/compute-mig/README.md
+++ b/modules/compute-mig/README.md
@@ -15,6 +15,7 @@ Stateful disks can be created directly, as shown in the last example below.
   - [Update Policy](#update-policy)
   - [Stateful MIGs - MIG Config](#stateful-migs-mig-config)
   - [Stateful MIGs - Instance Config](#stateful-migs-instance-config)
+- [Files](#files)
 - [Variables](#variables)
 - [Outputs](#outputs)
 <!-- END TOC -->
@@ -389,6 +390,17 @@ module "nginx-mig" {
 # tftest modules=2 resources=3 inventory=stateful.yaml
 ```
 <!-- BEGIN TFDOC -->
+## Files
+
+| name | description | resources |
+|---|---|---|
+| [autoscaler.tf](./autoscaler.tf) | Autoscaler resource. | <code>google_compute_autoscaler</code> · <code>google_compute_region_autoscaler</code> |
+| [health-check.tf](./health-check.tf) | Health check resource. | <code>google_compute_health_check</code> |
+| [main.tf](./main.tf) | Module-level locals and resources. | <code>google_compute_instance_group_manager</code> · <code>google_compute_region_instance_group_manager</code> |
+| [outputs.tf](./outputs.tf) | Module outputs. |  |
+| [stateful-config.tf](./stateful-config.tf) | Instance-level stateful configuration resources. | <code>google_compute_per_instance_config</code> · <code>google_compute_region_per_instance_config</code> |
+| [variables.tf](./variables.tf) | Module variables. |  |
+| [versions.tf](./versions.tf) | Version pins. |  |
 
 ## Variables
 
@@ -400,7 +412,7 @@ module "nginx-mig" {
 | [project_id](variables.tf#L198) | Project id. | <code>string</code> | ✓ |  |
 | [all_instances_config](variables.tf#L17) | Metadata and labels set to all instances in the group. | <code title="object&#40;&#123;&#10;  labels   &#61; optional&#40;map&#40;string&#41;&#41;&#10;  metadata &#61; optional&#40;map&#40;string&#41;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
 | [auto_healing_policies](variables.tf#L26) | Auto-healing policies for this group. | <code title="object&#40;&#123;&#10;  health_check      &#61; optional&#40;string&#41;&#10;  initial_delay_sec &#61; number&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [autoscaler_config](variables.tf#L35) | Optional autoscaler configuration. | <code title="object&#40;&#123;&#10;  max_replicas    &#61; number&#10;  min_replicas    &#61; number&#10;  cooldown_period &#61; optional&#40;number&#41;&#10;  mode            &#61; optional&#40;string&#41; &#35; OFF, ONLY_UP, ON&#10;  scaling_control &#61; optional&#40;object&#40;&#123;&#10;    down &#61; optional&#40;object&#40;&#123;&#10;      max_replicas_fixed   &#61; optional&#40;number&#41;&#10;      max_replicas_percent &#61; optional&#40;number&#41;&#10;      time_window_sec      &#61; optional&#40;number&#41;&#10;    &#125;&#41;&#41;&#10;    in &#61; optional&#40;object&#40;&#123;&#10;      max_replicas_fixed   &#61; optional&#40;number&#41;&#10;      max_replicas_percent &#61; optional&#40;number&#41;&#10;      time_window_sec      &#61; optional&#40;number&#41;&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;, &#123;&#125;&#41;&#10;  scaling_signals &#61; optional&#40;object&#40;&#123;&#10;    cpu_utilization &#61; optional&#40;object&#40;&#123;&#10;      target                &#61; number&#10;      optimize_availability &#61; optional&#40;bool&#41;&#10;    &#125;&#41;&#41;&#10;    load_balancing_utilization &#61; optional&#40;object&#40;&#123;&#10;      target &#61; number&#10;    &#125;&#41;&#41;&#10;    metrics &#61; optional&#40;list&#40;object&#40;&#123;&#10;      name                       &#61; string&#10;      type                       &#61; string &#35; GAUGE, DELTA_PER_SECOND, DELTA_PER_MINUTE&#10;      target_value               &#61; number&#10;      single_instance_assignment &#61; optional&#40;number&#41;&#10;      time_series_filter         &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#41;&#10;    schedules &#61; optional&#40;list&#40;object&#40;&#123;&#10;      duration_sec          &#61; number&#10;      name                  &#61; string&#10;      min_required_replicas &#61; number&#10;      cron_schedule         &#61; string&#10;      description           &#61; optional&#40;bool&#41;&#10;      timezone              &#61; optional&#40;string&#41;&#10;      disabled              &#61; optional&#40;bool&#41;&#10;    &#125;&#41;&#41;&#41;&#10;  &#125;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [autoscaler_config](variables.tf#L35) | Optional autoscaler configuration. | <code title="object&#40;&#123;&#10;  max_replicas    &#61; number&#10;  min_replicas    &#61; number&#10;  cooldown_period &#61; optional&#40;number&#41;&#10;  mode            &#61; optional&#40;string&#41; &#35; OFF, ONLY_UP, ON&#10;  scaling_control &#61; optional&#40;object&#40;&#123;&#10;    down &#61; optional&#40;object&#40;&#123;&#10;      max_replicas_fixed   &#61; optional&#40;number&#41;&#10;      max_replicas_percent &#61; optional&#40;number&#41;&#10;      time_window_sec      &#61; optional&#40;number&#41;&#10;    &#125;&#41;&#41;&#10;    in &#61; optional&#40;object&#40;&#123;&#10;      max_replicas_fixed   &#61; optional&#40;number&#41;&#10;      max_replicas_percent &#61; optional&#40;number&#41;&#10;      time_window_sec      &#61; optional&#40;number&#41;&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;, &#123;&#125;&#41;&#10;  scaling_signals &#61; optional&#40;object&#40;&#123;&#10;    cpu_utilization &#61; optional&#40;object&#40;&#123;&#10;      target                &#61; number&#10;      optimize_availability &#61; optional&#40;bool&#41;&#10;    &#125;&#41;&#41;&#10;    load_balancing_utilization &#61; optional&#40;object&#40;&#123;&#10;      target &#61; number&#10;    &#125;&#41;&#41;&#10;    metrics &#61; optional&#40;list&#40;object&#40;&#123;&#10;      name                       &#61; string&#10;      type                       &#61; optional&#40;string&#41; &#35; GAUGE, DELTA_PER_SECOND, DELTA_PER_MINUTE&#10;      target_value               &#61; optional&#40;number&#41;&#10;      single_instance_assignment &#61; optional&#40;number&#41;&#10;      time_series_filter         &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#41;&#10;    schedules &#61; optional&#40;list&#40;object&#40;&#123;&#10;      duration_sec          &#61; number&#10;      name                  &#61; string&#10;      min_required_replicas &#61; number&#10;      cron_schedule         &#61; string&#10;      description           &#61; optional&#40;bool&#41;&#10;      timezone              &#61; optional&#40;string&#41;&#10;      disabled              &#61; optional&#40;bool&#41;&#10;    &#125;&#41;&#41;&#41;&#10;  &#125;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
 | [default_version_name](variables.tf#L83) | Name used for the default version. | <code>string</code> |  | <code>&#34;default&#34;</code> |
 | [description](variables.tf#L89) | Optional description used for all resources managed by this module. | <code>string</code> |  | <code>&#34;Terraform managed.&#34;</code> |
 | [distribution_policy](variables.tf#L95) | DIstribution policy for regional MIG. | <code title="object&#40;&#123;&#10;  target_shape &#61; optional&#40;string&#41;&#10;  zones        &#61; optional&#40;list&#40;string&#41;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
@@ -422,5 +434,4 @@ module "nginx-mig" {
 | [group_manager](outputs.tf#L26) | Instance group resource. |  |
 | [health_check](outputs.tf#L35) | Auto-created health-check resource. |  |
 | [id](outputs.tf#L44) | Fully qualified group manager id. |  |
-
 <!-- END TFDOC -->

--- a/modules/compute-mig/variables.tf
+++ b/modules/compute-mig/variables.tf
@@ -61,8 +61,8 @@ variable "autoscaler_config" {
       }))
       metrics = optional(list(object({
         name                       = string
-        type                       = string # GAUGE, DELTA_PER_SECOND, DELTA_PER_MINUTE
-        target_value               = number
+        type                       = optional(string) # GAUGE, DELTA_PER_SECOND, DELTA_PER_MINUTE
+        target_value               = optional(number)
         single_instance_assignment = optional(number)
         time_series_filter         = optional(string)
       })))


### PR DESCRIPTION
## Description
In the `//modules/compute-mig` module there is a mismatch between the optionality of types and what the upstream terraform [docs](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_autoscaler#nested_metric:~:text=The-,metric,-block%20supports%3A) mention for `autoscaler_config.metrics.(type|target_value)`. It seems only the `autoscaler_config.metrics.name` type is required. 

## Notes
I've ran `tools/tfdoc.py` but linting seems to be failing, can maintainers PTAL?

**Checklist**

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [x] Made sure all relevant tests pass
