### PR TITLE
Fix always succeding test

### DIFF
--- a/modules/gcs/README.md
+++ b/modules/gcs/README.md
@@ -53,7 +53,7 @@ module "bucket" {
   location       = "EU"
 }
 
-# tftest skip e2e
+# tftest modules=3 skip e2e
 ```
 
 ### Example with retention policy and logging


### PR DESCRIPTION
<!-- Put a description of what this PR is for here -->
Lack of modules declaration was preventing to run this test properly as there was no match on [COUNT_TEST_RE](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/tests/examples/test_plan.py#L21)

I'm getting close to rewrite `# tftest` parsing into something less regexp oriented.

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [ ] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [ ] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass
