### PR TITLE
Use unique names for logging buckets in examples

### DIFF
--- a/modules/folder/README.md
+++ b/modules/folder/README.md
@@ -225,7 +225,7 @@ module "bucket" {
   source      = "./fabric/modules/logging-bucket"
   parent_type = "project"
   parent      = var.project_id
-  id          = "bucket"
+  id          = "${var.prefix}-bucket"
 }
 
 module "folder-sink" {

--- a/modules/organization/README.md
+++ b/modules/organization/README.md
@@ -291,7 +291,7 @@ module "bucket" {
   source      = "./fabric/modules/logging-bucket"
   parent_type = "project"
   parent      = var.project_id
-  id          = "bucket"
+  id          = "${var.prefix}-bucket"
 }
 
 module "org" {

--- a/modules/project/README.md
+++ b/modules/project/README.md
@@ -461,7 +461,7 @@ module "bucket" {
   source      = "./fabric/modules/logging-bucket"
   parent_type = "project"
   parent      = var.project_id
-  id          = "bucket"
+  id          = "${var.prefix}-bucket"
 }
 
 module "project-host" {
@@ -822,7 +822,7 @@ module "bucket" {
   source      = "./fabric/modules/logging-bucket"
   parent_type = "project"
   parent      = var.project_id
-  id          = "bucket"
+  id          = "${var.prefix}-bucket"
 }
 # tftest modules=7 resources=53 inventory=data.yaml e2e
 ```

--- a/tests/modules/project/examples/data.yaml
+++ b/tests/modules/project/examples/data.yaml
@@ -15,7 +15,7 @@
 
 values:
   module.bucket.google_logging_project_bucket_config.bucket[0]:
-    bucket_id: bucket
+    bucket_id: test-bucket
     project: project-id
   module.create-project.google_project.project[0]:
     billing_account: 123456-123456-123456


### PR DESCRIPTION
Logging bucket name can be reused only after 7 days (when it is actually deleted). When different tests reuse the same name, the ones that are executed as 2nd and later will fail with message:
```
Error updating Logging Bucket Config [...]: googleapi: Error 400: Buckets 
must be in an ACTIVE state to be modified
```

As their actual state is:
```
lifecycleState: DELETE_REQUESTED
```

<!-- Put a description of what this PR is for here -->

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass
