### PR TITLE
Fix e2e tests - vertex mlops and net-address

### DIFF
--- a/blueprints/data-solutions/vertex-mlops/vertex.tf
+++ b/blueprints/data-solutions/vertex-mlops/vertex.tf
@@ -105,6 +105,11 @@ resource "google_notebooks_instance" "playground" {
 
   instance_owners = try(tolist(var.notebooks[each.key].owner), null)
   service_account = module.service-account-notebook.email
+  service_account_scopes = [
+    "https://www.googleapis.com/auth/cloud-platform",
+    "https://www.googleapis.com/auth/userinfo.email",
+  ]
+
 
   metadata = {
     notebook-disable-nbconvert = "false"

--- a/modules/net-address/README.md
+++ b/modules/net-address/README.md
@@ -38,7 +38,7 @@ module "addresses" {
       subnetwork = var.subnet.self_link
     }
     ilb-2 = {
-      address    = "10.0.16.2"
+      address    = "10.0.16.102"
       region     = var.region
       subnetwork = var.subnet.self_link
     }

--- a/tests/modules/net_address/examples/internal.yaml
+++ b/tests/modules/net_address/examples/internal.yaml
@@ -23,7 +23,7 @@ values:
     region: europe-west8
     subnetwork: subnet_self_link
   module.addresses.google_compute_address.internal["ilb-2"]:
-    address: 10.0.16.2
+    address: 10.0.16.102
     address_type: INTERNAL
     labels: null
     name: ilb-2


### PR DESCRIPTION
<!-- Put a description of what this PR is for here -->
* Fix non empty plan after apply for `google_notebooks_instance` 
* Use different address in tests for `net-address` to avoid conflicts

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass
