### PR TITLE
Use new resources in GCVE module, bump provider versions

### DIFF
--- a/default-versions.tf
+++ b/default-versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/__experimental/alloydb-instance/versions.tf
+++ b/modules/__experimental/alloydb-instance/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/__experimental/net-neg/versions.tf
+++ b/modules/__experimental/net-neg/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/__experimental/project-iam-magic/versions.tf
+++ b/modules/__experimental/project-iam-magic/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/api-gateway/versions.tf
+++ b/modules/api-gateway/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/apigee/versions.tf
+++ b/modules/apigee/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/artifact-registry/versions.tf
+++ b/modules/artifact-registry/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/bigquery-dataset/versions.tf
+++ b/modules/bigquery-dataset/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/bigtable-instance/versions.tf
+++ b/modules/bigtable-instance/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/billing-account/versions.tf
+++ b/modules/billing-account/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/binauthz/versions.tf
+++ b/modules/binauthz/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/cloud-config-container/__need_fixing/onprem/versions.tf
+++ b/modules/cloud-config-container/__need_fixing/onprem/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/cloud-config-container/__need_fixing/squid/versions.tf
+++ b/modules/cloud-config-container/__need_fixing/squid/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/cloud-config-container/coredns/versions.tf
+++ b/modules/cloud-config-container/coredns/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/cloud-config-container/cos-generic-metadata/versions.tf
+++ b/modules/cloud-config-container/cos-generic-metadata/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/cloud-config-container/envoy-sni-dyn-fwd-proxy/versions.tf
+++ b/modules/cloud-config-container/envoy-sni-dyn-fwd-proxy/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/cloud-config-container/envoy-traffic-director/versions.tf
+++ b/modules/cloud-config-container/envoy-traffic-director/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/cloud-config-container/mysql/versions.tf
+++ b/modules/cloud-config-container/mysql/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/cloud-config-container/nginx-tls/versions.tf
+++ b/modules/cloud-config-container/nginx-tls/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/cloud-config-container/nginx/versions.tf
+++ b/modules/cloud-config-container/nginx/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/cloud-config-container/simple-nva/versions.tf
+++ b/modules/cloud-config-container/simple-nva/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/cloud-function-v1/versions.tf
+++ b/modules/cloud-function-v1/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/cloud-function-v2/versions.tf
+++ b/modules/cloud-function-v2/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/cloud-identity-group/versions.tf
+++ b/modules/cloud-identity-group/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/cloud-run/versions.tf
+++ b/modules/cloud-run/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/cloudsql-instance/versions.tf
+++ b/modules/cloudsql-instance/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/compute-mig/versions.tf
+++ b/modules/compute-mig/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/compute-vm/versions.tf
+++ b/modules/compute-vm/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/container-registry/versions.tf
+++ b/modules/container-registry/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/data-catalog-policy-tag/versions.tf
+++ b/modules/data-catalog-policy-tag/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/datafusion/versions.tf
+++ b/modules/datafusion/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/dataplex-datascan/versions.tf
+++ b/modules/dataplex-datascan/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/dataplex/versions.tf
+++ b/modules/dataplex/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/dataproc/versions.tf
+++ b/modules/dataproc/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/dns-response-policy/versions.tf
+++ b/modules/dns-response-policy/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/dns/versions.tf
+++ b/modules/dns/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/endpoints/versions.tf
+++ b/modules/endpoints/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/folder/versions.tf
+++ b/modules/folder/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/gcs/versions.tf
+++ b/modules/gcs/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/gcve-private-cloud/README.md
+++ b/modules/gcve-private-cloud/README.md
@@ -1,6 +1,6 @@
 # Google Cloud VMWare Engine Private Cloud Module
 
-This module implements the creation and management of a Google Cloud VMWare Engine Private Cloud with its management cluster. If configured, it also creates the VMWare engine network or it can work with an existing one. The creation of the private connection with the user VPC requires the execution of the  [Google SDK command](https://cloud.google.com/sdk/gcloud/reference/vmware/private-connections/create#--routing-mode) the module provides as an output.
+This module implements the creation and management of a Google Cloud VMWare Engine Private Cloud with its management cluster. If configured, it also creates the VMWare engine network or it can work with an existing one. The module optionally creates peering connections to users' VPCs or other VMware engine networks.
 
 To understand the limits and to properly configure the vSphere/vSAN subnets CIDR range please refer to the [GCVE public documentation](https://cloud.google.com/vmware-engine/docs/quickstart-networking-requirements).
 
@@ -29,17 +29,15 @@ module "gcve-pc" {
   zone       = "europe-west8-a"
   cidr       = "192.168.0.0/24"
 
-  private_connections = {
+  network_peerings = {
     transit-conn1 = {
-      name                = "transit-conn1"
-      network_self_link   = "projects/test-prj-gcve-01/global/networks/default"
-      tenant_host_project = "g39a814990532d10ap-tp"
-      type                = "PRIVATE_SERVICE_ACCESS"
-      routing_mode        = "REGIONAL"
+      name              = "transit-conn1"
+      network_self_link = "projects/test-prj-gcve-01/global/networks/default"
+      type              = "STANDARD"
     }
   }
 }
-# tftest modules=1 resources=2 inventory=basic.yaml
+# tftest modules=1 resources=3 inventory=basic.yaml
 ```
 ## Private Cloud Creation with custom nodes and cores count
 
@@ -57,17 +55,15 @@ module "gcve-pc" {
     custom_core_count = 28
   }
 
-  private_connections = {
+  network_peerings = {
     transit-conn1 = {
-      name                = "transit-conn1"
-      network_self_link   = "projects/test-prj-gcve-01/global/networks/default"
-      tenant_host_project = "g39a814990532d10ap-tp"
-      type                = "PRIVATE_SERVICE_ACCESS"
-      routing_mode        = "REGIONAL"
+      name              = "transit-conn1"
+      network_self_link = "projects/test-prj-gcve-01/global/networks/default"
+      type              = "STANDARD"
     }
   }
 }
-# tftest modules=1 resources=2 inventory=custom.yaml
+# tftest modules=1 resources=3 inventory=custom.yaml
 ```
 <!-- BEGIN TFDOC -->
 ## Variables
@@ -76,13 +72,13 @@ module "gcve-pc" {
 |---|---|:---:|:---:|:---:|
 | [cidr](variables.tf#L16) | vSphere/vSAN subnets CIDR range. To undersatnd the limits, please refer to [GCVE network requirements](https://cloud.google.com/vmware-engine/docs/quickstart-networking-requirements). | <code>string</code> | ✓ |  |
 | [name](variables.tf#L42) | Private cloud name. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L84) | Project id. | <code>string</code> | ✓ |  |
-| [zone](variables.tf#L101) | Private cloud zone. | <code>string</code> | ✓ |  |
+| [network_peerings](variables.tf#L47) | The network peerings towards users' VPCs or other VMware Engine networks. The key is the peering name suffix. | <code title="map&#40;object&#40;&#123;&#10;  description                         &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  network_self_link                   &#61; string&#10;  type                                &#61; string&#10;  export_custom_routes                &#61; optional&#40;bool, false&#41;&#10;  import_custom_routes                &#61; optional&#40;bool, false&#41;&#10;  export_custom_routes_with_public_ip &#61; optional&#40;bool, false&#41;&#10;  import_custom_routes_with_public_ip &#61; optional&#40;bool, false&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> | ✓ |  |
+| [project_id](variables.tf#L67) | Project id. | <code>string</code> | ✓ |  |
+| [zone](variables.tf#L84) | Private cloud zone. | <code>string</code> | ✓ |  |
 | [description](variables.tf#L21) | Private cloud description. | <code>string</code> |  | <code>&#34;Terraform-managed.&#34;</code> |
 | [management_cluster_config](variables.tf#L27) | Management cluster configuration. | <code title="object&#40;&#123;&#10;  node_type_id      &#61; string&#10;  node_count        &#61; number,&#10;  custom_core_count &#61; number&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code title="&#123;&#10;  node_type_id      &#61; &#34;standard-72&#34;,&#10;  node_count        &#61; 3,&#10;  custom_core_count &#61; null&#10;&#125;">&#123;&#8230;&#125;</code> |
-| [private_connections](variables.tf#L47) | VMWare private connections configuration. It is used to create the gcloud command printed as output. | <code title="map&#40;object&#40;&#123;&#10;  name                &#61; string&#10;  network_self_link   &#61; string&#10;  peering_name        &#61; optional&#40;string&#41;&#10;  tenant_host_project &#61; optional&#40;string&#41;&#10;  description         &#61; optional&#40;string, &#34;Terraform-managed.&#34;&#41;&#10;  type                &#61; optional&#40;string, &#34;PRIVATE_SERVICE_ACCESS&#34;&#41;&#10;  routing_mode        &#61; optional&#40;string, &#34;REGIONAL&#34;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [vmw_network_create](variables.tf#L89) | Create the VMware Engine network. When set to false, it uses a data source to reference an existing VMware Engine network. | <code>bool</code> |  | <code>true</code> |
-| [vmw_network_description](variables.tf#L95) |  VMware Engine network description. | <code>string</code> |  | <code>&#34;Terraform-managed.&#34;</code> |
+| [vmw_network_create](variables.tf#L72) | Create the VMware Engine network. When set to false, it uses a data source to reference an existing VMware Engine network. | <code>bool</code> |  | <code>true</code> |
+| [vmw_network_description](variables.tf#L78) |  VMware Engine network description. | <code>string</code> |  | <code>&#34;Terraform-managed.&#34;</code> |
 
 ## Outputs
 
@@ -94,7 +90,6 @@ module "gcve-pc" {
 | [network_config](outputs.tf#L32) | Details about the network configuration of the private cloud. |  |
 | [nsx](outputs.tf#L37) | Details about a NSX Manager appliance. |  |
 | [private-cloud](outputs.tf#L42) | The private cloud resource. |  |
-| [private_connections_setup](outputs.tf#L47) | Cloud SDK commands for the private connections manual setup. |  |
-| [state](outputs.tf#L63) | Details about the state of the private cloud. |  |
-| [vcenter](outputs.tf#L68) | Details about a vCenter Server management appliance. |  |
+| [state](outputs.tf#L47) | Details about the state of the private cloud. |  |
+| [vcenter](outputs.tf#L52) | Details about a vCenter Server management appliance. |  |
 <!-- END TFDOC -->

--- a/modules/gcve-private-cloud/README.md
+++ b/modules/gcve-private-cloud/README.md
@@ -1,6 +1,9 @@
 # Google Cloud VMWare Engine Private Cloud Module
 
-This module implements the creation and management of a Google Cloud VMWare Engine Private Cloud with its management cluster. If configured, it also creates the VMWare engine network or it can work with an existing one. The module optionally creates peering connections to users' VPCs or other VMware engine networks.
+The module manages one or more Google Cloud VMWare Engine Private Clouds.
+
+It also optionally creates:
+- A VMWare engine network, shared betwee or it can work with an existing one. The module optionally creates peering connections to users' VPCs or other VMware engine networks.
 
 To understand the limits and to properly configure the vSphere/vSAN subnets CIDR range please refer to the [GCVE public documentation](https://cloud.google.com/vmware-engine/docs/quickstart-networking-requirements).
 
@@ -9,87 +12,127 @@ Be aware that the deployment of this module might require up to 2 hours dependin
 <!-- BEGIN TOC -->
 - [Limitations](#limitations)
 - [Basic Private Cloud Creation](#basic-private-cloud-creation)
-- [Private Cloud Creation with custom nodes and cores count](#private-cloud-creation-with-custom-nodes-and-cores-count)
+- [Customize management cluster configs](#customize-management-cluster-configs)
+- [Create additional clusters](#create-additional-clusters)
 - [Variables](#variables)
 - [Outputs](#outputs)
 <!-- END TOC -->
 
 ## Limitations
-At the moment this module doesn't support the following use cases:
-- Single node private cloud
-- Stretched private cloud
+
+At the moment this module doesn't support the creation of stretched private clouds.
 
 ## Basic Private Cloud Creation
 
 ```hcl
 module "gcve-pc" {
   source     = "./fabric/modules/gcve-private-cloud"
-  name       = "gcve-pc"
+  prefix     = "gcve-pc"
   project_id = "gcve-test-project"
-  zone       = "europe-west8-a"
-  cidr       = "192.168.0.0/24"
 
-  network_peerings = {
+  vmw_network_peerings = {
     transit-conn1 = {
-      name              = "transit-conn1"
-      network_self_link = "projects/test-prj-gcve-01/global/networks/default"
-      type              = "STANDARD"
+      name         = "to-my-vpc"
+      peer_network = "projects/test-prj-gcve-01/global/networks/default"
+    }
+  }
+
+  vmw_private_cloud_configs = {
+    pcc_one = {
+      cidr = "192.168.0.0/24"
+      zone = "europe-west8-a"
     }
   }
 }
 # tftest modules=1 resources=3 inventory=basic.yaml
 ```
-## Private Cloud Creation with custom nodes and cores count
+
+## Customize management cluster configs
+
+You can customize the management cluster of each VMware engine private cloud.
 
 ```hcl
 module "gcve-pc" {
   source     = "./fabric/modules/gcve-private-cloud"
-  name       = "gcve-pc"
+  prefix     = "gcve-pc"
   project_id = "gcve-test-project"
-  zone       = "europe-west8-a"
-  cidr       = "192.168.0.0/24"
 
-  management_cluster_config = {
-    node_type_id      = "standard-72"
-    node_count        = 6
-    custom_core_count = 28
+  vmw_network_peerings = {
+    transit-conn1 = {
+      name         = "to-my-vpc"
+      peer_network = "projects/test-prj-gcve-01/global/networks/default"
+    }
   }
 
-  network_peerings = {
-    transit-conn1 = {
-      name              = "transit-conn1"
-      network_self_link = "projects/test-prj-gcve-01/global/networks/default"
-      type              = "STANDARD"
+  vmw_private_cloud_configs = {
+    pcc_one = {
+      cidr = "192.168.0.0/24"
+      management_cluster_config = {
+        node_type_id      = "standard-72"
+        node_count        = 6
+        custom_core_count = 28
+      }
+      zone = "europe-west8-a"
     }
   }
 }
-# tftest modules=1 resources=3 inventory=custom.yaml
+# tftest modules=1 resources=3 inventory=custom-management.yaml
+```
+
+## Create additional clusters
+
+You can optionally create additional clusters in each VMware engine private cloud.
+
+```hcl
+module "gcve-pc" {
+  source     = "./fabric/modules/gcve-private-cloud"
+  prefix     = "gcve-pc"
+  project_id = "gcve-test-project"
+
+  vmw_network_peerings = {
+    transit-conn1 = {
+      name         = "to-my-vpc"
+      peer_network = "projects/test-prj-gcve-01/global/networks/default"
+    }
+  }
+
+  vmw_private_cloud_configs = {
+    pcc_one = {
+      cidr = "192.168.0.0/24"
+      additional_cluster_configs = {
+        test-cluster-one = {
+          node_type_id      = "standard-72"
+          node_count        = 6
+          custom_core_count = 28
+        }
+        test-cluster-two = {
+          node_type_id      = "standard-72"
+          node_count        = 4
+          custom_core_count = 28
+        }
+      }
+      zone = "europe-west8-a"
+    }
+  }
+}
+# tftest modules=1 resources=5 inventory=additional-clusters.yaml
 ```
 <!-- BEGIN TFDOC -->
 ## Variables
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [cidr](variables.tf#L16) | vSphere/vSAN subnets CIDR range. To undersatnd the limits, please refer to [GCVE network requirements](https://cloud.google.com/vmware-engine/docs/quickstart-networking-requirements). | <code>string</code> | ✓ |  |
-| [name](variables.tf#L42) | Private cloud name. | <code>string</code> | ✓ |  |
-| [network_peerings](variables.tf#L47) | The network peerings towards users' VPCs or other VMware Engine networks. The key is the peering name suffix. | <code title="map&#40;object&#40;&#123;&#10;  description                         &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  network_self_link                   &#61; string&#10;  type                                &#61; string&#10;  export_custom_routes                &#61; optional&#40;bool, false&#41;&#10;  import_custom_routes                &#61; optional&#40;bool, false&#41;&#10;  export_custom_routes_with_public_ip &#61; optional&#40;bool, false&#41;&#10;  import_custom_routes_with_public_ip &#61; optional&#40;bool, false&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> | ✓ |  |
-| [project_id](variables.tf#L67) | Project id. | <code>string</code> | ✓ |  |
-| [zone](variables.tf#L84) | Private cloud zone. | <code>string</code> | ✓ |  |
-| [description](variables.tf#L21) | Private cloud description. | <code>string</code> |  | <code>&#34;Terraform-managed.&#34;</code> |
-| [management_cluster_config](variables.tf#L27) | Management cluster configuration. | <code title="object&#40;&#123;&#10;  node_type_id      &#61; string&#10;  node_count        &#61; number,&#10;  custom_core_count &#61; number&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code title="&#123;&#10;  node_type_id      &#61; &#34;standard-72&#34;,&#10;  node_count        &#61; 3,&#10;  custom_core_count &#61; null&#10;&#125;">&#123;&#8230;&#125;</code> |
-| [vmw_network_create](variables.tf#L72) | Create the VMware Engine network. When set to false, it uses a data source to reference an existing VMware Engine network. | <code>bool</code> |  | <code>true</code> |
-| [vmw_network_description](variables.tf#L78) |  VMware Engine network description. | <code>string</code> |  | <code>&#34;Terraform-managed.&#34;</code> |
+| [prefix](variables.tf#L17) | Resources name prefix. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L22) | Project id. | <code>string</code> | ✓ |  |
+| [vmw_network_config](variables.tf#L27) | VMware Engine network configuration. | <code title="object&#40;&#123;&#10;  create      &#61; optional&#40;bool, true&#41;&#10;  description &#61; optional&#40;string, &#34;Terraform-managed.&#34;&#41;&#10;  name        &#61; optional&#40;string, &#34;default&#34;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [vmw_network_peerings](variables.tf#L37) | The network peerings towards users' VPCs or other VMware Engine networks. The key is the peering name suffix. | <code title="map&#40;object&#40;&#123;&#10;  peer_network                        &#61; string&#10;  description                         &#61; optional&#40;string, &#34;Managed by Terraform.&#34;&#41;&#10;  export_custom_routes                &#61; optional&#40;bool, false&#41;&#10;  export_custom_routes_with_public_ip &#61; optional&#40;bool, false&#41;&#10;  import_custom_routes                &#61; optional&#40;bool, false&#41;&#10;  import_custom_routes_with_public_ip &#61; optional&#40;bool, false&#41;&#10;  peer_to_vmware_engine_network       &#61; optional&#40;bool, false&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [vmw_private_cloud_configs](variables.tf#L51) | The VMware private cloud configurations. The key is the unique private cloud name suffix. | <code title="map&#40;object&#40;&#123;&#10;  cidr &#61; string&#10;  zone &#61; string&#10;  additional_cluster_configs &#61; optional&#40;map&#40;object&#40;&#123;&#10;    custom_core_count &#61; optional&#40;number&#41;&#10;    node_count        &#61; optional&#40;number, 3&#41;&#10;    node_type_id      &#61; optional&#40;string, &#34;standard-72&#34;&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;  management_cluster_config &#61; optional&#40;object&#40;&#123;&#10;    custom_core_count &#61; optional&#40;number&#41;&#10;    name              &#61; optional&#40;string, &#34;mgmt-cluster&#34;&#41;&#10;    node_count        &#61; optional&#40;number, 3&#41;&#10;    node_type_id      &#61; optional&#40;string, &#34;standard-72&#34;&#41;&#10;  &#125;&#41;, &#123;&#125;&#41;&#10;  description &#61; optional&#40;string, &#34;Managed by Terraform.&#34;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code title="&#123;&#10;  pcc_one &#61; &#123;&#10;    cidr &#61; &#34;192.168.0.0&#47;24&#34;&#10;    additional_cluster_configs &#61; &#123;&#10;      test-cluster-one &#61; &#123;&#10;        node_type_id      &#61; &#34;standard-72&#34;&#10;        node_count        &#61; 6&#10;        custom_core_count &#61; 28&#10;      &#125;&#10;      test-cluster-two &#61; &#123;&#10;        node_type_id      &#61; &#34;standard-72&#34;&#10;        node_count        &#61; 4&#10;        custom_core_count &#61; 28&#10;      &#125;&#10;    &#125;&#10;    zone &#61; &#34;europe-west8-a&#34;&#10;  &#125;&#10;&#125;">&#123;&#8230;&#125;</code> |
 
 ## Outputs
 
 | name | description | sensitive |
 |---|---|:---:|
-| [hcx](outputs.tf#L17) | Details about a HCX Cloud Manager appliance. |  |
-| [id](outputs.tf#L22) | ID of the private cloud. |  |
-| [management_cluster](outputs.tf#L27) | Details of the management cluster of the private cloud. |  |
-| [network_config](outputs.tf#L32) | Details about the network configuration of the private cloud. |  |
-| [nsx](outputs.tf#L37) | Details about a NSX Manager appliance. |  |
-| [private-cloud](outputs.tf#L42) | The private cloud resource. |  |
-| [state](outputs.tf#L47) | Details about the state of the private cloud. |  |
-| [vcenter](outputs.tf#L52) | Details about a vCenter Server management appliance. |  |
+| [vmw_engine_network_config](outputs.tf#L17) | VMware engine network configuration. |  |
+| [vmw_engine_network_peerings](outputs.tf#L22) | The peerings created towards the user VPC or other VMware engine networks. |  |
+| [vmw_engine_private_clouds](outputs.tf#L27) | VMware engine private cloud resources. |  |
 <!-- END TFDOC -->

--- a/modules/gcve-private-cloud/main.tf
+++ b/modules/gcve-private-cloud/main.tf
@@ -15,63 +15,87 @@
  */
 
 locals {
-  region = regex("([a-z]*-[a-z]*[0-9]{1,2})-([a-z])", var.zone)[0]
+  # Creates a map of additional clusters objects, including their parent private cloud
+  additional_cluster_configs = merge(
+    [for pcc_name, pcc in var.vmw_private_cloud_configs
+      : { for cluster_name, cluster in pcc.additional_cluster_configs
+        : "${cluster_name}" => merge(
+          cluster,
+          { parent = try(google_vmwareengine_private_cloud.vmw_engine_private_clouds[pcc_name].id, null) }
+        )
+      }
+  ]...)
   vmw_network = (
-    var.vmw_network_create
-    ? try(google_vmwareengine_network.private-cloud-network.0, null)
-    : try(data.google_vmwareengine_network.private-cloud-network.0, null)
+    var.vmw_network_config.create
+    ? try(google_vmwareengine_network.private_cloud_network.0, null)
+    : try(data.google_vmwareengine_network.private_cloud_network.0, null)
   )
 }
 
-resource "google_vmwareengine_network" "private-cloud-network" {
-  count       = var.vmw_network_create ? 1 : 0
+resource "google_vmwareengine_network" "private_cloud_network" {
+  provider    = google-beta
+  count       = var.vmw_network_config.create ? 1 : 0
   project     = var.project_id
-  name        = "${var.name}-network-default"
+  name        = "${var.prefix}-${var.vmw_network_config.name}"
+  description = var.vmw_network_config.description
   location    = "global"
   type        = "STANDARD"
-  description = var.vmw_network_description
 }
 
-data "google_vmwareengine_network" "private-cloud-network" {
-  count    = var.vmw_network_create ? 0 : 1
+data "google_vmwareengine_network" "private_cloud_network" {
   provider = google-beta
+  count    = var.vmw_network_config.create ? 0 : 1
   project  = var.project_id
-  name     = "${local.region}-default"
+  name     = "${var.prefix}-${var.vmw_network_config.name}"
   location = "global"
 }
 
-resource "google_vmwareengine_network_peering" "vmw-engine-network-peering" {
-  for_each                            = var.network_peerings
-  name                                = "${var.name}-${each.key}"
+resource "google_vmwareengine_network_peering" "vmw_engine_network_peerings" {
+  provider                            = google-beta
+  for_each                            = var.vmw_network_peerings
   project                             = var.project_id
+  name                                = "${var.prefix}-${each.key}"
   description                         = each.value.description
-  vmware_engine_network               = local.vmw_network
-  peer_network                        = each.value.network_self_link
-  peer_network_type                   = each.value.type
   export_custom_routes                = each.value.export_custom_routes
-  import_custom_routes                = each.value.import_custom_routes
   export_custom_routes_with_public_ip = each.value.export_custom_routes_with_public_ip
+  import_custom_routes                = each.value.import_custom_routes
   import_custom_routes_with_public_ip = each.value.import_custom_routes_with_public_ip
+  peer_network                        = each.value.peer_network
+  peer_network_type                   = each.value.peer_to_vmware_engine_network ? "VMWARE_ENGINE_NETWORK" : "STANDARD"
+  vmware_engine_network               = local.vmw_network.id
 }
 
-resource "google_vmwareengine_private_cloud" "private-cloud" {
+resource "google_vmwareengine_private_cloud" "vmw_engine_private_clouds" {
   provider    = google-beta
+  for_each    = var.vmw_private_cloud_configs
   project     = var.project_id
-  location    = var.zone
-  name        = var.name
-  description = var.description
+  location    = each.value.zone
+  name        = "${var.prefix}-${each.key}"
+  description = each.value.description
 
   network_config {
-    management_cidr       = var.cidr
+    management_cidr       = each.value.cidr
     vmware_engine_network = local.vmw_network.id
   }
 
   management_cluster {
-    cluster_id = "${var.name}-mgmt-cluster"
+    cluster_id = "${var.prefix}-${each.key}-${each.value.management_cluster_config.name}"
     node_type_configs {
-      node_type_id      = var.management_cluster_config.node_type_id
-      node_count        = var.management_cluster_config.node_count
-      custom_core_count = var.management_cluster_config.custom_core_count
+      node_type_id      = each.value.management_cluster_config.node_type_id
+      node_count        = each.value.management_cluster_config.node_count
+      custom_core_count = each.value.management_cluster_config.custom_core_count
     }
+  }
+}
+
+resource "google_vmwareengine_cluster" "vmw_engine_additional_clusters" {
+  provider = google-beta
+  for_each = local.additional_cluster_configs
+  name     = "${var.prefix}-${each.key}"
+  parent   = each.value.parent
+  node_type_configs {
+    custom_core_count = each.value.custom_core_count
+    node_count        = each.value.node_count
+    node_type_id      = each.value.node_type_id
   }
 }

--- a/modules/gcve-private-cloud/main.tf
+++ b/modules/gcve-private-cloud/main.tf
@@ -25,10 +25,9 @@ locals {
 
 resource "google_vmwareengine_network" "private-cloud-network" {
   count       = var.vmw_network_create ? 1 : 0
-  provider    = google-beta
   project     = var.project_id
-  name        = "${local.region}-default"
-  location    = local.region
+  name        = "${var.name}-network-default"
+  location    = "global"
   type        = "STANDARD"
   description = var.vmw_network_description
 }
@@ -38,11 +37,10 @@ data "google_vmwareengine_network" "private-cloud-network" {
   provider = google-beta
   project  = var.project_id
   name     = "${local.region}-default"
-  location = local.region
+  location = "global"
 }
 
 resource "google_vmwareengine_network_peering" "vmw-engine-network-peering" {
-  provider                            = google-beta
   for_each                            = var.network_peerings
   name                                = "${var.name}-${each.key}"
   project                             = var.project_id

--- a/modules/gcve-private-cloud/main.tf
+++ b/modules/gcve-private-cloud/main.tf
@@ -21,11 +21,16 @@ locals {
     ? try(google_vmwareengine_network.private-cloud-network.0, null)
     : try(data.google_vmwareengine_network.private-cloud-network.0, null)
   )
-  tenant_host_project = {
-    for k, v in var.private_connections : k => v.tenant_host_project == null
-    ? regex("(.*)/projects/([a-z0-9-]*)/(.*)", "${data.google_compute_network_peering.psa_peering[k].peer_network}")[1]
-    : v.tenant_host_project
-  }
+}
+
+resource "google_vmwareengine_network" "private-cloud-network" {
+  count       = var.vmw_network_create ? 1 : 0
+  provider    = google-beta
+  project     = var.project_id
+  name        = "${local.region}-default"
+  location    = local.region
+  type        = "STANDARD"
+  description = var.vmw_network_description
 }
 
 data "google_vmwareengine_network" "private-cloud-network" {
@@ -36,10 +41,19 @@ data "google_vmwareengine_network" "private-cloud-network" {
   location = local.region
 }
 
-data "google_compute_network_peering" "psa_peering" {
-  for_each = { for k, v in var.private_connections : k => v if v.tenant_host_project == null }
-  name     = each.value.peering_name
-  network  = each.value.network_self_link
+resource "google_vmwareengine_network_peering" "vmw-engine-network-peering" {
+  provider                            = google-beta
+  for_each                            = var.network_peerings
+  name                                = "${var.name}-${each.key}"
+  project                             = var.project_id
+  description                         = each.value.description
+  vmware_engine_network               = local.vmw_network
+  peer_network                        = each.value.network_self_link
+  peer_network_type                   = each.value.type
+  export_custom_routes                = each.value.export_custom_routes
+  import_custom_routes                = each.value.import_custom_routes
+  export_custom_routes_with_public_ip = each.value.export_custom_routes_with_public_ip
+  import_custom_routes_with_public_ip = each.value.import_custom_routes_with_public_ip
 }
 
 resource "google_vmwareengine_private_cloud" "private-cloud" {
@@ -62,14 +76,4 @@ resource "google_vmwareengine_private_cloud" "private-cloud" {
       custom_core_count = var.management_cluster_config.custom_core_count
     }
   }
-}
-
-resource "google_vmwareengine_network" "private-cloud-network" {
-  count       = var.vmw_network_create ? 1 : 0
-  provider    = google-beta
-  project     = var.project_id
-  name        = "${local.region}-default"
-  location    = local.region
-  type        = "LEGACY"
-  description = var.vmw_network_description
 }

--- a/modules/gcve-private-cloud/outputs.tf
+++ b/modules/gcve-private-cloud/outputs.tf
@@ -44,22 +44,6 @@ output "private-cloud" {
   value       = google_vmwareengine_private_cloud.private-cloud
 }
 
-output "private_connections_setup" {
-  description = "Cloud SDK commands for the private connections manual setup."
-  value = {
-    for k, v in var.private_connections : k => <<EOT
-    gcloud vmware private-connections create ${v.name} \
-  --location=${local.region} \
-  --project=${var.project_id} \
-  --vmware-engine-network=${local.region}-default \ 
-  --description="${v.description}" \
-  --routing-mode=${v.routing_mode} \
-  --service-project=${local.tenant_host_project[k]} \ 
-  --type=${v.type}
-  EOT
-  }
-}
-
 output "state" {
   description = "Details about the state of the private cloud."
   value       = google_vmwareengine_private_cloud.private-cloud.state

--- a/modules/gcve-private-cloud/outputs.tf
+++ b/modules/gcve-private-cloud/outputs.tf
@@ -14,42 +14,17 @@
  * limitations under the License.
  */
 
-output "hcx" {
-  description = "Details about a HCX Cloud Manager appliance."
-  value       = google_vmwareengine_private_cloud.private-cloud.hcx
+output "vmw_engine_network_config" {
+  description = "VMware engine network configuration."
+  value       = local.vmw_network
 }
 
-output "id" {
-  description = "ID of the private cloud."
-  value       = google_vmwareengine_private_cloud.private-cloud.id
+output "vmw_engine_network_peerings" {
+  description = "The peerings created towards the user VPC or other VMware engine networks."
+  value       = google_vmwareengine_network_peering.vmw_engine_network_peerings
 }
 
-output "management_cluster" {
-  description = "Details of the management cluster of the private cloud."
-  value       = google_vmwareengine_private_cloud.private-cloud.management_cluster
-}
-
-output "network_config" {
-  description = "Details about the network configuration of the private cloud."
-  value       = google_vmwareengine_private_cloud.private-cloud.network_config
-}
-
-output "nsx" {
-  description = "Details about a NSX Manager appliance."
-  value       = google_vmwareengine_private_cloud.private-cloud.nsx
-}
-
-output "private-cloud" {
-  description = "The private cloud resource."
-  value       = google_vmwareengine_private_cloud.private-cloud
-}
-
-output "state" {
-  description = "Details about the state of the private cloud."
-  value       = google_vmwareengine_private_cloud.private-cloud.state
-}
-
-output "vcenter" {
-  description = "Details about a vCenter Server management appliance."
-  value       = google_vmwareengine_private_cloud.private-cloud.vcenter
+output "vmw_engine_private_clouds" {
+  description = "VMware engine private cloud resources."
+  value       = google_vmwareengine_private_cloud.vmw_engine_private_clouds
 }

--- a/modules/gcve-private-cloud/variables.tf
+++ b/modules/gcve-private-cloud/variables.tf
@@ -44,40 +44,23 @@ variable "name" {
   type        = string
 }
 
-variable "private_connections" {
-  description = "VMWare private connections configuration. It is used to create the gcloud command printed as output."
+variable "network_peerings" {
+  description = "The network peerings towards users' VPCs or other VMware Engine networks. The key is the peering name suffix."
   type = map(object({
-    name                = string
-    network_self_link   = string
-    peering_name        = optional(string)
-    tenant_host_project = optional(string)
-    description         = optional(string, "Terraform-managed.")
-    type                = optional(string, "PRIVATE_SERVICE_ACCESS")
-    routing_mode        = optional(string, "REGIONAL")
+    description                         = optional(string, "Terraform managed.")
+    network_self_link                   = string
+    type                                = string
+    export_custom_routes                = optional(bool, false)
+    import_custom_routes                = optional(bool, false)
+    export_custom_routes_with_public_ip = optional(bool, false)
+    import_custom_routes_with_public_ip = optional(bool, false)
   }))
-  default  = {}
-  nullable = false
   validation {
     condition = alltrue([
-      for k, v in var.private_connections :
-      (v.peering_name != null) != (v.tenant_host_project != null)
-      ]
-    )
-    error_message = "Both peering_name and tenant_host_project variables have been set. Only one variable is allowed."
-  }
-  validation {
-    condition = alltrue([
-      for r in var.private_connections :
-      contains(["GLOBAL", "REGIONAL"], r.routing_mode)
+      for r in var.network_peerings :
+      contains(["STANDARD", "VMWARE_ENGINE_NETWORK"], r.type)
     ])
-    error_message = "Routing mode must be one of GLOBAL, REGIONAL."
-  }
-  validation {
-    condition = alltrue([
-      for r in var.private_connections :
-      contains(["DELL_POWERSCALE", "NETAPP_CLOUD_VOLUMES", "PRIVATE_SERVICE_ACCESS", "THIRD_PARTY_SERVICE"], r.type)
-    ])
-    error_message = "Type must be one of DELL_POWERSCALE, NETAPP_CLOUD_VOLUMES, PRIVATE_SERVICE_ACCESS, THIRD_PARTY_SERVICE."
+    error_message = "Type must be one of STANDARD, VMWARE_ENGINE_NETWORK."
   }
 }
 
@@ -102,7 +85,3 @@ variable "zone" {
   description = "Private cloud zone."
   type        = string
 }
-
-
-
-

--- a/modules/gcve-private-cloud/variables.tf
+++ b/modules/gcve-private-cloud/variables.tf
@@ -13,55 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-variable "cidr" {
-  description = "vSphere/vSAN subnets CIDR range. To undersatnd the limits, please refer to [GCVE network requirements](https://cloud.google.com/vmware-engine/docs/quickstart-networking-requirements)."
+
+variable "prefix" {
+  description = "Resources name prefix."
   type        = string
-}
-
-variable "description" {
-  description = "Private cloud description."
-  type        = string
-  default     = "Terraform-managed."
-}
-
-variable "management_cluster_config" {
-  description = "Management cluster configuration."
-  type = object({
-    node_type_id      = string
-    node_count        = number,
-    custom_core_count = number
-  })
-  default = {
-    node_type_id      = "standard-72",
-    node_count        = 3,
-    custom_core_count = null
-  }
-  nullable = false
-}
-
-variable "name" {
-  description = "Private cloud name."
-  type        = string
-}
-
-variable "network_peerings" {
-  description = "The network peerings towards users' VPCs or other VMware Engine networks. The key is the peering name suffix."
-  type = map(object({
-    description                         = optional(string, "Terraform managed.")
-    network_self_link                   = string
-    type                                = string
-    export_custom_routes                = optional(bool, false)
-    import_custom_routes                = optional(bool, false)
-    export_custom_routes_with_public_ip = optional(bool, false)
-    import_custom_routes_with_public_ip = optional(bool, false)
-  }))
-  validation {
-    condition = alltrue([
-      for r in var.network_peerings :
-      contains(["STANDARD", "VMWARE_ENGINE_NETWORK"], r.type)
-    ])
-    error_message = "Type must be one of STANDARD, VMWARE_ENGINE_NETWORK."
-  }
 }
 
 variable "project_id" {
@@ -69,19 +24,65 @@ variable "project_id" {
   type        = string
 }
 
-variable "vmw_network_create" {
-  description = "Create the VMware Engine network. When set to false, it uses a data source to reference an existing VMware Engine network."
-  type        = bool
-  default     = true
+variable "vmw_network_config" {
+  description = "VMware Engine network configuration."
+  type = object({
+    create      = optional(bool, true)
+    description = optional(string, "Terraform-managed.")
+    name        = optional(string, "default")
+  })
+  default = {}
 }
 
-variable "vmw_network_description" {
-  description = " VMware Engine network description."
-  type        = string
-  default     = "Terraform-managed."
+variable "vmw_network_peerings" {
+  description = "The network peerings towards users' VPCs or other VMware Engine networks. The key is the peering name suffix."
+  type = map(object({
+    peer_network                        = string
+    description                         = optional(string, "Managed by Terraform.")
+    export_custom_routes                = optional(bool, false)
+    export_custom_routes_with_public_ip = optional(bool, false)
+    import_custom_routes                = optional(bool, false)
+    import_custom_routes_with_public_ip = optional(bool, false)
+    peer_to_vmware_engine_network       = optional(bool, false)
+  }))
+  default = {}
 }
 
-variable "zone" {
-  description = "Private cloud zone."
-  type        = string
+variable "vmw_private_cloud_configs" {
+  description = "The VMware private cloud configurations. The key is the unique private cloud name suffix."
+  type = map(object({
+    cidr = string
+    zone = string
+    # The key is the unique additional cluster name suffix
+    additional_cluster_configs = optional(map(object({
+      custom_core_count = optional(number)
+      node_count        = optional(number, 3)
+      node_type_id      = optional(string, "standard-72")
+    })), {})
+    management_cluster_config = optional(object({
+      custom_core_count = optional(number)
+      name              = optional(string, "mgmt-cluster")
+      node_count        = optional(number, 3)
+      node_type_id      = optional(string, "standard-72")
+    }), {})
+    description = optional(string, "Managed by Terraform.")
+  }))
+  default = {
+    pcc_one = {
+      cidr = "192.168.0.0/24"
+      additional_cluster_configs = {
+        test-cluster-one = {
+          node_type_id      = "standard-72"
+          node_count        = 6
+          custom_core_count = 28
+        }
+        test-cluster-two = {
+          node_type_id      = "standard-72"
+          node_count        = 4
+          custom_core_count = 28
+        }
+      }
+      zone = "europe-west8-a"
+    }
+  }
 }

--- a/modules/gcve-private-cloud/versions.tf
+++ b/modules/gcve-private-cloud/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/gke-cluster-autopilot/versions.tf
+++ b/modules/gke-cluster-autopilot/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/gke-cluster-standard/versions.tf
+++ b/modules/gke-cluster-standard/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/gke-hub/versions.tf
+++ b/modules/gke-hub/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/gke-nodepool/versions.tf
+++ b/modules/gke-nodepool/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/iam-service-account/versions.tf
+++ b/modules/iam-service-account/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/kms/versions.tf
+++ b/modules/kms/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/logging-bucket/versions.tf
+++ b/modules/logging-bucket/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/ncc-spoke-ra/versions.tf
+++ b/modules/ncc-spoke-ra/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/net-address/versions.tf
+++ b/modules/net-address/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/net-cloudnat/versions.tf
+++ b/modules/net-cloudnat/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/net-firewall-policy/versions.tf
+++ b/modules/net-firewall-policy/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/net-ipsec-over-interconnect/versions.tf
+++ b/modules/net-ipsec-over-interconnect/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/net-lb-app-ext/versions.tf
+++ b/modules/net-lb-app-ext/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/net-lb-app-int/versions.tf
+++ b/modules/net-lb-app-int/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/net-lb-ext/versions.tf
+++ b/modules/net-lb-ext/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/net-lb-int/versions.tf
+++ b/modules/net-lb-int/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/net-lb-proxy-int/versions.tf
+++ b/modules/net-lb-proxy-int/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/net-swp/versions.tf
+++ b/modules/net-swp/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/net-vlan-attachment/versions.tf
+++ b/modules/net-vlan-attachment/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/net-vpc-firewall/versions.tf
+++ b/modules/net-vpc-firewall/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/net-vpc-peering/versions.tf
+++ b/modules/net-vpc-peering/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/net-vpc/versions.tf
+++ b/modules/net-vpc/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/net-vpn-dynamic/versions.tf
+++ b/modules/net-vpn-dynamic/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/net-vpn-ha/versions.tf
+++ b/modules/net-vpn-ha/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/net-vpn-static/versions.tf
+++ b/modules/net-vpn-static/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/organization/versions.tf
+++ b/modules/organization/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/project/versions.tf
+++ b/modules/project/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/projects-data-source/versions.tf
+++ b/modules/projects-data-source/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/pubsub/versions.tf
+++ b/modules/pubsub/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/secret-manager/versions.tf
+++ b/modules/secret-manager/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/service-directory/versions.tf
+++ b/modules/service-directory/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/source-repository/versions.tf
+++ b/modules/source-repository/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/vpc-sc/versions.tf
+++ b/modules/vpc-sc/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/modules/workstation-cluster/versions.tf
+++ b/modules/workstation-cluster/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/tests/examples_e2e/setup_module/versions.tf
+++ b/tests/examples_e2e/setup_module/versions.tf
@@ -17,13 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 6.0.0" # tftest
+      version = ">= 5.10.0, < 6.0.0" # tftest
     }
   }
 }
-
-

--- a/tests/modules/gcve_private_cloud/examples/additional-clusters.yaml
+++ b/tests/modules/gcve_private_cloud/examples/additional-clusters.yaml
@@ -13,15 +13,26 @@
 # limitations under the License.
 
 values:
-  module.gcve-pc.google_vmwareengine_network.private-cloud-network[0]:
+  module.gcve-pc.google_vmwareengine_cluster.vmw_engine_additional_clusters["test-cluster-one"]:
+    name: gcve-pc-test-cluster-one
+    node_type_configs:
+    - custom_core_count: 28
+      node_count: 6
+      node_type_id: standard-72
+  module.gcve-pc.google_vmwareengine_cluster.vmw_engine_additional_clusters["test-cluster-two"]:
+    name: gcve-pc-test-cluster-two
+    node_type_configs:
+    - custom_core_count: 28
+      node_count: 4
+      node_type_id: standard-72
+  module.gcve-pc.google_vmwareengine_network.private_cloud_network[0]:
     description: Terraform-managed.
     location: global
-    name: gcve-pc-network-default
+    name: gcve-pc-default
     project: gcve-test-project
-    timeouts: null
     type: STANDARD
-  module.gcve-pc.google_vmwareengine_network_peering.vmw-engine-network-peering["transit-conn1"]:
-    description: Terraform managed.
+  module.gcve-pc.google_vmwareengine_network_peering.vmw_engine_network_peerings["transit-conn1"]:
+    description: Managed by Terraform.
     export_custom_routes: false
     export_custom_routes_with_public_ip: false
     import_custom_routes: false
@@ -30,26 +41,25 @@ values:
     peer_network: projects/test-prj-gcve-01/global/networks/default
     peer_network_type: STANDARD
     project: gcve-test-project
-    timeouts: null
-  module.gcve-pc.google_vmwareengine_private_cloud.private-cloud:
-    description: Terraform-managed.
+  module.gcve-pc.google_vmwareengine_private_cloud.vmw_engine_private_clouds["pcc_one"]:
+    description: Managed by Terraform.
     location: europe-west8-a
     management_cluster:
-    - cluster_id: gcve-pc-mgmt-cluster
+    - cluster_id: gcve-pc-pcc_one-mgmt-cluster
       node_type_configs:
-      - custom_core_count: 28
-        node_count: 6
+      - custom_core_count: 0
+        node_count: 3
         node_type_id: standard-72
-    name: gcve-pc
+    name: gcve-pc-pcc_one
     network_config:
     - management_cidr: 192.168.0.0/24
     project: gcve-test-project
-    timeouts: null
     type: STANDARD
 
 counts:
+  google_vmwareengine_cluster: 2
   google_vmwareengine_network: 1
   google_vmwareengine_network_peering: 1
   google_vmwareengine_private_cloud: 1
   modules: 1
-  resources: 3
+  resources: 5

--- a/tests/modules/gcve_private_cloud/examples/basic.yaml
+++ b/tests/modules/gcve_private_cloud/examples/basic.yaml
@@ -19,7 +19,18 @@ values:
     name: europe-west8-default
     project: gcve-test-project
     timeouts: null
-    type: LEGACY
+    type: STANDARD
+  module.gcve-pc.google_vmwareengine_network_peering.vmw-engine-network-peering["transit-conn1"]:
+    description: Terraform managed.
+    export_custom_routes: false
+    export_custom_routes_with_public_ip: false
+    import_custom_routes: false
+    import_custom_routes_with_public_ip: false
+    name: gcve-pc-transit-conn1
+    peer_network: projects/test-prj-gcve-01/global/networks/default
+    peer_network_type: STANDARD
+    project: gcve-test-project
+    timeouts: null
   module.gcve-pc.google_vmwareengine_private_cloud.private-cloud:
     description: Terraform-managed.
     location: europe-west8-a
@@ -34,9 +45,11 @@ values:
     - management_cidr: 192.168.0.0/24
     project: gcve-test-project
     timeouts: null
+    type: STANDARD
 
 counts:
   google_vmwareengine_network: 1
+  google_vmwareengine_network_peering: 1
   google_vmwareengine_private_cloud: 1
   modules: 1
-  resources: 2
+  resources: 3

--- a/tests/modules/gcve_private_cloud/examples/basic.yaml
+++ b/tests/modules/gcve_private_cloud/examples/basic.yaml
@@ -15,8 +15,8 @@
 values:
   module.gcve-pc.google_vmwareengine_network.private-cloud-network[0]:
     description: Terraform-managed.
-    location: europe-west8
-    name: europe-west8-default
+    location: global
+    name: gcve-pc-network-default
     project: gcve-test-project
     timeouts: null
     type: STANDARD

--- a/tests/modules/gcve_private_cloud/examples/custom-management.yaml
+++ b/tests/modules/gcve_private_cloud/examples/custom-management.yaml
@@ -35,8 +35,8 @@ values:
     management_cluster:
     - cluster_id: gcve-pc-pcc_one-mgmt-cluster
       node_type_configs:
-      - custom_core_count: 0
-        node_count: 3
+      - custom_core_count: 28
+        node_count: 6
         node_type_id: standard-72
     name: gcve-pc-pcc_one
     network_config:

--- a/tests/modules/gcve_private_cloud/examples/custom.yaml
+++ b/tests/modules/gcve_private_cloud/examples/custom.yaml
@@ -19,7 +19,18 @@ values:
     name: europe-west8-default
     project: gcve-test-project
     timeouts: null
-    type: LEGACY
+    type: STANDARD
+  module.gcve-pc.google_vmwareengine_network_peering.vmw-engine-network-peering["transit-conn1"]:
+    description: Terraform managed.
+    export_custom_routes: false
+    export_custom_routes_with_public_ip: false
+    import_custom_routes: false
+    import_custom_routes_with_public_ip: false
+    name: gcve-pc-transit-conn1
+    peer_network: projects/test-prj-gcve-01/global/networks/default
+    peer_network_type: STANDARD
+    project: gcve-test-project
+    timeouts: null
   module.gcve-pc.google_vmwareengine_private_cloud.private-cloud:
     description: Terraform-managed.
     location: europe-west8-a
@@ -34,9 +45,11 @@ values:
     - management_cidr: 192.168.0.0/24
     project: gcve-test-project
     timeouts: null
+    type: STANDARD
 
 counts:
   google_vmwareengine_network: 1
+  google_vmwareengine_network_peering: 1
   google_vmwareengine_private_cloud: 1
   modules: 1
-  resources: 2
+  resources: 3

--- a/tests/modules/gcve_private_cloud/examples/custom.yaml
+++ b/tests/modules/gcve_private_cloud/examples/custom.yaml
@@ -15,8 +15,8 @@
 values:
   module.gcve-pc.google_vmwareengine_network.private-cloud-network[0]:
     description: Terraform-managed.
-    location: europe-west8
-    name: europe-west8-default
+    location: global
+    name: gcve-pc-network-default
     project: gcve-test-project
     timeouts: null
     type: STANDARD

--- a/tests/modules/gke_hub/examples/full.yaml
+++ b/tests/modules/gke_hub/examples/full.yaml
@@ -13,14 +13,127 @@
 # limitations under the License.
 
 values:
+  module.cluster_1.google_container_cluster.cluster:
+    addons_config:
+    - cloudrun_config:
+      - disabled: true
+        load_balancer_type: null
+      config_connector_config:
+      - enabled: false
+      dns_cache_config:
+      - enabled: false
+      gce_persistent_disk_csi_driver_config:
+      - enabled: false
+      gcp_filestore_csi_driver_config:
+      - enabled: false
+      gcs_fuse_csi_driver_config:
+      - enabled: false
+      gke_backup_agent_config:
+      - enabled: false
+      horizontal_pod_autoscaling:
+      - disabled: false
+      http_load_balancing:
+      - disabled: false
+      istio_config:
+      - auth: null
+        disabled: true
+      kalm_config:
+      - enabled: false
+      network_policy_config:
+      - disabled: true
+    allow_net_admin: null
+    binary_authorization: []
+    datapath_provider: ADVANCED_DATAPATH
+    default_max_pods_per_node: 110
+    deletion_protection: true
+    description: null
+    dns_config: []
+    enable_autopilot: null
+    enable_fqdn_network_policy: false
+    enable_intranode_visibility: false
+    enable_k8s_beta_apis: []
+    enable_kubernetes_alpha: false
+    enable_l4_ilb_subsetting: false
+    enable_legacy_abac: false
+    enable_multi_networking: false
+    enable_shielded_nodes: false
+    enable_tpu: false
+    fleet: []
+    initial_node_count: 1
+    location: europe-west1
+    logging_config:
+    - enable_components:
+      - SYSTEM_COMPONENTS
+    maintenance_policy:
+    - daily_maintenance_window:
+      - start_time: 03:00
+      maintenance_exclusion: []
+      recurring_window: []
+    master_auth:
+    - client_certificate_config:
+      - issue_client_certificate: false
+    master_authorized_networks_config:
+    - cidr_blocks:
+      - cidr_block: 10.0.0.0/8
+        display_name: rfc1918_10_8
+    min_master_version: null
+    monitoring_config:
+    - enable_components:
+      - SYSTEM_COMPONENTS
+      managed_prometheus:
+      - enabled: true
+    name: cluster-1
+    network_policy: []
+    node_config:
+    - advanced_machine_features: []
+      boot_disk_kms_key: null
+      enable_confidential_storage: null
+      ephemeral_storage_config: []
+      ephemeral_storage_local_ssd_config: []
+      fast_socket: []
+      gcfs_config: []
+      gvnic: []
+      host_maintenance_policy: []
+      kubelet_config: []
+      linux_node_config: []
+      local_nvme_ssd_block_config: []
+      node_group: null
+      preemptible: false
+      reservation_affinity: []
+      resource_labels: null
+      sandbox_config: []
+      sole_tenant_config: []
+      spot: false
+      tags: null
+      taint: []
+    node_pool_defaults:
+    - node_config_defaults:
+      - gcfs_config:
+        - enabled: false
+    pod_security_policy_config: []
+    private_cluster_config:
+    - enable_private_endpoint: true
+      enable_private_nodes: true
+      master_global_access_config:
+      - enabled: false
+      master_ipv4_cidr_block: 192.168.0.0/28
+      private_endpoint_subnetwork: null
+    project: gkehub-test
+    remove_default_node_pool: true
+    resource_labels: null
+    resource_usage_export_config: []
+    workload_identity_config:
+    - workload_pool: gkehub-test.svc.id.goog
   module.hub.google_gke_hub_feature.default["configmanagement"]:
+    fleet_default_member_config: []
+    labels: null
     location: global
     name: configmanagement
     project: gkehub-test
+    spec: []
   module.hub.google_gke_hub_feature_membership.default["cluster-1"]:
     configmanagement:
-    - binauthz: []
-      config_sync:
+    - config_sync:
       - git:
         - gcp_service_account_email: null
           https_proxy: null
@@ -30,6 +143,7 @@ values:
           sync_repo: https://github.com/danielmarzini/configsync-platform-example
           sync_rev: null
           sync_wait_secs: null
+        metrics_gcp_service_account_email: null
         oci: []
         prevent_drift: false
         source_format: hierarchy
@@ -49,18 +163,115 @@ values:
     feature: configmanagement
     location: global
     membership: cluster-1
+    membership_location: null
     mesh: []
     project: gkehub-test
   module.hub.google_gke_hub_membership.default["cluster-1"]:
     authority: []
+    description: null
     endpoint:
     - gke_cluster:
       - {}
+    labels: null
+    location: global
     membership_id: cluster-1
     project: gkehub-test
+  module.project.google_project.project[0]:
+    auto_create_network: false
+    billing_account: 123456-123456-123456
+    folder_id: '12345'
+    labels: null
+    name: gkehub-test
+    org_id: null
+    project_id: gkehub-test
+    skip_delete: false
+  module.project.google_project_service.project_services["anthosconfigmanagement.googleapis.com"]:
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: gkehub-test
+    service: anthosconfigmanagement.googleapis.com
+  module.project.google_project_service.project_services["container.googleapis.com"]:
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: gkehub-test
+    service: container.googleapis.com
+  module.project.google_project_service.project_services["gkeconnect.googleapis.com"]:
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: gkehub-test
+    service: gkeconnect.googleapis.com
+  module.project.google_project_service.project_services["gkehub.googleapis.com"]:
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: gkehub-test
+    service: gkehub.googleapis.com
+  module.project.google_project_service.project_services["mesh.googleapis.com"]:
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: gkehub-test
+    service: mesh.googleapis.com
+  module.project.google_project_service.project_services["multiclusteringress.googleapis.com"]:
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: gkehub-test
+    service: multiclusteringress.googleapis.com
+  module.project.google_project_service.project_services["multiclusterservicediscovery.googleapis.com"]:
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: gkehub-test
+    service: multiclusterservicediscovery.googleapis.com
+  module.project.google_project_service_identity.jit_si["gkehub.googleapis.com"]:
+    project: gkehub-test
+    service: gkehub.googleapis.com
+  module.project.google_project_service_identity.jit_si["multiclusteringress.googleapis.com"]:
+    project: gkehub-test
+    service: multiclusteringress.googleapis.com
+  module.vpc.google_compute_network.network[0]:
+    auto_create_subnetworks: false
+    delete_default_routes_on_create: false
+    description: Terraform-managed.
+    enable_ula_internal_ipv6: null
+    name: network
+    network_firewall_policy_enforcement_order: AFTER_CLASSIC_FIREWALL
+    project: gkehub-test
+    routing_mode: GLOBAL
+  module.vpc.google_compute_route.gateway["private-googleapis"]:
+    description: Terraform-managed.
+    dest_range: 199.36.153.8/30
+    name: network-private-googleapis
+    next_hop_gateway: default-internet-gateway
+    next_hop_ilb: null
+    next_hop_instance: null
+    next_hop_vpn_tunnel: null
+    priority: 1000
+    project: gkehub-test
+    tags: null
+  module.vpc.google_compute_route.gateway["restricted-googleapis"]:
+    description: Terraform-managed.
+    dest_range: 199.36.153.4/30
+    name: network-restricted-googleapis
+    next_hop_gateway: default-internet-gateway
+    next_hop_ilb: null
+    next_hop_instance: null
+    next_hop_vpn_tunnel: null
+    priority: 1000
+    project: gkehub-test
+    tags: null
+  module.vpc.google_compute_subnetwork.subnetwork["europe-west1/cluster-1"]:
+    description: Terraform-managed.
+    ip_cidr_range: 10.0.0.0/24
+    ipv6_access_type: null
+    log_config: []
+    name: cluster-1
+    private_ip_google_access: true
+    project: gkehub-test
+    region: europe-west1
+    role: null
+    secondary_ip_range: []
 
 counts:
   google_compute_network: 1
+  google_compute_route: 2
   google_compute_subnetwork: 1
   google_container_cluster: 1
   google_gke_hub_feature: 1
@@ -69,3 +280,5 @@ counts:
   google_project: 1
   google_project_service: 7
   google_project_service_identity: 2
+  modules: 4
+  resources: 18


### PR DESCRIPTION
- Allows users to create the new GCVE standard private cloud
- Allows users to create multiple private clouds using the same module instantiation
- Allows users to create peerings between the shared private cloud network and users' VPCs / other private vmware networks
- Allows users to create additional clusters for each private cloud
- Adds optionals/defaults to variables so users don't have to specify all of them for default configs
- Bumps up the provider to the latest version (needed for new GCVE resources)
- Fixes a gkehub test that now returns values in a slightly different format when using the new provider

---
**Checklist**

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
