### PR TITLE
[#1764] net-lb-int: add support for dual stack and multiple forwarding rules

### DIFF
--- a/blueprints/data-solutions/sqlserver-alwayson/README.md
+++ b/blueprints/data-solutions/sqlserver-alwayson/README.md
@@ -18,7 +18,6 @@ and to `C:\GcpSetupLog.txt` file.
 
 <!-- TFDOC OPTS files:1 -->
 <!-- BEGIN TFDOC -->
-
 ## Files
 
 | name | description | modules |
@@ -66,10 +65,8 @@ and to `C:\GcpSetupLog.txt` file.
 
 | name | description | sensitive |
 |---|---|:---:|
-| [instructions](outputs.tf#L19) | List of steps to follow after applying. |  |
-
+| [instructions](outputs.tf#L22) | List of steps to follow after applying. |  |
 <!-- END TFDOC -->
-
 ## Test
 
 ```hcl

--- a/blueprints/data-solutions/sqlserver-alwayson/outputs.tf
+++ b/blueprints/data-solutions/sqlserver-alwayson/outputs.tf
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,10 @@
 # limitations under the License.
 
 locals {
-  loadbalancer_outputs = [for aog in var.always_on_groups : format("%s (%s)", module.listener-ilb[aog].forwarding_rule_address, aog)]
+  loadbalancer_outputs = [
+    for aog, ilb in module.listener-ilb
+    : format("%s (%s)", ilb.forwarding_rule_addresses[""], aog)
+  ]
 }
 
 output "instructions" {

--- a/blueprints/data-solutions/sqlserver-alwayson/vpc.tf
+++ b/blueprints/data-solutions/sqlserver-alwayson/vpc.tf
@@ -142,8 +142,8 @@ module "listener-ilb" {
   name          = "${var.prefix}-${each.value}-ilb"
   service_label = "${var.prefix}-${each.value}-ilb"
   forwarding_rules_config = {
-    default = {
-      ip_address = local.internal_address_ips["${var.prefix}-lb-${each.value}"]
+    "" = {
+      address = local.internal_address_ips["${var.prefix}-lb-${each.value}"]
     }
   }
   vpc_config = {

--- a/blueprints/data-solutions/sqlserver-alwayson/vpc.tf
+++ b/blueprints/data-solutions/sqlserver-alwayson/vpc.tf
@@ -141,7 +141,11 @@ module "listener-ilb" {
   region        = var.region
   name          = "${var.prefix}-${each.value}-ilb"
   service_label = "${var.prefix}-${each.value}-ilb"
-  address       = local.internal_address_ips["${var.prefix}-lb-${each.value}"]
+  forwarding_rules_config = {
+    default = {
+      ip_address = local.internal_address_ips["${var.prefix}-lb-${each.value}"]
+    }
+  }
   vpc_config = {
     network    = local.network
     subnetwork = local.subnetwork

--- a/blueprints/networking/filtering-proxy-psc/main.tf
+++ b/blueprints/networking/filtering-proxy-psc/main.tf
@@ -106,7 +106,7 @@ resource "google_compute_service_attachment" "service_attachment" {
   enable_proxy_protocol = true
   connection_preference = "ACCEPT_MANUAL"
   nat_subnets           = [module.vpc.subnets_psc["${var.region}/psc"].self_link]
-  target_service        = module.squid-ilb.forwarding_rule_self_link
+  target_service        = module.squid-ilb.forwarding_rule_self_links[""]
   consumer_accept_lists {
     project_id_or_num = module.project.project_id
     connection_limit  = 10
@@ -208,7 +208,7 @@ module "squid-ilb" {
   name          = "squid-ilb"
   service_label = "squid-ilb"
   forwarding_rules_config = {
-    default = {
+    "" = {
       ports = [3128]
     }
   }

--- a/blueprints/networking/filtering-proxy-psc/main.tf
+++ b/blueprints/networking/filtering-proxy-psc/main.tf
@@ -206,8 +206,12 @@ module "squid-ilb" {
   project_id    = module.project.project_id
   region        = var.region
   name          = "squid-ilb"
-  ports         = [3128]
   service_label = "squid-ilb"
+  forwarding_rules_config = {
+    default = {
+      ports = [3128]
+    }
+  }
   vpc_config = {
     network    = module.vpc.self_link
     subnetwork = module.vpc.subnet_self_links["${var.region}/proxy"]

--- a/blueprints/networking/filtering-proxy/main.tf
+++ b/blueprints/networking/filtering-proxy/main.tf
@@ -210,8 +210,12 @@ module "squid-ilb" {
   project_id    = module.project-host.project_id
   region        = var.region
   name          = "squid-ilb"
-  ports         = [3128]
   service_label = "squid-ilb"
+  forwarding_rules_config = {
+    default = {
+      ports = [3128]
+    }
+  }
   vpc_config = {
     network    = module.vpc.self_link
     subnetwork = module.vpc.subnet_self_links["${var.region}/proxy"]

--- a/blueprints/networking/filtering-proxy/main.tf
+++ b/blueprints/networking/filtering-proxy/main.tf
@@ -17,7 +17,7 @@
 locals {
   squid_address = (
     var.mig
-    ? module.squid-ilb.0.forwarding_rule_address
+    ? module.squid-ilb.0.forwarding_rule_addresses["default"]
     : module.squid-vm.internal_ip
   )
 }

--- a/blueprints/networking/filtering-proxy/main.tf
+++ b/blueprints/networking/filtering-proxy/main.tf
@@ -17,7 +17,7 @@
 locals {
   squid_address = (
     var.mig
-    ? module.squid-ilb.0.forwarding_rule_addresses["default"]
+    ? module.squid-ilb.0.forwarding_rule_addresses[""]
     : module.squid-vm.internal_ip
   )
 }
@@ -212,7 +212,7 @@ module "squid-ilb" {
   name          = "squid-ilb"
   service_label = "squid-ilb"
   forwarding_rules_config = {
-    default = {
+    "" = {
       ports = [3128]
     }
   }

--- a/blueprints/networking/glb-hybrid-neg-internal/glb.tf
+++ b/blueprints/networking/glb-hybrid-neg-internal/glb.tf
@@ -44,7 +44,7 @@ module "hybrid-glb" {
         endpoints = {
           primary = {
             ip_address = (var.ilb_create
-              ? module.test_vm_ilbs["primary"].forwarding_rule_addresses["default"]
+              ? module.test_vm_ilbs["primary"].forwarding_rule_addresses[""]
               : module.test_vms["primary"].internal_ip
             )
             port = 80
@@ -59,7 +59,7 @@ module "hybrid-glb" {
         endpoints = {
           secondary = {
             ip_address = (var.ilb_create
-              ? module.test_vm_ilbs["secondary"].forwarding_rule_addresses["default"]
+              ? module.test_vm_ilbs["secondary"].forwarding_rule_addresses[""]
               : module.test_vms["secondary"].internal_ip
             )
             port = 80

--- a/blueprints/networking/glb-hybrid-neg-internal/glb.tf
+++ b/blueprints/networking/glb-hybrid-neg-internal/glb.tf
@@ -44,7 +44,7 @@ module "hybrid-glb" {
         endpoints = {
           primary = {
             ip_address = (var.ilb_create
-              ? module.test_vm_ilbs["primary"].forwarding_rule_address
+              ? module.test_vm_ilbs["primary"].forwarding_rule_addresses["default"]
               : module.test_vms["primary"].internal_ip
             )
             port = 80
@@ -59,7 +59,7 @@ module "hybrid-glb" {
         endpoints = {
           secondary = {
             ip_address = (var.ilb_create
-              ? module.test_vm_ilbs["secondary"].forwarding_rule_address
+              ? module.test_vm_ilbs["secondary"].forwarding_rule_addresses["default"]
               : module.test_vms["secondary"].internal_ip
             )
             port = 80

--- a/blueprints/networking/glb-hybrid-neg-internal/main.tf
+++ b/blueprints/networking/glb-hybrid-neg-internal/main.tf
@@ -53,12 +53,12 @@ module "vpc_landing_untrusted" {
     spoke1-primary = {
       dest_range    = var.ip_config.spoke_primary
       next_hop_type = "ilb"
-      next_hop      = module.nva_untrusted_ilbs["primary"].forwarding_rule_self_link
+      next_hop      = module.nva_untrusted_ilbs["primary"].forwarding_rule_self_links[""]
     }
     spoke1-secondary = {
       dest_range    = var.ip_config.spoke_secondary
       next_hop_type = "ilb"
-      next_hop      = module.nva_untrusted_ilbs["secondary"].forwarding_rule_self_link
+      next_hop      = module.nva_untrusted_ilbs["secondary"].forwarding_rule_self_links[""]
     }
   }
 

--- a/blueprints/networking/ilb-next-hop/gateways.tf
+++ b/blueprints/networking/ilb-next-hop/gateways.tf
@@ -68,7 +68,7 @@ module "ilb-left" {
     subnetwork = values(module.vpc-left.subnet_self_links)[0]
   }
   forwarding_rules_config = {
-    default = {
+    "" = {
       address = local.addresses.ilb-left
     }
   }
@@ -96,7 +96,7 @@ module "ilb-right" {
     subnetwork = values(module.vpc-right.subnet_self_links)[0]
   }
   forwarding_rules_config = {
-    default = {
+    "" = {
       address = local.addresses.ilb-right
     }
   }

--- a/blueprints/networking/ilb-next-hop/gateways.tf
+++ b/blueprints/networking/ilb-next-hop/gateways.tf
@@ -67,7 +67,11 @@ module "ilb-left" {
     network    = module.vpc-left.self_link
     subnetwork = values(module.vpc-left.subnet_self_links)[0]
   }
-  address = local.addresses.ilb-left
+  forwarding_rules_config = {
+    default = {
+      address = local.addresses.ilb-left
+    }
+  }
   backend_service_config = {
     session_affinity = var.ilb_session_affinity
   }
@@ -91,7 +95,11 @@ module "ilb-right" {
     network    = module.vpc-right.self_link
     subnetwork = values(module.vpc-right.subnet_self_links)[0]
   }
-  address = local.addresses.ilb-right
+  forwarding_rules_config = {
+    default = {
+      address = local.addresses.ilb-right
+    }
+  }
   backend_service_config = {
     session_affinity = var.ilb_session_affinity
   }

--- a/blueprints/networking/ilb-next-hop/outputs.tf
+++ b/blueprints/networking/ilb-next-hop/outputs.tf
@@ -18,8 +18,8 @@ output "addresses" {
   description = "IP addresses."
   value = {
     gw        = [for z, mod in module.gw : mod.internal_ip]
-    ilb-left  = module.ilb-left.forwarding_rule_addresses["default"]
-    ilb-right = module.ilb-right.forwarding_rule_addresses["default"]
+    ilb-left  = module.ilb-left.forwarding_rule_addresses[""]
+    ilb-right = module.ilb-right.forwarding_rule_addresses[""]
     vm-left   = [for z, mod in module.vm-left : mod.internal_ip]
     vm-right  = [for z, mod in module.vm-right : mod.internal_ip]
   }

--- a/blueprints/networking/ilb-next-hop/outputs.tf
+++ b/blueprints/networking/ilb-next-hop/outputs.tf
@@ -18,8 +18,8 @@ output "addresses" {
   description = "IP addresses."
   value = {
     gw        = [for z, mod in module.gw : mod.internal_ip]
-    ilb-left  = module.ilb-left.forwarding_rule_address
-    ilb-right = module.ilb-right.forwarding_rule_address
+    ilb-left  = module.ilb-left.forwarding_rule_addresses["default"]
+    ilb-right = module.ilb-right.forwarding_rule_addresses["default"]
     vm-left   = [for z, mod in module.vm-left : mod.internal_ip]
     vm-right  = [for z, mod in module.vm-right : mod.internal_ip]
   }

--- a/blueprints/networking/ilb-next-hop/vpc-left.tf
+++ b/blueprints/networking/ilb-next-hop/vpc-left.tf
@@ -29,7 +29,7 @@ module "vpc-left" {
     to-right = {
       dest_range    = var.ip_ranges.right
       next_hop_type = "ilb"
-      next_hop      = module.ilb-left.forwarding_rule.self_link
+      next_hop      = module.ilb-left.forwarding_rule_self_links[""]
     }
   }
 }

--- a/blueprints/networking/ilb-next-hop/vpc-right.tf
+++ b/blueprints/networking/ilb-next-hop/vpc-right.tf
@@ -30,7 +30,7 @@ module "vpc-right" {
       dest_range    = var.ip_ranges.left
       priority      = var.ilb_right_enable ? 900 : 1100
       next_hop_type = "ilb"
-      next_hop      = module.ilb-right.forwarding_rule.self_link
+      next_hop      = module.ilb-right.forwarding_rule_self_links[""]
     }
     to-left-gw-1 = {
       dest_range    = var.ip_ranges.left

--- a/fast/stages/2-networking-c-nva/nva.tf
+++ b/fast/stages/2-networking-c-nva/nva.tf
@@ -130,7 +130,7 @@ module "ilb-nva-untrusted" {
   name          = "nva-untrusted-${each.key}"
   service_label = var.prefix
   forwarding_rules_config = {
-    default = {
+    "" = {
       global_access = true
     }
   }
@@ -165,7 +165,7 @@ module "ilb-nva-trusted" {
   name          = "nva-trusted-${each.key}"
   service_label = var.prefix
   forwarding_rules_config = {
-    default = {
+    "" = {
       global_access = true
     }
   }

--- a/fast/stages/2-networking-c-nva/nva.tf
+++ b/fast/stages/2-networking-c-nva/nva.tf
@@ -129,7 +129,11 @@ module "ilb-nva-untrusted" {
   region        = each.value.region
   name          = "nva-untrusted-${each.key}"
   service_label = var.prefix
-  global_access = true
+  forwarding_rules_config = {
+    default = {
+      global_access = true
+    }
+  }
   vpc_config = {
     network    = module.landing-untrusted-vpc.self_link
     subnetwork = module.landing-untrusted-vpc.subnet_self_links[each.value.subnet]
@@ -160,7 +164,11 @@ module "ilb-nva-trusted" {
   region        = each.value.region
   name          = "nva-trusted-${each.key}"
   service_label = var.prefix
-  global_access = true
+  forwarding_rules_config = {
+    default = {
+      global_access = true
+    }
+  }
   vpc_config = {
     network    = module.landing-trusted-vpc.self_link
     subnetwork = module.landing-trusted-vpc.subnet_self_links[each.value.subnet]

--- a/fast/stages/2-networking-c-nva/spoke-dev.tf
+++ b/fast/stages/2-networking-c-nva/spoke-dev.tf
@@ -65,28 +65,28 @@ module "dev-spoke-vpc" {
       priority      = 1000
       tags          = ["primary"]
       next_hop_type = "ilb"
-      next_hop      = module.ilb-nva-trusted["primary"].forwarding_rule_address
+      next_hop      = module.ilb-nva-trusted["primary"].forwarding_rule_addresses["default"]
     }
     nva-secondary-to-secondary = {
       dest_range    = "0.0.0.0/0"
       priority      = 1000
       tags          = ["secondary"]
       next_hop_type = "ilb"
-      next_hop      = module.ilb-nva-trusted["secondary"].forwarding_rule_address
+      next_hop      = module.ilb-nva-trusted["secondary"].forwarding_rule_addresses["default"]
     }
     nva-primary-to-secondary = {
       dest_range    = "0.0.0.0/0"
       priority      = 1001
       tags          = ["primary"]
       next_hop_type = "ilb"
-      next_hop      = module.ilb-nva-trusted["primary"].forwarding_rule_address
+      next_hop      = module.ilb-nva-trusted["primary"].forwarding_rule_addresses["default"]
     }
     nva-secondary-to-primary = {
       dest_range    = "0.0.0.0/0"
       priority      = 1001
       tags          = ["secondary"]
       next_hop_type = "ilb"
-      next_hop      = module.ilb-nva-trusted["secondary"].forwarding_rule_address
+      next_hop      = module.ilb-nva-trusted["secondary"].forwarding_rule_addresses["default"]
     }
   }
 }

--- a/fast/stages/2-networking-c-nva/spoke-dev.tf
+++ b/fast/stages/2-networking-c-nva/spoke-dev.tf
@@ -65,28 +65,28 @@ module "dev-spoke-vpc" {
       priority      = 1000
       tags          = ["primary"]
       next_hop_type = "ilb"
-      next_hop      = module.ilb-nva-trusted["primary"].forwarding_rule_addresses["default"]
+      next_hop      = module.ilb-nva-trusted["primary"].forwarding_rule_addresses[""]
     }
     nva-secondary-to-secondary = {
       dest_range    = "0.0.0.0/0"
       priority      = 1000
       tags          = ["secondary"]
       next_hop_type = "ilb"
-      next_hop      = module.ilb-nva-trusted["secondary"].forwarding_rule_addresses["default"]
+      next_hop      = module.ilb-nva-trusted["secondary"].forwarding_rule_addresses[""]
     }
     nva-primary-to-secondary = {
       dest_range    = "0.0.0.0/0"
       priority      = 1001
       tags          = ["primary"]
       next_hop_type = "ilb"
-      next_hop      = module.ilb-nva-trusted["primary"].forwarding_rule_addresses["default"]
+      next_hop      = module.ilb-nva-trusted["primary"].forwarding_rule_addresses[""]
     }
     nva-secondary-to-primary = {
       dest_range    = "0.0.0.0/0"
       priority      = 1001
       tags          = ["secondary"]
       next_hop_type = "ilb"
-      next_hop      = module.ilb-nva-trusted["secondary"].forwarding_rule_addresses["default"]
+      next_hop      = module.ilb-nva-trusted["secondary"].forwarding_rule_addresses[""]
     }
   }
 }

--- a/fast/stages/2-networking-c-nva/spoke-prod.tf
+++ b/fast/stages/2-networking-c-nva/spoke-prod.tf
@@ -64,28 +64,28 @@ module "prod-spoke-vpc" {
       priority      = 1000
       tags          = ["primary"]
       next_hop_type = "ilb"
-      next_hop      = module.ilb-nva-trusted["primary"].forwarding_rule_addresses["default"]
+      next_hop      = module.ilb-nva-trusted["primary"].forwarding_rule_addresses[""]
     }
     nva-secondary-to-secondary = {
       dest_range    = "0.0.0.0/0"
       priority      = 1000
       tags          = ["secondary"]
       next_hop_type = "ilb"
-      next_hop      = module.ilb-nva-trusted["secondary"].forwarding_rule_addresses["default"]
+      next_hop      = module.ilb-nva-trusted["secondary"].forwarding_rule_addresses[""]
     }
     nva-primary-to-secondary = {
       dest_range    = "0.0.0.0/0"
       priority      = 1001
       tags          = ["primary"]
       next_hop_type = "ilb"
-      next_hop      = module.ilb-nva-trusted["secondary"].forwarding_rule_addresses["default"]
+      next_hop      = module.ilb-nva-trusted["secondary"].forwarding_rule_addresses[""]
     }
     nva-secondary-to-primary = {
       dest_range    = "0.0.0.0/0"
       priority      = 1001
       tags          = ["secondary"]
       next_hop_type = "ilb"
-      next_hop      = module.ilb-nva-trusted["primary"].forwarding_rule_addresses["default"]
+      next_hop      = module.ilb-nva-trusted["primary"].forwarding_rule_addresses[""]
     }
   }
 }

--- a/fast/stages/2-networking-c-nva/spoke-prod.tf
+++ b/fast/stages/2-networking-c-nva/spoke-prod.tf
@@ -64,28 +64,28 @@ module "prod-spoke-vpc" {
       priority      = 1000
       tags          = ["primary"]
       next_hop_type = "ilb"
-      next_hop      = module.ilb-nva-trusted["primary"].forwarding_rule_address
+      next_hop      = module.ilb-nva-trusted["primary"].forwarding_rule_addresses["default"]
     }
     nva-secondary-to-secondary = {
       dest_range    = "0.0.0.0/0"
       priority      = 1000
       tags          = ["secondary"]
       next_hop_type = "ilb"
-      next_hop      = module.ilb-nva-trusted["secondary"].forwarding_rule_address
+      next_hop      = module.ilb-nva-trusted["secondary"].forwarding_rule_addresses["default"]
     }
     nva-primary-to-secondary = {
       dest_range    = "0.0.0.0/0"
       priority      = 1001
       tags          = ["primary"]
       next_hop_type = "ilb"
-      next_hop      = module.ilb-nva-trusted["secondary"].forwarding_rule_address
+      next_hop      = module.ilb-nva-trusted["secondary"].forwarding_rule_addresses["default"]
     }
     nva-secondary-to-primary = {
       dest_range    = "0.0.0.0/0"
       priority      = 1001
       tags          = ["secondary"]
       next_hop_type = "ilb"
-      next_hop      = module.ilb-nva-trusted["primary"].forwarding_rule_address
+      next_hop      = module.ilb-nva-trusted["primary"].forwarding_rule_addresses["default"]
     }
   }
 }

--- a/modules/net-lb-int/README.md
+++ b/modules/net-lb-int/README.md
@@ -119,11 +119,15 @@ module "ilb" {
   project_id    = var.project_id
   region        = "europe-west1"
   name          = "ilb-test"
-  protocol      = "L3_DEFAULT"
   service_label = "ilb-test"
   vpc_config = {
     network    = var.vpc.self_link
     subnetwork = var.subnet.self_link
+  }
+  forwarding_rules_config = {
+    default = {
+      ip_protocol = "L3_DEFAULT"
+    }
   }
   group_configs = {
     my-group = {
@@ -192,7 +196,11 @@ module "ilb" {
     network    = var.vpc.self_link
     subnetwork = var.subnet.self_link
   }
-  ports = [80]
+  forwarding_rules_config = {
+    default = {
+      ports = [80]
+    }
+  }
   backends = [
     for z, mod in module.instance-group : {
       group          = mod.group.self_link
@@ -212,22 +220,20 @@ module "ilb" {
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [name](variables.tf#L189) | Name used for all resources. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L200) | Project id where resources will be created. | <code>string</code> | ✓ |  |
-| [region](variables.tf#L211) | GCP region. | <code>string</code> | ✓ |  |
-| [vpc_config](variables.tf#L222) | VPC-level configuration. | <code title="object&#40;&#123;&#10;  network    &#61; string&#10;  subnetwork &#61; string&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
-| [address](variables.tf#L17) | Optional IP address used for the forwarding rule. | <code>string</code> |  | <code>null</code> |
-| [backend_service_config](variables.tf#L23) | Backend service level configuration. | <code title="object&#40;&#123;&#10;  connection_draining_timeout_sec &#61; optional&#40;number&#41;&#10;  connection_tracking &#61; optional&#40;object&#40;&#123;&#10;    idle_timeout_sec          &#61; optional&#40;number&#41;&#10;    persist_conn_on_unhealthy &#61; optional&#40;string&#41;&#10;    track_per_session         &#61; optional&#40;bool&#41;&#10;  &#125;&#41;&#41;&#10;  enable_subsetting &#61; optional&#40;bool&#41;&#10;  failover_config &#61; optional&#40;object&#40;&#123;&#10;    disable_conn_drain        &#61; optional&#40;bool&#41;&#10;    drop_traffic_if_unhealthy &#61; optional&#40;bool&#41;&#10;    ratio                     &#61; optional&#40;number&#41;&#10;  &#125;&#41;&#41;&#10;  log_sample_rate  &#61; optional&#40;number&#41;&#10;  protocol         &#61; optional&#40;string, &#34;UNSPECIFIED&#34;&#41;&#10;  session_affinity &#61; optional&#40;string&#41;&#10;  timeout_sec      &#61; optional&#40;number&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [backends](variables.tf#L57) | Load balancer backends, balancing mode is one of 'CONNECTION' or 'UTILIZATION'. | <code title="list&#40;object&#40;&#123;&#10;  group          &#61; string&#10;  balancing_mode &#61; optional&#40;string, &#34;CONNECTION&#34;&#41;&#10;  description    &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  failover       &#61; optional&#40;bool, false&#41;&#10;&#125;&#41;&#41;">list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
-| [description](variables.tf#L76) | Optional description used for resources. | <code>string</code> |  | <code>&#34;Terraform managed.&#34;</code> |
-| [global_access](variables.tf#L82) | Global access, defaults to false if not set. | <code>bool</code> |  | <code>null</code> |
-| [group_configs](variables.tf#L88) | Optional unmanaged groups to create. Can be referenced in backends via outputs. | <code title="map&#40;object&#40;&#123;&#10;  zone        &#61; string&#10;  description &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  instances   &#61; optional&#40;list&#40;string&#41;&#41;&#10;  named_ports &#61; optional&#40;map&#40;number&#41;, &#123;&#125;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [health_check](variables.tf#L100) | Name of existing health check to use, disables auto-created health check. | <code>string</code> |  | <code>null</code> |
-| [health_check_config](variables.tf#L106) | Optional auto-created health check configuration, use the output self-link to set it in the auto healing policy. Refer to examples for usage. | <code title="object&#40;&#123;&#10;  check_interval_sec  &#61; optional&#40;number&#41;&#10;  description         &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  enable_logging      &#61; optional&#40;bool, false&#41;&#10;  healthy_threshold   &#61; optional&#40;number&#41;&#10;  timeout_sec         &#61; optional&#40;number&#41;&#10;  unhealthy_threshold &#61; optional&#40;number&#41;&#10;  grpc &#61; optional&#40;object&#40;&#123;&#10;    port               &#61; optional&#40;number&#41;&#10;    port_name          &#61; optional&#40;string&#41;&#10;    port_specification &#61; optional&#40;string&#41; &#35; USE_FIXED_PORT USE_NAMED_PORT USE_SERVING_PORT&#10;    service_name       &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;  http &#61; optional&#40;object&#40;&#123;&#10;    host               &#61; optional&#40;string&#41;&#10;    port               &#61; optional&#40;number&#41;&#10;    port_name          &#61; optional&#40;string&#41;&#10;    port_specification &#61; optional&#40;string&#41; &#35; USE_FIXED_PORT USE_NAMED_PORT USE_SERVING_PORT&#10;    proxy_header       &#61; optional&#40;string&#41;&#10;    request_path       &#61; optional&#40;string&#41;&#10;    response           &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;  http2 &#61; optional&#40;object&#40;&#123;&#10;    host               &#61; optional&#40;string&#41;&#10;    port               &#61; optional&#40;number&#41;&#10;    port_name          &#61; optional&#40;string&#41;&#10;    port_specification &#61; optional&#40;string&#41; &#35; USE_FIXED_PORT USE_NAMED_PORT USE_SERVING_PORT&#10;    proxy_header       &#61; optional&#40;string&#41;&#10;    request_path       &#61; optional&#40;string&#41;&#10;    response           &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;  https &#61; optional&#40;object&#40;&#123;&#10;    host               &#61; optional&#40;string&#41;&#10;    port               &#61; optional&#40;number&#41;&#10;    port_name          &#61; optional&#40;string&#41;&#10;    port_specification &#61; optional&#40;string&#41; &#35; USE_FIXED_PORT USE_NAMED_PORT USE_SERVING_PORT&#10;    proxy_header       &#61; optional&#40;string&#41;&#10;    request_path       &#61; optional&#40;string&#41;&#10;    response           &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;  tcp &#61; optional&#40;object&#40;&#123;&#10;    port               &#61; optional&#40;number&#41;&#10;    port_name          &#61; optional&#40;string&#41;&#10;    port_specification &#61; optional&#40;string&#41; &#35; USE_FIXED_PORT USE_NAMED_PORT USE_SERVING_PORT&#10;    proxy_header       &#61; optional&#40;string&#41;&#10;    request            &#61; optional&#40;string&#41;&#10;    response           &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;  ssl &#61; optional&#40;object&#40;&#123;&#10;    port               &#61; optional&#40;number&#41;&#10;    port_name          &#61; optional&#40;string&#41;&#10;    port_specification &#61; optional&#40;string&#41; &#35; USE_FIXED_PORT USE_NAMED_PORT USE_SERVING_PORT&#10;    proxy_header       &#61; optional&#40;string&#41;&#10;    request            &#61; optional&#40;string&#41;&#10;    response           &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code title="&#123;&#10;  tcp &#61; &#123;&#10;    port_specification &#61; &#34;USE_SERVING_PORT&#34;&#10;  &#125;&#10;&#125;">&#123;&#8230;&#125;</code> |
-| [labels](variables.tf#L183) | Labels set on resources. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
-| [ports](variables.tf#L194) | Comma-separated ports, leave null to use all ports. | <code>list&#40;string&#41;</code> |  | <code>null</code> |
-| [protocol](variables.tf#L205) | Forwarding rule protocol used, defaults to TCP. | <code>string</code> |  | <code>&#34;TCP&#34;</code> |
-| [service_label](variables.tf#L216) | Optional prefix of the fully qualified forwarding rule name. | <code>string</code> |  | <code>null</code> |
+| [name](variables.tf#L193) | Name used for all resources. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L198) | Project id where resources will be created. | <code>string</code> | ✓ |  |
+| [region](variables.tf#L209) | GCP region. | <code>string</code> | ✓ |  |
+| [vpc_config](variables.tf#L220) | VPC-level configuration. | <code title="object&#40;&#123;&#10;  network    &#61; string&#10;  subnetwork &#61; string&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
+| [backend_service_config](variables.tf#L17) | Backend service level configuration. | <code title="object&#40;&#123;&#10;  connection_draining_timeout_sec &#61; optional&#40;number&#41;&#10;  connection_tracking &#61; optional&#40;object&#40;&#123;&#10;    idle_timeout_sec          &#61; optional&#40;number&#41;&#10;    persist_conn_on_unhealthy &#61; optional&#40;string&#41;&#10;    track_per_session         &#61; optional&#40;bool&#41;&#10;  &#125;&#41;&#41;&#10;  enable_subsetting &#61; optional&#40;bool&#41;&#10;  failover_config &#61; optional&#40;object&#40;&#123;&#10;    disable_conn_drain        &#61; optional&#40;bool&#41;&#10;    drop_traffic_if_unhealthy &#61; optional&#40;bool&#41;&#10;    ratio                     &#61; optional&#40;number&#41;&#10;  &#125;&#41;&#41;&#10;  log_sample_rate  &#61; optional&#40;number&#41;&#10;  protocol         &#61; optional&#40;string, &#34;UNSPECIFIED&#34;&#41;&#10;  session_affinity &#61; optional&#40;string&#41;&#10;  timeout_sec      &#61; optional&#40;number&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [backends](variables.tf#L51) | Load balancer backends, balancing mode is one of 'CONNECTION' or 'UTILIZATION'. | <code title="list&#40;object&#40;&#123;&#10;  group          &#61; string&#10;  balancing_mode &#61; optional&#40;string, &#34;CONNECTION&#34;&#41;&#10;  description    &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  failover       &#61; optional&#40;bool, false&#41;&#10;&#125;&#41;&#41;">list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
+| [description](variables.tf#L70) | Optional description used for resources. | <code>string</code> |  | <code>&#34;Terraform managed.&#34;</code> |
+| [forwarding_rules_config](variables.tf#L76) | The optional forwarding rules configuration. | <code title="map&#40;object&#40;&#123;&#10;  description   &#61; optional&#40;string&#41;&#10;  global_access &#61; optional&#40;bool, true&#41;&#10;  ip_address    &#61; optional&#40;string&#41;&#10;  ip_protocol   &#61; optional&#40;string, &#34;TCP&#34;&#41;&#10;  ip_version    &#61; optional&#40;string&#41;&#10;  ports         &#61; optional&#40;list&#40;string&#41;, null&#41;&#10;&#10;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code title="&#123;&#10;  default &#61; &#123;&#125;&#10;&#125;">&#123;&#8230;&#125;</code> |
+| [group_configs](variables.tf#L92) | Optional unmanaged groups to create. Can be referenced in backends via outputs. | <code title="map&#40;object&#40;&#123;&#10;  zone        &#61; string&#10;  description &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  instances   &#61; optional&#40;list&#40;string&#41;&#41;&#10;  named_ports &#61; optional&#40;map&#40;number&#41;, &#123;&#125;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [health_check](variables.tf#L104) | Name of existing health check to use, disables auto-created health check. | <code>string</code> |  | <code>null</code> |
+| [health_check_config](variables.tf#L110) | Optional auto-created health check configuration, use the output self-link to set it in the auto healing policy. Refer to examples for usage. | <code title="object&#40;&#123;&#10;  check_interval_sec  &#61; optional&#40;number&#41;&#10;  description         &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  enable_logging      &#61; optional&#40;bool, false&#41;&#10;  healthy_threshold   &#61; optional&#40;number&#41;&#10;  timeout_sec         &#61; optional&#40;number&#41;&#10;  unhealthy_threshold &#61; optional&#40;number&#41;&#10;  grpc &#61; optional&#40;object&#40;&#123;&#10;    port               &#61; optional&#40;number&#41;&#10;    port_name          &#61; optional&#40;string&#41;&#10;    port_specification &#61; optional&#40;string&#41; &#35; USE_FIXED_PORT USE_NAMED_PORT USE_SERVING_PORT&#10;    service_name       &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;  http &#61; optional&#40;object&#40;&#123;&#10;    host               &#61; optional&#40;string&#41;&#10;    port               &#61; optional&#40;number&#41;&#10;    port_name          &#61; optional&#40;string&#41;&#10;    port_specification &#61; optional&#40;string&#41; &#35; USE_FIXED_PORT USE_NAMED_PORT USE_SERVING_PORT&#10;    proxy_header       &#61; optional&#40;string&#41;&#10;    request_path       &#61; optional&#40;string&#41;&#10;    response           &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;  http2 &#61; optional&#40;object&#40;&#123;&#10;    host               &#61; optional&#40;string&#41;&#10;    port               &#61; optional&#40;number&#41;&#10;    port_name          &#61; optional&#40;string&#41;&#10;    port_specification &#61; optional&#40;string&#41; &#35; USE_FIXED_PORT USE_NAMED_PORT USE_SERVING_PORT&#10;    proxy_header       &#61; optional&#40;string&#41;&#10;    request_path       &#61; optional&#40;string&#41;&#10;    response           &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;  https &#61; optional&#40;object&#40;&#123;&#10;    host               &#61; optional&#40;string&#41;&#10;    port               &#61; optional&#40;number&#41;&#10;    port_name          &#61; optional&#40;string&#41;&#10;    port_specification &#61; optional&#40;string&#41; &#35; USE_FIXED_PORT USE_NAMED_PORT USE_SERVING_PORT&#10;    proxy_header       &#61; optional&#40;string&#41;&#10;    request_path       &#61; optional&#40;string&#41;&#10;    response           &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;  tcp &#61; optional&#40;object&#40;&#123;&#10;    port               &#61; optional&#40;number&#41;&#10;    port_name          &#61; optional&#40;string&#41;&#10;    port_specification &#61; optional&#40;string&#41; &#35; USE_FIXED_PORT USE_NAMED_PORT USE_SERVING_PORT&#10;    proxy_header       &#61; optional&#40;string&#41;&#10;    request            &#61; optional&#40;string&#41;&#10;    response           &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;  ssl &#61; optional&#40;object&#40;&#123;&#10;    port               &#61; optional&#40;number&#41;&#10;    port_name          &#61; optional&#40;string&#41;&#10;    port_specification &#61; optional&#40;string&#41; &#35; USE_FIXED_PORT USE_NAMED_PORT USE_SERVING_PORT&#10;    proxy_header       &#61; optional&#40;string&#41;&#10;    request            &#61; optional&#40;string&#41;&#10;    response           &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code title="&#123;&#10;  tcp &#61; &#123;&#10;    port_specification &#61; &#34;USE_SERVING_PORT&#34;&#10;  &#125;&#10;&#125;">&#123;&#8230;&#125;</code> |
+| [labels](variables.tf#L187) | Labels set on resources. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [protocol](variables.tf#L203) | Forwarding rule protocol used, defaults to TCP. | <code>string</code> |  | <code>&#34;TCP&#34;</code> |
+| [service_label](variables.tf#L214) | Optional prefix of the fully qualified forwarding rule name. | <code>string</code> |  | <code>null</code> |
 
 ## Outputs
 
@@ -236,13 +242,13 @@ module "ilb" {
 | [backend_service](outputs.tf#L17) | Backend resource. |  |
 | [backend_service_id](outputs.tf#L22) | Backend id. |  |
 | [backend_service_self_link](outputs.tf#L27) | Backend self link. |  |
-| [forwarding_rule](outputs.tf#L32) | Forwarding rule resource. |  |
-| [forwarding_rule_address](outputs.tf#L37) | Forwarding rule address. |  |
-| [forwarding_rule_self_link](outputs.tf#L42) | Forwarding rule self link. |  |
-| [group_self_links](outputs.tf#L47) | Optional unmanaged instance group self links. |  |
-| [groups](outputs.tf#L54) | Optional unmanaged instance group resources. |  |
-| [health_check](outputs.tf#L59) | Auto-created health-check resource. |  |
-| [health_check_self_id](outputs.tf#L64) | Auto-created health-check self id. |  |
-| [health_check_self_link](outputs.tf#L69) | Auto-created health-check self link. |  |
-| [id](outputs.tf#L74) | Fully qualified forwarding rule id. |  |
+| [forwarding_rule_addresses](outputs.tf#L40) | Forwarding rule address. |  |
+| [forwarding_rule_self_link](outputs.tf#L48) | Forwarding rule self links. |  |
+| [forwarding_rules](outputs.tf#L32) | Forwarding rule resources. |  |
+| [group_self_links](outputs.tf#L56) | Optional unmanaged instance group self links. |  |
+| [groups](outputs.tf#L63) | Optional unmanaged instance group resources. |  |
+| [health_check](outputs.tf#L68) | Auto-created health-check resource. |  |
+| [health_check_self_id](outputs.tf#L73) | Auto-created health-check self id. |  |
+| [health_check_self_link](outputs.tf#L78) | Auto-created health-check self link. |  |
+| [id](outputs.tf#L83) | Fully qualified forwarding rule ids. |  |
 <!-- END TFDOC -->

--- a/modules/net-lb-int/README.md
+++ b/modules/net-lb-int/README.md
@@ -242,9 +242,9 @@ module "ilb" {
 | [backend_service](outputs.tf#L17) | Backend resource. |  |
 | [backend_service_id](outputs.tf#L22) | Backend id. |  |
 | [backend_service_self_link](outputs.tf#L27) | Backend self link. |  |
-| [forwarding_rule_addresses](outputs.tf#L40) | Forwarding rule address. |  |
-| [forwarding_rule_self_link](outputs.tf#L48) | Forwarding rule self links. |  |
-| [forwarding_rules](outputs.tf#L32) | Forwarding rule resources. |  |
+| [forwarding_rule_addresses](outputs.tf#L32) | Forwarding rule address. |  |
+| [forwarding_rule_self_link](outputs.tf#L40) | Forwarding rule self links. |  |
+| [forwarding_rules](outputs.tf#L48) | Forwarding rule resources. |  |
 | [group_self_links](outputs.tf#L56) | Optional unmanaged instance group self links. |  |
 | [groups](outputs.tf#L63) | Optional unmanaged instance group resources. |  |
 | [health_check](outputs.tf#L68) | Auto-created health-check resource. |  |

--- a/modules/net-lb-int/README.md
+++ b/modules/net-lb-int/README.md
@@ -125,8 +125,8 @@ module "ilb" {
     subnetwork = var.subnet.self_link
   }
   forwarding_rules_config = {
-    default = {
-      ip_protocol = "L3_DEFAULT"
+    "" = {
+      protocol = "L3_DEFAULT"
     }
   }
   group_configs = {
@@ -143,6 +143,90 @@ module "ilb" {
   }]
 }
 # tftest modules=1 resources=4
+```
+
+### Mutiple forwarding rules
+
+You can add more forwarding rules to your load balancer and override some forwarding rules defaults, including the global access policy, the IP protocol, the IP version and ports.
+
+The example adds two forwarding rules:
+
+- the first one, called `ilb-test-vip-one` exposes an IPv4 address, it listens on all ports, and allows connections from any region.
+- the second one, called `ilb-test-vip-two` exposes an IPv4 address, it listens on port 80 and allows connections from the same region only.
+
+
+```hcl
+module "ilb" {
+  source        = "./fabric/modules/net-lb-int"
+  project_id    = var.project_id
+  region        = "europe-west1"
+  name          = "ilb-test"
+  service_label = "ilb-test"
+  vpc_config = {
+    network    = var.vpc.self_link
+    subnetwork = var.subnet.self_link
+  }
+  forwarding_rules_config = {
+    vip-one = {}
+    vip-two = {
+      global_access = false
+      ports         = [80]
+    }
+  }
+  group_configs = {
+    my-group = {
+      zone = "europe-west1-b"
+      instances = [
+        "instance-1-self-link",
+        "instance-2-self-link"
+      ]
+    }
+  }
+  backends = [{
+    group = module.ilb.groups.my-group.self_link
+  }]
+}
+# tftest modules=1 resources=5
+```
+
+### Dual stack (IPv4 and IPv6)
+
+Your load balancer can use a combination of either or both IPv4 and IPv6 forwarding rules.
+In this example we set the load balancer to work as dual stack, meaning it exposes both an IPv4 and an IPv6 address.
+
+```hcl
+module "ilb" {
+  source        = "./fabric/modules/net-lb-int"
+  project_id    = var.project_id
+  region        = "europe-west1"
+  name          = "ilb-test"
+  service_label = "ilb-test"
+  vpc_config = {
+    network    = var.vpc.self_link
+    subnetwork = var.subnet.self_link
+  }
+  forwarding_rules_config = {
+    ipv4 = {
+      version = "IPV4"
+    }
+    ipv6 = {
+      version = "IPV6"
+    }
+  }
+  group_configs = {
+    my-group = {
+      zone = "europe-west1-b"
+      instances = [
+        "instance-1-self-link",
+        "instance-2-self-link"
+      ]
+    }
+  }
+  backends = [{
+    group = module.ilb.groups.my-group.self_link
+  }]
+}
+# tftest modules=1 resources=5
 ```
 
 ### End to end example
@@ -197,7 +281,7 @@ module "ilb" {
     subnetwork = var.subnet.self_link
   }
   forwarding_rules_config = {
-    default = {
+    "" = {
       ports = [80]
     }
   }
@@ -220,20 +304,20 @@ module "ilb" {
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [name](variables.tf#L193) | Name used for all resources. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L198) | Project id where resources will be created. | <code>string</code> | ✓ |  |
-| [region](variables.tf#L209) | GCP region. | <code>string</code> | ✓ |  |
-| [vpc_config](variables.tf#L220) | VPC-level configuration. | <code title="object&#40;&#123;&#10;  network    &#61; string&#10;  subnetwork &#61; string&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
+| [name](variables.tf#L192) | Name used for all resources. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L197) | Project id where resources will be created. | <code>string</code> | ✓ |  |
+| [region](variables.tf#L208) | GCP region. | <code>string</code> | ✓ |  |
+| [vpc_config](variables.tf#L219) | VPC-level configuration. | <code title="object&#40;&#123;&#10;  network    &#61; string&#10;  subnetwork &#61; string&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
 | [backend_service_config](variables.tf#L17) | Backend service level configuration. | <code title="object&#40;&#123;&#10;  connection_draining_timeout_sec &#61; optional&#40;number&#41;&#10;  connection_tracking &#61; optional&#40;object&#40;&#123;&#10;    idle_timeout_sec          &#61; optional&#40;number&#41;&#10;    persist_conn_on_unhealthy &#61; optional&#40;string&#41;&#10;    track_per_session         &#61; optional&#40;bool&#41;&#10;  &#125;&#41;&#41;&#10;  enable_subsetting &#61; optional&#40;bool&#41;&#10;  failover_config &#61; optional&#40;object&#40;&#123;&#10;    disable_conn_drain        &#61; optional&#40;bool&#41;&#10;    drop_traffic_if_unhealthy &#61; optional&#40;bool&#41;&#10;    ratio                     &#61; optional&#40;number&#41;&#10;  &#125;&#41;&#41;&#10;  log_sample_rate  &#61; optional&#40;number&#41;&#10;  protocol         &#61; optional&#40;string, &#34;UNSPECIFIED&#34;&#41;&#10;  session_affinity &#61; optional&#40;string&#41;&#10;  timeout_sec      &#61; optional&#40;number&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [backends](variables.tf#L51) | Load balancer backends, balancing mode is one of 'CONNECTION' or 'UTILIZATION'. | <code title="list&#40;object&#40;&#123;&#10;  group          &#61; string&#10;  balancing_mode &#61; optional&#40;string, &#34;CONNECTION&#34;&#41;&#10;  description    &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  failover       &#61; optional&#40;bool, false&#41;&#10;&#125;&#41;&#41;">list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
 | [description](variables.tf#L70) | Optional description used for resources. | <code>string</code> |  | <code>&#34;Terraform managed.&#34;</code> |
-| [forwarding_rules_config](variables.tf#L76) | The optional forwarding rules configuration. | <code title="map&#40;object&#40;&#123;&#10;  description   &#61; optional&#40;string&#41;&#10;  global_access &#61; optional&#40;bool, true&#41;&#10;  ip_address    &#61; optional&#40;string&#41;&#10;  ip_protocol   &#61; optional&#40;string, &#34;TCP&#34;&#41;&#10;  ip_version    &#61; optional&#40;string&#41;&#10;  ports         &#61; optional&#40;list&#40;string&#41;, null&#41;&#10;&#10;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code title="&#123;&#10;  default &#61; &#123;&#125;&#10;&#125;">&#123;&#8230;&#125;</code> |
-| [group_configs](variables.tf#L92) | Optional unmanaged groups to create. Can be referenced in backends via outputs. | <code title="map&#40;object&#40;&#123;&#10;  zone        &#61; string&#10;  description &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  instances   &#61; optional&#40;list&#40;string&#41;&#41;&#10;  named_ports &#61; optional&#40;map&#40;number&#41;, &#123;&#125;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [health_check](variables.tf#L104) | Name of existing health check to use, disables auto-created health check. | <code>string</code> |  | <code>null</code> |
-| [health_check_config](variables.tf#L110) | Optional auto-created health check configuration, use the output self-link to set it in the auto healing policy. Refer to examples for usage. | <code title="object&#40;&#123;&#10;  check_interval_sec  &#61; optional&#40;number&#41;&#10;  description         &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  enable_logging      &#61; optional&#40;bool, false&#41;&#10;  healthy_threshold   &#61; optional&#40;number&#41;&#10;  timeout_sec         &#61; optional&#40;number&#41;&#10;  unhealthy_threshold &#61; optional&#40;number&#41;&#10;  grpc &#61; optional&#40;object&#40;&#123;&#10;    port               &#61; optional&#40;number&#41;&#10;    port_name          &#61; optional&#40;string&#41;&#10;    port_specification &#61; optional&#40;string&#41; &#35; USE_FIXED_PORT USE_NAMED_PORT USE_SERVING_PORT&#10;    service_name       &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;  http &#61; optional&#40;object&#40;&#123;&#10;    host               &#61; optional&#40;string&#41;&#10;    port               &#61; optional&#40;number&#41;&#10;    port_name          &#61; optional&#40;string&#41;&#10;    port_specification &#61; optional&#40;string&#41; &#35; USE_FIXED_PORT USE_NAMED_PORT USE_SERVING_PORT&#10;    proxy_header       &#61; optional&#40;string&#41;&#10;    request_path       &#61; optional&#40;string&#41;&#10;    response           &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;  http2 &#61; optional&#40;object&#40;&#123;&#10;    host               &#61; optional&#40;string&#41;&#10;    port               &#61; optional&#40;number&#41;&#10;    port_name          &#61; optional&#40;string&#41;&#10;    port_specification &#61; optional&#40;string&#41; &#35; USE_FIXED_PORT USE_NAMED_PORT USE_SERVING_PORT&#10;    proxy_header       &#61; optional&#40;string&#41;&#10;    request_path       &#61; optional&#40;string&#41;&#10;    response           &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;  https &#61; optional&#40;object&#40;&#123;&#10;    host               &#61; optional&#40;string&#41;&#10;    port               &#61; optional&#40;number&#41;&#10;    port_name          &#61; optional&#40;string&#41;&#10;    port_specification &#61; optional&#40;string&#41; &#35; USE_FIXED_PORT USE_NAMED_PORT USE_SERVING_PORT&#10;    proxy_header       &#61; optional&#40;string&#41;&#10;    request_path       &#61; optional&#40;string&#41;&#10;    response           &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;  tcp &#61; optional&#40;object&#40;&#123;&#10;    port               &#61; optional&#40;number&#41;&#10;    port_name          &#61; optional&#40;string&#41;&#10;    port_specification &#61; optional&#40;string&#41; &#35; USE_FIXED_PORT USE_NAMED_PORT USE_SERVING_PORT&#10;    proxy_header       &#61; optional&#40;string&#41;&#10;    request            &#61; optional&#40;string&#41;&#10;    response           &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;  ssl &#61; optional&#40;object&#40;&#123;&#10;    port               &#61; optional&#40;number&#41;&#10;    port_name          &#61; optional&#40;string&#41;&#10;    port_specification &#61; optional&#40;string&#41; &#35; USE_FIXED_PORT USE_NAMED_PORT USE_SERVING_PORT&#10;    proxy_header       &#61; optional&#40;string&#41;&#10;    request            &#61; optional&#40;string&#41;&#10;    response           &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code title="&#123;&#10;  tcp &#61; &#123;&#10;    port_specification &#61; &#34;USE_SERVING_PORT&#34;&#10;  &#125;&#10;&#125;">&#123;&#8230;&#125;</code> |
-| [labels](variables.tf#L187) | Labels set on resources. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
-| [protocol](variables.tf#L203) | Forwarding rule protocol used, defaults to TCP. | <code>string</code> |  | <code>&#34;TCP&#34;</code> |
-| [service_label](variables.tf#L214) | Optional prefix of the fully qualified forwarding rule name. | <code>string</code> |  | <code>null</code> |
+| [forwarding_rules_config](variables.tf#L76) | The optional forwarding rules configuration. | <code title="map&#40;object&#40;&#123;&#10;  address       &#61; optional&#40;string&#41;&#10;  description   &#61; optional&#40;string&#41;&#10;  global_access &#61; optional&#40;bool, true&#41;&#10;  ip_version    &#61; optional&#40;string&#41;&#10;  ports         &#61; optional&#40;list&#40;string&#41;, null&#41;&#10;  protocol      &#61; optional&#40;string, &#34;TCP&#34;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code title="&#123;&#10;  &#34;&#34; &#61; &#123;&#125;&#10;&#125;">&#123;&#8230;&#125;</code> |
+| [group_configs](variables.tf#L91) | Optional unmanaged groups to create. Can be referenced in backends via outputs. | <code title="map&#40;object&#40;&#123;&#10;  zone        &#61; string&#10;  description &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  instances   &#61; optional&#40;list&#40;string&#41;&#41;&#10;  named_ports &#61; optional&#40;map&#40;number&#41;, &#123;&#125;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [health_check](variables.tf#L103) | Name of existing health check to use, disables auto-created health check. | <code>string</code> |  | <code>null</code> |
+| [health_check_config](variables.tf#L109) | Optional auto-created health check configuration, use the output self-link to set it in the auto healing policy. Refer to examples for usage. | <code title="object&#40;&#123;&#10;  check_interval_sec  &#61; optional&#40;number&#41;&#10;  description         &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  enable_logging      &#61; optional&#40;bool, false&#41;&#10;  healthy_threshold   &#61; optional&#40;number&#41;&#10;  timeout_sec         &#61; optional&#40;number&#41;&#10;  unhealthy_threshold &#61; optional&#40;number&#41;&#10;  grpc &#61; optional&#40;object&#40;&#123;&#10;    port               &#61; optional&#40;number&#41;&#10;    port_name          &#61; optional&#40;string&#41;&#10;    port_specification &#61; optional&#40;string&#41; &#35; USE_FIXED_PORT USE_NAMED_PORT USE_SERVING_PORT&#10;    service_name       &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;  http &#61; optional&#40;object&#40;&#123;&#10;    host               &#61; optional&#40;string&#41;&#10;    port               &#61; optional&#40;number&#41;&#10;    port_name          &#61; optional&#40;string&#41;&#10;    port_specification &#61; optional&#40;string&#41; &#35; USE_FIXED_PORT USE_NAMED_PORT USE_SERVING_PORT&#10;    proxy_header       &#61; optional&#40;string&#41;&#10;    request_path       &#61; optional&#40;string&#41;&#10;    response           &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;  http2 &#61; optional&#40;object&#40;&#123;&#10;    host               &#61; optional&#40;string&#41;&#10;    port               &#61; optional&#40;number&#41;&#10;    port_name          &#61; optional&#40;string&#41;&#10;    port_specification &#61; optional&#40;string&#41; &#35; USE_FIXED_PORT USE_NAMED_PORT USE_SERVING_PORT&#10;    proxy_header       &#61; optional&#40;string&#41;&#10;    request_path       &#61; optional&#40;string&#41;&#10;    response           &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;  https &#61; optional&#40;object&#40;&#123;&#10;    host               &#61; optional&#40;string&#41;&#10;    port               &#61; optional&#40;number&#41;&#10;    port_name          &#61; optional&#40;string&#41;&#10;    port_specification &#61; optional&#40;string&#41; &#35; USE_FIXED_PORT USE_NAMED_PORT USE_SERVING_PORT&#10;    proxy_header       &#61; optional&#40;string&#41;&#10;    request_path       &#61; optional&#40;string&#41;&#10;    response           &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;  tcp &#61; optional&#40;object&#40;&#123;&#10;    port               &#61; optional&#40;number&#41;&#10;    port_name          &#61; optional&#40;string&#41;&#10;    port_specification &#61; optional&#40;string&#41; &#35; USE_FIXED_PORT USE_NAMED_PORT USE_SERVING_PORT&#10;    proxy_header       &#61; optional&#40;string&#41;&#10;    request            &#61; optional&#40;string&#41;&#10;    response           &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;  ssl &#61; optional&#40;object&#40;&#123;&#10;    port               &#61; optional&#40;number&#41;&#10;    port_name          &#61; optional&#40;string&#41;&#10;    port_specification &#61; optional&#40;string&#41; &#35; USE_FIXED_PORT USE_NAMED_PORT USE_SERVING_PORT&#10;    proxy_header       &#61; optional&#40;string&#41;&#10;    request            &#61; optional&#40;string&#41;&#10;    response           &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code title="&#123;&#10;  tcp &#61; &#123;&#10;    port_specification &#61; &#34;USE_SERVING_PORT&#34;&#10;  &#125;&#10;&#125;">&#123;&#8230;&#125;</code> |
+| [labels](variables.tf#L186) | Labels set on resources. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [protocol](variables.tf#L202) | Forwarding rule protocol used, defaults to TCP. | <code>string</code> |  | <code>&#34;TCP&#34;</code> |
+| [service_label](variables.tf#L213) | Optional prefix of the fully qualified forwarding rule name. | <code>string</code> |  | <code>null</code> |
 
 ## Outputs
 
@@ -243,7 +327,7 @@ module "ilb" {
 | [backend_service_id](outputs.tf#L22) | Backend id. |  |
 | [backend_service_self_link](outputs.tf#L27) | Backend self link. |  |
 | [forwarding_rule_addresses](outputs.tf#L32) | Forwarding rule address. |  |
-| [forwarding_rule_self_link](outputs.tf#L40) | Forwarding rule self links. |  |
+| [forwarding_rule_self_links](outputs.tf#L40) | Forwarding rule self links. |  |
 | [forwarding_rules](outputs.tf#L48) | Forwarding rule resources. |  |
 | [group_self_links](outputs.tf#L56) | Optional unmanaged instance group self links. |  |
 | [groups](outputs.tf#L63) | Optional unmanaged instance group resources. |  |

--- a/modules/net-lb-int/groups.tf
+++ b/modules/net-lb-int/groups.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/net-lb-int/health-check.tf
+++ b/modules/net-lb-int/health-check.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/net-lb-int/main.tf
+++ b/modules/net-lb-int/main.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/net-lb-int/main.tf
+++ b/modules/net-lb-int/main.tf
@@ -25,24 +25,26 @@ locals {
   )
 }
 
-resource "google_compute_forwarding_rule" "default" {
+resource "google_compute_forwarding_rule" "forwarding_rules" {
+  for_each    = var.forwarding_rules_config
   provider    = google-beta
   project     = var.project_id
   region      = var.region
-  name        = var.name
-  description = var.description
-  ip_address  = var.address
-  ip_protocol = var.protocol
+  name        = "${var.name}-${each.key}"
+  description = each.value.description
+  ip_address  = each.value.ip_address
+  ip_protocol = each.value.ip_protocol
+  ip_version  = each.value.ip_version
   backend_service = (
     google_compute_region_backend_service.default.self_link
   )
   load_balancing_scheme = "INTERNAL"
   network               = var.vpc_config.network
-  ports                 = var.ports # "nnnnn" or "nnnnn,nnnnn,nnnnn" max 5
+  ports                 = each.value.ports # "nnnnn" or "nnnnn,nnnnn,nnnnn" max 5
   subnetwork            = var.vpc_config.subnetwork
-  allow_global_access   = var.global_access
+  allow_global_access   = each.value.global_access
   labels                = var.labels
-  all_ports             = var.ports == null ? true : null
+  all_ports             = each.value.ports == null ? true : null
   service_label         = var.service_label
   # is_mirroring_collector = false
 }

--- a/modules/net-lb-int/main.tf
+++ b/modules/net-lb-int/main.tf
@@ -26,14 +26,16 @@ locals {
 }
 
 resource "google_compute_forwarding_rule" "forwarding_rules" {
-  for_each    = var.forwarding_rules_config
-  provider    = google-beta
-  project     = var.project_id
+  for_each = var.forwarding_rules_config
+  provider = google-beta
+  project  = var.project_id
+  name = (
+    each.key == "" ? var.name : "${var.name}-${each.key}"
+  )
   region      = var.region
-  name        = "${var.name}-${each.key}"
   description = each.value.description
-  ip_address  = each.value.ip_address
-  ip_protocol = each.value.ip_protocol
+  ip_address  = each.value.address
+  ip_protocol = each.value.protocol
   ip_version  = each.value.ip_version
   backend_service = (
     google_compute_region_backend_service.default.self_link

--- a/modules/net-lb-int/outputs.tf
+++ b/modules/net-lb-int/outputs.tf
@@ -31,26 +31,26 @@ output "backend_service_self_link" {
 
 output "forwarding_rule_addresses" {
   description = "Forwarding rule address."
-  value = [
-    for fwr in google_compute_forwarding_rule.forwarding_rules
-    : fwr.ip_address
-  ]
+  value = {
+    for fwr_name, fwr in google_compute_forwarding_rule.forwarding_rules
+    : fwr_name => fwr.ip_address
+  }
 }
 
-output "forwarding_rule_self_link" {
+output "forwarding_rule_self_links" {
   description = "Forwarding rule self links."
-  value = [
-    for fwr in google_compute_forwarding_rule.forwarding_rules
-    : fwr.self_link
-  ]
+  value = {
+    for fwr_name, fwr in google_compute_forwarding_rule.forwarding_rules
+    : fwr_name => fwr.self_link
+  }
 }
 
 output "forwarding_rules" {
   description = "Forwarding rule resources."
-  value = [
-    for fwr in google_compute_forwarding_rule.forwarding_rules
-    : fwr
-  ]
+  value = {
+    for fwr_name, fwr in google_compute_forwarding_rule.forwarding_rules
+    : fwr_name => fwr
+  }
 }
 
 output "group_self_links" {
@@ -82,8 +82,8 @@ output "health_check_self_link" {
 
 output "id" {
   description = "Fully qualified forwarding rule ids."
-  value = [
-    for fwr in google_compute_forwarding_rule.forwarding_rules
-    : fwr.id
-  ]
+  value = {
+    for fwr_name, fwr in google_compute_forwarding_rule.forwarding_rules
+    : fwr_name => fwr.id
+  }
 }

--- a/modules/net-lb-int/outputs.tf
+++ b/modules/net-lb-int/outputs.tf
@@ -29,19 +29,28 @@ output "backend_service_self_link" {
   value       = google_compute_region_backend_service.default.self_link
 }
 
-output "forwarding_rule" {
-  description = "Forwarding rule resource."
-  value       = google_compute_forwarding_rule.default
+output "forwarding_rules" {
+  description = "Forwarding rule resources."
+  value = [
+    for fwr in google_compute_forwarding_rule.forwarding_rules
+    : fwr
+  ]
 }
 
-output "forwarding_rule_address" {
+output "forwarding_rule_addresses" {
   description = "Forwarding rule address."
-  value       = google_compute_forwarding_rule.default.ip_address
+  value = [
+    for fwr in google_compute_forwarding_rule.forwarding_rules
+    : fwr.ip_address
+  ]
 }
 
 output "forwarding_rule_self_link" {
-  description = "Forwarding rule self link."
-  value       = google_compute_forwarding_rule.default.self_link
+  description = "Forwarding rule self links."
+  value = [
+    for fwr in google_compute_forwarding_rule.forwarding_rules
+    : fwr.self_link
+  ]
 }
 
 output "group_self_links" {
@@ -72,6 +81,9 @@ output "health_check_self_link" {
 }
 
 output "id" {
-  description = "Fully qualified forwarding rule id."
-  value       = google_compute_forwarding_rule.default.id
+  description = "Fully qualified forwarding rule ids."
+  value = [
+    for fwr in google_compute_forwarding_rule.forwarding_rules
+    : fwr.id
+  ]
 }

--- a/modules/net-lb-int/outputs.tf
+++ b/modules/net-lb-int/outputs.tf
@@ -29,14 +29,6 @@ output "backend_service_self_link" {
   value       = google_compute_region_backend_service.default.self_link
 }
 
-output "forwarding_rules" {
-  description = "Forwarding rule resources."
-  value = [
-    for fwr in google_compute_forwarding_rule.forwarding_rules
-    : fwr
-  ]
-}
-
 output "forwarding_rule_addresses" {
   description = "Forwarding rule address."
   value = [
@@ -50,6 +42,14 @@ output "forwarding_rule_self_link" {
   value = [
     for fwr in google_compute_forwarding_rule.forwarding_rules
     : fwr.self_link
+  ]
+}
+
+output "forwarding_rules" {
+  description = "Forwarding rule resources."
+  value = [
+    for fwr in google_compute_forwarding_rule.forwarding_rules
+    : fwr
   ]
 }
 

--- a/modules/net-lb-int/outputs.tf
+++ b/modules/net-lb-int/outputs.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,24 +32,24 @@ output "backend_service_self_link" {
 output "forwarding_rule_addresses" {
   description = "Forwarding rule address."
   value = {
-    for fwr_name, fwr in google_compute_forwarding_rule.forwarding_rules
-    : fwr_name => fwr.ip_address
+    for k, v in google_compute_forwarding_rule.forwarding_rules
+    : k => v.ip_address
   }
 }
 
 output "forwarding_rule_self_links" {
   description = "Forwarding rule self links."
   value = {
-    for fwr_name, fwr in google_compute_forwarding_rule.forwarding_rules
-    : fwr_name => fwr.self_link
+    for k, v in google_compute_forwarding_rule.forwarding_rules
+    : k => v.self_link
   }
 }
 
 output "forwarding_rules" {
   description = "Forwarding rule resources."
   value = {
-    for fwr_name, fwr in google_compute_forwarding_rule.forwarding_rules
-    : fwr_name => fwr
+    for k, v in google_compute_forwarding_rule.forwarding_rules
+    : k => v
   }
 }
 
@@ -83,7 +83,7 @@ output "health_check_self_link" {
 output "id" {
   description = "Fully qualified forwarding rule ids."
   value = {
-    for fwr_name, fwr in google_compute_forwarding_rule.forwarding_rules
-    : fwr_name => fwr.id
+    for k, v in google_compute_forwarding_rule.forwarding_rules
+    : k => v.id
   }
 }

--- a/modules/net-lb-int/variables.tf
+++ b/modules/net-lb-int/variables.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/net-lb-int/variables.tf
+++ b/modules/net-lb-int/variables.tf
@@ -76,16 +76,15 @@ variable "description" {
 variable "forwarding_rules_config" {
   description = "The optional forwarding rules configuration."
   type = map(object({
+    address       = optional(string)
     description   = optional(string)
     global_access = optional(bool, true)
-    ip_address    = optional(string)
-    ip_protocol   = optional(string, "TCP")
     ip_version    = optional(string)
     ports         = optional(list(string), null)
-
+    protocol      = optional(string, "TCP")
   }))
   default = {
-    default = {}
+    "" = {}
   }
 }
 

--- a/modules/net-lb-int/variables.tf
+++ b/modules/net-lb-int/variables.tf
@@ -14,12 +14,6 @@
  * limitations under the License.
  */
 
-variable "address" {
-  description = "Optional IP address used for the forwarding rule."
-  type        = string
-  default     = null
-}
-
 variable "backend_service_config" {
   description = "Backend service level configuration."
   type = object({
@@ -79,10 +73,20 @@ variable "description" {
   default     = "Terraform managed."
 }
 
-variable "global_access" {
-  description = "Global access, defaults to false if not set."
-  type        = bool
-  default     = null
+variable "forwarding_rules_config" {
+  description = "The optional forwarding rules configuration."
+  type = map(object({
+    description   = optional(string)
+    global_access = optional(bool, true)
+    ip_address    = optional(string)
+    ip_protocol   = optional(string, "TCP")
+    ip_version    = optional(string)
+    ports         = optional(list(string), null)
+
+  }))
+  default = {
+    default = {}
+  }
 }
 
 variable "group_configs" {
@@ -189,12 +193,6 @@ variable "labels" {
 variable "name" {
   description = "Name used for all resources."
   type        = string
-}
-
-variable "ports" {
-  description = "Comma-separated ports, leave null to use all ports."
-  type        = list(string)
-  default     = null
 }
 
 variable "project_id" {

--- a/tests/modules/net_lb_int/defaults.yaml
+++ b/tests/modules/net_lb_int/defaults.yaml
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 values:
-  google_compute_forwarding_rule.forwarding_rules["default"]:
+  google_compute_forwarding_rule.forwarding_rules[""]:
     all_ports: true
     ip_protocol: TCP
     labels: null
     load_balancing_scheme: INTERNAL
-    name: ilb-test-default
+    name: ilb-test
     network: default
     project: my-project
     region: europe-west1

--- a/tests/modules/net_lb_int/defaults.yaml
+++ b/tests/modules/net_lb_int/defaults.yaml
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 values:
-  google_compute_forwarding_rule.default:
+  google_compute_forwarding_rule.forwarding_rules["default"]:
     all_ports: true
     ip_protocol: TCP
     labels: null
     load_balancing_scheme: INTERNAL
-    name: ilb-test
+    name: ilb-test-default
     network: default
     project: my-project
     region: europe-west1

--- a/tests/modules/net_lb_int/forwarding-rule.tfvars
+++ b/tests/modules/net_lb_int/forwarding-rule.tfvars
@@ -11,4 +11,10 @@ backends = [{
   failover       = false
 }]
 global_access = true
-ports         = [80]
+
+forwarding_rules_config = {
+  default = {
+    ports = [80]
+  }
+}
+

--- a/tests/modules/net_lb_int/forwarding-rule.tfvars
+++ b/tests/modules/net_lb_int/forwarding-rule.tfvars
@@ -13,7 +13,7 @@ backends = [{
 global_access = true
 
 forwarding_rules_config = {
-  default = {
+  "port-80" = {
     ports = [80]
   }
 }

--- a/tests/modules/net_lb_int/forwarding-rule.yaml
+++ b/tests/modules/net_lb_int/forwarding-rule.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 values:
-  google_compute_forwarding_rule.default:
+  google_compute_forwarding_rule.forwarding_rules["default"]:
     all_ports: null
     allow_global_access: true
     ports:

--- a/tests/modules/net_lb_int/forwarding-rule.yaml
+++ b/tests/modules/net_lb_int/forwarding-rule.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 values:
-  google_compute_forwarding_rule.forwarding_rules["default"]:
+  google_compute_forwarding_rule.forwarding_rules["port-80"]:
     all_ports: null
     allow_global_access: true
     ports:


### PR DESCRIPTION
The PR adds support for:
* dual stack: being able to configure both IPv4 and IPv6 addresses on the same ILB
* use of multiple forwarding rules (indeed, both IPv4 and IPv6), thus being able to expose multiple frontend IPs

---
**Checklist**

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
