### PR TITLE
Only apply org policies when bootstrap user is not set

### DIFF
--- a/fast/stages/0-bootstrap/README.md
+++ b/fast/stages/0-bootstrap/README.md
@@ -170,7 +170,7 @@ export FAST_ORG_ID=123456
 # set needed roles
 export FAST_ROLES="roles/billing.admin roles/logging.admin \
   roles/iam.organizationRoleAdmin roles/resourcemanager.projectCreator \
-  roles/resourcemanager.tagAdmin"
+  roles/resourcemanager.tagAdmin roles/orgpolicy.policyAdmin"
 
 for role in $FAST_ROLES; do
   gcloud organizations add-iam-policy-binding $FAST_ORG_ID \

--- a/fast/stages/0-bootstrap/README.md
+++ b/fast/stages/0-bootstrap/README.md
@@ -64,7 +64,7 @@ A full reference of IAM roles managed by this stage [is available here](./IAM.md
 
 It's often desirable to have organization policies deployed before any other resource in the org, so as to ensure compliance with specific requirements (e.g. location restrictions), or control the configuration of specific resources (e.g. default network at project creation or service account grants).
 
-To cover this use case, organization policies have been moved from the resource management to the bootstrap stage in FAST versions after 26.0.0. They are managed via the usual factory approach, and a [sample set of data files](./data/org-policies/) is included with this stage.
+To cover this use case, organization policies have been moved from the resource management to the bootstrap stage in FAST versions after 26.0.0. They are managed via the usual factory approach, and a [sample set of data files](./data/org-policies/) is included with this stage. They are not applied during the initial run when the `bootstrap_user` variable is set, to work around incompatibilies with user credentials.
 
 The only current exception to the factory approach is the `iam.allowedPolicyMemberDomains` constraint, which is managed in code so as to be able to auto-allow the organization's domain. More domains can be added via the `org_policies_config` variable, which also serves as an umbrella for future policies that will need to be managed in code.
 

--- a/fast/stages/0-bootstrap/organization.tf
+++ b/fast/stages/0-bootstrap/organization.tf
@@ -156,8 +156,12 @@ module "organization" {
       type                 = attrs.type
     }
   }
-  org_policies_data_path = var.factories_config.org_policy_data_path
-  org_policies = {
+  org_policies_data_path = (
+    var.bootstrap_user != null
+    ? null
+    : var.factories_config.org_policy_data_path
+  )
+  org_policies = var.bootstrap_user != null ? {} : {
     "iam.allowedPolicyMemberDomains" = {
       rules = [
         {

--- a/fast/stages/CLEANUP.md
+++ b/fast/stages/CLEANUP.md
@@ -92,7 +92,7 @@ When the destroy fails, continue with the steps below. Again, make sure your use
 # to finish the destruction
 export FAST_DESTROY_ROLES="roles/billing.admin roles/logging.admin \
   roles/iam.organizationRoleAdmin roles/resourcemanager.projectDeleter \
-  roles/resourcemanager.folderAdmin roles/owner"
+  roles/resourcemanager.folderAdmin roles/owner roles/resourcemanager.organizationAdmin"
 
 export FAST_BU=$(gcloud config list --format 'value(core.account)')
 
@@ -102,9 +102,12 @@ gcloud organizations list --filter display_name:[part of your domain]
 # set your org id
 export FAST_ORG_ID=XXXX
 
+terraform destroy -var boostrap_user=$FAST_BU
+terraform destroy
+
 for role in $FAST_DESTROY_ROLES; do
   gcloud organizations add-iam-policy-binding $FAST_ORG_ID \
-    --member user:$FAST_BU --role $role
+    --member user:$FAST_BU --role $role --condition None
 done
 
 terraform destroy


### PR DESCRIPTION
This is a potential fix for an issue we're seeing with org policies in stage 0, when applied with user credentials. In draft until we verify the fix actually addresses the issue.