### PR TITLE
import job support for kms module

### DIFF
--- a/modules/kms/README.md
+++ b/modules/kms/README.md
@@ -5,14 +5,15 @@ This module allows creating and managing KMS crypto keys and IAM bindings at bot
 When using an existing keyring be mindful about applying IAM bindings, as all bindings used by this module are authoritative, and you might inadvertently override bindings managed by the keyring creator.
 
 <!-- BEGIN TOC -->
-- [Protecting against destroy](#protecting-against-destroy)
-- [Examples](#examples)
-  - [Using an existing keyring](#using-an-existing-keyring)
-  - [Keyring creation and crypto key rotation and IAM roles](#keyring-creation-and-crypto-key-rotation-and-iam-roles)
-  - [Crypto key purpose](#crypto-key-purpose)
-  - [Import job](#import-job)
-- [Variables](#variables)
-- [Outputs](#outputs)
+- [Google KMS Module](#google-kms-module)
+  - [Protecting against destroy](#protecting-against-destroy)
+  - [Examples](#examples)
+    - [Using an existing keyring](#using-an-existing-keyring)
+    - [Keyring creation and crypto key rotation and IAM roles](#keyring-creation-and-crypto-key-rotation-and-iam-roles)
+    - [Crypto key purpose](#crypto-key-purpose)
+    - [Import job](#import-job)
+  - [Variables](#variables)
+  - [Outputs](#outputs)
 <!-- END TOC -->
 
 ## Protecting against destroy
@@ -115,6 +116,7 @@ module "kms" {
     protection_level = "SOFTWARE"
   }
 }
+# tftest modules=1 resources=2 inventory=import-job.yaml
 ```
 <!-- BEGIN TFDOC -->
 ## Variables

--- a/modules/kms/README.md
+++ b/modules/kms/README.md
@@ -5,10 +5,9 @@ This module allows creating and managing KMS crypto keys and IAM bindings at bot
 When using an existing keyring be mindful about applying IAM bindings, as all bindings used by this module are authoritative, and you might inadvertently override bindings managed by the keyring creator.
 
 <!-- BEGIN TOC -->
-- [Google KMS Module](#google-kms-module)
-  - [Protecting against destroy](#protecting-against-destroy)
-  - [Examples](#examples)
-    - [Using an existing keyring](#using-an-existing-keyring)
+- [Protecting against destroy](#protecting-against-destroy)
+- [Examples](#examples)
+  - [Using an existing keyring](#using-an-existing-keyring)
     - [Keyring creation and crypto key rotation and IAM roles](#keyring-creation-and-crypto-key-rotation-and-iam-roles)
     - [Crypto key purpose](#crypto-key-purpose)
     - [Import job](#import-job)
@@ -103,9 +102,6 @@ module "kms" {
 module "kms" {
   source     = "./fabric/modules/kms"
   project_id = "my-project"
-  iam = {
-    "roles/cloudkms.admin" = ["user:user1@example.com"]
-  }
   keyring = {
     location = "europe-west1"
     name     = "test"

--- a/modules/kms/README.md
+++ b/modules/kms/README.md
@@ -5,13 +5,15 @@ This module allows creating and managing KMS crypto keys and IAM bindings at bot
 When using an existing keyring be mindful about applying IAM bindings, as all bindings used by this module are authoritative, and you might inadvertently override bindings managed by the keyring creator.
 
 <!-- BEGIN TOC -->
-- [Protecting against destroy](#protecting-against-destroy)
-- [Examples](#examples)
-  - [Using an existing keyring](#using-an-existing-keyring)
-  - [Keyring creation and crypto key rotation and IAM roles](#keyring-creation-and-crypto-key-rotation-and-iam-roles)
-  - [Crypto key purpose](#crypto-key-purpose)
-- [Variables](#variables)
-- [Outputs](#outputs)
+- [Google KMS Module](#google-kms-module)
+  - [Protecting against destroy](#protecting-against-destroy)
+  - [Examples](#examples)
+    - [Using an existing keyring](#using-an-existing-keyring)
+    - [Keyring creation and crypto key rotation and IAM roles](#keyring-creation-and-crypto-key-rotation-and-iam-roles)
+    - [Crypto key purpose](#crypto-key-purpose)
+    - [Import job](#import-job)
+  - [Variables](#variables)
+  - [Outputs](#outputs)
 <!-- END TOC -->
 
 ## Protecting against destroy
@@ -93,6 +95,27 @@ module "kms" {
   }
 }
 # tftest modules=1 resources=2 inventory=purpose.yaml
+```
+
+### Import job
+
+```hcl
+module "kms" {
+  source     = "./fabric/modules/kms"
+  project_id = "my-project"
+  iam = {
+    "roles/cloudkms.admin" = ["user:user1@example.com"]
+  }
+  keyring = {
+    location = "europe-west1"
+    name     = "test"
+  }
+  import_job = {
+    id               = "my-import-job"
+    import_method    = "RSA_OAEP_3072_SHA1_AES_256"
+    protection_level = "SOFTWARE"
+  }
+}
 ```
 <!-- BEGIN TFDOC -->
 ## Variables

--- a/modules/kms/README.md
+++ b/modules/kms/README.md
@@ -5,15 +5,14 @@ This module allows creating and managing KMS crypto keys and IAM bindings at bot
 When using an existing keyring be mindful about applying IAM bindings, as all bindings used by this module are authoritative, and you might inadvertently override bindings managed by the keyring creator.
 
 <!-- BEGIN TOC -->
-- [Google KMS Module](#google-kms-module)
-  - [Protecting against destroy](#protecting-against-destroy)
-  - [Examples](#examples)
-    - [Using an existing keyring](#using-an-existing-keyring)
-    - [Keyring creation and crypto key rotation and IAM roles](#keyring-creation-and-crypto-key-rotation-and-iam-roles)
-    - [Crypto key purpose](#crypto-key-purpose)
-    - [Import job](#import-job)
-  - [Variables](#variables)
-  - [Outputs](#outputs)
+- [Protecting against destroy](#protecting-against-destroy)
+- [Examples](#examples)
+  - [Using an existing keyring](#using-an-existing-keyring)
+  - [Keyring creation and crypto key rotation and IAM roles](#keyring-creation-and-crypto-key-rotation-and-iam-roles)
+  - [Crypto key purpose](#crypto-key-purpose)
+  - [Import job](#import-job)
+- [Variables](#variables)
+- [Outputs](#outputs)
 <!-- END TOC -->
 
 ## Protecting against destroy

--- a/modules/kms/README.md
+++ b/modules/kms/README.md
@@ -5,15 +5,14 @@ This module allows creating and managing KMS crypto keys and IAM bindings at bot
 When using an existing keyring be mindful about applying IAM bindings, as all bindings used by this module are authoritative, and you might inadvertently override bindings managed by the keyring creator.
 
 <!-- BEGIN TOC -->
-- [Google KMS Module](#google-kms-module)
-  - [Protecting against destroy](#protecting-against-destroy)
-  - [Examples](#examples)
-    - [Using an existing keyring](#using-an-existing-keyring)
-    - [Keyring creation and crypto key rotation and IAM roles](#keyring-creation-and-crypto-key-rotation-and-iam-roles)
-    - [Crypto key purpose](#crypto-key-purpose)
-    - [Import job](#import-job)
-  - [Variables](#variables)
-  - [Outputs](#outputs)
+- [Protecting against destroy](#protecting-against-destroy)
+- [Examples](#examples)
+  - [Using an existing keyring](#using-an-existing-keyring)
+  - [Keyring creation and crypto key rotation and IAM roles](#keyring-creation-and-crypto-key-rotation-and-iam-roles)
+  - [Crypto key purpose](#crypto-key-purpose)
+  - [Import job](#import-job)
+- [Variables](#variables)
+- [Outputs](#outputs)
 <!-- END TOC -->
 
 ## Protecting against destroy
@@ -110,6 +109,7 @@ module "kms" {
     location = "europe-west1"
     name     = "test"
   }
+  import_job_create = true
   import_job = {
     id               = "my-import-job"
     import_method    = "RSA_OAEP_3072_SHA1_AES_256"
@@ -122,23 +122,26 @@ module "kms" {
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [keyring](variables.tf#L54) | Keyring attributes. | <code title="object&#40;&#123;&#10;  location &#61; string&#10;  name     &#61; string&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
-| [project_id](variables.tf#L103) | Project id where the keyring will be created. | <code>string</code> | ✓ |  |
+| [keyring](variables.tf#L70) | Keyring attributes. | <code title="object&#40;&#123;&#10;  location &#61; string&#10;  name     &#61; string&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
+| [project_id](variables.tf#L119) | Project id where the keyring will be created. | <code>string</code> | ✓ |  |
 | [iam](variables.tf#L17) | Keyring IAM bindings in {ROLE => [MEMBERS]} format. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_bindings](variables.tf#L24) | Authoritative IAM bindings in {KEY => {role = ROLE, members = [], condition = {}}}. Keys are arbitrary. | <code title="map&#40;object&#40;&#123;&#10;  members &#61; list&#40;string&#41;&#10;  role    &#61; string&#10;  condition &#61; optional&#40;object&#40;&#123;&#10;    expression  &#61; string&#10;    title       &#61; string&#10;    description &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_bindings_additive](variables.tf#L39) | Keyring individual additive IAM bindings. Keys are arbitrary. | <code title="map&#40;object&#40;&#123;&#10;  member &#61; string&#10;  role   &#61; string&#10;  condition &#61; optional&#40;object&#40;&#123;&#10;    expression  &#61; string&#10;    title       &#61; string&#10;    description &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [keyring_create](variables.tf#L62) | Set to false to manage keys and IAM bindings in an existing keyring. | <code>bool</code> |  | <code>true</code> |
-| [keys](variables.tf#L68) | Key names and base attributes. Set attributes to null if not needed. | <code title="map&#40;object&#40;&#123;&#10;  rotation_period               &#61; optional&#40;string&#41;&#10;  labels                        &#61; optional&#40;map&#40;string&#41;&#41;&#10;  purpose                       &#61; optional&#40;string, &#34;ENCRYPT_DECRYPT&#34;&#41;&#10;  skip_initial_version_creation &#61; optional&#40;bool, false&#41;&#10;  version_template &#61; optional&#40;object&#40;&#123;&#10;    algorithm        &#61; string&#10;    protection_level &#61; optional&#40;string, &#34;SOFTWARE&#34;&#41;&#10;  &#125;&#41;&#41;&#10;&#10;&#10;  iam &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;  iam_bindings &#61; optional&#40;map&#40;object&#40;&#123;&#10;    members &#61; list&#40;string&#41;&#10;    condition &#61; optional&#40;object&#40;&#123;&#10;      expression  &#61; string&#10;      title       &#61; string&#10;      description &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;  iam_bindings_additive &#61; optional&#40;map&#40;object&#40;&#123;&#10;    member &#61; string&#10;    role   &#61; string&#10;    condition &#61; optional&#40;object&#40;&#123;&#10;      expression  &#61; string&#10;      title       &#61; string&#10;      description &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [tag_bindings](variables.tf#L108) | Tag bindings for this keyring, in key => tag value id format. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [import_job](variables.tf#L54) | Keyring import job attributes. | <code title="object&#40;&#123;&#10;  id               &#61; string&#10;  import_method    &#61; string&#10;  protection_level &#61; string&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [import_job_create](variables.tf#L64) | Set to true to create an import job for a keyring. | <code>bool</code> |  | <code>false</code> |
+| [keyring_create](variables.tf#L78) | Set to false to manage keys and IAM bindings in an existing keyring. | <code>bool</code> |  | <code>true</code> |
+| [keys](variables.tf#L84) | Key names and base attributes. Set attributes to null if not needed. | <code title="map&#40;object&#40;&#123;&#10;  rotation_period               &#61; optional&#40;string&#41;&#10;  labels                        &#61; optional&#40;map&#40;string&#41;&#41;&#10;  purpose                       &#61; optional&#40;string, &#34;ENCRYPT_DECRYPT&#34;&#41;&#10;  skip_initial_version_creation &#61; optional&#40;bool, false&#41;&#10;  version_template &#61; optional&#40;object&#40;&#123;&#10;    algorithm        &#61; string&#10;    protection_level &#61; optional&#40;string, &#34;SOFTWARE&#34;&#41;&#10;  &#125;&#41;&#41;&#10;&#10;&#10;  iam &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;  iam_bindings &#61; optional&#40;map&#40;object&#40;&#123;&#10;    members &#61; list&#40;string&#41;&#10;    condition &#61; optional&#40;object&#40;&#123;&#10;      expression  &#61; string&#10;      title       &#61; string&#10;      description &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;  iam_bindings_additive &#61; optional&#40;map&#40;object&#40;&#123;&#10;    member &#61; string&#10;    role   &#61; string&#10;    condition &#61; optional&#40;object&#40;&#123;&#10;      expression  &#61; string&#10;      title       &#61; string&#10;      description &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [tag_bindings](variables.tf#L124) | Tag bindings for this keyring, in key => tag value id format. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
 
 ## Outputs
 
 | name | description | sensitive |
 |---|---|:---:|
 | [id](outputs.tf#L17) | Fully qualified keyring id. |  |
-| [key_ids](outputs.tf#L26) | Fully qualified key ids. |  |
-| [keyring](outputs.tf#L38) | Keyring resource. |  |
-| [keys](outputs.tf#L47) | Key resources. |  |
-| [location](outputs.tf#L56) | Keyring location. |  |
-| [name](outputs.tf#L65) | Keyring name. |  |
+| [import_job](outputs.tf#L26) | Keyring import job resources. |  |
+| [key_ids](outputs.tf#L35) | Fully qualified key ids. |  |
+| [keyring](outputs.tf#L47) | Keyring resource. |  |
+| [keys](outputs.tf#L56) | Key resources. |  |
+| [location](outputs.tf#L65) | Keyring location. |  |
+| [name](outputs.tf#L74) | Keyring name. |  |
 <!-- END TFDOC -->

--- a/modules/kms/README.md
+++ b/modules/kms/README.md
@@ -5,14 +5,15 @@ This module allows creating and managing KMS crypto keys and IAM bindings at bot
 When using an existing keyring be mindful about applying IAM bindings, as all bindings used by this module are authoritative, and you might inadvertently override bindings managed by the keyring creator.
 
 <!-- BEGIN TOC -->
-- [Protecting against destroy](#protecting-against-destroy)
-- [Examples](#examples)
-  - [Using an existing keyring](#using-an-existing-keyring)
-  - [Keyring creation and crypto key rotation and IAM roles](#keyring-creation-and-crypto-key-rotation-and-iam-roles)
-  - [Crypto key purpose](#crypto-key-purpose)
-  - [Import job](#import-job)
-- [Variables](#variables)
-- [Outputs](#outputs)
+- [Google KMS Module](#google-kms-module)
+  - [Protecting against destroy](#protecting-against-destroy)
+  - [Examples](#examples)
+    - [Using an existing keyring](#using-an-existing-keyring)
+    - [Keyring creation and crypto key rotation and IAM roles](#keyring-creation-and-crypto-key-rotation-and-iam-roles)
+    - [Crypto key purpose](#crypto-key-purpose)
+    - [Import job](#import-job)
+  - [Variables](#variables)
+  - [Outputs](#outputs)
 <!-- END TOC -->
 
 ## Protecting against destroy
@@ -109,7 +110,6 @@ module "kms" {
     location = "europe-west1"
     name     = "test"
   }
-  import_job_create = true
   import_job = {
     id               = "my-import-job"
     import_method    = "RSA_OAEP_3072_SHA1_AES_256"
@@ -122,16 +122,15 @@ module "kms" {
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [keyring](variables.tf#L70) | Keyring attributes. | <code title="object&#40;&#123;&#10;  location &#61; string&#10;  name     &#61; string&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
-| [project_id](variables.tf#L119) | Project id where the keyring will be created. | <code>string</code> | ✓ |  |
+| [keyring](variables.tf#L64) | Keyring attributes. | <code title="object&#40;&#123;&#10;  location &#61; string&#10;  name     &#61; string&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
+| [project_id](variables.tf#L113) | Project id where the keyring will be created. | <code>string</code> | ✓ |  |
 | [iam](variables.tf#L17) | Keyring IAM bindings in {ROLE => [MEMBERS]} format. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_bindings](variables.tf#L24) | Authoritative IAM bindings in {KEY => {role = ROLE, members = [], condition = {}}}. Keys are arbitrary. | <code title="map&#40;object&#40;&#123;&#10;  members &#61; list&#40;string&#41;&#10;  role    &#61; string&#10;  condition &#61; optional&#40;object&#40;&#123;&#10;    expression  &#61; string&#10;    title       &#61; string&#10;    description &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_bindings_additive](variables.tf#L39) | Keyring individual additive IAM bindings. Keys are arbitrary. | <code title="map&#40;object&#40;&#123;&#10;  member &#61; string&#10;  role   &#61; string&#10;  condition &#61; optional&#40;object&#40;&#123;&#10;    expression  &#61; string&#10;    title       &#61; string&#10;    description &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [import_job](variables.tf#L54) | Keyring import job attributes. | <code title="object&#40;&#123;&#10;  id               &#61; string&#10;  import_method    &#61; string&#10;  protection_level &#61; string&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [import_job_create](variables.tf#L64) | Set to true to create an import job for a keyring. | <code>bool</code> |  | <code>false</code> |
-| [keyring_create](variables.tf#L78) | Set to false to manage keys and IAM bindings in an existing keyring. | <code>bool</code> |  | <code>true</code> |
-| [keys](variables.tf#L84) | Key names and base attributes. Set attributes to null if not needed. | <code title="map&#40;object&#40;&#123;&#10;  rotation_period               &#61; optional&#40;string&#41;&#10;  labels                        &#61; optional&#40;map&#40;string&#41;&#41;&#10;  purpose                       &#61; optional&#40;string, &#34;ENCRYPT_DECRYPT&#34;&#41;&#10;  skip_initial_version_creation &#61; optional&#40;bool, false&#41;&#10;  version_template &#61; optional&#40;object&#40;&#123;&#10;    algorithm        &#61; string&#10;    protection_level &#61; optional&#40;string, &#34;SOFTWARE&#34;&#41;&#10;  &#125;&#41;&#41;&#10;&#10;&#10;  iam &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;  iam_bindings &#61; optional&#40;map&#40;object&#40;&#123;&#10;    members &#61; list&#40;string&#41;&#10;    condition &#61; optional&#40;object&#40;&#123;&#10;      expression  &#61; string&#10;      title       &#61; string&#10;      description &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;  iam_bindings_additive &#61; optional&#40;map&#40;object&#40;&#123;&#10;    member &#61; string&#10;    role   &#61; string&#10;    condition &#61; optional&#40;object&#40;&#123;&#10;      expression  &#61; string&#10;      title       &#61; string&#10;      description &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [tag_bindings](variables.tf#L124) | Tag bindings for this keyring, in key => tag value id format. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [keyring_create](variables.tf#L72) | Set to false to manage keys and IAM bindings in an existing keyring. | <code>bool</code> |  | <code>true</code> |
+| [keys](variables.tf#L78) | Key names and base attributes. Set attributes to null if not needed. | <code title="map&#40;object&#40;&#123;&#10;  rotation_period               &#61; optional&#40;string&#41;&#10;  labels                        &#61; optional&#40;map&#40;string&#41;&#41;&#10;  purpose                       &#61; optional&#40;string, &#34;ENCRYPT_DECRYPT&#34;&#41;&#10;  skip_initial_version_creation &#61; optional&#40;bool, false&#41;&#10;  version_template &#61; optional&#40;object&#40;&#123;&#10;    algorithm        &#61; string&#10;    protection_level &#61; optional&#40;string, &#34;SOFTWARE&#34;&#41;&#10;  &#125;&#41;&#41;&#10;&#10;&#10;  iam &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;  iam_bindings &#61; optional&#40;map&#40;object&#40;&#123;&#10;    members &#61; list&#40;string&#41;&#10;    condition &#61; optional&#40;object&#40;&#123;&#10;      expression  &#61; string&#10;      title       &#61; string&#10;      description &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;  iam_bindings_additive &#61; optional&#40;map&#40;object&#40;&#123;&#10;    member &#61; string&#10;    role   &#61; string&#10;    condition &#61; optional&#40;object&#40;&#123;&#10;      expression  &#61; string&#10;      title       &#61; string&#10;      description &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [tag_bindings](variables.tf#L118) | Tag bindings for this keyring, in key => tag value id format. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
 
 ## Outputs
 

--- a/modules/kms/main.tf
+++ b/modules/kms/main.tf
@@ -55,6 +55,7 @@ resource "google_kms_crypto_key" "default" {
 }
 
 resource "google_kms_key_ring_import_job" "default" {
+  count            = var.import_job_create ? 1 : 0
   key_ring         = local.keyring.id
   import_job_id    = var.import_job.id
   import_method    = var.import_job.import_method

--- a/modules/kms/main.tf
+++ b/modules/kms/main.tf
@@ -55,7 +55,7 @@ resource "google_kms_crypto_key" "default" {
 }
 
 resource "google_kms_key_ring_import_job" "default" {
-  count            = var.import_job_create ? 1 : 0
+  count            = var.import_job != null ? 1 : 0
   key_ring         = local.keyring.id
   import_job_id    = var.import_job.id
   import_method    = var.import_job.import_method

--- a/modules/kms/main.tf
+++ b/modules/kms/main.tf
@@ -53,3 +53,10 @@ resource "google_kms_crypto_key" "default" {
     }
   }
 }
+
+resource "google_kms_key_ring_import_job" "default" {
+  key_ring         = local.keyring.id
+  import_job_id    = var.import_job.id
+  import_method    = var.import_job.import_method
+  protection_level = var.import_job.protection_level
+}

--- a/modules/kms/outputs.tf
+++ b/modules/kms/outputs.tf
@@ -23,6 +23,15 @@ output "id" {
   ]
 }
 
+output "import_job" {
+  description = "Keyring import job resources."
+  value       = google_kms_key_ring_import_job.default
+  depends_on = [
+    google_kms_key_ring_iam_binding.authoritative,
+    google_kms_key_ring_iam_binding.bindings
+  ]
+}
+
 output "key_ids" {
   description = "Fully qualified key ids."
   value = {

--- a/modules/kms/variables.tf
+++ b/modules/kms/variables.tf
@@ -61,12 +61,6 @@ variable "import_job" {
   default = null
 }
 
-variable "import_job_create" {
-  description = "Set to true to create an import job for a keyring."
-  type        = bool
-  default     = false
-}
-
 variable "keyring" {
   description = "Keyring attributes."
   type = object({

--- a/modules/kms/variables.tf
+++ b/modules/kms/variables.tf
@@ -51,6 +51,15 @@ variable "iam_bindings_additive" {
   default  = {}
 }
 
+variable "import_job" {
+  description = "Keyring import job attributes."
+  type = object({
+    id               = string
+    import_method    = string
+    protection_level = string
+  })
+}
+
 variable "keyring" {
   description = "Keyring attributes."
   type = object({

--- a/modules/kms/variables.tf
+++ b/modules/kms/variables.tf
@@ -58,6 +58,13 @@ variable "import_job" {
     import_method    = string
     protection_level = string
   })
+  default = null
+}
+
+variable "import_job_create" {
+  description = "Set to true to create an import job for a keyring."
+  type        = bool
+  default     = false
 }
 
 variable "keyring" {

--- a/tests/modules/kms/examples/import-job.yaml
+++ b/tests/modules/kms/examples/import-job.yaml
@@ -1,0 +1,29 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values:
+  module.kms.google_kms_key_ring_import_job.default[0]:
+    import_job_id: my-import-job
+    import_method: RSA_OAEP_3072_SHA1_AES_256
+    protection_level: SOFTWARE
+  module.kms.google_kms_key_ring.default[0]:
+    location: europe-west1
+    name: test
+    project: my-project
+
+counts:
+  google_kms_key_ring_import_job: 1
+  google_kms_key_ring: 1
+  modules: 1
+  resources: 2


### PR DESCRIPTION
Added support import job support for the "kms" module using the official terraform resource "google_kms_key_ring_import_job". Link: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/kms_key_ring_import_job. 

I have successfully tested the "kms" module's new functionality by creating the Cloud KMS Import job resource in my test GCP environment. I was not sure if I needed to write any new python tests since this change was minor and only limited to the "kms" module.

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
