### PR TITLE
artifact-registry: Support cleanup policies

### DIFF
--- a/modules/artifact-registry/README.md
+++ b/modules/artifact-registry/README.md
@@ -6,6 +6,7 @@ This module simplifies the creation of repositories using Google Cloud Artifact 
 - [Standard Repository](#standard-repository)
 - [Remote and Virtual Repositories](#remote-and-virtual-repositories)
 - [Additional Docker and Maven Options](#additional-docker-and-maven-options)
+- [Cleanup Policies](#cleanup-policies)
 - [Variables](#variables)
 - [Outputs](#outputs)
 <!-- END TOC -->
@@ -100,20 +101,56 @@ module "registry-maven" {
 
 # tftest modules=2 resources=2
 ```
+
+## Cleanup Policies
+
+```hcl
+
+module "registry-docker" {
+  source                 = "./fabric/modules/artifact-registry"
+  project_id             = var.project_id
+  location               = "europe-west1"
+  name                   = "docker-cleanup-policies"
+  format                 = { docker = {} }
+  cleanup_policy_dry_run = false
+  cleanup_policies = {
+    keep-5-versions = {
+      action = "KEEP"
+      most_recent_versions = {
+        package_name_prefixes = ["test"]
+        keep_count            = 5
+      }
+    }
+    keep-tagged-release = {
+      action = "KEEP"
+      condition = {
+        tag_state             = "TAGGED"
+        tag_prefixes          = ["release"]
+        package_name_prefixes = ["webapp", "mobile"]
+      }
+    }
+  }
+}
+
+
+# tftest modules=1 resources=1 inventory=cleanup-policies.yaml
+```
 <!-- BEGIN TFDOC -->
 ## Variables
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [location](variables.tf#L68) | Registry location. Use `gcloud beta artifacts locations list' to get valid values. | <code>string</code> | ✓ |  |
-| [name](variables.tf#L93) | Registry name. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L98) | Registry project id. | <code>string</code> | ✓ |  |
-| [description](variables.tf#L17) | An optional description for the repository. | <code>string</code> |  | <code>&#34;Terraform-managed registry&#34;</code> |
-| [encryption_key](variables.tf#L23) | The KMS key name to use for encryption at rest. | <code>string</code> |  | <code>null</code> |
-| [format](variables.tf#L29) | Repository format. | <code title="object&#40;&#123;&#10;  apt &#61; optional&#40;object&#40;&#123;&#125;&#41;&#41;&#10;  docker &#61; optional&#40;object&#40;&#123;&#10;    immutable_tags &#61; optional&#40;bool&#41;&#10;  &#125;&#41;&#41;&#10;  kfp &#61; optional&#40;object&#40;&#123;&#125;&#41;&#41;&#10;  go  &#61; optional&#40;object&#40;&#123;&#125;&#41;&#41;&#10;  maven &#61; optional&#40;object&#40;&#123;&#10;    allow_snapshot_overwrites &#61; optional&#40;bool&#41;&#10;    version_policy            &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;  npm    &#61; optional&#40;object&#40;&#123;&#125;&#41;&#41;&#10;  python &#61; optional&#40;object&#40;&#123;&#125;&#41;&#41;&#10;  yum    &#61; optional&#40;object&#40;&#123;&#125;&#41;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123; docker &#61; &#123;&#125; &#125;</code> |
-| [iam](variables.tf#L56) | IAM bindings in {ROLE => [MEMBERS]} format. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [labels](variables.tf#L62) | Labels to be attached to the registry. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
-| [mode](variables.tf#L73) | Repository mode. | <code title="object&#40;&#123;&#10;  standard &#61; optional&#40;bool&#41;&#10;  remote   &#61; optional&#40;bool&#41;&#10;  virtual &#61; optional&#40;map&#40;object&#40;&#123;&#10;    repository &#61; string&#10;    priority   &#61; number&#10;  &#125;&#41;&#41;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123; standard &#61; true &#125;</code> |
+| [cleanup_policies](variables.tf#L17) | Object containing details about the cleanup policies for an Artifact Registry repository. | <code title="map&#40;object&#40;&#123;&#10;  action &#61; string&#10;  condition &#61; optional&#40;object&#40;&#123;&#10;    tag_state             &#61; optional&#40;string&#41;&#10;    tag_prefixes          &#61; optional&#40;list&#40;string&#41;&#41;&#10;    older_than            &#61; optional&#40;string&#41;&#10;    newer_than            &#61; optional&#40;string&#41;&#10;    package_name_prefixes &#61; optional&#40;list&#40;string&#41;&#41;&#10;    version_name_prefixes &#61; optional&#40;list&#40;string&#41;&#41;&#10;  &#125;&#41;&#41;&#10;  most_recent_versions &#61; optional&#40;object&#40;&#123;&#10;    package_name_prefixes &#61; optional&#40;list&#40;string&#41;&#41;&#10;    keep_count            &#61; optional&#40;number&#41;&#10;  &#125;&#41;&#41;&#10;&#125;&#41;&#41;&#10;&#10;&#10;default &#61; null">map&#40;object&#40;&#123;&#8230;default &#61; null</code> | ✓ |  |
+| [location](variables.tf#L95) | Registry location. Use `gcloud beta artifacts locations list' to get valid values. | <code>string</code> | ✓ |  |
+| [name](variables.tf#L120) | Registry name. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L125) | Registry project id. | <code>string</code> | ✓ |  |
+| [cleanup_policy_dry_run](variables.tf#L38) | If true, the cleanup pipeline is prevented from deleting versions in this repository. | <code>bool</code> |  | <code>null</code> |
+| [description](variables.tf#L44) | An optional description for the repository. | <code>string</code> |  | <code>&#34;Terraform-managed registry&#34;</code> |
+| [encryption_key](variables.tf#L50) | The KMS key name to use for encryption at rest. | <code>string</code> |  | <code>null</code> |
+| [format](variables.tf#L56) | Repository format. | <code title="object&#40;&#123;&#10;  apt &#61; optional&#40;object&#40;&#123;&#125;&#41;&#41;&#10;  docker &#61; optional&#40;object&#40;&#123;&#10;    immutable_tags &#61; optional&#40;bool&#41;&#10;  &#125;&#41;&#41;&#10;  kfp &#61; optional&#40;object&#40;&#123;&#125;&#41;&#41;&#10;  go  &#61; optional&#40;object&#40;&#123;&#125;&#41;&#41;&#10;  maven &#61; optional&#40;object&#40;&#123;&#10;    allow_snapshot_overwrites &#61; optional&#40;bool&#41;&#10;    version_policy            &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;  npm    &#61; optional&#40;object&#40;&#123;&#125;&#41;&#41;&#10;  python &#61; optional&#40;object&#40;&#123;&#125;&#41;&#41;&#10;  yum    &#61; optional&#40;object&#40;&#123;&#125;&#41;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123; docker &#61; &#123;&#125; &#125;</code> |
+| [iam](variables.tf#L83) | IAM bindings in {ROLE => [MEMBERS]} format. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [labels](variables.tf#L89) | Labels to be attached to the registry. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [mode](variables.tf#L100) | Repository mode. | <code title="object&#40;&#123;&#10;  standard &#61; optional&#40;bool&#41;&#10;  remote   &#61; optional&#40;bool&#41;&#10;  virtual &#61; optional&#40;map&#40;object&#40;&#123;&#10;    repository &#61; string&#10;    priority   &#61; number&#10;  &#125;&#41;&#41;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123; standard &#61; true &#125;</code> |
 
 ## Outputs
 

--- a/modules/artifact-registry/variables.tf
+++ b/modules/artifact-registry/variables.tf
@@ -14,6 +14,33 @@
  * limitations under the License.
  */
 
+variable "cleanup_policies" {
+  description = "Object containing details about the cleanup policies for an Artifact Registry repository."
+  type = map(object({
+    action = string
+    condition = optional(object({
+      tag_state             = optional(string)
+      tag_prefixes          = optional(list(string))
+      older_than            = optional(string)
+      newer_than            = optional(string)
+      package_name_prefixes = optional(list(string))
+      version_name_prefixes = optional(list(string))
+    }))
+    most_recent_versions = optional(object({
+      package_name_prefixes = optional(list(string))
+      keep_count            = optional(number)
+    }))
+  }))
+
+  default = null
+}
+
+variable "cleanup_policy_dry_run" {
+  description = "If true, the cleanup pipeline is prevented from deleting versions in this repository."
+  type        = bool
+  default     = null
+}
+
 variable "description" {
   description = "An optional description for the repository."
   type        = string

--- a/tests/modules/artifact_registry/examples/cleanup-policies.yaml
+++ b/tests/modules/artifact_registry/examples/cleanup-policies.yaml
@@ -1,0 +1,46 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values:
+values:
+  module.registry-docker.google_artifact_registry_repository.registry:
+    cleanup_policies:
+    - id: keep-tagged-release
+      action: KEEP
+      condition:
+      - package_name_prefixes:
+        - webapp
+        - mobile
+        tag_prefixes:
+        - release
+        tag_state: TAGGED
+    - id: keep-5-versions
+      action: KEEP
+      condition: []
+      most_recent_versions:
+      - keep_count: 5
+        package_name_prefixes:
+        - test
+    cleanup_policy_dry_run: false
+    format: DOCKER
+    location: europe-west1
+    mode: STANDARD_REPOSITORY
+    project: project-id
+    repository_id: docker-cleanup-policies
+    
+
+counts:
+  google_artifact_registry_repository: 1
+  modules: 1
+  resources: 1


### PR DESCRIPTION
<!-- Put a description of what this PR is for here -->
This PR aim to add support of cleanup policies for artifact registry module.

ie : https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/artifact_registry_repository#example-usage---artifact-registry-repository-cleanup

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [x] Made sure all relevant tests pass
