### PR TITLE
Less verbose project factory stage outputs

### DIFF
--- a/fast/stages/3-project-factory/dev/README.md
+++ b/fast/stages/3-project-factory/dev/README.md
@@ -87,5 +87,5 @@ terraform apply
 | name | description | sensitive | consumers |
 |---|---|:---:|---|
 | [projects](outputs.tf#L17) | Created projects. |  |  |
-| [service_accounts](outputs.tf#L22) | Created service accounts. |  |  |
+| [service_accounts](outputs.tf#L27) | Created service accounts. |  |  |
 <!-- END TFDOC -->

--- a/fast/stages/3-project-factory/dev/outputs.tf
+++ b/fast/stages/3-project-factory/dev/outputs.tf
@@ -16,7 +16,12 @@
 
 output "projects" {
   description = "Created projects."
-  value       = module.projects.projects
+  value = {
+    for k, v in module.projects.projects : k => {
+      number     = v.number
+      project_id = v.id
+    }
+  }
 }
 
 output "service_accounts" {


### PR DESCRIPTION
Don't dump all project module outputs in the FAST project factory stage outputs.