### PR TITLE
GCVE: add network policy configuration

### DIFF
--- a/modules/gcve-private-cloud/README.md
+++ b/modules/gcve-private-cloud/README.md
@@ -13,6 +13,7 @@ The deployment might require up to 2 hours, depending on the selected private cl
 - [Basic Private Cloud Creation](#basic-private-cloud-creation)
 - [Customize management cluster configs](#customize-management-cluster-configs)
 - [Create additional clusters](#create-additional-clusters)
+- [Enable cluster Internet access and inbound connectivity](#enable-cluster-internet-access-and-inbound-connectivity)
 - [Variables](#variables)
 - [Outputs](#outputs)
 <!-- END TOC -->
@@ -113,6 +114,33 @@ module "gcve-pc" {
 }
 # tftest modules=1 resources=5 inventory=additional-clusters.yaml
 ```
+
+## Enable cluster Internet access and inbound connectivity
+
+```hcl
+module "gcve-pc" {
+  source     = "./fabric/modules/gcve-private-cloud"
+  prefix     = "gcve-pc"
+  project_id = "gcve-test-project"
+  vmw_network_config = {
+    network_policies = {
+      ew8 = {
+        edge_services_cidr       = "192.168.100.0/26"
+        region                   = "europe-west8"
+        expose_on_internet       = true
+        outbound_internet_access = true
+      }
+    }
+  }
+  vmw_private_cloud_configs = {
+    pcc_one = {
+      cidr = "192.168.0.0/24"
+      zone = "europe-west8-a"
+    }
+  }
+}
+# tftest modules=1 resources=3 inventory=network-policy.yaml
+```
 <!-- BEGIN TFDOC -->
 ## Variables
 
@@ -120,9 +148,9 @@ module "gcve-pc" {
 |---|---|:---:|:---:|:---:|
 | [prefix](variables.tf#L17) | Resources name prefix. | <code>string</code> | ✓ |  |
 | [project_id](variables.tf#L22) | Project id. | <code>string</code> | ✓ |  |
-| [vmw_network_config](variables.tf#L27) | VMware Engine network configuration. | <code title="object&#40;&#123;&#10;  create      &#61; optional&#40;bool, true&#41;&#10;  description &#61; optional&#40;string, &#34;Terraform-managed.&#34;&#41;&#10;  name        &#61; optional&#40;string, &#34;default&#34;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [vmw_network_peerings](variables.tf#L37) | The network peerings towards users' VPCs or other VMware Engine networks. The key is the peering name suffix. | <code title="map&#40;object&#40;&#123;&#10;  peer_network                        &#61; string&#10;  description                         &#61; optional&#40;string, &#34;Managed by Terraform.&#34;&#41;&#10;  export_custom_routes                &#61; optional&#40;bool, false&#41;&#10;  export_custom_routes_with_public_ip &#61; optional&#40;bool, false&#41;&#10;  import_custom_routes                &#61; optional&#40;bool, false&#41;&#10;  import_custom_routes_with_public_ip &#61; optional&#40;bool, false&#41;&#10;  peer_to_vmware_engine_network       &#61; optional&#40;bool, false&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [vmw_private_cloud_configs](variables.tf#L51) | The VMware private cloud configurations. The key is the unique private cloud name suffix. | <code title="map&#40;object&#40;&#123;&#10;  cidr &#61; string&#10;  zone &#61; string&#10;  additional_cluster_configs &#61; optional&#40;map&#40;object&#40;&#123;&#10;    custom_core_count &#61; optional&#40;number&#41;&#10;    node_count        &#61; optional&#40;number, 3&#41;&#10;    node_type_id      &#61; optional&#40;string, &#34;standard-72&#34;&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;  management_cluster_config &#61; optional&#40;object&#40;&#123;&#10;    custom_core_count &#61; optional&#40;number&#41;&#10;    name              &#61; optional&#40;string, &#34;mgmt-cluster&#34;&#41;&#10;    node_count        &#61; optional&#40;number, 3&#41;&#10;    node_type_id      &#61; optional&#40;string, &#34;standard-72&#34;&#41;&#10;  &#125;&#41;, &#123;&#125;&#41;&#10;  description &#61; optional&#40;string, &#34;Managed by Terraform.&#34;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code title="&#123;&#10;  pcc_one &#61; &#123;&#10;    cidr &#61; &#34;192.168.0.0&#47;24&#34;&#10;    additional_cluster_configs &#61; &#123;&#10;      test-cluster-one &#61; &#123;&#10;        node_type_id      &#61; &#34;standard-72&#34;&#10;        node_count        &#61; 6&#10;        custom_core_count &#61; 28&#10;      &#125;&#10;      test-cluster-two &#61; &#123;&#10;        node_type_id      &#61; &#34;standard-72&#34;&#10;        node_count        &#61; 4&#10;        custom_core_count &#61; 28&#10;      &#125;&#10;    &#125;&#10;    zone &#61; &#34;europe-west8-a&#34;&#10;  &#125;&#10;&#125;">&#123;&#8230;&#125;</code> |
+| [vmw_network_config](variables.tf#L27) | VMware Engine network configuration. | <code title="object&#40;&#123;&#10;  create      &#61; optional&#40;bool, true&#41;&#10;  description &#61; optional&#40;string, &#34;Terraform-managed.&#34;&#41;&#10;  name        &#61; optional&#40;string, &#34;default&#34;&#41;&#10;  network_policies &#61; optional&#40;map&#40;object&#40;&#123;&#10;    edge_services_cidr       &#61; string&#10;    region                   &#61; string&#10;    description              &#61; optional&#40;string, &#34;Terraform-managed.&#34;&#41;&#10;    expose_on_internet       &#61; optional&#40;bool&#41;&#10;    outbound_internet_access &#61; optional&#40;bool&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [vmw_network_peerings](variables.tf#L44) | The network peerings towards users' VPCs or other VMware Engine networks. The key is the peering name suffix. | <code title="map&#40;object&#40;&#123;&#10;  peer_network                        &#61; string&#10;  description                         &#61; optional&#40;string, &#34;Managed by Terraform.&#34;&#41;&#10;  export_custom_routes                &#61; optional&#40;bool, false&#41;&#10;  export_custom_routes_with_public_ip &#61; optional&#40;bool, false&#41;&#10;  import_custom_routes                &#61; optional&#40;bool, false&#41;&#10;  import_custom_routes_with_public_ip &#61; optional&#40;bool, false&#41;&#10;  peer_to_vmware_engine_network       &#61; optional&#40;bool, false&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [vmw_private_cloud_configs](variables.tf#L58) | The VMware private cloud configurations. The key is the unique private cloud name suffix. | <code title="map&#40;object&#40;&#123;&#10;  cidr &#61; string&#10;  zone &#61; string&#10;  additional_cluster_configs &#61; optional&#40;map&#40;object&#40;&#123;&#10;    custom_core_count &#61; optional&#40;number&#41;&#10;    node_count        &#61; optional&#40;number, 3&#41;&#10;    node_type_id      &#61; optional&#40;string, &#34;standard-72&#34;&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;  management_cluster_config &#61; optional&#40;object&#40;&#123;&#10;    custom_core_count &#61; optional&#40;number&#41;&#10;    name              &#61; optional&#40;string, &#34;mgmt-cluster&#34;&#41;&#10;    node_count        &#61; optional&#40;number, 3&#41;&#10;    node_type_id      &#61; optional&#40;string, &#34;standard-72&#34;&#41;&#10;  &#125;&#41;, &#123;&#125;&#41;&#10;  description &#61; optional&#40;string, &#34;Managed by Terraform.&#34;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code title="&#123;&#10;  pcc_one &#61; &#123;&#10;    cidr &#61; &#34;192.168.0.0&#47;24&#34;&#10;    additional_cluster_configs &#61; &#123;&#10;      test-cluster-one &#61; &#123;&#10;        node_type_id      &#61; &#34;standard-72&#34;&#10;        node_count        &#61; 6&#10;        custom_core_count &#61; 28&#10;      &#125;&#10;      test-cluster-two &#61; &#123;&#10;        node_type_id      &#61; &#34;standard-72&#34;&#10;        node_count        &#61; 4&#10;        custom_core_count &#61; 28&#10;      &#125;&#10;    &#125;&#10;    zone &#61; &#34;europe-west8-a&#34;&#10;  &#125;&#10;&#125;">&#123;&#8230;&#125;</code> |
 
 ## Outputs
 

--- a/modules/gcve-private-cloud/main.tf
+++ b/modules/gcve-private-cloud/main.tf
@@ -50,6 +50,25 @@ data "google_vmwareengine_network" "private_cloud_network" {
   location = "global"
 }
 
+resource "google_vmwareengine_network_policy" "vmw-engine-network-policy" {
+  provider              = google-beta
+  for_each              = var.vmw_network_config.network_policies
+  project               = var.project_id
+  name                  = "${var.prefix}-${each.key}"
+  description           = each.value.description
+  edge_services_cidr    = each.value.edge_services_cidr
+  location              = each.value.region
+  vmware_engine_network = local.vmw_network
+
+  external_ip {
+    enabled = each.value.expose_on_internet
+  }
+
+  internet_access {
+    enabled = each.value.outbound_internet_access
+  }
+}
+
 resource "google_vmwareengine_network_peering" "vmw_engine_network_peerings" {
   provider                            = google-beta
   for_each                            = var.vmw_network_peerings

--- a/modules/gcve-private-cloud/variables.tf
+++ b/modules/gcve-private-cloud/variables.tf
@@ -30,6 +30,13 @@ variable "vmw_network_config" {
     create      = optional(bool, true)
     description = optional(string, "Terraform-managed.")
     name        = optional(string, "default")
+    network_policies = optional(map(object({
+      edge_services_cidr       = string
+      region                   = string
+      description              = optional(string, "Terraform-managed.")
+      expose_on_internet       = optional(bool)
+      outbound_internet_access = optional(bool)
+    })), {})
   })
   default = {}
 }

--- a/tests/modules/gcve_private_cloud/examples/network-policy.yaml
+++ b/tests/modules/gcve_private_cloud/examples/network-policy.yaml
@@ -1,0 +1,52 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values:
+  module.gcve-pc.google_vmwareengine_network.private_cloud_network[0]:
+    description: Terraform-managed.
+    location: global
+    name: gcve-pc-default
+    project: gcve-test-project
+    type: STANDARD
+  module.gcve-pc.google_vmwareengine_network_policy.vmw-engine-network-policy["ew8"]:
+    description: Terraform-managed.
+    edge_services_cidr: 192.168.100.0/26
+    external_ip:
+    - enabled: true
+    internet_access:
+    - enabled: true
+    location: europe-west8
+    name: gcve-pc-ew8
+    project: gcve-test-project
+  module.gcve-pc.google_vmwareengine_private_cloud.vmw_engine_private_clouds["pcc_one"]:
+    description: Managed by Terraform.
+    location: europe-west8-a
+    management_cluster:
+    - cluster_id: gcve-pc-pcc_one-mgmt-cluster
+      node_type_configs:
+      - custom_core_count: 0
+        node_count: 3
+        node_type_id: standard-72
+    name: gcve-pc-pcc_one
+    network_config:
+    - management_cidr: 192.168.0.0/24
+    project: gcve-test-project
+    type: STANDARD
+
+counts:
+  google_vmwareengine_network: 1
+  google_vmwareengine_network_policy: 1
+  google_vmwareengine_private_cloud: 1
+  modules: 1
+  resources: 3


### PR DESCRIPTION
Adds the ability to configure regional network policies (internet access, inbound access) 

---
**Checklist**

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
