### PR TITLE
Fix too long project names in e2e tests

### DIFF
--- a/modules/folder/README.md
+++ b/modules/folder/README.md
@@ -233,7 +233,7 @@ module "bucket" {
 
 module "destination-project" {
   source          = "./fabric/modules/project"
-  name            = "destination-project"
+  name            = "dest-project"
   billing_account = var.billing_account_id
   parent          = var.folder_id
   prefix          = var.prefix

--- a/modules/organization/README.md
+++ b/modules/organization/README.md
@@ -295,7 +295,7 @@ module "bucket" {
 
 module "destination-project" {
   source          = "./fabric/modules/project"
-  name            = "destination-project"
+  name            = "dest-project"
   billing_account = var.billing_account_id
   parent          = var.folder_id
   prefix          = var.prefix

--- a/modules/project/README.md
+++ b/modules/project/README.md
@@ -563,7 +563,7 @@ module "bucket" {
 
 module "destination-project" {
   source          = "./fabric/modules/project"
-  name            = "destination-project"
+  name            = "dest-project"
   billing_account = var.billing_account_id
   parent          = var.folder_id
   prefix          = var.prefix

--- a/tests/modules/folder/examples/logging.yaml
+++ b/tests/modules/folder/examples/logging.yaml
@@ -39,14 +39,14 @@ values:
     billing_account: 123456-123456-123456
     folder_id: '1122334455'
     labels: null
-    name: test-destination-project
+    name: test-dest-project
     org_id: null
-    project_id: test-destination-project
+    project_id: test-dest-project
     skip_delete: false
   module.destination-project.google_project_service.project_services["logging.googleapis.com"]:
     disable_dependent_services: false
     disable_on_destroy: false
-    project: test-destination-project
+    project: test-dest-project
     service: logging.googleapis.com
   module.folder-sink.google_bigquery_dataset_iam_member.bq-sinks-binding["info"]:
     condition: []
@@ -61,7 +61,7 @@ values:
     name: no-gce-instances
   module.folder-sink.google_logging_folder_sink.sink["alert"]:
     description: alert (Terraform-managed).
-    destination: logging.googleapis.com/projects/test-destination-project
+    destination: logging.googleapis.com/projects/test-dest-project
     disabled: false
     exclusions: []
     filter: severity=ALERT
@@ -109,7 +109,7 @@ values:
     role: roles/logging.bucketWriter
   module.folder-sink.google_project_iam_member.project-sinks-binding["alert"]:
     condition: []
-    project: test-destination-project
+    project: test-dest-project
     role: roles/logging.logWriter
   module.folder-sink.google_pubsub_topic_iam_member.pubsub-sinks-binding["notice"]:
     condition: []

--- a/tests/modules/organization/examples/logging.yaml
+++ b/tests/modules/organization/examples/logging.yaml
@@ -39,14 +39,14 @@ values:
     billing_account: 123456-123456-123456
     folder_id: '1122334455'
     labels: null
-    name: test-destination-project
+    name: test-dest-project
     org_id: null
-    project_id: test-destination-project
+    project_id: test-dest-project
     skip_delete: false
   module.destination-project.google_project_service.project_services["logging.googleapis.com"]:
     disable_dependent_services: false
     disable_on_destroy: false
-    project: test-destination-project
+    project: test-dest-project
     service: logging.googleapis.com
   module.gcs.google_storage_bucket.bucket:
     autoclass:
@@ -80,7 +80,7 @@ values:
     org_id: '1122334455'
   module.org.google_logging_organization_sink.sink["alert"]:
     description: alert (Terraform-managed).
-    destination: logging.googleapis.com/projects/test-destination-project
+    destination: logging.googleapis.com/projects/test-dest-project
     disabled: false
     exclusions: []
     filter: severity=ALERT
@@ -133,7 +133,7 @@ values:
     role: roles/logging.bucketWriter
   module.org.google_project_iam_member.project-sinks-binding["alert"]:
     condition: []
-    project: test-destination-project
+    project: test-dest-project
     role: roles/logging.logWriter
   module.org.google_pubsub_topic_iam_member.pubsub-sinks-binding["notice"]:
     condition: []

--- a/tests/modules/project/examples/logging.yaml
+++ b/tests/modules/project/examples/logging.yaml
@@ -39,14 +39,14 @@ values:
     billing_account: 123456-123456-123456
     folder_id: '1122334455'
     labels: null
-    name: test-destination-project
+    name: test-dest-project
     org_id: null
-    project_id: test-destination-project
+    project_id: test-dest-project
     skip_delete: false
   module.destination-project.google_project_service.project_services["logging.googleapis.com"]:
     disable_dependent_services: false
     disable_on_destroy: false
-    project: test-destination-project
+    project: test-dest-project
     service: logging.googleapis.com
   module.gcs.google_storage_bucket.bucket:
     autoclass:
@@ -81,7 +81,7 @@ values:
   module.project-host.google_logging_project_sink.sink["alert"]:
     custom_writer_identity: null
     description: alert (Terraform-managed).
-    destination: logging.googleapis.com/projects/test-destination-project
+    destination: logging.googleapis.com/projects/test-dest-project
     disabled: false
     exclusions: []
     filter: severity=ALERT
@@ -147,7 +147,7 @@ values:
     role: roles/logging.bucketWriter
   module.project-host.google_project_iam_member.project-sinks-binding["alert"]:
     condition: []
-    project: test-destination-project
+    project: test-dest-project
     role: roles/logging.logWriter
   module.project-host.google_project_service.project_services["logging.googleapis.com"]:
     disable_dependent_services: false


### PR DESCRIPTION
This fixes recent E2E failures:
```
Error: "***-1708673310w5-destination-project" name must be 4 to 30 characters with lowercase and uppercase letters, numbers, hyphen, single-quote, double-quote, space, and exclamation point
```

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [ ] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [x] Made sure all relevant tests pass
