### PR TITLE
Fix validation and dynamic block for optional gpu_driver

### DIFF
--- a/modules/gke-nodepool/main.tf
+++ b/modules/gke-nodepool/main.tf
@@ -168,10 +168,7 @@ resource "google_container_node_pool" "nodepool" {
         gpu_partition_size = var.node_config.guest_accelerator.gpu_driver == null ? null : var.node_config.guest_accelerator.gpu_driver.partition_size
 
         dynamic "gpu_sharing_config" {
-          for_each = lookup(
-            lookup(var.node_config.guest_accelerator, "gpu_driver", {}),
-            "max_shared_clients_per_gpu"
-          ) != null ? [""] : []
+          for_each = try(var.node_config.guest_accelerator.gpu_driver.max_shared_clients_per_gpu, null) != null ? [""] : []
           content {
             gpu_sharing_strategy       = var.node_config.guest_accelerator.gpu_driver.max_shared_clients_per_gpu != null ? "TIME_SHARING" : null
             max_shared_clients_per_gpu = var.node_config.guest_accelerator.gpu_driver.max_shared_clients_per_gpu

--- a/modules/gke-nodepool/variables.tf
+++ b/modules/gke-nodepool/variables.tf
@@ -100,7 +100,7 @@ variable "node_config" {
   validation {
     condition = (
       alltrue([
-        for k, v in var.node_config.guest_accelerator[*].gpu_driver : contains([
+        for k, v in try(var.node_config.guest_accelerator[0].gpu_driver, {}) : contains([
           "GPU_DRIVER_VERSION_UNSPECIFIED", "INSTALLATION_DISABLED",
           "DEFAULT", "LATEST"
         ], v.version)


### PR DESCRIPTION
Fix validation and dynamic block for optional gpu_driver as it errors out on null when the block is not provided.
---
**Checklist**

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass
