### PR TITLE
Don't fail on missing project in quota monitor blueprint

### DIFF
--- a/blueprints/cloud-operations/quota-monitoring/src/main.py
+++ b/blueprints/cloud-operations/quota-monitoring/src/main.py
@@ -157,10 +157,6 @@ def fetch(request, delete=False):
     raise SystemExit(f'Error decoding response: {response.content}')
   if response.status_code != 200:
     raise  requests.exceptions.HTTPError(rdata)
-    #error = rdata.get('error', {})
-    #raise  requests.exceptions.HTTPError('API error: {} (HTTP {})'.format(
-    #    error.get('message', 'error message cannot be decoded'),
-    #    error.get('code', 'no code found')))
   return json.loads(response.content)
 
 


### PR DESCRIPTION
Refactored fetch method in Quota Monitor main.py to raise an exception upon !=200 response codes, instead of a system exit. 
updated callers to handle requests.exceptions.HTTPError 



I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X ] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
