### PR TITLE
Fix Internal App LB serverless NEG backend example

### DIFF
--- a/modules/net-lb-app-int/README.md
+++ b/modules/net-lb-app-int/README.md
@@ -331,7 +331,7 @@ module "ilb-l7" {
   backend_service_configs = {
     default = {
       backends = [{
-        group          = "my-neg"
+        group = "my-neg"
       }]
       health_checks = []
     }

--- a/modules/net-lb-app-int/README.md
+++ b/modules/net-lb-app-int/README.md
@@ -331,9 +331,7 @@ module "ilb-l7" {
   backend_service_configs = {
     default = {
       backends = [{
-        balancing_mode = "RATE"
         group          = "my-neg"
-        max_rate       = { per_endpoint = 1 }
       }]
       health_checks = []
     }


### PR DESCRIPTION
Serverless NEG backends don't support RATE balancing:

Error: Error creating RegionBackendService: googleapi: Error 400: Invalid value for field 'resource.backends[0].balancingMode': 'RATE'. Balancing mode is not supported for Serverless network endpoint groups., invalid

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [ ] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [ ] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass
