### PR TITLE
Add kernels.googleusercontent.com zone in dns response policy

### DIFF
--- a/fast/stages/2-networking-a-peering/data/dns-policy-rules.yaml
+++ b/fast/stages/2-networking-a-peering/data/dns-policy-rules.yaml
@@ -81,6 +81,12 @@ googleapis-restricted:
 gstatic-all:
   dns_name: "*.gstatic.com."
   local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
+kernels-gu:
+  dns_name: "kernels.googleusercontent.com."
+  local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
+kernels-gu-all:
+  dns_name: "*.kernels.googleusercontent.com."
+  local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
 notebooks-all:
   dns_name: "*.notebooks.cloud.google.com."
   local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }

--- a/fast/stages/2-networking-b-vpn/data/dns-policy-rules.yaml
+++ b/fast/stages/2-networking-b-vpn/data/dns-policy-rules.yaml
@@ -81,6 +81,12 @@ googleapis-restricted:
 gstatic-all:
   dns_name: "*.gstatic.com."
   local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
+kernels-gu:
+  dns_name: "kernels.googleusercontent.com."
+  local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
+kernels-gu-all:
+  dns_name: "*.kernels.googleusercontent.com."
+  local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
 notebooks-all:
   dns_name: "*.notebooks.cloud.google.com."
   local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }

--- a/fast/stages/2-networking-c-nva/data/dns-policy-rules.yaml
+++ b/fast/stages/2-networking-c-nva/data/dns-policy-rules.yaml
@@ -81,6 +81,12 @@ googleapis-restricted:
 gstatic-all:
   dns_name: "*.gstatic.com."
   local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
+kernels-gu:
+  dns_name: "kernels.googleusercontent.com."
+  local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
+kernels-gu-all:
+  dns_name: "*.kernels.googleusercontent.com."
+  local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
 notebooks-all:
   dns_name: "*.notebooks.cloud.google.com."
   local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }

--- a/fast/stages/2-networking-d-separate-envs/data/dns-policy-rules.yaml
+++ b/fast/stages/2-networking-d-separate-envs/data/dns-policy-rules.yaml
@@ -81,6 +81,12 @@ googleapis-restricted:
 gstatic-all:
   dns_name: "*.gstatic.com."
   local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
+kernels-gu:
+  dns_name: "kernels.googleusercontent.com."
+  local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
+kernels-gu-all:
+  dns_name: "*.kernels.googleusercontent.com."
+  local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
 notebooks-all:
   dns_name: "*.notebooks.cloud.google.com."
   local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }

--- a/fast/stages/2-networking-e-nva-bgp/data/dns-policy-rules.yaml
+++ b/fast/stages/2-networking-e-nva-bgp/data/dns-policy-rules.yaml
@@ -81,6 +81,12 @@ googleapis-restricted:
 gstatic-all:
   dns_name: "*.gstatic.com."
   local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
+kernels-gu:
+  dns_name: "kernels.googleusercontent.com."
+  local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
+kernels-gu-all:
+  dns_name: "*.kernels.googleusercontent.com."
+  local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
 notebooks-all:
   dns_name: "*.notebooks.cloud.google.com."
   local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }

--- a/tests/fast/stages/s2_networking_a_peering/stage.yaml
+++ b/tests/fast/stages/s2_networking_a_peering/stage.yaml
@@ -14,4 +14,4 @@
 
 counts:
   modules: 28
-  resources: 145
+  resources: 147

--- a/tests/fast/stages/s2_networking_b_vpn/stage.yaml
+++ b/tests/fast/stages/s2_networking_b_vpn/stage.yaml
@@ -14,4 +14,4 @@
 
 counts:
   modules: 30
-  resources: 182
+  resources: 184

--- a/tests/fast/stages/s2_networking_c_nva/stage.yaml
+++ b/tests/fast/stages/s2_networking_c_nva/stage.yaml
@@ -14,4 +14,4 @@
 
 counts:
   modules: 42
-  resources: 192
+  resources: 194

--- a/tests/fast/stages/s2_networking_d_separate_envs/stage.yaml
+++ b/tests/fast/stages/s2_networking_d_separate_envs/stage.yaml
@@ -14,4 +14,4 @@
 
 counts:
   modules: 21
-  resources: 167
+  resources: 169

--- a/tests/fast/stages/s2_networking_d_separate_envs/stage.yaml
+++ b/tests/fast/stages/s2_networking_d_separate_envs/stage.yaml
@@ -14,4 +14,4 @@
 
 counts:
   modules: 21
-  resources: 165
+  resources: 167

--- a/tests/fast/stages/s2_networking_e_nva_bgp/stage.yaml
+++ b/tests/fast/stages/s2_networking_e_nva_bgp/stage.yaml
@@ -14,4 +14,4 @@
 
 counts:
   modules: 36
-  resources: 203
+  resources: 205


### PR DESCRIPTION
This PR adds kernels.googleusercontent.com zone in DNS response policy for supporting Vertex AI Managed Notebook as per the [following](https://cloud.google.com/vertex-ai/docs/workbench/managed/service-perimeter) documentation.

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
