### PR TITLE
Add PNA support to Service Directory module

### DIFF
--- a/modules/service-directory/README.md
+++ b/modules/service-directory/README.md
@@ -90,20 +90,59 @@ module "dns-sd" {
 }
 # tftest modules=2 resources=5 inventory=dns.yaml
 ```
-<!-- BEGIN TFDOC -->
 
+### Services with endpoints using private network access
+
+[Private network access](https://cloud.google.com/service-directory/docs/private-network-access-overview) enables supported Google Cloud products to send HTTP requests to resources inside a VPC.
+
+```hcl
+locals {
+  project_number = "123456789012"
+}
+
+module "service-directory" {
+  source     = "./fabric/modules/service-directory"
+  project_id = "my-project"
+  location   = "europe-west1"
+  name       = "sd-1"
+  services = {
+    one = {
+      endpoints = ["first", "second"]
+      metadata  = null
+    }
+  }
+  endpoint_config = {
+    "one/first" = {
+      address  = "10.0.0.11",
+      port     = 443,
+      network  = "projects/${local.project_number}/locations/global/networks/${var.vpc.name}"
+      metadata = {}
+    }
+    "one/second" = {
+      address  = "10.0.0.12",
+      port     = 443,
+      network  = "projects/${local.project_number}/locations/global/networks/${var.vpc.name}"
+      metadata = {}
+    }
+  }
+}
+# tftest modules=1 resources=4 inventory=pna.yaml
+```
+
+Note that the `network` argument is unusual in that it requires the project number, instead of the more common project ID.
+<!-- BEGIN TFDOC -->
 ## Variables
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [location](variables.tf#L40) | Namespace location. | <code>string</code> | ✓ |  |
-| [name](variables.tf#L45) | Namespace name. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L50) | Project used for resources. | <code>string</code> | ✓ |  |
-| [endpoint_config](variables.tf#L18) | Map of endpoint attributes, keys are in service/endpoint format. | <code title="map&#40;object&#40;&#123;&#10;  address  &#61; string&#10;  port     &#61; number&#10;  metadata &#61; map&#40;string&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [iam](variables.tf#L28) | IAM bindings for namespace, in {ROLE => [MEMBERS]} format. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [labels](variables.tf#L34) | Labels. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
-| [service_iam](variables.tf#L55) | IAM bindings for services, in {SERVICE => {ROLE => [MEMBERS]}} format. | <code>map&#40;map&#40;list&#40;string&#41;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [services](variables.tf#L61) | Service configuration, using service names as keys. | <code title="map&#40;object&#40;&#123;&#10;  endpoints &#61; list&#40;string&#41;&#10;  metadata  &#61; map&#40;string&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [location](variables.tf#L41) | Namespace location. | <code>string</code> | ✓ |  |
+| [name](variables.tf#L46) | Namespace name. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L51) | Project used for resources. | <code>string</code> | ✓ |  |
+| [endpoint_config](variables.tf#L18) | Map of endpoint attributes, keys are in service/endpoint format. | <code title="map&#40;object&#40;&#123;&#10;  address  &#61; string&#10;  port     &#61; number&#10;  network  &#61; optional&#40;string, null&#41;&#10;  metadata &#61; map&#40;string&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [iam](variables.tf#L29) | IAM bindings for namespace, in {ROLE => [MEMBERS]} format. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [labels](variables.tf#L35) | Labels. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [service_iam](variables.tf#L56) | IAM bindings for services, in {SERVICE => {ROLE => [MEMBERS]}} format. | <code>map&#40;map&#40;list&#40;string&#41;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [services](variables.tf#L62) | Service configuration, using service names as keys. | <code title="map&#40;object&#40;&#123;&#10;  endpoints &#61; list&#40;string&#41;&#10;  metadata  &#61; map&#40;string&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 
 ## Outputs
 
@@ -116,5 +155,4 @@ module "dns-sd" {
 | [service_id](outputs.tf#L40) | Service ids (short names). |  |
 | [service_names](outputs.tf#L50) | Service ids (long names). |  |
 | [services](outputs.tf#L60) | Service resources. |  |
-
 <!-- END TFDOC -->

--- a/modules/service-directory/README.md
+++ b/modules/service-directory/README.md
@@ -91,9 +91,9 @@ module "dns-sd" {
 # tftest modules=2 resources=5 inventory=dns.yaml
 ```
 
-### Services with endpoints using private network access
+### Services with endpoints using Private Network Access
 
-[Private network access](https://cloud.google.com/service-directory/docs/private-network-access-overview) enables supported Google Cloud products to send HTTP requests to resources inside a VPC.
+[Private Network Access](https://cloud.google.com/service-directory/docs/private-network-access-overview) enables supported Google Cloud products to send HTTP requests to resources inside a VPC.
 
 ```hcl
 locals {

--- a/modules/service-directory/main.tf
+++ b/modules/service-directory/main.tf
@@ -75,4 +75,5 @@ resource "google_service_directory_endpoint" "default" {
   metadata    = try(var.endpoint_config[each.key].metadata, null)
   address     = try(var.endpoint_config[each.key].address, null)
   port        = try(var.endpoint_config[each.key].port, null)
+  network     = try(var.endpoint_config[each.key].network, null)
 }

--- a/modules/service-directory/variables.tf
+++ b/modules/service-directory/variables.tf
@@ -20,6 +20,7 @@ variable "endpoint_config" {
   type = map(object({
     address  = string
     port     = number
+    network  = optional(string, null)
     metadata = map(string)
   }))
   default = {}

--- a/tests/modules/service_directory/examples/pna.yaml
+++ b/tests/modules/service_directory/examples/pna.yaml
@@ -1,0 +1,37 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values:
+  module.service-directory.google_service_directory_endpoint.default["one/first"]:
+    address: 10.0.0.11
+    endpoint_id: first
+    port: 443
+    network: projects/123456789012/locations/global/networks/vpc-name
+  module.service-directory.google_service_directory_endpoint.default["one/second"]:
+    address: 10.0.0.12
+    endpoint_id: second
+    port: 443
+    network: projects/123456789012/locations/global/networks/vpc-name
+  module.service-directory.google_service_directory_namespace.default:
+    location: europe-west1
+    namespace_id: sd-1
+    project: my-project
+  module.service-directory.google_service_directory_service.default["one"]:
+    metadata: null
+    service_id: one
+
+counts:
+  google_service_directory_endpoint: 2
+  google_service_directory_namespace: 1
+  google_service_directory_service: 1


### PR DESCRIPTION
Endpoints in Service Directory can be *associated* with a VPC. In this case, they can be used by supported Google Cloud products to send requests directly to resources inside a VPC. This feature is called [Private Network Access](https://cloud.google.com/service-directory/docs/private-network-access-overview).

The `google_service_directory_endpoint` resource supports this configuration with a new argument `network`.
Unfortunately, this argument has an unusual format: it is similar to a standard VPC ID, but instead of the project ID, it expects the project number.

---
**Checklist**

If applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
