### PR TITLE
Proper validation of empty string value in identity_type

### DIFF
--- a/modules/vpc-sc/variables.tf
+++ b/modules/vpc-sc/variables.tf
@@ -90,10 +90,10 @@ variable "egress_policies" {
   validation {
     condition = alltrue([
       for k, v in var.egress_policies :
-      v.from.identity_type == null || contains([
+      v.from.identity_type == null ? true : contains([
         "IDENTITY_TYPE_UNSPECIFIED", "ANY_IDENTITY",
         "ANY_USER_ACCOUNT", "ANY_SERVICE_ACCOUNT", ""
-      ], coalesce(v.from.identity_type, "-"))
+      ], v.from.identity_type)
     ])
     error_message = "Invalid `from.identity_type` value in egress policy."
   }
@@ -158,10 +158,10 @@ variable "ingress_policies" {
   validation {
     condition = alltrue([
       for k, v in var.ingress_policies :
-      v.from.identity_type == null || contains([
+      v.from.identity_type == null ? true : contains([
         "IDENTITY_TYPE_UNSPECIFIED", "ANY_IDENTITY",
         "ANY_USER_ACCOUNT", "ANY_SERVICE_ACCOUNT", ""
-      ], coalesce(v.from.identity_type, "-"))
+      ], v.from.identity_type)
     ])
     error_message = "Invalid `from.identity_type` value in ingress policy."
   }


### PR DESCRIPTION
This is continuation of https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/pull/1978.

Because the logical operators (`||`, `&&`) in Terraform [do not short-circuit](https://developer.hashicorp.com/terraform/language/expressions/operators#logical-operators), and [coalesce()](https://developer.hashicorp.com/terraform/language/functions/coalesce) never returns non-empty string, empty string validation needs to be done differently.

The provided code change properly validates if `identity_type` is null or empty string or any of the allowed keywords.

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
