### PR TITLE
Support for ANY_USER_ACCOUNT in module vpc-sc egress rule.

### DIFF
--- a/modules/vpc-sc/variables.tf
+++ b/modules/vpc-sc/variables.tf
@@ -92,7 +92,7 @@ variable "egress_policies" {
       for k, v in var.egress_policies :
       v.from.identity_type == null || contains([
         "IDENTITY_TYPE_UNSPECIFIED", "ANY_IDENTITY",
-        "ANY_USER", "ANY_SERVICE_ACCOUNT"
+        "ANY_USER_ACCOUNT", "ANY_SERVICE_ACCOUNT"
       ], coalesce(v.from.identity_type, "-"))
     ])
     error_message = "Invalid `from.identity_type` value in egress policy."


### PR DESCRIPTION
This PR enables to support keyword ANY_USER_ACCOUNT when crafting VPC SC **egress rule**. 
This keyword (identity_type) is currently not enabled by validation block in [modules/vpc-sc/variable.tf](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/modules/vpc-sc/variables.tf#L95). 

Despite the fact that this option is specifically not enabled by **fast vpc-sc module**, it is indeed fully supported by underlying terraform resource [google_access_context_manager_service_perimeters](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/access_context_manager_service_perimeters#identity_type). 

**Desired state:**
<img width="472" alt="Screenshot 2024-01-08 at 13 26 07" src="https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/assets/3645561/c09eb61d-5dde-4790-aae4-8a09042513d3">


I applicable, I acknowledge that I have:
- [ x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [ x] Ran `terraform fmt` on all modified files
- [ x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ x] Made sure all relevant tests pass
