### PR TITLE
Added tomap when loading factory data from yaml to solve error

### DIFF
--- a/blueprints/factories/project-factory/factory.tf
+++ b/blueprints/factories/project-factory/factory.tf
@@ -18,10 +18,10 @@ locals {
   _data = (
     var.factory_data.data != null
     ? var.factory_data.data
-    : {
+    : tomap({
       for f in fileset("${local._data_path}", "**/*.yaml") :
       trimsuffix(f, ".yaml") => yamldecode(file("${local._data_path}/${f}"))
-    }
+    })
   )
   _data_path = var.factory_data.data_path == null ? null : pathexpand(
     var.factory_data.data_path


### PR DESCRIPTION
I was getting the following error 

│ Error: Inconsistent conditional result types
│
│   on ../../modules/project-factory/factory.tf line 10, in locals:
│    8:     var.factory_data.data != null
│    9:     ? var.factory_data.data
│   10:     : {
│   11:       for f in fileset("${local._data_path}", "**/*.yaml") :
│   12:       trimsuffix(f, ".yaml") => yamldecode(file("${local._data_path}/${f}"))
│   13:     }
│     ├────────────────
│     │ local._data_path is "./data/projects"
│


---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X ] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [ X] Ran `terraform fmt` on all modified files
- [ X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ X] Made sure all relevant tests pass
