### PR TITLE
Fix dnssec_config issue on state off

### DIFF
--- a/modules/dns/main.tf
+++ b/modules/dns/main.tf
@@ -158,7 +158,7 @@ resource "google_dns_managed_zone_iam_binding" "iam_bindings" {
 }
 
 data "google_dns_keys" "dns_keys" {
-  count        = try(var.zone_config.public.dnssec_config, null) != null ? 1 : 0
+  count        = try(var.zone_config.public.dnssec_config.state, "off") != "off" ? 1 : 0
   managed_zone = local.managed_zone.id
   project      = var.project_id
 }


### PR DESCRIPTION
If a Cloud DNS managed zone has been created through this module without `dnssec_config` and the DNS Zone is manually modified in the UI, for example to enable logging, even if you do not touch the DNSSEC configuration, a `dnssec_config` will be added to the terraform state, with the variable `state` set to `off`:
```
      + dnssec_config {
          + kind          = "dns#managedZoneDnsSecConfig"
          + non_existence = "nsec3"
          + state         = "off"

          + default_key_specs {
              + algorithm  = "rsasha256"
              + key_length = 2048
              + key_type   = "keySigning"
              + kind       = "dns#dnsKeySpec"
            }
          + default_key_specs {
              + algorithm  = "rsasha256"
              + key_length = 1024
              + key_type   = "zoneSigning"
              + kind       = "dns#dnsKeySpec"
            }
        }
```
From this point on, you can no longer run terraform without running into an error of the API complaining about the missing `dnssec_config`:
```
│ Error: Error updating ManagedZone "projects/<project-id>/managedZones/<zone-name>": googleapi: Error 400: The 'entity.managedZone.dnssecConfig' parameter is required but was missing., required
```
Adding the `dnssec_config` with `state = "off"` currently leads to the google_dns_keys being fetched, which is not allowed if no keys exist, as highlighted in the providers documentation [google_dns_keys](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/dns_keys) leading to a different error:
```
│ googleapi: Error 404: The 'collection' resource named 'dnsKeys' does not exist., notFound
``` 

This fix changes the behaviour of `google_dns_keys` being retrieved only when the `state` is set to `on` instead of relying on the general presence of the `dnssec_config`.

---
**Checklist**

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
