### PR TITLE
Accept email in service account module name

### DIFF
--- a/modules/iam-service-account/main.tf
+++ b/modules/iam-service-account/main.tf
@@ -21,8 +21,9 @@ locals {
     ? google_service_account_key.key["1"]
     : map("", null)
   , {})
+  name                  = split("@", var.name)[0]
   prefix                = var.prefix == null ? "" : "${var.prefix}-"
-  resource_email_static = "${local.prefix}${var.name}@${var.project_id}.iam.gserviceaccount.com"
+  resource_email_static = "${local.prefix}${local.name}@${var.project_id}.iam.gserviceaccount.com"
   resource_iam_email = (
     local.service_account != null
     ? "serviceAccount:${local.service_account.email}"
@@ -64,13 +65,13 @@ locals {
 data "google_service_account" "service_account" {
   count      = var.service_account_create ? 0 : 1
   project    = var.project_id
-  account_id = "${local.prefix}${var.name}"
+  account_id = "${local.prefix}${local.name}"
 }
 
 resource "google_service_account" "service_account" {
   count        = var.service_account_create ? 1 : 0
   project      = var.project_id
-  account_id   = "${local.prefix}${var.name}"
+  account_id   = "${local.prefix}${local.name}"
   display_name = var.display_name
   description  = var.description
 }


### PR DESCRIPTION
This fixes a corner case where an email is passed it to the service account module, e.g. when consuming an existing service account with no creation, and the full email is then used as the name.