### PR TITLE
Fix identity_type

### DIFF
--- a/modules/vpc-sc/variables.tf
+++ b/modules/vpc-sc/variables.tf
@@ -93,7 +93,7 @@ variable "egress_policies" {
       v.from.identity_type == null || contains([
         "IDENTITY_TYPE_UNSPECIFIED", "ANY_IDENTITY",
         "ANY_USER_ACCOUNT", "ANY_SERVICE_ACCOUNT", ""
-      ], v.from.identity_type)
+      ], coalesce(v.from.identity_type, "-"))
     ])
     error_message = "Invalid `from.identity_type` value in egress policy."
   }
@@ -161,7 +161,7 @@ variable "ingress_policies" {
       v.from.identity_type == null || contains([
         "IDENTITY_TYPE_UNSPECIFIED", "ANY_IDENTITY",
         "ANY_USER_ACCOUNT", "ANY_SERVICE_ACCOUNT", ""
-      ], v.from.identity_type)
+      ], coalesce(v.from.identity_type, "-"))
     ])
     error_message = "Invalid `from.identity_type` value in ingress policy."
   }

--- a/modules/vpc-sc/variables.tf
+++ b/modules/vpc-sc/variables.tf
@@ -92,8 +92,8 @@ variable "egress_policies" {
       for k, v in var.egress_policies :
       v.from.identity_type == null || contains([
         "IDENTITY_TYPE_UNSPECIFIED", "ANY_IDENTITY",
-        "ANY_USER_ACCOUNT", "ANY_SERVICE_ACCOUNT"
-      ], coalesce(v.from.identity_type, "-"))
+        "ANY_USER_ACCOUNT", "ANY_SERVICE_ACCOUNT", ""
+      ], v.from.identity_type)
     ])
     error_message = "Invalid `from.identity_type` value in egress policy."
   }
@@ -160,8 +160,8 @@ variable "ingress_policies" {
       for k, v in var.ingress_policies :
       v.from.identity_type == null || contains([
         "IDENTITY_TYPE_UNSPECIFIED", "ANY_IDENTITY",
-        "ANY_USER", "ANY_SERVICE_ACCOUNT"
-      ], coalesce(v.from.identity_type, "-"))
+        "ANY_USER_ACCOUNT", "ANY_SERVICE_ACCOUNT", ""
+      ], v.from.identity_type)
     ])
     error_message = "Invalid `from.identity_type` value in ingress policy."
   }


### PR DESCRIPTION
Google provider supports empty string for `identity_type`. Even if `IDENTITY_TYPE_UNSPECIFIED` is used as the value, Terraform state stores empty string as the value instead. Hence it make sense to support empty string as a value in the module.

Also `ANY_USER_ACCOUNT` is the correct value for ingress `identity_type`.

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
