### PR TITLE
Fix permissions assignments

### DIFF
--- a/modules/cloud-config-container/cos-generic-metadata/cloud-config.yaml
+++ b/modules/cloud-config-container/cos-generic-metadata/cloud-config.yaml
@@ -24,7 +24,7 @@ users:
 
 write_files:
   - path: /var/lib/docker/daemon.json
-    permissions: 0644
+    permissions: "0644"
     owner: root
     content: |
       {
@@ -36,7 +36,7 @@ write_files:
       }
   # ${container_name} container service
   - path: /etc/systemd/system/${container_name}.service
-    permissions: 0644
+    permissions: "0644"
     owner: root
     content: |
       [Unit]


### PR DESCRIPTION
Fix permission assignments to cloud init configuration.

Otherwise you obtain error during the initialization:
```
$ sudo cloud-init schema --system

Invalid cloud-config /var/lib/cloud/instances/XXX/cloud-config.txt Error: Cloud config schema errors: write_files.0.permissions: 420 is not of type 'string', write_files.1.permissions: 420 is not of type 'string'
```
