### PR TITLE
Ensure data platform service accounts meet FAST requirements

### DIFF
--- a/blueprints/data-solutions/data-platform-foundations/README.md
+++ b/blueprints/data-solutions/data-platform-foundations/README.md
@@ -226,7 +226,8 @@ module "data-platform" {
     billing_account_id = "123456-123456-123456"
     parent             = "folders/12345678"
   }
-  prefix = "myprefix"
+  # test 9-chars long prefix for FAST compatibility
+  prefix = "test-01234"
 }
 # tftest modules=43 resources=293
 ```

--- a/blueprints/data-solutions/data-platform-foundations/README.md
+++ b/blueprints/data-solutions/data-platform-foundations/README.md
@@ -226,8 +226,8 @@ module "data-platform" {
     billing_account_id = "123456-123456-123456"
     parent             = "folders/12345678"
   }
-  # test 9-chars long prefix for FAST compatibility
-  prefix = "test-01234"
+  # test 12-chars long prefix for FAST mt compatibility
+  prefix = "test-0123456"
 }
 # tftest modules=43 resources=293
 ```


### PR DESCRIPTION
This PR fixes #1314 by setting the prefix used in the data platform's example to 12 characters, which is the longest allowed in FAST multitenant stages.

Service account names which are too long will fail provider validation in the plan with an error similar to this one:

```
Error: "account_id" ("test-0123456789-orc-sa-df-build") doesn't match regexp "^[a-z](?:[-a-z0-9]{4,28}[a-z0-9])$"
```