### PR TITLE
FAST: Add VPC serverless connector NAT ranges to hierarchical fw

### DIFF
--- a/fast/stages/2-networking-a-peering/data/hierarchical-ingress-rules.yaml
+++ b/fast/stages/2-networking-a-peering/data/hierarchical-ingress-rules.yaml
@@ -1,11 +1,11 @@
 # skip boilerplate check
 
-allow-admins:
-  description: Access from the admin subnet to all subnets
-  priority: 1000
-  match:
-    source_ranges:
-      - rfc1918
+# allow-admins:
+#   description: Access from the admin subnet to all subnets
+#   priority: 1000
+#   match:
+#     source_ranges:
+#       - rfc1918
 
 allow-healthchecks:
   description: Enable HTTP and HTTPS healthchecks
@@ -14,8 +14,8 @@ allow-healthchecks:
     source_ranges:
       - healthchecks
     layer4_configs:
-    - protocol: tcp
-      ports: ["80", "443"]
+      - protocol: tcp
+        ports: ["80", "443"]
 
 allow-ssh-from-iap:
   description: Enable SSH from IAP
@@ -24,8 +24,8 @@ allow-ssh-from-iap:
     source_ranges:
       - 35.235.240.0/20
     layer4_configs:
-    - protocol: tcp
-      ports: ["22"]
+      - protocol: tcp
+        ports: ["22"]
 
 allow-icmp:
   description: Enable ICMP
@@ -34,4 +34,12 @@ allow-icmp:
     source_ranges:
       - 0.0.0.0/0
     layer4_configs:
-    - protocol: icmp
+      - protocol: icmp
+
+allow-nat-ranges:
+  description: Enable NAT ranges for VPC serverless connector
+  priority: 1001
+  match:
+    source_ranges:
+      - 107.178.230.64/26
+      - 35.199.224.0/19

--- a/fast/stages/2-networking-b-vpn/data/hierarchical-ingress-rules.yaml
+++ b/fast/stages/2-networking-b-vpn/data/hierarchical-ingress-rules.yaml
@@ -1,11 +1,11 @@
 # skip boilerplate check
 
-allow-admins:
-  description: Access from the admin subnet to all subnets
-  priority: 1000
-  match:
-    source_ranges:
-      - rfc1918
+# allow-admins:
+#   description: Access from the admin subnet to all subnets
+#   priority: 1000
+#   match:
+#     source_ranges:
+#       - rfc1918
 
 allow-healthchecks:
   description: Enable HTTP and HTTPS healthchecks
@@ -14,8 +14,8 @@ allow-healthchecks:
     source_ranges:
       - healthchecks
     layer4_configs:
-    - protocol: tcp
-      ports: ["80", "443"]
+      - protocol: tcp
+        ports: ["80", "443"]
 
 allow-ssh-from-iap:
   description: Enable SSH from IAP
@@ -24,8 +24,8 @@ allow-ssh-from-iap:
     source_ranges:
       - 35.235.240.0/20
     layer4_configs:
-    - protocol: tcp
-      ports: ["22"]
+      - protocol: tcp
+        ports: ["22"]
 
 allow-icmp:
   description: Enable ICMP
@@ -34,4 +34,12 @@ allow-icmp:
     source_ranges:
       - 0.0.0.0/0
     layer4_configs:
-    - protocol: icmp
+      - protocol: icmp
+
+allow-nat-ranges:
+  description: Enable NAT ranges for VPC serverless connector
+  priority: 1001
+  match:
+    source_ranges:
+      - 107.178.230.64/26
+      - 35.199.224.0/19

--- a/fast/stages/2-networking-c-nva/data/hierarchical-ingress-rules.yaml
+++ b/fast/stages/2-networking-c-nva/data/hierarchical-ingress-rules.yaml
@@ -1,11 +1,11 @@
 # skip boilerplate check
 
-allow-admins:
-  description: Access from the admin subnet to all subnets
-  priority: 1000
-  match:
-    source_ranges:
-      - rfc1918
+# allow-admins:
+#   description: Access from the admin subnet to all subnets
+#   priority: 1000
+#   match:
+#     source_ranges:
+#       - rfc1918
 
 allow-healthchecks:
   description: Enable HTTP and HTTPS healthchecks
@@ -14,8 +14,8 @@ allow-healthchecks:
     source_ranges:
       - healthchecks
     layer4_configs:
-    - protocol: tcp
-      ports: ["80", "443"]
+      - protocol: tcp
+        ports: ["80", "443"]
 
 allow-ssh-from-iap:
   description: Enable SSH from IAP
@@ -24,8 +24,8 @@ allow-ssh-from-iap:
     source_ranges:
       - 35.235.240.0/20
     layer4_configs:
-    - protocol: tcp
-      ports: ["22"]
+      - protocol: tcp
+        ports: ["22"]
 
 allow-icmp:
   description: Enable ICMP
@@ -34,4 +34,12 @@ allow-icmp:
     source_ranges:
       - 0.0.0.0/0
     layer4_configs:
-    - protocol: icmp
+      - protocol: icmp
+
+allow-nat-ranges:
+  description: Enable NAT ranges for VPC serverless connector
+  priority: 1001
+  match:
+    source_ranges:
+      - 107.178.230.64/26
+      - 35.199.224.0/19

--- a/fast/stages/2-networking-d-separate-envs/data/hierarchical-ingress-rules.yaml
+++ b/fast/stages/2-networking-d-separate-envs/data/hierarchical-ingress-rules.yaml
@@ -1,11 +1,11 @@
 # skip boilerplate check
 
-allow-admins:
-  description: Access from the admin subnet to all subnets
-  priority: 1000
-  match:
-    source_ranges:
-      - rfc1918
+# allow-admins:
+#   description: Access from the admin subnet to all subnets
+#   priority: 1000
+#   match:
+#     source_ranges:
+#       - rfc1918
 
 allow-healthchecks:
   description: Enable HTTP and HTTPS healthchecks
@@ -14,8 +14,8 @@ allow-healthchecks:
     source_ranges:
       - healthchecks
     layer4_configs:
-    - protocol: tcp
-      ports: ["80", "443"]
+      - protocol: tcp
+        ports: ["80", "443"]
 
 allow-ssh-from-iap:
   description: Enable SSH from IAP
@@ -24,8 +24,8 @@ allow-ssh-from-iap:
     source_ranges:
       - 35.235.240.0/20
     layer4_configs:
-    - protocol: tcp
-      ports: ["22"]
+      - protocol: tcp
+        ports: ["22"]
 
 allow-icmp:
   description: Enable ICMP
@@ -34,4 +34,12 @@ allow-icmp:
     source_ranges:
       - 0.0.0.0/0
     layer4_configs:
-    - protocol: icmp
+      - protocol: icmp
+
+allow-nat-ranges:
+  description: Enable NAT ranges for VPC serverless connector
+  priority: 1001
+  match:
+    source_ranges:
+      - 107.178.230.64/26
+      - 35.199.224.0/19

--- a/fast/stages/2-networking-e-nva-bgp/data/hierarchical-ingress-rules.yaml
+++ b/fast/stages/2-networking-e-nva-bgp/data/hierarchical-ingress-rules.yaml
@@ -1,11 +1,11 @@
 # skip boilerplate check
 
-allow-admins:
-  description: Access from the admin subnet to all subnets
-  priority: 1000
-  match:
-    source_ranges:
-      - rfc1918
+# allow-admins:
+#   description: Access from the admin subnet to all subnets
+#   priority: 1000
+#   match:
+#     source_ranges:
+#       - rfc1918
 
 allow-healthchecks:
   description: Enable HTTP and HTTPS healthchecks
@@ -14,8 +14,8 @@ allow-healthchecks:
     source_ranges:
       - healthchecks
     layer4_configs:
-    - protocol: tcp
-      ports: ["80", "443"]
+      - protocol: tcp
+        ports: ["80", "443"]
 
 allow-ssh-from-iap:
   description: Enable SSH from IAP
@@ -24,8 +24,8 @@ allow-ssh-from-iap:
     source_ranges:
       - 35.235.240.0/20
     layer4_configs:
-    - protocol: tcp
-      ports: ["22"]
+      - protocol: tcp
+        ports: ["22"]
 
 allow-icmp:
   description: Enable ICMP
@@ -34,4 +34,12 @@ allow-icmp:
     source_ranges:
       - 0.0.0.0/0
     layer4_configs:
-    - protocol: icmp
+      - protocol: icmp
+
+allow-nat-ranges:
+  description: Enable NAT ranges for VPC serverless connector
+  priority: 1001
+  match:
+    source_ranges:
+      - 107.178.230.64/26
+      - 35.199.224.0/19


### PR DESCRIPTION
<!-- Put a description of what this PR is for here -->

- Adds VPC serverless connector NAT ranges to hierarchical fw
- Comments out an almighty allow all from hierarchical fw

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [x] Made sure all relevant tests pass
