### PR TITLE
enabling dataform service agent upon activating the API

### DIFF
--- a/modules/project/service-agents.yaml
+++ b/modules/project/service-agents.yaml
@@ -146,6 +146,7 @@
   service_agent: "service-%s@dataflow-service-producer-prod.iam.gserviceaccount.com"
 - name: "dataform"
   service_agent: "service-%s@gcp-sa-dataform.iam.gserviceaccount.com"
+  jit: true
 - name: "datafusion"
   service_agent: "service-%s@gcp-sa-datafusion.iam.gserviceaccount.com"
 - name: "datalabeling"
@@ -374,7 +375,6 @@
   service_agent: "service-%s@gcp-sa-workloadmanager.iam.gserviceaccount.com"
 - name: "workstations"
   service_agent: "service-%s@gcp-sa-workstations.iam.gserviceaccount.com"
-
 
   # "accessapproval.googleapis.com.
   #   For the project: service-p%s@gcp-sa-accessapproval


### PR DESCRIPTION
This is to activate the Dataform service agent when the API is activated. jit set to true in the project module

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
