### PR TITLE
import default org-level org-policies 

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.5.1
+          terraform_version: 1.7.0
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ env:
   PYTEST_ADDOPTS: "--color=yes"
   PYTHON_VERSION: "3.10"
   TF_PLUGIN_CACHE_DIR: "/home/runner/.terraform.d/plugin-cache"
-  TF_VERSION: 1.5.1
+  TF_VERSION: 1.7.0
   TFTEST_COPY: 1
 
 jobs:

--- a/default-versions.tf
+++ b/default-versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/fast/stages/0-bootstrap/organization.tf
+++ b/fast/stages/0-bootstrap/organization.tf
@@ -108,6 +108,24 @@ locals {
 
 # TODO: add a check block to ensure our custom roles exist in the factory files
 
+# import roles enabled by default on org creation (since Dec 2023)
+import {
+  for_each = toset([
+    "compute.requireOsLogin",
+    "compute.skipDefaultNetworkCreation",
+    "compute.vmExternalIpAccess",
+    "iam.allowedPolicyMemberDomains",
+    "iam.automaticIamGrantsForDefaultServiceAccounts",
+    "iam.disableServiceAccountKeyCreation",
+    "iam.disableServiceAccountKeyUpload",
+    "sql.restrictAuthorizedNetworks",
+    "sql.restrictPublicIp",
+    "storage.uniformBucketLevelAccess",
+  ])
+  id = "organizations/${var.organization.id}/policies/${each.key}"
+  to = module.organization.google_org_policy_policy.default[each.key]
+}
+
 module "organization" {
   source          = "../../../modules/organization"
   organization_id = "organizations/${var.organization.id}"

--- a/modules/__experimental/alloydb-instance/versions.tf
+++ b/modules/__experimental/alloydb-instance/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/__experimental/net-neg/versions.tf
+++ b/modules/__experimental/net-neg/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/__experimental/project-iam-magic/versions.tf
+++ b/modules/__experimental/project-iam-magic/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/api-gateway/versions.tf
+++ b/modules/api-gateway/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/apigee/versions.tf
+++ b/modules/apigee/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/artifact-registry/versions.tf
+++ b/modules/artifact-registry/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/bigquery-dataset/versions.tf
+++ b/modules/bigquery-dataset/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/bigtable-instance/versions.tf
+++ b/modules/bigtable-instance/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/billing-account/versions.tf
+++ b/modules/billing-account/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/binauthz/versions.tf
+++ b/modules/binauthz/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/cloud-config-container/__need_fixing/onprem/versions.tf
+++ b/modules/cloud-config-container/__need_fixing/onprem/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/cloud-config-container/__need_fixing/squid/versions.tf
+++ b/modules/cloud-config-container/__need_fixing/squid/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/cloud-config-container/coredns/versions.tf
+++ b/modules/cloud-config-container/coredns/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/cloud-config-container/cos-generic-metadata/versions.tf
+++ b/modules/cloud-config-container/cos-generic-metadata/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/cloud-config-container/envoy-sni-dyn-fwd-proxy/versions.tf
+++ b/modules/cloud-config-container/envoy-sni-dyn-fwd-proxy/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/cloud-config-container/envoy-traffic-director/versions.tf
+++ b/modules/cloud-config-container/envoy-traffic-director/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/cloud-config-container/mysql/versions.tf
+++ b/modules/cloud-config-container/mysql/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/cloud-config-container/nginx-tls/versions.tf
+++ b/modules/cloud-config-container/nginx-tls/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/cloud-config-container/nginx/versions.tf
+++ b/modules/cloud-config-container/nginx/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/cloud-config-container/simple-nva/versions.tf
+++ b/modules/cloud-config-container/simple-nva/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/cloud-function-v1/versions.tf
+++ b/modules/cloud-function-v1/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/cloud-function-v2/versions.tf
+++ b/modules/cloud-function-v2/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/cloud-identity-group/versions.tf
+++ b/modules/cloud-identity-group/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/cloud-run-v2/versions.tf
+++ b/modules/cloud-run-v2/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/cloud-run/versions.tf
+++ b/modules/cloud-run/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/cloudsql-instance/versions.tf
+++ b/modules/cloudsql-instance/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/compute-mig/versions.tf
+++ b/modules/compute-mig/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/compute-vm/versions.tf
+++ b/modules/compute-vm/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/container-registry/versions.tf
+++ b/modules/container-registry/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/data-catalog-policy-tag/versions.tf
+++ b/modules/data-catalog-policy-tag/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/data-catalog-tag-template/versions.tf
+++ b/modules/data-catalog-tag-template/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/dataform-repository/versions.tf
+++ b/modules/dataform-repository/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/datafusion/versions.tf
+++ b/modules/datafusion/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/dataplex-datascan/versions.tf
+++ b/modules/dataplex-datascan/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/dataplex/versions.tf
+++ b/modules/dataplex/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/dataproc/versions.tf
+++ b/modules/dataproc/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/dns-response-policy/versions.tf
+++ b/modules/dns-response-policy/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/dns/versions.tf
+++ b/modules/dns/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/endpoints/versions.tf
+++ b/modules/endpoints/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/folder/versions.tf
+++ b/modules/folder/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/gcs/versions.tf
+++ b/modules/gcs/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/gcve-private-cloud/versions.tf
+++ b/modules/gcve-private-cloud/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/gke-cluster-autopilot/versions.tf
+++ b/modules/gke-cluster-autopilot/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/gke-cluster-standard/versions.tf
+++ b/modules/gke-cluster-standard/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/gke-hub/versions.tf
+++ b/modules/gke-hub/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/gke-nodepool/versions.tf
+++ b/modules/gke-nodepool/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/iam-service-account/versions.tf
+++ b/modules/iam-service-account/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/kms/versions.tf
+++ b/modules/kms/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/logging-bucket/versions.tf
+++ b/modules/logging-bucket/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/ncc-spoke-ra/versions.tf
+++ b/modules/ncc-spoke-ra/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/net-address/versions.tf
+++ b/modules/net-address/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/net-cloudnat/versions.tf
+++ b/modules/net-cloudnat/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/net-firewall-policy/versions.tf
+++ b/modules/net-firewall-policy/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/net-ipsec-over-interconnect/versions.tf
+++ b/modules/net-ipsec-over-interconnect/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/net-lb-app-ext-regional/versions.tf
+++ b/modules/net-lb-app-ext-regional/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/net-lb-app-ext/versions.tf
+++ b/modules/net-lb-app-ext/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/net-lb-app-int-cross-region/versions.tf
+++ b/modules/net-lb-app-int-cross-region/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/net-lb-app-int/versions.tf
+++ b/modules/net-lb-app-int/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/net-lb-ext/versions.tf
+++ b/modules/net-lb-ext/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/net-lb-int/versions.tf
+++ b/modules/net-lb-int/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/net-lb-proxy-int/versions.tf
+++ b/modules/net-lb-proxy-int/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/net-swp/versions.tf
+++ b/modules/net-swp/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/net-vlan-attachment/versions.tf
+++ b/modules/net-vlan-attachment/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/net-vpc-firewall/versions.tf
+++ b/modules/net-vpc-firewall/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/net-vpc-peering/versions.tf
+++ b/modules/net-vpc-peering/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/net-vpc/versions.tf
+++ b/modules/net-vpc/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/net-vpn-dynamic/versions.tf
+++ b/modules/net-vpn-dynamic/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/net-vpn-ha/versions.tf
+++ b/modules/net-vpn-ha/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/net-vpn-static/versions.tf
+++ b/modules/net-vpn-static/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/organization/versions.tf
+++ b/modules/organization/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/project/versions.tf
+++ b/modules/project/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/projects-data-source/versions.tf
+++ b/modules/projects-data-source/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/pubsub/versions.tf
+++ b/modules/pubsub/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/secret-manager/versions.tf
+++ b/modules/secret-manager/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/service-directory/versions.tf
+++ b/modules/service-directory/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/source-repository/versions.tf
+++ b/modules/source-repository/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/vpc-sc/versions.tf
+++ b/modules/vpc-sc/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/workstation-cluster/versions.tf
+++ b/modules/workstation-cluster/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/tests/examples_e2e/setup_module/versions.tf
+++ b/tests/examples_e2e/setup_module/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.1"
+  required_version = ">= 1.7.0"
   required_providers {
     google = {
       source  = "hashicorp/google"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here -->
Import policies that are created by default when creating a new org (since Dec 2023). Closes #2052.

Bump terraform version to 1.7.0, so we can use [for_each within import statement](https://github.com/hashicorp/terraform/pull/33932).

Those import statements will fail, if the polices do not exists.

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass
