### PR TITLE
[net-address] enable ipv6

### DIFF
--- a/blueprints/apigee/hybrid-gke/glb.tf
+++ b/blueprints/apigee/hybrid-gke/glb.tf
@@ -19,7 +19,9 @@ locals {
 }
 
 module "addresses" {
-  source           = "../../../modules/net-address"
-  project_id       = module.project.project_id
-  global_addresses = [local.ingress_ip_name]
+  source     = "../../../modules/net-address"
+  project_id = module.project.project_id
+  global_addresses = {
+    "${local.ingress_ip_name}" = {}
+  }
 }

--- a/blueprints/gke/autopilot/glbs.tf
+++ b/blueprints/gke/autopilot/glbs.tf
@@ -19,7 +19,11 @@ locals {
 }
 
 module "addresses" {
-  source           = "../../../modules/net-address"
-  project_id       = module.project.project_id
-  global_addresses = ["grafana", "locust", "app"]
+  source     = "../../../modules/net-address"
+  project_id = module.project.project_id
+  global_addresses = {
+    app     = {}
+    grafana = {}
+    locust  = {}
+  }
 }

--- a/blueprints/third-party-solutions/phpipam/glb.tf
+++ b/blueprints/third-party-solutions/phpipam/glb.tf
@@ -21,10 +21,12 @@ locals {
 
 # Reserved static IP for the Load Balancer
 module "addresses" {
-  source           = "../../../modules/net-address"
-  count            = local.glb_create ? 1 : 0
-  project_id       = var.project_id
-  global_addresses = ["phpipam"]
+  source     = "../../../modules/net-address"
+  count      = local.glb_create ? 1 : 0
+  project_id = var.project_id
+  global_addresses = {
+    phpipam = {}
+  }
 }
 
 # Global L7 HTTPS Load Balancer in front of Cloud Run

--- a/modules/net-address/README.md
+++ b/modules/net-address/README.md
@@ -54,25 +54,24 @@ module "addresses" {
   project_id = var.project_id
   external_addresses = {
     nlb = {
-      ip_version         = "IPV6"
-      ipv6_endpoint_type = "NETLB"
-      region             = var.region
-      subnetwork         = var.subnet.self_link
+      region     = var.region
+      subnetwork = var.subnet.self_link
+      ipv6 = {
+        endpoint_type = "NETLB"
+      }
     }
   }
   internal_addresses = {
     ilb = {
-      ip_version         = "IPV6"
-      ipv6_endpoint_type = "NETLB"
-      purpose            = "SHARED_LOADBALANCER_VIP"
-      region             = var.region
-      subnetwork         = var.subnet.self_link
+      ipv6       = {}
+      purpose    = "SHARED_LOADBALANCER_VIP"
+      region     = var.region
+      subnetwork = var.subnet.self_link
     }
     vm = {
-      ip_version         = "IPV6"
-      ipv6_endpoint_type = "VM"
-      region             = var.region
-      subnetwork         = var.subnet.self_link
+      ipv6       = {}
+      region     = var.region
+      subnetwork = var.subnet.self_link
     }
   }
 }
@@ -144,13 +143,13 @@ module "addresses" {
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [project_id](variables.tf#L76) | Project where the addresses will be created. | <code>string</code> | ✓ |  |
-| [external_addresses](variables.tf#L17) | Map of external addresses, keyed by name. | <code title="map&#40;object&#40;&#123;&#10;  region             &#61; string&#10;  description        &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  ip_version         &#61; optional&#40;string, &#34;IPV4&#34;&#41;&#10;  ipv6_endpoint_type &#61; optional&#40;string&#41;&#10;  labels             &#61; optional&#40;map&#40;string&#41;, &#123;&#125;&#41;&#10;  name               &#61; optional&#40;string&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [global_addresses](variables.tf#L30) | List of global addresses to create. | <code title="map&#40;object&#40;&#123;&#10;  description &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  ip_version  &#61; optional&#40;string, &#34;IPV4&#34;&#41;&#10;  name        &#61; optional&#40;string&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [internal_addresses](variables.tf#L40) | Map of internal addresses to create, keyed by name. | <code title="map&#40;object&#40;&#123;&#10;  region             &#61; string&#10;  subnetwork         &#61; string&#10;  address            &#61; optional&#40;string&#41;&#10;  description        &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  ip_version         &#61; optional&#40;string, &#34;IPV4&#34;&#41;&#10;  ipv6_endpoint_type &#61; optional&#40;string&#41;&#10;  labels             &#61; optional&#40;map&#40;string&#41;&#41;&#10;  name               &#61; optional&#40;string&#41;&#10;  purpose            &#61; optional&#40;string&#41;&#10;  tier               &#61; optional&#40;string&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [ipsec_interconnect_addresses](variables.tf#L57) | Map of internal addresses used for HPA VPN over Cloud Interconnect. | <code title="map&#40;object&#40;&#123;&#10;  region        &#61; string&#10;  address       &#61; string&#10;  network       &#61; string&#10;  description   &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  name          &#61; optional&#40;string&#41;&#10;  prefix_length &#61; number&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [psa_addresses](variables.tf#L81) | Map of internal addresses used for Private Service Access. | <code title="map&#40;object&#40;&#123;&#10;  address       &#61; string&#10;  network       &#61; string&#10;  prefix_length &#61; number&#10;  description   &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  name          &#61; optional&#40;string&#41;&#10;&#10;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [psc_addresses](variables.tf#L94) | Map of internal addresses used for Private Service Connect. | <code title="map&#40;object&#40;&#123;&#10;  address     &#61; string&#10;  network     &#61; string&#10;  description &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  name        &#61; optional&#40;string&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [project_id](variables.tf#L83) | Project where the addresses will be created. | <code>string</code> | ✓ |  |
+| [external_addresses](variables.tf#L17) | Map of external addresses, keyed by name. | <code title="map&#40;object&#40;&#123;&#10;  region      &#61; string&#10;  description &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  ipv6 &#61; optional&#40;object&#40;&#123;&#10;    endpoint_type &#61; string&#10;  &#125;&#41;&#41;&#10;  labels &#61; optional&#40;map&#40;string&#41;, &#123;&#125;&#41;&#10;  name   &#61; optional&#40;string&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [global_addresses](variables.tf#L38) | List of global addresses to create. | <code title="map&#40;object&#40;&#123;&#10;  description &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  ipv6        &#61; optional&#40;map&#40;string&#41;&#41; &#35; To be left empty for ipv6&#10;  name        &#61; optional&#40;string&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [internal_addresses](variables.tf#L48) | Map of internal addresses to create, keyed by name. | <code title="map&#40;object&#40;&#123;&#10;  region      &#61; string&#10;  subnetwork  &#61; string&#10;  address     &#61; optional&#40;string&#41;&#10;  description &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  ipv6        &#61; optional&#40;map&#40;string&#41;&#41; &#35; To be left empty for ipv6&#10;  labels      &#61; optional&#40;map&#40;string&#41;&#41;&#10;  name        &#61; optional&#40;string&#41;&#10;  purpose     &#61; optional&#40;string&#41;&#10;  tier        &#61; optional&#40;string&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [ipsec_interconnect_addresses](variables.tf#L64) | Map of internal addresses used for HPA VPN over Cloud Interconnect. | <code title="map&#40;object&#40;&#123;&#10;  region        &#61; string&#10;  address       &#61; string&#10;  network       &#61; string&#10;  description   &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  name          &#61; optional&#40;string&#41;&#10;  prefix_length &#61; number&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [psa_addresses](variables.tf#L88) | Map of internal addresses used for Private Service Access. | <code title="map&#40;object&#40;&#123;&#10;  address       &#61; string&#10;  network       &#61; string&#10;  prefix_length &#61; number&#10;  description   &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  name          &#61; optional&#40;string&#41;&#10;&#10;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [psc_addresses](variables.tf#L101) | Map of internal addresses used for Private Service Connect. | <code title="map&#40;object&#40;&#123;&#10;  address     &#61; string&#10;  network     &#61; string&#10;  description &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  name        &#61; optional&#40;string&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 
 ## Outputs
 

--- a/modules/net-address/README.md
+++ b/modules/net-address/README.md
@@ -14,7 +14,10 @@ module "addresses" {
     one = { region = "europe-west1" }
     two = { region = "europe-west2" }
   }
-  global_addresses = ["app-1", "app-2"]
+  global_addresses = {
+    app-1 = {}
+    app-2 = {}
+  }
 }
 # tftest modules=1 resources=4 inventory=external.yaml
 ```
@@ -39,6 +42,41 @@ module "addresses" {
   }
 }
 # tftest modules=1 resources=2 inventory=internal.yaml
+```
+
+### IPv6 addresses
+
+You can reserve both external and internal IPv6 addresses.
+
+```hcl
+module "addresses" {
+  source     = "./fabric/modules/net-address"
+  project_id = var.project_id
+  external_addresses = {
+    nlb = {
+      ip_version         = "IPV6"
+      ipv6_endpoint_type = "NETLB"
+      region             = var.region
+      subnetwork         = var.subnet.self_link
+    }
+  }
+  internal_addresses = {
+    ilb = {
+      ip_version         = "IPV6"
+      ipv6_endpoint_type = "NETLB"
+      purpose            = "SHARED_LOADBALANCER_VIP"
+      region             = var.region
+      subnetwork         = var.subnet.self_link
+    }
+    vm = {
+      ip_version         = "IPV6"
+      ipv6_endpoint_type = "VM"
+      region             = var.region
+      subnetwork         = var.subnet.self_link
+    }
+  }
+}
+# tftest modules=1 resources=3 inventory=ipv6.yaml
 ```
 
 ### PSA addresses
@@ -106,13 +144,13 @@ module "addresses" {
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [project_id](variables.tf#L68) | Project where the addresses will be created. | <code>string</code> | ✓ |  |
-| [external_addresses](variables.tf#L17) | Map of external addresses, keyed by name. | <code title="map&#40;object&#40;&#123;&#10;  region      &#61; string&#10;  description &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  labels      &#61; optional&#40;map&#40;string&#41;, &#123;&#125;&#41;&#10;  name        &#61; optional&#40;string&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [global_addresses](variables.tf#L28) | List of global addresses to create. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
-| [internal_addresses](variables.tf#L34) | Map of internal addresses to create, keyed by name. | <code title="map&#40;object&#40;&#123;&#10;  region      &#61; string&#10;  subnetwork  &#61; string&#10;  address     &#61; optional&#40;string&#41;&#10;  description &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  labels      &#61; optional&#40;map&#40;string&#41;&#41;&#10;  name        &#61; optional&#40;string&#41;&#10;  purpose     &#61; optional&#40;string&#41;&#10;  tier        &#61; optional&#40;string&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [ipsec_interconnect_addresses](variables.tf#L49) | Map of internal addresses used for HPA VPN over Cloud Interconnect. | <code title="map&#40;object&#40;&#123;&#10;  region        &#61; string&#10;  address       &#61; string&#10;  network       &#61; string&#10;  description   &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  name          &#61; optional&#40;string&#41;&#10;  prefix_length &#61; number&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [psa_addresses](variables.tf#L73) | Map of internal addresses used for Private Service Access. | <code title="map&#40;object&#40;&#123;&#10;  address       &#61; string&#10;  network       &#61; string&#10;  prefix_length &#61; number&#10;  description   &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  name          &#61; optional&#40;string&#41;&#10;&#10;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [psc_addresses](variables.tf#L86) | Map of internal addresses used for Private Service Connect. | <code title="map&#40;object&#40;&#123;&#10;  address     &#61; string&#10;  network     &#61; string&#10;  description &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  name        &#61; optional&#40;string&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [project_id](variables.tf#L76) | Project where the addresses will be created. | <code>string</code> | ✓ |  |
+| [external_addresses](variables.tf#L17) | Map of external addresses, keyed by name. | <code title="map&#40;object&#40;&#123;&#10;  region             &#61; string&#10;  description        &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  ip_version         &#61; optional&#40;string, &#34;IPV4&#34;&#41;&#10;  ipv6_endpoint_type &#61; optional&#40;string&#41;&#10;  labels             &#61; optional&#40;map&#40;string&#41;, &#123;&#125;&#41;&#10;  name               &#61; optional&#40;string&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [global_addresses](variables.tf#L30) | List of global addresses to create. | <code title="map&#40;object&#40;&#123;&#10;  description &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  ip_version  &#61; optional&#40;string, &#34;IPV4&#34;&#41;&#10;  name        &#61; optional&#40;string&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [internal_addresses](variables.tf#L40) | Map of internal addresses to create, keyed by name. | <code title="map&#40;object&#40;&#123;&#10;  region             &#61; string&#10;  subnetwork         &#61; string&#10;  address            &#61; optional&#40;string&#41;&#10;  description        &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  ip_version         &#61; optional&#40;string, &#34;IPV4&#34;&#41;&#10;  ipv6_endpoint_type &#61; optional&#40;string&#41;&#10;  labels             &#61; optional&#40;map&#40;string&#41;&#41;&#10;  name               &#61; optional&#40;string&#41;&#10;  purpose            &#61; optional&#40;string&#41;&#10;  tier               &#61; optional&#40;string&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [ipsec_interconnect_addresses](variables.tf#L57) | Map of internal addresses used for HPA VPN over Cloud Interconnect. | <code title="map&#40;object&#40;&#123;&#10;  region        &#61; string&#10;  address       &#61; string&#10;  network       &#61; string&#10;  description   &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  name          &#61; optional&#40;string&#41;&#10;  prefix_length &#61; number&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [psa_addresses](variables.tf#L81) | Map of internal addresses used for Private Service Access. | <code title="map&#40;object&#40;&#123;&#10;  address       &#61; string&#10;  network       &#61; string&#10;  prefix_length &#61; number&#10;  description   &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  name          &#61; optional&#40;string&#41;&#10;&#10;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [psc_addresses](variables.tf#L94) | Map of internal addresses used for Private Service Connect. | <code title="map&#40;object&#40;&#123;&#10;  address     &#61; string&#10;  network     &#61; string&#10;  description &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  name        &#61; optional&#40;string&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 
 ## Outputs
 

--- a/modules/net-address/main.tf
+++ b/modules/net-address/main.tf
@@ -19,7 +19,7 @@ resource "google_compute_global_address" "global" {
   project     = var.project_id
   name        = coalesce(each.value.name, each.key)
   description = each.value.description
-  ip_version  = each.value.ip_version
+  ip_version  = each.value.ipv6 != null ? "IPV6" : "IPV4"
 }
 
 resource "google_compute_address" "external" {
@@ -29,27 +29,26 @@ resource "google_compute_address" "external" {
   name               = coalesce(each.value.name, each.key)
   description        = each.value.description
   address_type       = "EXTERNAL"
-  ip_version         = each.value.ip_version
-  ipv6_endpoint_type = each.value.ipv6_endpoint_type
+  ip_version         = each.value.ipv6 != null ? "IPV6" : "IPV4"
+  ipv6_endpoint_type = try(each.value.ipv6.endpoint_type, null)
   region             = each.value.region
   labels             = each.value.labels
 }
 
 resource "google_compute_address" "internal" {
-  provider           = google-beta
-  for_each           = var.internal_addresses
-  project            = var.project_id
-  name               = coalesce(each.value.name, each.key)
-  description        = each.value.description
-  address_type       = "INTERNAL"
-  region             = each.value.region
-  subnetwork         = each.value.subnetwork
-  address            = each.value.address
-  ip_version         = each.value.ip_version
-  ipv6_endpoint_type = each.value.ipv6_endpoint_type
-  network_tier       = each.value.tier
-  purpose            = each.value.purpose
-  labels             = coalesce(each.value.labels, {})
+  provider     = google-beta
+  for_each     = var.internal_addresses
+  project      = var.project_id
+  name         = coalesce(each.value.name, each.key)
+  description  = each.value.description
+  address_type = "INTERNAL"
+  region       = each.value.region
+  subnetwork   = each.value.subnetwork
+  address      = each.value.address
+  ip_version   = each.value.ipv6 != null ? "IPV6" : "IPV4"
+  network_tier = each.value.tier
+  purpose      = each.value.purpose
+  labels       = coalesce(each.value.labels, {})
 }
 
 resource "google_compute_global_address" "psc" {

--- a/modules/net-address/main.tf
+++ b/modules/net-address/main.tf
@@ -15,35 +15,41 @@
  */
 
 resource "google_compute_global_address" "global" {
-  for_each = toset(var.global_addresses)
-  project  = var.project_id
-  name     = each.value
+  for_each    = var.global_addresses
+  project     = var.project_id
+  name        = coalesce(each.value.name, each.key)
+  description = each.value.description
+  ip_version  = each.value.ip_version
 }
 
 resource "google_compute_address" "external" {
-  provider     = google-beta
-  for_each     = var.external_addresses
-  project      = var.project_id
-  name         = coalesce(each.value.name, each.key)
-  description  = each.value.description
-  address_type = "EXTERNAL"
-  region       = each.value.region
-  labels       = each.value.labels
+  provider           = google-beta
+  for_each           = var.external_addresses
+  project            = var.project_id
+  name               = coalesce(each.value.name, each.key)
+  description        = each.value.description
+  address_type       = "EXTERNAL"
+  ip_version         = each.value.ip_version
+  ipv6_endpoint_type = each.value.ipv6_endpoint_type
+  region             = each.value.region
+  labels             = each.value.labels
 }
 
 resource "google_compute_address" "internal" {
-  provider     = google-beta
-  for_each     = var.internal_addresses
-  project      = var.project_id
-  name         = coalesce(each.value.name, each.key)
-  description  = each.value.description
-  address_type = "INTERNAL"
-  region       = each.value.region
-  subnetwork   = each.value.subnetwork
-  address      = each.value.address
-  network_tier = each.value.tier
-  purpose      = each.value.purpose
-  labels       = coalesce(each.value.labels, {})
+  provider           = google-beta
+  for_each           = var.internal_addresses
+  project            = var.project_id
+  name               = coalesce(each.value.name, each.key)
+  description        = each.value.description
+  address_type       = "INTERNAL"
+  region             = each.value.region
+  subnetwork         = each.value.subnetwork
+  address            = each.value.address
+  ip_version         = each.value.ip_version
+  ipv6_endpoint_type = each.value.ipv6_endpoint_type
+  network_tier       = each.value.tier
+  purpose            = each.value.purpose
+  labels             = coalesce(each.value.labels, {})
 }
 
 resource "google_compute_global_address" "psc" {

--- a/modules/net-address/variables.tf
+++ b/modules/net-address/variables.tf
@@ -17,31 +17,39 @@
 variable "external_addresses" {
   description = "Map of external addresses, keyed by name."
   type = map(object({
-    region      = string
-    description = optional(string, "Terraform managed.")
-    labels      = optional(map(string), {})
-    name        = optional(string)
+    region             = string
+    description        = optional(string, "Terraform managed.")
+    ip_version         = optional(string, "IPV4")
+    ipv6_endpoint_type = optional(string)
+    labels             = optional(map(string), {})
+    name               = optional(string)
   }))
   default = {}
 }
 
 variable "global_addresses" {
   description = "List of global addresses to create."
-  type        = list(string)
-  default     = []
+  type = map(object({
+    description = optional(string, "Terraform managed.")
+    ip_version  = optional(string, "IPV4")
+    name        = optional(string)
+  }))
+  default = {}
 }
 
 variable "internal_addresses" {
   description = "Map of internal addresses to create, keyed by name."
   type = map(object({
-    region      = string
-    subnetwork  = string
-    address     = optional(string)
-    description = optional(string, "Terraform managed.")
-    labels      = optional(map(string))
-    name        = optional(string)
-    purpose     = optional(string)
-    tier        = optional(string)
+    region             = string
+    subnetwork         = string
+    address            = optional(string)
+    description        = optional(string, "Terraform managed.")
+    ip_version         = optional(string, "IPV4")
+    ipv6_endpoint_type = optional(string)
+    labels             = optional(map(string))
+    name               = optional(string)
+    purpose            = optional(string)
+    tier               = optional(string)
   }))
   default = {}
 }

--- a/modules/net-address/variables.tf
+++ b/modules/net-address/variables.tf
@@ -17,21 +17,29 @@
 variable "external_addresses" {
   description = "Map of external addresses, keyed by name."
   type = map(object({
-    region             = string
-    description        = optional(string, "Terraform managed.")
-    ip_version         = optional(string, "IPV4")
-    ipv6_endpoint_type = optional(string)
-    labels             = optional(map(string), {})
-    name               = optional(string)
+    region      = string
+    description = optional(string, "Terraform managed.")
+    ipv6 = optional(object({
+      endpoint_type = string
+    }))
+    labels = optional(map(string), {})
+    name   = optional(string)
   }))
   default = {}
+  validation {
+    condition = (
+      try(var.external_addresses.ipv6, null) == null
+      || can(regex("^(NETLB|VM)$", try(var.external_addresses.ipv6.endpoint_type, null)))
+    )
+    error_message = "IPv6 endpoint type must be NETLB, VM."
+  }
 }
 
 variable "global_addresses" {
   description = "List of global addresses to create."
   type = map(object({
     description = optional(string, "Terraform managed.")
-    ip_version  = optional(string, "IPV4")
+    ipv6        = optional(map(string)) # To be left empty for ipv6
     name        = optional(string)
   }))
   default = {}
@@ -40,16 +48,15 @@ variable "global_addresses" {
 variable "internal_addresses" {
   description = "Map of internal addresses to create, keyed by name."
   type = map(object({
-    region             = string
-    subnetwork         = string
-    address            = optional(string)
-    description        = optional(string, "Terraform managed.")
-    ip_version         = optional(string, "IPV4")
-    ipv6_endpoint_type = optional(string)
-    labels             = optional(map(string))
-    name               = optional(string)
-    purpose            = optional(string)
-    tier               = optional(string)
+    region      = string
+    subnetwork  = string
+    address     = optional(string)
+    description = optional(string, "Terraform managed.")
+    ipv6        = optional(map(string)) # To be left empty for ipv6
+    labels      = optional(map(string))
+    name        = optional(string)
+    purpose     = optional(string)
+    tier        = optional(string)
   }))
   default = {}
 }

--- a/modules/net-lb-app-ext/README.md
+++ b/modules/net-lb-app-ext/README.md
@@ -129,8 +129,8 @@ Redirect is implemented via an additional HTTP load balancer with a custom URL m
 
 ```hcl
 module "addresses" {
-  source           = "./fabric/modules/net-address"
-  project_id       = "myprj"
+  source     = "./fabric/modules/net-address"
+  project_id = "myprj"
   global_addresses = {
     "glb-test-0" = {}
   }

--- a/modules/net-lb-app-ext/README.md
+++ b/modules/net-lb-app-ext/README.md
@@ -131,7 +131,9 @@ Redirect is implemented via an additional HTTP load balancer with a custom URL m
 module "addresses" {
   source           = "./fabric/modules/net-address"
   project_id       = "myprj"
-  global_addresses = ["glb-test-0"]
+  global_addresses = {
+    "glb-test-0" = {}
+  }
 }
 
 module "glb-test-0-redirect" {

--- a/tests/modules/net_address/examples/ipv6.yaml
+++ b/tests/modules/net_address/examples/ipv6.yaml
@@ -1,0 +1,46 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values:
+  module.addresses.google_compute_address.external["nlb"]:
+    address_type: EXTERNAL
+    ip_version: IPV6
+    ipv6_endpoint_type: NETLB
+    name: nlb
+    project: project-id
+    region: region
+  module.addresses.google_compute_address.internal["ilb"]:
+    address_type: INTERNAL
+    ip_version: IPV6
+    ipv6_endpoint_type: NETLB
+    labels: null
+    name: ilb
+    network: null
+    project: project-id
+    purpose: SHARED_LOADBALANCER_VIP
+    region: region
+    subnetwork: subnet_self_link
+  module.addresses.google_compute_address.internal["vm"]:
+    address_type: INTERNAL
+    ip_version: IPV6
+    ipv6_endpoint_type: VM
+    labels: null
+    name: vm
+    network: null
+    project: project-id
+    region: region
+    subnetwork: subnet_self_link
+
+counts:
+  google_compute_address: 3

--- a/tests/modules/net_address/examples/ipv6.yaml
+++ b/tests/modules/net_address/examples/ipv6.yaml
@@ -23,7 +23,6 @@ values:
   module.addresses.google_compute_address.internal["ilb"]:
     address_type: INTERNAL
     ip_version: IPV6
-    ipv6_endpoint_type: NETLB
     labels: null
     name: ilb
     network: null
@@ -34,7 +33,6 @@ values:
   module.addresses.google_compute_address.internal["vm"]:
     address_type: INTERNAL
     ip_version: IPV6
-    ipv6_endpoint_type: VM
     labels: null
     name: vm
     network: null


### PR DESCRIPTION
Allows users to reserve IPv6 addresses.

FYI I submitted the initial PR without modifying the BP tests (yet), so we can first make sure that the modification to global addresses is done the way we want. Please, let me know if looks of to you.

---
**Checklist**

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
