### PR TITLE
Fix phpipam blueprint

### DIFF
--- a/blueprints/third-party-solutions/phpipam/README.md
+++ b/blueprints/third-party-solutions/phpipam/README.md
@@ -236,5 +236,5 @@ module "test" {
   }
   project_id = "test-prj"
 }
-# tftest modules=7 resources=43
+# tftest modules=8 resources=46
 ```

--- a/blueprints/third-party-solutions/phpipam/cloudsql.tf
+++ b/blueprints/third-party-solutions/phpipam/cloudsql.tf
@@ -35,6 +35,7 @@ module "cloudsql" {
   users = {
     "${local.cloudsql_conf.user}" = {
       password = var.cloudsql_password
+      type     = "BUILT_IN"
     }
   }
 }

--- a/blueprints/third-party-solutions/phpipam/glb.tf
+++ b/blueprints/third-party-solutions/phpipam/glb.tf
@@ -29,6 +29,22 @@ module "addresses" {
   }
 }
 
+module "glb-redirect" {
+  source               = "../../../modules/net-lb-app-ext"
+  count                = local.glb_create ? 1 : 0
+  project_id           = module.project.project_id
+  name                 = "phpipam-glb-redirect"
+  address              = module.addresses.0.global_addresses["phpipam"].address
+  health_check_configs = {}
+  urlmap_config = {
+    description = "URL redirect for phpipam glb."
+    default_url_redirect = {
+      https         = true
+      response_code = "MOVED_PERMANENTLY_DEFAULT"
+    }
+  }
+}
+
 # Global L7 HTTPS Load Balancer in front of Cloud Run
 module "glb" {
   source     = "../../../modules/net-lb-app-ext"

--- a/blueprints/third-party-solutions/phpipam/main.tf
+++ b/blueprints/third-party-solutions/phpipam/main.tf
@@ -21,7 +21,8 @@ locals {
     db               = "phpipam"
     user             = "admin"
   }
-  connector = var.connector == null ? module.cloud_run.vpc_connector : var.connector
+  cloudsql_password = var.cloudsql_password == null ? module.cloudsql.user_passwords[local.cloudsql_conf.user] : var.cloudsql_password
+  connector         = var.connector == null ? module.cloud_run.vpc_connector : var.connector
   domain = (
     var.custom_domain != null ? var.custom_domain : (
       var.phpipam_exposure == "EXTERNAL" ?
@@ -112,12 +113,13 @@ module "cloud_run" {
       env_from = null
       # set up the database connection
       env = {
-        "TZ"                 = "Europe/Rome"
-        "IPAM_DATABASE_HOST" = module.cloudsql.ip
-        "IPAM_DATABASE_USER" = local.cloudsql_conf.user
-        "IPAM_DATABASE_PASS" = var.cloudsql_password == null ? module.cloudsql.user_passwords[local.cloudsql_conf.user] : var.cloudsql_password
-        "IPAM_DATABASE_NAME" = local.cloudsql_conf.db
-        "IPAM_DATABASE_PORT" = "3306"
+        "TZ"                     = "Europe/Rome"
+        "IPAM_TRUST_X_FORWARDED" = "true"
+        "IPAM_DATABASE_HOST"     = module.cloudsql.ip
+        "IPAM_DATABASE_USER"     = local.cloudsql_conf.user
+        "IPAM_DATABASE_PASS"     = var.cloudsql_password == null ? module.cloudsql.user_passwords[local.cloudsql_conf.user] : var.cloudsql_password
+        "IPAM_DATABASE_NAME"     = local.cloudsql_conf.db
+        "IPAM_DATABASE_PORT"     = "3306"
       }
     }
   }

--- a/blueprints/third-party-solutions/phpipam/main.tf
+++ b/blueprints/third-party-solutions/phpipam/main.tf
@@ -21,8 +21,11 @@ locals {
     db               = "phpipam"
     user             = "admin"
   }
-  cloudsql_password = var.cloudsql_password == null ? module.cloudsql.user_passwords[local.cloudsql_conf.user] : var.cloudsql_password
-  connector         = var.connector == null ? module.cloud_run.vpc_connector : var.connector
+  cloudsql_password = coalesce(
+    var.cloudsql_password,
+    module.cloudsql.user_passwords[local.cloudsql_conf.user]
+  )
+  connector = coalesce(var.connector, module.cloud_run.vpc_connector)
   domain = (
     var.custom_domain != null ? var.custom_domain : (
       var.phpipam_exposure == "EXTERNAL" ?
@@ -117,7 +120,7 @@ module "cloud_run" {
         "IPAM_TRUST_X_FORWARDED" = "true"
         "IPAM_DATABASE_HOST"     = module.cloudsql.ip
         "IPAM_DATABASE_USER"     = local.cloudsql_conf.user
-        "IPAM_DATABASE_PASS"     = var.cloudsql_password == null ? module.cloudsql.user_passwords[local.cloudsql_conf.user] : var.cloudsql_password
+        "IPAM_DATABASE_PASS"     = local.cloudsql_password
         "IPAM_DATABASE_NAME"     = local.cloudsql_conf.db
         "IPAM_DATABASE_PORT"     = "3306"
       }

--- a/blueprints/third-party-solutions/phpipam/outputs.tf
+++ b/blueprints/third-party-solutions/phpipam/outputs.tf
@@ -22,7 +22,7 @@ output "cloud_run_service" {
 
 output "cloudsql_password" {
   description = "CloudSQL password."
-  value       = var.cloudsql_password == null ? module.cloudsql.user_passwords[local.cloudsql_conf.user] : var.cloudsql_password
+  value       = local.cloudsql_password
   sensitive   = true
 }
 


### PR DESCRIPTION
Fix #2114 

For the jquery / mixed content issues on PHPIPAM the proposed fix is based on the solution proposed on the [official repo](https://github.com/phpipam/phpipam/issues/802#issuecomment-1864710950). 

I also notice the error on the cloud sql password in output not available, the issue was related to the missing user type in cloud sql module preventing the password from being populated in the module's output. This was causing the blueprint output not being shown due to null value.

I had the chance to also update the following:
- add http to https redirect in GLB
- use local value for cloudsql_password output 

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass
