### PR TITLE
compute-vm: remove old todo

### DIFF
--- a/modules/compute-vm/README.md
+++ b/modules/compute-vm/README.md
@@ -37,7 +37,6 @@ In both modes, an optional service account can be created and assigned to either
   - [Resource Manager Tags](#resource-manager-tags)
 - [Variables](#variables)
 - [Outputs](#outputs)
-- [TODO](#todo)
 <!-- END TOC -->
 
 ### Instance using defaults
@@ -755,6 +754,3 @@ module "simple-vm-example" {
 | [template](outputs.tf#L82) | Template resource. |  |
 | [template_name](outputs.tf#L87) | Template name. |  |
 <!-- END TFDOC -->
-## TODO
-
-- [ ] add support for instance groups

--- a/modules/compute-vm/README.md
+++ b/modules/compute-vm/README.md
@@ -754,3 +754,4 @@ module "simple-vm-example" {
 | [template](outputs.tf#L82) | Template resource. |  |
 | [template_name](outputs.tf#L87) | Template name. |  |
 <!-- END TFDOC -->
+


### PR DESCRIPTION
Remove old todo from compute-vm module readme.

---
**Checklist**

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
