### PR TITLE
Update shared vpc config for Project Factory and Project module

### DIFF
--- a/blueprints/factories/project-factory/README.md
+++ b/blueprints/factories/project-factory/README.md
@@ -85,26 +85,33 @@ service_accounts:
 
 ```yaml
 labels:
- app: app-2
- team: foo
+  app: app-2
+  team: foo
 parent: folders/12345678
+org_policies:
+  "compute.restrictSharedVpcSubnetworks":
+    rules:
+    - allow:
+        values:
+        - projects/foo-host/regions/europe-west1/subnetworks/prod-default-ew1
 service_accounts:
   app-2-be: {}
 services:
 - compute.googleapis.com
 - container.googleapis.com
-- run.googleapis.com
 - storage.googleapis.com
 shared_vpc_service_config:
   host_project: foo-host
   service_identity_iam:
-    "roles/compute.networkUser":
-      - cloudservices
-      - container-engine
-    "roles/vpcaccess.user":
-      - cloudrun
     "roles/container.hostServiceAgentUser":
-      - container-engine
+    - container-engine
+  service_identity_subnets_iam:
+    europe-west1/prod-default-ew1:
+    - cloudservices
+    - container-engine
+  subnets_iam:
+    europe-west1/prod-default-ew1:
+    - user:team-1@example.com
 
 # tftest-file id=prj-app-2 path=data/prj-app-2.yaml
 ```
@@ -117,15 +124,16 @@ services:
 
 # tftest-file id=prj-app-3 path=data/prj-app-3.yaml
 ```
+
 <!-- BEGIN TFDOC -->
 ## Variables
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [factory_data_path](variables.tf#L89) | Path to folder with YAML project description data files. | <code>string</code> | ✓ |  |
-| [data_defaults](variables.tf#L17) | Optional default values used when corresponding project data from files are missing. | <code title="object&#40;&#123;&#10;  billing_account            &#61; optional&#40;string&#41;&#10;  contacts                   &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;  labels                     &#61; optional&#40;map&#40;string&#41;, &#123;&#125;&#41;&#10;  metric_scopes              &#61; optional&#40;list&#40;string&#41;, &#91;&#93;&#41;&#10;  parent                     &#61; optional&#40;string&#41;&#10;  prefix                     &#61; optional&#40;string&#41;&#10;  service_encryption_key_ids &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;  service_perimeter_bridges  &#61; optional&#40;list&#40;string&#41;, &#91;&#93;&#41;&#10;  service_perimeter_standard &#61; optional&#40;string&#41;&#10;  services                   &#61; optional&#40;list&#40;string&#41;, &#91;&#93;&#41;&#10;  shared_vpc_service_config &#61; optional&#40;object&#40;&#123;&#10;    host_project                &#61; string&#10;    service_identity_iam        &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;    service_identity_subnet_iam &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;    service_iam_grants          &#61; optional&#40;list&#40;string&#41;, &#91;&#93;&#41;&#10;  &#125;&#41;, &#123; host_project &#61; null &#125;&#41;&#10;  tag_bindings &#61; optional&#40;map&#40;string&#41;, &#123;&#125;&#41;&#10;  service_accounts &#61; optional&#40;map&#40;object&#40;&#123;&#10;    display_name      &#61; optional&#40;string, &#34;Terraform-managed.&#34;&#41;&#10;    iam_project_roles &#61; optional&#40;list&#40;string&#41;&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [data_merges](variables.tf#L47) | Optional values that will be merged with corresponding data from files. Combines with `data_defaults`, file data, and `data_overrides`. | <code title="object&#40;&#123;&#10;  contacts                   &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;  labels                     &#61; optional&#40;map&#40;string&#41;, &#123;&#125;&#41;&#10;  metric_scopes              &#61; optional&#40;list&#40;string&#41;, &#91;&#93;&#41;&#10;  service_encryption_key_ids &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;  service_perimeter_bridges  &#61; optional&#40;list&#40;string&#41;, &#91;&#93;&#41;&#10;  services                   &#61; optional&#40;list&#40;string&#41;, &#91;&#93;&#41;&#10;  tag_bindings               &#61; optional&#40;map&#40;string&#41;, &#123;&#125;&#41;&#10;  service_accounts &#61; optional&#40;map&#40;object&#40;&#123;&#10;    display_name      &#61; optional&#40;string, &#34;Terraform-managed.&#34;&#41;&#10;    iam_project_roles &#61; optional&#40;list&#40;string&#41;&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [data_overrides](variables.tf#L67) | Optional values that override corresponding data from files. Takes precedence over file data and `data_defaults`. | <code title="object&#40;&#123;&#10;  billing_account            &#61; optional&#40;string&#41;&#10;  contacts                   &#61; optional&#40;map&#40;list&#40;string&#41;&#41;&#41;&#10;  parent                     &#61; optional&#40;string&#41;&#10;  prefix                     &#61; optional&#40;string&#41;&#10;  service_encryption_key_ids &#61; optional&#40;map&#40;list&#40;string&#41;&#41;&#41;&#10;  service_perimeter_bridges  &#61; optional&#40;list&#40;string&#41;&#41;&#10;  service_perimeter_standard &#61; optional&#40;string&#41;&#10;  tag_bindings               &#61; optional&#40;map&#40;string&#41;&#41;&#10;  services                   &#61; optional&#40;list&#40;string&#41;&#41;&#10;  service_accounts &#61; optional&#40;map&#40;object&#40;&#123;&#10;    display_name      &#61; optional&#40;string, &#34;Terraform-managed.&#34;&#41;&#10;    iam_project_roles &#61; optional&#40;list&#40;string&#41;&#41;&#10;  &#125;&#41;&#41;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [factory_data_path](variables.tf#L91) | Path to folder with YAML project description data files. | <code>string</code> | ✓ |  |
+| [data_defaults](variables.tf#L17) | Optional default values used when corresponding project data from files are missing. | <code title="object&#40;&#123;&#10;  billing_account            &#61; optional&#40;string&#41;&#10;  contacts                   &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;  labels                     &#61; optional&#40;map&#40;string&#41;, &#123;&#125;&#41;&#10;  metric_scopes              &#61; optional&#40;list&#40;string&#41;, &#91;&#93;&#41;&#10;  parent                     &#61; optional&#40;string&#41;&#10;  prefix                     &#61; optional&#40;string&#41;&#10;  service_encryption_key_ids &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;  service_perimeter_bridges  &#61; optional&#40;list&#40;string&#41;, &#91;&#93;&#41;&#10;  service_perimeter_standard &#61; optional&#40;string&#41;&#10;  services                   &#61; optional&#40;list&#40;string&#41;, &#91;&#93;&#41;&#10;  shared_vpc_service_config &#61; optional&#40;object&#40;&#123;&#10;    host_project                 &#61; string&#10;    host_project_iam             &#61; optional&#40;list&#40;string&#41;, &#91;&#93;&#41;&#10;    service_identity_iam         &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;    service_identity_subnets_iam &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;    service_iam_grants           &#61; optional&#40;list&#40;string&#41;, &#91;&#93;&#41;&#10;    subnets_iam                  &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;  &#125;&#41;, &#123; host_project &#61; null &#125;&#41;&#10;  tag_bindings &#61; optional&#40;map&#40;string&#41;, &#123;&#125;&#41;&#10;  service_accounts &#61; optional&#40;map&#40;object&#40;&#123;&#10;    display_name      &#61; optional&#40;string, &#34;Terraform-managed.&#34;&#41;&#10;    iam_project_roles &#61; optional&#40;list&#40;string&#41;&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [data_merges](variables.tf#L49) | Optional values that will be merged with corresponding data from files. Combines with `data_defaults`, file data, and `data_overrides`. | <code title="object&#40;&#123;&#10;  contacts                   &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;  labels                     &#61; optional&#40;map&#40;string&#41;, &#123;&#125;&#41;&#10;  metric_scopes              &#61; optional&#40;list&#40;string&#41;, &#91;&#93;&#41;&#10;  service_encryption_key_ids &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;  service_perimeter_bridges  &#61; optional&#40;list&#40;string&#41;, &#91;&#93;&#41;&#10;  services                   &#61; optional&#40;list&#40;string&#41;, &#91;&#93;&#41;&#10;  tag_bindings               &#61; optional&#40;map&#40;string&#41;, &#123;&#125;&#41;&#10;  service_accounts &#61; optional&#40;map&#40;object&#40;&#123;&#10;    display_name      &#61; optional&#40;string, &#34;Terraform-managed.&#34;&#41;&#10;    iam_project_roles &#61; optional&#40;list&#40;string&#41;&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [data_overrides](variables.tf#L69) | Optional values that override corresponding data from files. Takes precedence over file data and `data_defaults`. | <code title="object&#40;&#123;&#10;  billing_account            &#61; optional&#40;string&#41;&#10;  contacts                   &#61; optional&#40;map&#40;list&#40;string&#41;&#41;&#41;&#10;  parent                     &#61; optional&#40;string&#41;&#10;  prefix                     &#61; optional&#40;string&#41;&#10;  service_encryption_key_ids &#61; optional&#40;map&#40;list&#40;string&#41;&#41;&#41;&#10;  service_perimeter_bridges  &#61; optional&#40;list&#40;string&#41;&#41;&#10;  service_perimeter_standard &#61; optional&#40;string&#41;&#10;  tag_bindings               &#61; optional&#40;map&#40;string&#41;&#41;&#10;  services                   &#61; optional&#40;list&#40;string&#41;&#41;&#10;  service_accounts &#61; optional&#40;map&#40;object&#40;&#123;&#10;    display_name      &#61; optional&#40;string, &#34;Terraform-managed.&#34;&#41;&#10;    iam_project_roles &#61; optional&#40;list&#40;string&#41;&#41;&#10;  &#125;&#41;&#41;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 
 ## Outputs
 
@@ -134,6 +142,7 @@ services:
 | [projects](outputs.tf#L17) | Project module outputs. |  |
 | [service_accounts](outputs.tf#L22) | Service account emails. |  |
 <!-- END TFDOC -->
+
 ## Tests
 
 These tests validate fixes to the project factory.

--- a/blueprints/factories/project-factory/factory.tf
+++ b/blueprints/factories/project-factory/factory.tf
@@ -79,9 +79,11 @@ locals {
         try(v.shared_vpc_service_config, null) != null
         ? merge(
           {
-            service_identity_iam        = {}
-            service_identity_subnet_iam = {}
-            service_iam_grants          = []
+            host_project_iam             = []
+            service_identity_iam         = {}
+            service_identity_subnets_iam = {}
+            service_iam_grants           = []
+            subnets_iam                  = {}
           },
           v.shared_vpc_service_config
         )

--- a/blueprints/factories/project-factory/variables.tf
+++ b/blueprints/factories/project-factory/variables.tf
@@ -28,10 +28,12 @@ variable "data_defaults" {
     service_perimeter_standard = optional(string)
     services                   = optional(list(string), [])
     shared_vpc_service_config = optional(object({
-      host_project                = string
-      service_identity_iam        = optional(map(list(string)), {})
-      service_identity_subnet_iam = optional(map(list(string)), {})
-      service_iam_grants          = optional(list(string), [])
+      host_project                 = string
+      host_project_iam             = optional(list(string), [])
+      service_identity_iam         = optional(map(list(string)), {})
+      service_identity_subnets_iam = optional(map(list(string)), {})
+      service_iam_grants           = optional(list(string), [])
+      subnets_iam                  = optional(map(list(string)), {})
     }), { host_project = null })
     tag_bindings = optional(map(string), {})
     # non-project resources

--- a/modules/project/README.md
+++ b/modules/project/README.md
@@ -317,9 +317,53 @@ module "service-project" {
 # tftest modules=2 resources=9 inventory=shared-vpc-auto-grants.yaml e2e
 ```
 
-In specific cases it might make sense to selectively grant the `compute.networkUser` role for service identities at the subnet level, and while that is best done via org policies it's also supported by this module.
+The 'networkUser' role for identities other than API services (e.g. users, groups or service accounts) can be managed via the `host_project_iam` attribute, by specifying the list of identities.
 
-In this example, Compute service identity will be granted compute.networkUser in the `gce` subnet defined in `europe-west1` region.
+Note that this configuration grants the 'networkUser' role at project level which results in the identity being able to configure resources on all the VPCs and subnets belonging to the host project without further restrictions. It is possible, or better recommended, to restrict which subnets can be used on the newly created project using an Org Policy. The latter applied at project level can restrict access to a list of subnets from the host project. For more information on the Org Policy configuration check the corresponding [Organization Policy section](#organization-policies). The following example details this configuration.
+
+```hcl
+module "host-project" {
+  source          = "./fabric/modules/project"
+  billing_account = var.billing_account_id
+  name            = "host"
+  parent          = var.folder_id
+  prefix          = var.prefix
+  shared_vpc_host_config = {
+    enabled = true
+  }
+}
+
+module "service-project" {
+  source          = "./fabric/modules/project"
+  billing_account = var.billing_account_id
+  name            = "service"
+  parent          = var.folder_id
+  prefix          = var.prefix
+  org_policies = {
+    "compute.restrictSharedVpcSubnetworks" = {
+      rules = [{
+        allow = {
+          values = ["projects/host/regions/europe-west1/subnetworks/prod-default-ew1"]
+        }
+      }]
+    }
+  }
+  services = [
+    "container.googleapis.com",
+  ]
+  shared_vpc_service_config = {
+    host_project     = module.host-project.project_id
+    host_project_iam = ["group:team-1@example.com"]
+    # reuse the list of services from the module's outputs
+    service_iam_grants = module.service-project.services
+  }
+}
+# tftest modules=2 resources=11 inventory=shared-vpc-host-project-iam.yaml e2e
+```
+
+In specific cases it might make sense to selectively grant the `compute.networkUser` role for all kind of identities at the subnet level, although you can restrict access via org policies this is also supported by this module.
+
+In this example, Compute service identity and `team-1@example.com` Google Group will be granted compute.networkUser in the `gce` subnet defined in `europe-west1` region via the `service_identity_subnets_iam` and `subnets_iam` attributes.
 
 ```hcl
 module "host-project" {
@@ -344,12 +388,66 @@ module "service-project" {
   ]
   shared_vpc_service_config = {
     host_project = module.host-project.project_id
-    service_identity_subnet_iam = {
+    service_identity_subnets_iam = {
       "europe-west1/gce" = ["compute"]
+    }
+    subnets_iam = {
+      "europe-west1/gce" = ["group:team-1@example.com"]
     }
   }
 }
-# tftest modules=2 resources=6 inventory=shared-vpc-subnet-grants.yaml
+# tftest modules=2 resources=7 inventory=shared-vpc-subnet-grants.yaml
+```
+
+The last example provides a reference Shared VPC configuration that adheres to the principle of least privilege by:
+- Granting API services and other identities roles at the subnet level
+- Restricting access to the list of subnets for the new project via Org Policy
+
+```hcl
+module "host-project" {
+  source          = "./fabric/modules/project"
+  billing_account = var.billing_account_id
+  name            = "host"
+  parent          = var.folder_id
+  prefix          = var.prefix
+  shared_vpc_host_config = {
+    enabled = true
+  }
+}
+
+module "service-project" {
+  source          = "./fabric/modules/project"
+  billing_account = var.billing_account_id
+  name            = "service"
+  parent          = var.folder_id
+  prefix          = var.prefix
+  org_policies = {
+    "compute.restrictSharedVpcSubnetworks" = {
+      rules = [{
+        allow = {
+          values = ["projects/host/regions/europe-west1/subnetworks/gce"]
+        }
+      }]
+    }
+  }
+  services = [
+    "compute.googleapis.com",
+    "container.googleapis.com"
+  ]
+  shared_vpc_service_config = {
+    host_project = module.host-project.project_id
+    service_identity_iam = {
+      "roles/container.hostServiceAgentUser" = ["container-engine"]
+    }
+    service_identity_subnets_iam = {
+      "europe-west1/gce" = ["cloudservices", "container-engine"]
+    }
+    subnets_iam = {
+      "europe-west1/gce" = ["group:team-1@example.com"]
+    }
+  }
+}
+# tftest modules=2 resources=11 inventory=shared-vpc-reference.yaml
 ```
 
 ## Organization Policies
@@ -929,9 +1027,9 @@ module "bucket" {
 | [service_perimeter_standard](variables.tf#L280) | Name of VPC-SC Standard perimeter to add project into. See comment in the variables file for format. | <code>string</code> |  | <code>null</code> |
 | [services](variables.tf#L286) | Service APIs to enable. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
 | [shared_vpc_host_config](variables.tf#L292) | Configures this project as a Shared VPC host project (mutually exclusive with shared_vpc_service_project). | <code title="object&#40;&#123;&#10;  enabled          &#61; bool&#10;  service_projects &#61; optional&#40;list&#40;string&#41;, &#91;&#93;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [shared_vpc_service_config](variables.tf#L301) | Configures this project as a Shared VPC service project (mutually exclusive with shared_vpc_host_config). | <code title="object&#40;&#123;&#10;  host_project                &#61; string&#10;  service_identity_iam        &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;  service_identity_subnet_iam &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;  service_iam_grants          &#61; optional&#40;list&#40;string&#41;, &#91;&#93;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code title="&#123;&#10;  host_project &#61; null&#10;&#125;">&#123;&#8230;&#125;</code> |
-| [skip_delete](variables.tf#L324) | Allows the underlying resources to be destroyed without destroying the project itself. | <code>bool</code> |  | <code>false</code> |
-| [tag_bindings](variables.tf#L330) | Tag bindings for this project, in key => tag value id format. | <code>map&#40;string&#41;</code> |  | <code>null</code> |
+| [shared_vpc_service_config](variables.tf#L301) | Configures this project as a Shared VPC service project (mutually exclusive with shared_vpc_host_config). | <code title="object&#40;&#123;&#10;  host_project                 &#61; string&#10;  host_project_iam             &#61; optional&#40;list&#40;string&#41;, &#91;&#93;&#41;&#10;  service_identity_iam         &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;  service_identity_subnets_iam &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;  service_iam_grants           &#61; optional&#40;list&#40;string&#41;, &#91;&#93;&#41;&#10;  subnets_iam                  &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code title="&#123;&#10;  host_project &#61; null&#10;&#125;">&#123;&#8230;&#125;</code> |
+| [skip_delete](variables.tf#L328) | Allows the underlying resources to be destroyed without destroying the project itself. | <code>bool</code> |  | <code>false</code> |
+| [tag_bindings](variables.tf#L334) | Tag bindings for this project, in key => tag value id format. | <code>map&#40;string&#41;</code> |  | <code>null</code> |
 
 ## Outputs
 

--- a/modules/project/variables.tf
+++ b/modules/project/variables.tf
@@ -302,10 +302,12 @@ variable "shared_vpc_service_config" {
   description = "Configures this project as a Shared VPC service project (mutually exclusive with shared_vpc_host_config)."
   # the list of valid service identities is in service-agents.yaml
   type = object({
-    host_project                = string
-    service_identity_iam        = optional(map(list(string)), {})
-    service_identity_subnet_iam = optional(map(list(string)), {})
-    service_iam_grants          = optional(list(string), [])
+    host_project                 = string
+    host_project_iam             = optional(list(string), [])
+    service_identity_iam         = optional(map(list(string)), {})
+    service_identity_subnets_iam = optional(map(list(string)), {})
+    service_iam_grants           = optional(list(string), [])
+    subnets_iam                  = optional(map(list(string)), {})
   })
   default = {
     host_project = null
@@ -314,10 +316,12 @@ variable "shared_vpc_service_config" {
   validation {
     condition = var.shared_vpc_service_config.host_project != null || (
       var.shared_vpc_service_config.host_project == null &&
+      length(var.shared_vpc_service_config.host_project_iam) == 0 &&
       length(var.shared_vpc_service_config.service_iam_grants) == 0 &&
-      length(var.shared_vpc_service_config.service_iam_grants) == 0
+      length(var.shared_vpc_service_config.service_identity_iam) == 0 &&
+      length(var.shared_vpc_service_config.subnets_iam) == 0
     )
-    error_message = "You need to provide host_project when providing service_identity_iam or service_iam_grants"
+    error_message = "You need to provide host_project when providing shared vpc host and subnets iam permissions."
   }
 }
 

--- a/tests/examples/test_plan.py
+++ b/tests/examples/test_plan.py
@@ -66,7 +66,7 @@ def test_example(plan_validator, tmp_path, example):
     counts = summary.counts
     num_modules, num_resources = counts['modules'], counts['resources']
     assert expected_modules == num_modules, 'wrong number of modules'
-    assert expected_resources == num_resources, 'wrong number of resources'
+    assert expected_resources == num_resources, f'wrong number of resources {counts["resources"]}'
 
     # TODO(jccb): this should probably be done in check_documentation
     # but we already have all the data here.

--- a/tests/modules/project/examples/shared-vpc-host-project-iam.yaml
+++ b/tests/modules/project/examples/shared-vpc-host-project-iam.yaml
@@ -1,0 +1,62 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values:
+  module.host-project.google_compute_shared_vpc_host_project.shared_vpc_host[0]:
+    project: test-host
+  module.host-project.google_project.project[0]:
+    project_id: test-host
+  module.service-project.google_compute_shared_vpc_service_project.shared_vpc_service[0]:
+    host_project: test-host
+    service_project: test-service
+  module.service-project.google_project.project[0]:
+    project_id: test-service
+  module.service-project.google_project_iam_member.shared_vpc_host_robots["roles/compute.networkUser:cloudservices"]:
+    condition: []
+    project: test-host
+    role: roles/compute.networkUser
+  module.service-project.google_project_iam_member.shared_vpc_host_robots["roles/compute.networkUser:container"]:
+    condition: []
+    project: test-host
+    role: roles/compute.networkUser
+  module.service-project.google_project_iam_member.shared_vpc_host_robots["roles/container.hostServiceAgentUser:container"]:
+    condition: []
+    project: test-host
+    role: roles/container.hostServiceAgentUser
+  module.service-project.google_project_iam_member.shared_vpc_host_iam["group:team-1@example.com"]:
+    condition: [ ]
+    project: test-host
+    role: roles/compute.networkUser
+  module.service-project.google_org_policy_policy.default["compute.restrictSharedVpcSubnetworks"]:
+    name: projects/test-service/policies/compute.restrictSharedVpcSubnetworks
+    parent: projects/test-service
+    spec:
+    - inherit_from_parent: null
+      reset: null
+      rules:
+      - allow_all: null
+        condition: [ ]
+        deny_all: null
+        enforce: null
+        values:
+        - allowed_values:
+          - projects/host/regions/europe-west1/subnetworks/prod-default-ew1
+          denied_values: null
+
+counts:
+  google_compute_shared_vpc_host_project: 1
+  google_compute_shared_vpc_service_project: 1
+  google_project: 2
+  google_project_iam_member: 5
+  google_org_policy_policy: 1

--- a/tests/modules/project/examples/shared-vpc-reference.yaml
+++ b/tests/modules/project/examples/shared-vpc-reference.yaml
@@ -31,8 +31,20 @@ values:
     host_project: test-host
     service_project: test-service
     timeouts: null
-  module.service-project.google_compute_subnetwork_iam_member.shared_vpc_host_robots["europe-west1:gce:compute"]:
+  module.service-project.google_compute_subnetwork_iam_member.shared_vpc_host_robots["europe-west1:gce:cloudservices"]:
     condition: []
+    project: test-host
+    region: europe-west1
+    role: roles/compute.networkUser
+    subnetwork: gce
+  module.service-project.google_compute_subnetwork_iam_member.shared_vpc_host_robots["europe-west1:gce:container-engine"]:
+    condition: [ ]
+    project: test-host
+    region: europe-west1
+    role: roles/compute.networkUser
+    subnetwork: gce
+  module.service-project.google_compute_subnetwork_iam_member.shared_vpc_host_subnets_iam["europe-west1:gce:group:team-1@example.com"]:
+    condition: [ ]
     project: test-host
     region: europe-west1
     role: roles/compute.networkUser
@@ -53,14 +65,41 @@ values:
     project: test-service
     service: compute.googleapis.com
     timeouts: null
+  module.service-project.google_project_service.project_services["container.googleapis.com"]:
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: test-service
+    service: container.googleapis.com
+    timeouts: null
+  module.service-project.google_project_iam_member.shared_vpc_host_robots["roles/container.hostServiceAgentUser:container-engine"]:
+    condition: [ ]
+    project: test-host
+    role: roles/container.hostServiceAgentUser
+  module.service-project.google_org_policy_policy.default["compute.restrictSharedVpcSubnetworks"]:
+    name: projects/test-service/policies/compute.restrictSharedVpcSubnetworks
+    parent: projects/test-service
+    spec:
+    - inherit_from_parent: null
+      reset: null
+      rules:
+      - allow_all: null
+        condition: [ ]
+        deny_all: null
+        enforce: null
+        values:
+        - allowed_values:
+          - projects/host/regions/europe-west1/subnetworks/gce
+          denied_values: null
 
 counts:
   google_compute_shared_vpc_host_project: 1
   google_compute_shared_vpc_service_project: 1
-  google_compute_subnetwork_iam_member: 2
+  google_compute_subnetwork_iam_member: 3
   google_project: 2
-  google_project_service: 1
+  google_project_iam_member: 1
+  google_project_service: 2
+  google_org_policy_policy: 1
   modules: 2
-  resources: 7
+  resources: 11
 
 outputs: {}


### PR DESCRIPTION
Update shared vpc config for project factory and project module for more granular Shared VPC configuration. Added the following attributes to shared_vpc_service_config variable:

- subnets_iam: for subnet level IAM binding for non API services identities
- host_project_iam: for granting network user role to identities other than API services

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
