### PR TITLE
Fix variable region

### DIFF
--- a/tests/examples/variables.tf
+++ b/tests/examples/variables.tf
@@ -49,7 +49,7 @@ variable "project_id" {
 }
 
 variable "region" {
-  default = "region"
+  default = "europe-west8"
 }
 
 variable "service_account" {

--- a/tests/modules/cloud_run/examples/secrets.yaml
+++ b/tests/modules/cloud_run/examples/secrets.yaml
@@ -15,7 +15,7 @@
 values:
   module.cloud_run.google_cloud_run_service.service:
     autogenerate_revision_name: false
-    location: region
+    location: europe-west8
     metadata:
     - {}
     name: hello

--- a/tests/modules/net_address/examples/internal.yaml
+++ b/tests/modules/net_address/examples/internal.yaml
@@ -20,7 +20,7 @@ values:
     network: null
     project: project-id
     purpose: SHARED_LOADBALANCER_VIP
-    region: region
+    region: europe-west8
     subnetwork: subnet_self_link
   module.addresses.google_compute_address.internal["ilb-2"]:
     address: 10.0.0.2
@@ -29,7 +29,7 @@ values:
     name: ilb-2
     network: null
     project: project-id
-    region: region
+    region: europe-west8
     subnetwork: subnet_self_link
 
 counts:

--- a/tests/modules/net_address/examples/ipsec-interconnect.yaml
+++ b/tests/modules/net_address/examples/ipsec-interconnect.yaml
@@ -21,7 +21,7 @@ values:
     prefix_length: 29
     project: project-id
     purpose: IPSEC_INTERCONNECT
-    region: region
+    region: europe-west8
   module.addresses.google_compute_address.ipsec_interconnect["vpn-gw-range-2"]:
     address: 10.255.255.8
     address_type: INTERNAL
@@ -30,7 +30,7 @@ values:
     prefix_length: 29
     project: project-id
     purpose: IPSEC_INTERCONNECT
-    region: region
+    region: europe-west8
 
 counts:
   google_compute_address: 2

--- a/tests/modules/net_address/examples/ipv6.yaml
+++ b/tests/modules/net_address/examples/ipv6.yaml
@@ -19,7 +19,7 @@ values:
     ipv6_endpoint_type: NETLB
     name: nlb
     project: project-id
-    region: region
+    region: europe-west8
   module.addresses.google_compute_address.internal["ilb"]:
     address_type: INTERNAL
     ip_version: IPV6
@@ -28,7 +28,7 @@ values:
     network: null
     project: project-id
     purpose: SHARED_LOADBALANCER_VIP
-    region: region
+    region: europe-west8
     subnetwork: subnet_self_link
   module.addresses.google_compute_address.internal["vm"]:
     address_type: INTERNAL
@@ -37,7 +37,7 @@ values:
     name: vm
     network: null
     project: project-id
-    region: region
+    region: europe-west8
     subnetwork: subnet_self_link
 
 counts:

--- a/tests/modules/net_lb_ext/examples/dual_stack.yaml
+++ b/tests/modules/net_lb_ext/examples/dual_stack.yaml
@@ -27,7 +27,7 @@ values:
     ports: null
     project: project-id
     recreate_closed_psc: false
-    region: region
+    region: europe-west8
     service_label: null
     source_ip_ranges: null
     target: null
@@ -46,7 +46,7 @@ values:
     ports: null
     project: project-id
     recreate_closed_psc: false
-    region: region
+    region: europe-west8
     service_label: null
     source_ip_ranges: null
     target: null
@@ -68,7 +68,7 @@ values:
     outlier_detection: []
     project: project-id
     protocol: UNSPECIFIED
-    region: region
+    region: europe-west8
     security_policy: null
     subsetting: []
     timeouts: null
@@ -82,7 +82,7 @@ values:
     https_health_check: []
     name: nlb-test
     project: project-id
-    region: region
+    region: europe-west8
     ssl_health_check: []
     tcp_health_check:
     - port: null

--- a/tests/modules/net_lb_ext/examples/e2e.yaml
+++ b/tests/modules/net_lb_ext/examples/e2e.yaml
@@ -28,7 +28,7 @@ values:
     - '80'
     project: project-id
     recreate_closed_psc: false
-    region: region
+    region: europe-west8
     service_label: null
     source_ip_ranges: null
     target: null
@@ -50,7 +50,7 @@ values:
     outlier_detection: []
     project: project-id
     protocol: UNSPECIFIED
-    region: region
+    region: europe-west8
     security_policy: null
     subsetting: []
     timeouts: null
@@ -71,7 +71,7 @@ values:
     https_health_check: []
     name: nlb-test
     project: project-id
-    region: region
+    region: europe-west8
     ssl_health_check: []
     tcp_health_check: []
     timeout_sec: 5

--- a/tests/modules/net_lb_ext/examples/ext_migs.yaml
+++ b/tests/modules/net_lb_ext/examples/ext_migs.yaml
@@ -27,7 +27,7 @@ values:
     ports: null
     project: project-id
     recreate_closed_psc: false
-    region: region
+    region: europe-west8
     service_label: null
     source_ip_ranges: null
     target: null
@@ -38,7 +38,7 @@ values:
     named_port: []
     project: project-id
     timeouts: null
-    zone: region-b
+    zone: europe-west8-b
   module.nlb.google_compute_region_backend_service.default:
     affinity_cookie_ttl_sec: null
     circuit_breakers: []
@@ -56,7 +56,7 @@ values:
     outlier_detection: []
     project: project-id
     protocol: UNSPECIFIED
-    region: region
+    region: europe-west8
     security_policy: null
     subsetting: []
     timeouts: null
@@ -77,7 +77,7 @@ values:
     https_health_check: []
     name: nlb-test
     project: project-id
-    region: region
+    region: europe-west8
     ssl_health_check: []
     tcp_health_check: []
     timeout_sec: 5

--- a/tests/modules/net_lb_ext/examples/fwd_rules.yaml
+++ b/tests/modules/net_lb_ext/examples/fwd_rules.yaml
@@ -27,7 +27,7 @@ values:
     ports: null
     project: project-id
     recreate_closed_psc: false
-    region: region
+    region: europe-west8
     service_label: null
     source_ip_ranges: null
     target: null
@@ -47,7 +47,7 @@ values:
     - '80'
     project: project-id
     recreate_closed_psc: false
-    region: region
+    region: europe-west8
     service_label: null
     source_ip_ranges: null
     target: null
@@ -58,7 +58,7 @@ values:
     named_port: []
     project: project-id
     timeouts: null
-    zone: region-b
+    zone: europe-west8-b
   module.nlb.google_compute_region_backend_service.default:
     affinity_cookie_ttl_sec: null
     circuit_breakers: []
@@ -76,7 +76,7 @@ values:
     outlier_detection: []
     project: project-id
     protocol: UNSPECIFIED
-    region: region
+    region: europe-west8
     security_policy: null
     subsetting: []
     timeouts: null
@@ -90,7 +90,7 @@ values:
     https_health_check: []
     name: nlb-test
     project: project-id
-    region: region
+    region: europe-west8
     ssl_health_check: []
     tcp_health_check:
     - port: null

--- a/tests/modules/net_lb_ext/examples/migs.yaml
+++ b/tests/modules/net_lb_ext/examples/migs.yaml
@@ -27,7 +27,7 @@ values:
     ports: null
     project: project-id
     recreate_closed_psc: false
-    region: region
+    region: europe-west8
     service_label: null
     source_ip_ranges: null
     target: null
@@ -49,7 +49,7 @@ values:
     outlier_detection: []
     project: project-id
     protocol: UNSPECIFIED
-    region: region
+    region: europe-west8
     security_policy: null
     subsetting: []
     timeouts: null
@@ -70,7 +70,7 @@ values:
     https_health_check: []
     name: nlb-test
     project: project-id
-    region: region
+    region: europe-west8
     ssl_health_check: []
     tcp_health_check: []
     timeout_sec: 5

--- a/tests/modules/net_vpn_ha/examples/gcp-to-onprem.yaml
+++ b/tests/modules/net_vpn_ha/examples/gcp-to-onprem.yaml
@@ -26,7 +26,7 @@ values:
     name: mynet-to-onprem
     network: projects/xxx/global/networks/aaa
     project: project-id
-    region: region
+    region: europe-west8
     stack_type: IPV4_ONLY
   module.vpn_ha.google_compute_router.router[0]:
     bgp:
@@ -40,14 +40,14 @@ values:
     name: vpn-mynet-to-onprem
     network: projects/xxx/global/networks/aaa
     project: project-id
-    region: region
+    region: europe-west8
   module.vpn_ha.google_compute_router_interface.router_interface["remote-0"]:
     interconnect_attachment: null
     ip_range: 169.254.1.2/30
     name: mynet-to-onprem-remote-0
     private_ip_address: null
     project: project-id
-    region: region
+    region: europe-west8
     router: vpn-mynet-to-onprem
     subnetwork: null
     vpn_tunnel: mynet-to-onprem-remote-0
@@ -57,7 +57,7 @@ values:
     name: mynet-to-onprem-remote-1
     private_ip_address: null
     project: project-id
-    region: region
+    region: europe-west8
     router: vpn-mynet-to-onprem
     subnetwork: null
     vpn_tunnel: mynet-to-onprem-remote-1
@@ -73,7 +73,7 @@ values:
     peer_asn: 64513
     peer_ip_address: 169.254.1.1
     project: project-id
-    region: region
+    region: europe-west8
     router: vpn-mynet-to-onprem
     router_appliance_instance: null
   module.vpn_ha.google_compute_router_peer.bgp_peer["remote-1"]:
@@ -88,7 +88,7 @@ values:
     peer_asn: 64513
     peer_ip_address: 169.254.2.1
     project: project-id
-    region: region
+    region: europe-west8
     router: vpn-mynet-to-onprem
     router_appliance_instance: null
   module.vpn_ha.google_compute_vpn_tunnel.tunnels["remote-0"]:
@@ -98,7 +98,7 @@ values:
     peer_external_gateway_interface: 0
     peer_gcp_gateway: null
     project: project-id
-    region: region
+    region: europe-west8
     router: vpn-mynet-to-onprem
     shared_secret: mySecret
     target_vpn_gateway: null
@@ -110,7 +110,7 @@ values:
     peer_external_gateway_interface: 0
     peer_gcp_gateway: null
     project: project-id
-    region: region
+    region: europe-west8
     router: vpn-mynet-to-onprem
     shared_secret: mySecret
     target_vpn_gateway: null

--- a/tests/modules/workstation_cluster/examples/custom-image.yaml
+++ b/tests/modules/workstation_cluster/examples/custom-image.yaml
@@ -21,7 +21,7 @@ values:
     env: null
     labels:
       team: my-team
-    location: region
+    location: europe-west8
     project: project-id
     terraform_labels:
       team: my-team
@@ -34,7 +34,7 @@ values:
     display_name: null
     domain_config: []
     labels: null
-    location: region
+    location: europe-west8
     network: projects/xxx/global/networks/aaa
     private_cluster_config:
     - enable_private_endpoint: false
@@ -62,7 +62,7 @@ values:
     encryption_key: []
     idle_timeout: 1200s
     labels: null
-    location: region
+    location: europe-west8
     project: project-id
     running_timeout: 43200s
     timeouts: null

--- a/tests/modules/workstation_cluster/examples/iam.yaml
+++ b/tests/modules/workstation_cluster/examples/iam.yaml
@@ -21,7 +21,7 @@ values:
     env: null
     labels:
       team: my-team
-    location: region
+    location: europe-west8
     project: project-id
     terraform_labels:
       team: my-team
@@ -34,7 +34,7 @@ values:
     display_name: null
     domain_config: []
     labels: null
-    location: region
+    location: europe-west8
     network: projects/xxx/global/networks/aaa
     private_cluster_config:
     - enable_private_endpoint: false
@@ -49,7 +49,7 @@ values:
     encryption_key: []
     idle_timeout: 1200s
     labels: null
-    location: region
+    location: europe-west8
     project: project-id
     running_timeout: 43200s
     timeouts: null
@@ -57,7 +57,7 @@ values:
     workstation_config_id: my-workstation-config
   ? module.workstation-cluster.google_workstations_workstation_config_iam_binding.authoritative["my-workstation-config-roles/viewer"]
   : condition: []
-    location: region
+    location: europe-west8
     members:
     - group:group1@my-org.com
     project: project-id
@@ -66,7 +66,7 @@ values:
     workstation_config_id: my-workstation-config
   ? module.workstation-cluster.google_workstations_workstation_config_iam_binding.bindings["my-workstation-config-workstations-config-viewer"]
   : condition: []
-    location: region
+    location: europe-west8
     members:
     - group:group2@my-org.com
     project: project-id
@@ -75,7 +75,7 @@ values:
     workstation_config_id: my-workstation-config
   ? module.workstation-cluster.google_workstations_workstation_config_iam_member.bindings["my-workstation-config-workstations-config-editor"]
   : condition: []
-    location: region
+    location: europe-west8
     member: group:group3@my-org.com
     project: project-id
     role: roles/editor
@@ -83,7 +83,7 @@ values:
     workstation_config_id: my-workstation-config
   ? module.workstation-cluster.google_workstations_workstation_iam_binding.authoritative["my-workstation-config-my-workstation-roles/workstations.user"]
   : condition: []
-    location: region
+    location: europe-west8
     members:
     - user:user1@my-org.com
     project: project-id

--- a/tests/modules/workstation_cluster/examples/private-cluster.yaml
+++ b/tests/modules/workstation_cluster/examples/private-cluster.yaml
@@ -21,7 +21,7 @@ values:
     env: null
     labels:
       team: my-team
-    location: region
+    location: europe-west8
     project: project-id
     terraform_labels:
       team: my-team
@@ -34,7 +34,7 @@ values:
     display_name: null
     domain_config: []
     labels: null
-    location: region
+    location: europe-west8
     network: projects/xxx/global/networks/aaa
     private_cluster_config:
     - enable_private_endpoint: true
@@ -49,7 +49,7 @@ values:
     encryption_key: []
     idle_timeout: 1200s
     labels: null
-    location: region
+    location: europe-west8
     project: project-id
     running_timeout: 43200s
     timeouts: null

--- a/tests/modules/workstation_cluster/examples/simple.yaml
+++ b/tests/modules/workstation_cluster/examples/simple.yaml
@@ -21,7 +21,7 @@ values:
     env: null
     labels:
       team: my-team
-    location: region
+    location: europe-west8
     project: project-id
     terraform_labels:
       team: my-team
@@ -34,7 +34,7 @@ values:
     display_name: null
     domain_config: []
     labels: null
-    location: region
+    location: europe-west8
     network: projects/xxx/global/networks/aaa
     private_cluster_config:
     - enable_private_endpoint: false
@@ -49,7 +49,7 @@ values:
     encryption_key: []
     idle_timeout: 1200s
     labels: null
-    location: region
+    location: europe-west8
     project: project-id
     running_timeout: 43200s
     timeouts: null


### PR DESCRIPTION
This PR changes variable region's default value in example tests to real region value.

Some of the modules parse the region name to decide whether to create regional or zonal resources.

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [x] Made sure all relevant tests pass
