### PR TITLE
Add locations on terraform.tfvars.sample for bootstrap stage

### DIFF
--- a/fast/stages/0-bootstrap/terraform.tfvars.sample
+++ b/fast/stages/0-bootstrap/terraform.tfvars.sample
@@ -4,6 +4,14 @@ billing_account = {
   id = "012345-67890A-BCDEF0"
 }
 
+# locations for GCS, BigQuery, and logging buckets created here
+locations = {
+  bq      = "EU"
+  gcs     = "EU"
+  logging = "global"
+  pubsub  = []
+}
+
 # use `gcloud organizations list`
 organization = {
   domain      = "example.org"
@@ -15,4 +23,3 @@ outputs_location = "~/fast-config"
 
 # use something unique and no longer than 9 characters
 prefix = "abcd"
-


### PR DESCRIPTION
add locations on terraform.tfvars.sample for bootstrap stage

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
