### PR TITLE
WIP - Allow changes of the LB configurations

### DIFF
--- a/modules/net-lb-app-int/README.md
+++ b/modules/net-lb-app-int/README.md
@@ -641,12 +641,12 @@ module "ilb-l7" {
 
 | name | description | resources |
 |---|---|---|
-| [backend-service.tf](./backend-service.tf) | Backend service resources. | <code>google_compute_region_backend_service</code> |
+| [backend-service.tf](./backend-service.tf) | Backend service resources. | <code>google_compute_region_backend_service</code> · <code>terraform_data</code> |
 | [groups.tf](./groups.tf) | None | <code>google_compute_instance_group</code> |
 | [health-check.tf](./health-check.tf) | Health check resource. | <code>google_compute_health_check</code> |
 | [main.tf](./main.tf) | Module-level locals and resources. | <code>google_compute_forwarding_rule</code> · <code>google_compute_network_endpoint</code> · <code>google_compute_network_endpoint_group</code> · <code>google_compute_region_network_endpoint_group</code> · <code>google_compute_region_ssl_certificate</code> · <code>google_compute_region_target_http_proxy</code> · <code>google_compute_region_target_https_proxy</code> |
 | [outputs.tf](./outputs.tf) | Module outputs. |  |
-| [urlmap.tf](./urlmap.tf) | URL map resources. | <code>google_compute_region_url_map</code> |
+| [urlmap.tf](./urlmap.tf) | URL map resources. | <code>google_compute_region_url_map</code> · <code>terraform_data</code> |
 | [variables-backend-service.tf](./variables-backend-service.tf) | Backend services variables. |  |
 | [variables-health-check.tf](./variables-health-check.tf) | Health check variable. |  |
 | [variables-urlmap.tf](./variables-urlmap.tf) | URLmap variable. |  |

--- a/modules/net-lb-app-int/backend-service.tf
+++ b/modules/net-lb-app-int/backend-service.tf
@@ -212,4 +212,16 @@ resource "google_compute_region_backend_service" "default" {
       policy = "CONSISTENT_HASH_SUBSETTING"
     }
   }
+  lifecycle {
+    replace_triggered_by = [
+      terraform_data.backend_replace_trigger
+
+    ]
+  }
+}
+
+resource "terraform_data" "backend_replace_trigger" {
+  triggers_replace = {
+    group_ids = local.group_ids
+  }
 }

--- a/modules/net-lb-app-int/urlmap.tf
+++ b/modules/net-lb-app-int/urlmap.tf
@@ -572,5 +572,16 @@ resource "google_compute_region_url_map" "default" {
       description = test.value.description
     }
   }
+  lifecycle {
+    replace_triggered_by = [
+      terraform_data.urlmap_replace_trigger
 
+    ]
+  }
+}
+
+resource "terraform_data" "urlmap_replace_trigger" {
+  triggers_replace = {
+    group_ids = local.backend_ids
+  }
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here -->
Work in progress, to discuss approach

This is approach, which could solve #1972 

The idea is to force recreation of the resource when used resources are recreated. Resource is recreated, it's `id` should be known only after apply, hence even if it stays the same, the plan will include replacement of the `terraform_data` trigger resource and then - the resource itself.

The approach should be added to almost all resources within each load-balancer module.

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass
