### PR TITLE
Net VPC Peering: added stack_type field

### DIFF
--- a/modules/net-vpc-peering/README.md
+++ b/modules/net-vpc-peering/README.md
@@ -82,6 +82,7 @@ module "peering" {
 | [peer_create_peering](variables.tf#L22) | Create the peering on the remote side. If false, only the peering from this network to the remote network is created. | <code>bool</code> |  | <code>true</code> |
 | [prefix](variables.tf#L33) | Optional name prefix for the network peerings. | <code>string</code> |  | <code>null</code> |
 | [routes_config](variables.tf#L43) | Control import/export for local and remote peer. Remote configuration is only used when creating remote peering. | <code title="object&#40;&#123;&#10;  local &#61; optional&#40;object&#40;&#123;&#10;    export        &#61; optional&#40;bool, true&#41;&#10;    import        &#61; optional&#40;bool, true&#41;&#10;    public_export &#61; optional&#40;bool&#41;&#10;    public_import &#61; optional&#40;bool&#41;&#10;  &#125;&#41;, &#123;&#125;&#41;&#10;  peer &#61; optional&#40;object&#40;&#123;&#10;    export        &#61; optional&#40;bool, true&#41;&#10;    import        &#61; optional&#40;bool, true&#41;&#10;    public_export &#61; optional&#40;bool&#41;&#10;    public_import &#61; optional&#40;bool&#41;&#10;  &#125;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [stack_type](variables.tf#L63) | IP version(s) of traffic and routes that are allowed to be imported or exported between peer networks. Possible values: IPV4_ONLY, IPV4_IPV6 | <code>string</code> |  | <code>&#34;IPV4_ONLY&#34;</code> |
 
 ## Outputs
 

--- a/modules/net-vpc-peering/README.md
+++ b/modules/net-vpc-peering/README.md
@@ -82,7 +82,7 @@ module "peering" {
 | [peer_create_peering](variables.tf#L22) | Create the peering on the remote side. If false, only the peering from this network to the remote network is created. | <code>bool</code> |  | <code>true</code> |
 | [prefix](variables.tf#L33) | Optional name prefix for the network peerings. | <code>string</code> |  | <code>null</code> |
 | [routes_config](variables.tf#L43) | Control import/export for local and remote peer. Remote configuration is only used when creating remote peering. | <code title="object&#40;&#123;&#10;  local &#61; optional&#40;object&#40;&#123;&#10;    export        &#61; optional&#40;bool, true&#41;&#10;    import        &#61; optional&#40;bool, true&#41;&#10;    public_export &#61; optional&#40;bool&#41;&#10;    public_import &#61; optional&#40;bool&#41;&#10;  &#125;&#41;, &#123;&#125;&#41;&#10;  peer &#61; optional&#40;object&#40;&#123;&#10;    export        &#61; optional&#40;bool, true&#41;&#10;    import        &#61; optional&#40;bool, true&#41;&#10;    public_export &#61; optional&#40;bool&#41;&#10;    public_import &#61; optional&#40;bool&#41;&#10;  &#125;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [stack_type](variables.tf#L63) | IP version(s) of traffic and routes that are allowed to be imported or exported between peer networks. Possible values: IPV4_ONLY, IPV4_IPV6 | <code>string</code> |  | <code>&#34;IPV4_ONLY&#34;</code> |
+| [stack_type](variables.tf#L63) | IP version(s) of traffic and routes that are allowed to be imported or exported between peer networks. Possible values: IPV4_ONLY, IPV4_IPV6. | <code>string</code> |  | <code>null</code> |
 
 ## Outputs
 

--- a/modules/net-vpc-peering/main.tf
+++ b/modules/net-vpc-peering/main.tf
@@ -36,6 +36,7 @@ resource "google_compute_network_peering" "local_network_peering" {
   import_subnet_routes_with_public_ip = try(
     var.routes_config.local.public_import, null
   )
+  stack_type = var.stack_type
 }
 
 resource "google_compute_network_peering" "peer_network_peering" {
@@ -55,5 +56,6 @@ resource "google_compute_network_peering" "peer_network_peering" {
   import_subnet_routes_with_public_ip = try(
     var.routes_config.peer.public_import, null
   )
+  stack_type = var.stack_type
   depends_on = [google_compute_network_peering.local_network_peering]
 }

--- a/modules/net-vpc-peering/variables.tf
+++ b/modules/net-vpc-peering/variables.tf
@@ -63,5 +63,9 @@ variable "routes_config" {
 variable "stack_type" {
   description = "IP version(s) of traffic and routes that are allowed to be imported or exported between peer networks. Possible values: IPV4_ONLY, IPV4_IPV6."
   type        = string
-  default     = "IPV4_ONLY"
+  default     = null
+  validation {
+    condition     = var.stack_type == "IPV4_ONLY" || var.stack_type == "IPV4_IPV6" || var.stack_type == null
+    error_message = "The stack_type must be either 'IPV4_ONLY' or 'IPV4_IPV6'."
+  }
 }

--- a/modules/net-vpc-peering/variables.tf
+++ b/modules/net-vpc-peering/variables.tf
@@ -61,7 +61,7 @@ variable "routes_config" {
 }
 
 variable "stack_type" {
-  description = "IP version(s) of traffic and routes that are allowed to be imported or exported between peer networks. Possible values: IPV4_ONLY, IPV4_IPV6"
+  description = "IP version(s) of traffic and routes that are allowed to be imported or exported between peer networks. Possible values: IPV4_ONLY, IPV4_IPV6."
   type        = string
   default     = "IPV4_ONLY"
 }

--- a/modules/net-vpc-peering/variables.tf
+++ b/modules/net-vpc-peering/variables.tf
@@ -59,3 +59,9 @@ variable "routes_config" {
   nullable = false
   default  = {}
 }
+
+variable "stack_type" {
+  description = "IP version(s) of traffic and routes that are allowed to be imported or exported between peer networks. Possible values: IPV4_ONLY, IPV4_IPV6"
+  type        = string
+  default     = "IPV4_ONLY"
+}


### PR DESCRIPTION
Added the stack_type field for the "google_compute_network_peering" terraform resource. Link to documentation: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network_peering#stack_type

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass
