### PR TITLE
Add support for PSC network attachments and interfaces in modules

### DIFF
--- a/modules/compute-vm/README.md
+++ b/modules/compute-vm/README.md
@@ -25,6 +25,7 @@ In both modes, an optional service account can be created and assigned to either
     - [Internal and external IPs](#internal-and-external-ips)
     - [Using Alias IPs](#using-alias-ips)
     - [Using gVNIC](#using-gvnic)
+    - [PSC interfaces](#psc-interfaces)
   - [Metadata](#metadata)
   - [IAM](#iam)
   - [Spot VM](#spot-vm)
@@ -380,6 +381,40 @@ module "vm-with-gvnic" {
   }
 }
 # tftest modules=1 resources=3 inventory=gvnic.yaml
+```
+
+#### PSC interfaces
+
+[Private Service Connect interfaces](https://cloud.google.com/vpc/docs/about-private-service-connect-interfaces) can be configured via the `network_attached_interfaces` variable, which is a simple list of network attachment ids, one per interface. PSC interfaces will be defined after regular interfaces.
+
+```hcl
+
+# create the network attachment from a service project
+module "net-attachment" {
+  source     = "./fabric/modules/net-address"
+  project_id = "prj-svc"
+  network_attachments = {
+    svc-0 = {
+      subnet_self_link      = "projects/prj-host/regions/europe-west8/subnetworks/gce"
+      producer_accept_lists = ["my-vm-project"]
+    }
+  }
+}
+
+module "vm-psc-interface" {
+  source     = "./fabric/modules/compute-vm"
+  project_id = "my-vm-project"
+  zone       = "europe-west8-b"
+  name       = "vm-internal-ip"
+  network_interfaces = [{
+    network    = "internal"
+    subnetwork = "internal"
+  }]
+  network_attached_interfaces = [
+    module.net-attachment.network_attachment_ids["svc-0"]
+  ]
+}
+# tftest modules=2 resources=2
 ```
 
 ### Metadata
@@ -773,9 +808,9 @@ module "sole-tenancy" {
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
 | [name](variables.tf#L235) | Instance name. | <code>string</code> | ✓ |  |
-| [network_interfaces](variables.tf#L240) | Network interfaces configuration. Use self links for Shared VPC, set addresses to null if not needed. | <code title="list&#40;object&#40;&#123;&#10;  network    &#61; string&#10;  subnetwork &#61; string&#10;  alias_ips  &#61; optional&#40;map&#40;string&#41;, &#123;&#125;&#41;&#10;  nat        &#61; optional&#40;bool, false&#41;&#10;  nic_type   &#61; optional&#40;string&#41;&#10;  stack_type &#61; optional&#40;string&#41;&#10;  addresses &#61; optional&#40;object&#40;&#123;&#10;    internal &#61; optional&#40;string&#41;&#10;    external &#61; optional&#40;string&#41;&#10;  &#125;&#41;, null&#41;&#10;&#125;&#41;&#41;">list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> | ✓ |  |
-| [project_id](variables.tf#L282) | Project id. | <code>string</code> | ✓ |  |
-| [zone](variables.tf#L380) | Compute zone. | <code>string</code> | ✓ |  |
+| [network_interfaces](variables.tf#L247) | Network interfaces configuration. Use self links for Shared VPC, set addresses to null if not needed. | <code title="list&#40;object&#40;&#123;&#10;  network    &#61; string&#10;  subnetwork &#61; string&#10;  alias_ips  &#61; optional&#40;map&#40;string&#41;, &#123;&#125;&#41;&#10;  nat        &#61; optional&#40;bool, false&#41;&#10;  nic_type   &#61; optional&#40;string&#41;&#10;  stack_type &#61; optional&#40;string&#41;&#10;  addresses &#61; optional&#40;object&#40;&#123;&#10;    internal &#61; optional&#40;string&#41;&#10;    external &#61; optional&#40;string&#41;&#10;  &#125;&#41;, null&#41;&#10;&#125;&#41;&#41;">list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> | ✓ |  |
+| [project_id](variables.tf#L289) | Project id. | <code>string</code> | ✓ |  |
+| [zone](variables.tf#L387) | Compute zone. | <code>string</code> | ✓ |  |
 | [attached_disk_defaults](variables.tf#L17) | Defaults for attached disks options. | <code title="object&#40;&#123;&#10;  auto_delete  &#61; optional&#40;bool, false&#41;&#10;  mode         &#61; string&#10;  replica_zone &#61; string&#10;  type         &#61; string&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code title="&#123;&#10;  auto_delete  &#61; true&#10;  mode         &#61; &#34;READ_WRITE&#34;&#10;  replica_zone &#61; null&#10;  type         &#61; &#34;pd-balanced&#34;&#10;&#125;">&#123;&#8230;&#125;</code> |
 | [attached_disks](variables.tf#L37) | Additional disks, if options is null defaults will be used in its place. Source type is one of 'image' (zonal disks in vms and template), 'snapshot' (vm), 'existing', and null. | <code title="list&#40;object&#40;&#123;&#10;  name        &#61; string&#10;  device_name &#61; optional&#40;string&#41;&#10;  size              &#61; string&#10;  snapshot_schedule &#61; optional&#40;string&#41;&#10;  source            &#61; optional&#40;string&#41;&#10;  source_type       &#61; optional&#40;string&#41;&#10;  options &#61; optional&#40;&#10;    object&#40;&#123;&#10;      auto_delete  &#61; optional&#40;bool, false&#41;&#10;      mode         &#61; optional&#40;string, &#34;READ_WRITE&#34;&#41;&#10;      replica_zone &#61; optional&#40;string&#41;&#10;      type         &#61; optional&#40;string, &#34;pd-balanced&#34;&#41;&#10;    &#125;&#41;,&#10;    &#123;&#10;      auto_delete  &#61; true&#10;      mode         &#61; &#34;READ_WRITE&#34;&#10;      replica_zone &#61; null&#10;      type         &#61; &#34;pd-balanced&#34;&#10;    &#125;&#10;  &#41;&#10;&#125;&#41;&#41;">list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
 | [boot_disk](variables.tf#L83) | Boot disk properties. | <code title="object&#40;&#123;&#10;  auto_delete       &#61; optional&#40;bool, true&#41;&#10;  snapshot_schedule &#61; optional&#40;string&#41;&#10;  source            &#61; optional&#40;string&#41;&#10;  initialize_params &#61; optional&#40;object&#40;&#123;&#10;    image &#61; optional&#40;string, &#34;projects&#47;debian-cloud&#47;global&#47;images&#47;family&#47;debian-11&#34;&#41;&#10;    size  &#61; optional&#40;number, 10&#41;&#10;    type  &#61; optional&#40;string, &#34;pd-balanced&#34;&#41;&#10;  &#125;&#41;&#41;&#10;  use_independent_disk &#61; optional&#40;bool, false&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code title="&#123;&#10;  initialize_params &#61; &#123;&#125;&#10;&#125;">&#123;&#8230;&#125;</code> |
@@ -793,14 +828,15 @@ module "sole-tenancy" {
 | [labels](variables.tf#L217) | Instance labels. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
 | [metadata](variables.tf#L223) | Instance metadata. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
 | [min_cpu_platform](variables.tf#L229) | Minimum CPU platform. | <code>string</code> |  | <code>null</code> |
-| [options](variables.tf#L256) | Instance options. | <code title="object&#40;&#123;&#10;  allow_stopping_for_update &#61; optional&#40;bool, true&#41;&#10;  deletion_protection       &#61; optional&#40;bool, false&#41;&#10;  node_affinities &#61; optional&#40;map&#40;object&#40;&#123;&#10;    values &#61; list&#40;string&#41;&#10;    in     &#61; optional&#40;bool, true&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;  spot               &#61; optional&#40;bool, false&#41;&#10;  termination_action &#61; optional&#40;string&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code title="&#123;&#10;  allow_stopping_for_update &#61; true&#10;  deletion_protection       &#61; false&#10;  spot                      &#61; false&#10;  termination_action        &#61; null&#10;&#125;">&#123;&#8230;&#125;</code> |
-| [scratch_disks](variables.tf#L287) | Scratch disks configuration. | <code title="object&#40;&#123;&#10;  count     &#61; number&#10;  interface &#61; string&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code title="&#123;&#10;  count     &#61; 0&#10;  interface &#61; &#34;NVME&#34;&#10;&#125;">&#123;&#8230;&#125;</code> |
-| [service_account](variables.tf#L299) | Service account email and scopes. If email is null, the default Compute service account will be used unless auto_create is true, in which case a service account will be created. Set the variable to null to avoid attaching a service account. | <code title="object&#40;&#123;&#10;  auto_create &#61; optional&#40;bool, false&#41;&#10;  email       &#61; optional&#40;string&#41;&#10;  scopes      &#61; optional&#40;list&#40;string&#41;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [shielded_config](variables.tf#L309) | Shielded VM configuration of the instances. | <code title="object&#40;&#123;&#10;  enable_secure_boot          &#61; bool&#10;  enable_vtpm                 &#61; bool&#10;  enable_integrity_monitoring &#61; bool&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [snapshot_schedules](variables.tf#L319) | Snapshot schedule resource policies that can be attached to disks. | <code title="map&#40;object&#40;&#123;&#10;  schedule &#61; object&#40;&#123;&#10;    daily &#61; optional&#40;object&#40;&#123;&#10;      days_in_cycle &#61; number&#10;      start_time    &#61; string&#10;    &#125;&#41;&#41;&#10;    hourly &#61; optional&#40;object&#40;&#123;&#10;      hours_in_cycle &#61; number&#10;      start_time     &#61; string&#10;    &#125;&#41;&#41;&#10;    weekly &#61; optional&#40;list&#40;object&#40;&#123;&#10;      day        &#61; string&#10;      start_time &#61; string&#10;    &#125;&#41;&#41;&#41;&#10;  &#125;&#41;&#10;  description &#61; optional&#40;string&#41;&#10;  retention_policy &#61; optional&#40;object&#40;&#123;&#10;    max_retention_days         &#61; number&#10;    on_source_disk_delete_keep &#61; optional&#40;bool&#41;&#10;  &#125;&#41;&#41;&#10;  snapshot_properties &#61; optional&#40;object&#40;&#123;&#10;    chain_name        &#61; optional&#40;string&#41;&#10;    guest_flush       &#61; optional&#40;bool&#41;&#10;    labels            &#61; optional&#40;map&#40;string&#41;&#41;&#10;    storage_locations &#61; optional&#40;list&#40;string&#41;&#41;&#10;  &#125;&#41;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [tag_bindings](variables.tf#L362) | Resource manager tag bindings for this instance, in tag key => tag value format. | <code>map&#40;string&#41;</code> |  | <code>null</code> |
-| [tag_bindings_firewall](variables.tf#L368) | Firewall (network scoped) tag bindings for this instance, in tag key => tag value format. | <code>map&#40;string&#41;</code> |  | <code>null</code> |
-| [tags](variables.tf#L374) | Instance network tags for firewall rule targets. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
+| [network_attached_interfaces](variables.tf#L240) | Network interfaces using network attachments. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
+| [options](variables.tf#L263) | Instance options. | <code title="object&#40;&#123;&#10;  allow_stopping_for_update &#61; optional&#40;bool, true&#41;&#10;  deletion_protection       &#61; optional&#40;bool, false&#41;&#10;  node_affinities &#61; optional&#40;map&#40;object&#40;&#123;&#10;    values &#61; list&#40;string&#41;&#10;    in     &#61; optional&#40;bool, true&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;  spot               &#61; optional&#40;bool, false&#41;&#10;  termination_action &#61; optional&#40;string&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code title="&#123;&#10;  allow_stopping_for_update &#61; true&#10;  deletion_protection       &#61; false&#10;  spot                      &#61; false&#10;  termination_action        &#61; null&#10;&#125;">&#123;&#8230;&#125;</code> |
+| [scratch_disks](variables.tf#L294) | Scratch disks configuration. | <code title="object&#40;&#123;&#10;  count     &#61; number&#10;  interface &#61; string&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code title="&#123;&#10;  count     &#61; 0&#10;  interface &#61; &#34;NVME&#34;&#10;&#125;">&#123;&#8230;&#125;</code> |
+| [service_account](variables.tf#L306) | Service account email and scopes. If email is null, the default Compute service account will be used unless auto_create is true, in which case a service account will be created. Set the variable to null to avoid attaching a service account. | <code title="object&#40;&#123;&#10;  auto_create &#61; optional&#40;bool, false&#41;&#10;  email       &#61; optional&#40;string&#41;&#10;  scopes      &#61; optional&#40;list&#40;string&#41;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [shielded_config](variables.tf#L316) | Shielded VM configuration of the instances. | <code title="object&#40;&#123;&#10;  enable_secure_boot          &#61; bool&#10;  enable_vtpm                 &#61; bool&#10;  enable_integrity_monitoring &#61; bool&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [snapshot_schedules](variables.tf#L326) | Snapshot schedule resource policies that can be attached to disks. | <code title="map&#40;object&#40;&#123;&#10;  schedule &#61; object&#40;&#123;&#10;    daily &#61; optional&#40;object&#40;&#123;&#10;      days_in_cycle &#61; number&#10;      start_time    &#61; string&#10;    &#125;&#41;&#41;&#10;    hourly &#61; optional&#40;object&#40;&#123;&#10;      hours_in_cycle &#61; number&#10;      start_time     &#61; string&#10;    &#125;&#41;&#41;&#10;    weekly &#61; optional&#40;list&#40;object&#40;&#123;&#10;      day        &#61; string&#10;      start_time &#61; string&#10;    &#125;&#41;&#41;&#41;&#10;  &#125;&#41;&#10;  description &#61; optional&#40;string&#41;&#10;  retention_policy &#61; optional&#40;object&#40;&#123;&#10;    max_retention_days         &#61; number&#10;    on_source_disk_delete_keep &#61; optional&#40;bool&#41;&#10;  &#125;&#41;&#41;&#10;  snapshot_properties &#61; optional&#40;object&#40;&#123;&#10;    chain_name        &#61; optional&#40;string&#41;&#10;    guest_flush       &#61; optional&#40;bool&#41;&#10;    labels            &#61; optional&#40;map&#40;string&#41;&#41;&#10;    storage_locations &#61; optional&#40;list&#40;string&#41;&#41;&#10;  &#125;&#41;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [tag_bindings](variables.tf#L369) | Resource manager tag bindings for this instance, in tag key => tag value format. | <code>map&#40;string&#41;</code> |  | <code>null</code> |
+| [tag_bindings_firewall](variables.tf#L375) | Firewall (network scoped) tag bindings for this instance, in tag key => tag value format. | <code>map&#40;string&#41;</code> |  | <code>null</code> |
+| [tags](variables.tf#L381) | Instance network tags for firewall rule targets. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
 
 ## Outputs
 

--- a/modules/compute-vm/main.tf
+++ b/modules/compute-vm/main.tf
@@ -267,6 +267,13 @@ resource "google_compute_instance" "default" {
     }
   }
 
+  dynamic "network_interface" {
+    for_each = var.network_attached_interfaces
+    content {
+      network_attachment = network_interface.value
+    }
+  }
+
   scheduling {
     automatic_restart           = !var.options.spot
     instance_termination_action = local.termination_action
@@ -422,6 +429,13 @@ resource "google_compute_instance_template" "default" {
           ip_cidr_range         = config_alias.value
         }
       }
+    }
+  }
+
+  dynamic "network_interface" {
+    for_each = var.network_attached_interfaces
+    content {
+      network_attachment = network_interface.value
     }
   }
 

--- a/modules/compute-vm/variables.tf
+++ b/modules/compute-vm/variables.tf
@@ -237,6 +237,13 @@ variable "name" {
   type        = string
 }
 
+variable "network_attached_interfaces" {
+  description = "Network interfaces using network attachments."
+  type        = list(string)
+  nullable    = false
+  default     = []
+}
+
 variable "network_interfaces" {
   description = "Network interfaces configuration. Use self links for Shared VPC, set addresses to null if not needed."
   type = list(object({

--- a/modules/net-address/README.md
+++ b/modules/net-address/README.md
@@ -148,7 +148,7 @@ module "addresses" {
 
 ### PSC Network Attachments
 
-Network attachments can be created from Shared VPC service projects.
+The project where the network attachment is created must be either the VPC project, or a Shared VPC service project of the host owning the VPC.
 
 ```hcl
 module "addresses" {

--- a/modules/net-address/README.md
+++ b/modules/net-address/README.md
@@ -159,7 +159,6 @@ module "addresses" {
       subnet_self_link = (
         "projects/net-host/regions/europe-west8/subnetworks/gce"
       )
-      automatic_connection  = true
       producer_accept_lists = [var.project_id]
     }
   }

--- a/modules/net-address/README.md
+++ b/modules/net-address/README.md
@@ -1,6 +1,20 @@
 # Net Address Reservation Module
 
-This module allows reserving Compute Engine external, global, and internal addresses.
+This module allows reserving Compute Engine external, global, and internal addresses. The module also supports managing VPC network attachments from service projects.
+
+<!-- BEGIN TOC -->
+- [Examples](#examples)
+  - [External and global addresses](#external-and-global-addresses)
+  - [Internal addresses](#internal-addresses)
+  - [IPv6 addresses](#ipv6-addresses)
+  - [PSA addresses](#psa-addresses)
+  - [PSC addresses](#psc-addresses)
+  - [IPSec Interconnect addresses](#ipsec-interconnect-addresses)
+  - [PSC Network Attachments](#psc-network-attachments)
+- [Variables](#variables)
+- [Outputs](#outputs)
+- [Fixtures](#fixtures)
+<!-- END TOC -->
 
 ## Examples
 
@@ -108,7 +122,7 @@ module "addresses" {
 # tftest modules=1 resources=1 inventory=psc.yaml e2e
 ```
 
-# IPSec Interconnect addresses
+### IPSec Interconnect addresses
 
 ```hcl
 module "addresses" {
@@ -131,18 +145,40 @@ module "addresses" {
 }
 # tftest modules=1 resources=2 inventory=ipsec-interconnect.yaml e2e
 ```
+
+### PSC Network Attachments
+
+Network attachments can be created from Shared VPC service projects.
+
+```hcl
+module "addresses" {
+  source     = "./fabric/modules/net-address"
+  project_id = var.project_id
+  network_attachments = {
+    gce-0 = {
+      subnet_self_link = (
+        "projects/net-host/regions/europe-west8/subnetworks/gce"
+      )
+      automatic_connection  = true
+      producer_accept_lists = [var.project_id]
+    }
+  }
+}
+# tftest modules=1 resources=1 inventory=network-attachments.yaml
+```
 <!-- BEGIN TFDOC -->
 ## Variables
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [project_id](variables.tf#L84) | Project where the addresses will be created. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L97) | Project where the addresses will be created. | <code>string</code> | ✓ |  |
 | [external_addresses](variables.tf#L17) | Map of external addresses, keyed by name. | <code title="map&#40;object&#40;&#123;&#10;  region      &#61; string&#10;  description &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  ipv6 &#61; optional&#40;object&#40;&#123;&#10;    endpoint_type &#61; string&#10;  &#125;&#41;&#41;&#10;  labels     &#61; optional&#40;map&#40;string&#41;, &#123;&#125;&#41;&#10;  name       &#61; optional&#40;string&#41;&#10;  subnetwork &#61; optional&#40;string&#41; &#35; for IPv6&#10;  tier       &#61; optional&#40;string&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [global_addresses](variables.tf#L40) | List of global addresses to create. | <code title="map&#40;object&#40;&#123;&#10;  description &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  ipv6        &#61; optional&#40;map&#40;string&#41;&#41; &#35; To be left empty for ipv6&#10;  name        &#61; optional&#40;string&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [internal_addresses](variables.tf#L50) | Map of internal addresses to create, keyed by name. | <code title="map&#40;object&#40;&#123;&#10;  region      &#61; string&#10;  subnetwork  &#61; string&#10;  address     &#61; optional&#40;string&#41;&#10;  description &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  ipv6        &#61; optional&#40;map&#40;string&#41;&#41; &#35; To be left empty for ipv6&#10;  labels      &#61; optional&#40;map&#40;string&#41;&#41;&#10;  name        &#61; optional&#40;string&#41;&#10;  purpose     &#61; optional&#40;string&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [ipsec_interconnect_addresses](variables.tf#L65) | Map of internal addresses used for HPA VPN over Cloud Interconnect. | <code title="map&#40;object&#40;&#123;&#10;  region        &#61; string&#10;  address       &#61; string&#10;  network       &#61; string&#10;  description   &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  name          &#61; optional&#40;string&#41;&#10;  prefix_length &#61; number&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [psa_addresses](variables.tf#L89) | Map of internal addresses used for Private Service Access. | <code title="map&#40;object&#40;&#123;&#10;  address       &#61; string&#10;  network       &#61; string&#10;  prefix_length &#61; number&#10;  description   &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  name          &#61; optional&#40;string&#41;&#10;&#10;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [psc_addresses](variables.tf#L102) | Map of internal addresses used for Private Service Connect. | <code title="map&#40;object&#40;&#123;&#10;  address     &#61; string&#10;  network     &#61; string&#10;  description &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  name        &#61; optional&#40;string&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [network_attachments](variables.tf#L84) | PSC network attachments, names as keys. | <code title="map&#40;object&#40;&#123;&#10;  subnet_self_link      &#61; string&#10;  automatic_connection  &#61; optional&#40;bool, false&#41;&#10;  description           &#61; optional&#40;string, &#34;Terraform-managed.&#34;&#41;&#10;  producer_accept_lists &#61; optional&#40;list&#40;string&#41;&#41;&#10;  producer_reject_lists &#61; optional&#40;list&#40;string&#41;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [psa_addresses](variables.tf#L102) | Map of internal addresses used for Private Service Access. | <code title="map&#40;object&#40;&#123;&#10;  address       &#61; string&#10;  network       &#61; string&#10;  prefix_length &#61; number&#10;  description   &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  name          &#61; optional&#40;string&#41;&#10;&#10;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [psc_addresses](variables.tf#L115) | Map of internal addresses used for Private Service Connect. | <code title="map&#40;object&#40;&#123;&#10;  address     &#61; string&#10;  network     &#61; string&#10;  description &#61; optional&#40;string, &#34;Terraform managed.&#34;&#41;&#10;  name        &#61; optional&#40;string&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 
 ## Outputs
 
@@ -152,8 +188,9 @@ module "addresses" {
 | [global_addresses](outputs.tf#L25) | Allocated global external addresses. |  |
 | [internal_addresses](outputs.tf#L33) | Allocated internal addresses. |  |
 | [ipsec_interconnect_addresses](outputs.tf#L41) | Allocated internal addresses for HA VPN over Cloud Interconnect. |  |
-| [psa_addresses](outputs.tf#L49) | Allocated internal addresses for PSA endpoints. |  |
-| [psc_addresses](outputs.tf#L57) | Allocated internal addresses for PSC endpoints. |  |
+| [network_attachment_ids](outputs.tf#L49) | IDs of network attachments. |  |
+| [psa_addresses](outputs.tf#L57) | Allocated internal addresses for PSA endpoints. |  |
+| [psc_addresses](outputs.tf#L65) | Allocated internal addresses for PSC endpoints. |  |
 
 ## Fixtures
 

--- a/modules/net-address/outputs.tf
+++ b/modules/net-address/outputs.tf
@@ -46,6 +46,14 @@ output "ipsec_interconnect_addresses" {
   }
 }
 
+output "network_attachment_ids" {
+  description = "IDs of network attachments."
+  value = {
+    for k, v in google_compute_network_attachment.default :
+    k => v.id
+  }
+}
+
 output "psa_addresses" {
   description = "Allocated internal addresses for PSA endpoints."
   value = {

--- a/modules/net-address/variables.tf
+++ b/modules/net-address/variables.tf
@@ -81,6 +81,19 @@ variable "ipsec_interconnect_addresses" {
 #   default     = {}
 # }
 
+variable "network_attachments" {
+  description = "PSC network attachments, names as keys."
+  type = map(object({
+    subnet_self_link      = string
+    automatic_connection  = optional(bool, false)
+    description           = optional(string, "Terraform-managed.")
+    producer_accept_lists = optional(list(string))
+    producer_reject_lists = optional(list(string))
+  }))
+  nullable = false
+  default  = {}
+}
+
 variable "project_id" {
   description = "Project where the addresses will be created."
   type        = string

--- a/modules/net-vpc/README.md
+++ b/modules/net-vpc/README.md
@@ -14,6 +14,7 @@ This module allows creation and management of VPC networks including subnetworks
   - [Private Service Networking](#private-service-networking)
   - [Private Service Networking with peering routes and peered Cloud DNS domains](#private-service-networking-with-peering-routes-and-peered-cloud-dns-domains)
   - [Subnets for Private Service Connect, Proxy-only subnets](#subnets-for-private-service-connect-proxy-only-subnets)
+  - [PSC Network Attachments](#psc-network-attachments)
   - [DNS Policies](#dns-policies)
   - [Subnet Factory](#subnet-factory)
   - [Custom Routes](#custom-routes)
@@ -318,6 +319,43 @@ module "vpc" {
 # tftest modules=1 resources=6 inventory=proxy-only-subnets.yaml e2e
 ```
 
+### PSC Network Attachments
+
+[Network attachments](https://cloud.google.com/vpc/docs/about-network-attachments) are only supported for subnets directly managed by the module. To create network attachments in service projects, refer to the [`net-address`](../net-address/) module documentation.
+
+```hcl
+module "vpc" {
+  source     = "./fabric/modules/net-vpc"
+  project_id = var.project_id
+  name       = "my-network"
+  network_attachments = {
+    prod-ew1 = {
+      subnet = "europe-west1/production"
+    }
+    prod-ew2 = {
+      subnet               = "europe-west2/production"
+      automatic_connection = true
+      producer_accept_lists = [
+        "my-project-1"
+      ]
+    }
+  }
+  subnets = [
+    {
+      ip_cidr_range = "10.0.0.0/24"
+      name          = "production"
+      region        = "europe-west1"
+    },
+    {
+      ip_cidr_range = "10.0.16.0/24"
+      name          = "production"
+      region        = "europe-west2"
+    }
+  ]
+}
+# tftest modules=1 resources=7 inventory=network-attachments.yaml
+```
+
 ### DNS Policies
 
 ```hcl
@@ -576,7 +614,7 @@ module "vpc" {
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
 | [name](variables.tf#L95) | The name of the network being created. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L159) | The ID of the project where this VPC will be created. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L172) | The ID of the project where this VPC will be created. | <code>string</code> | ✓ |  |
 | [auto_create_subnetworks](variables.tf#L17) | Set to true to create an auto mode subnet, defaults to custom mode. | <code>bool</code> |  | <code>false</code> |
 | [create_googleapis_routes](variables.tf#L23) | Toggle creation of googleapis private/restricted routes. Disabled when vpc creation is turned off, or when set to null. | <code title="object&#40;&#123;&#10;  private      &#61; optional&#40;bool, true&#41;&#10;  private-6    &#61; optional&#40;bool, false&#41;&#10;  restricted   &#61; optional&#40;bool, true&#41;&#10;  restricted-6 &#61; optional&#40;bool, false&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [delete_default_routes_on_create](variables.tf#L34) | Set to true to delete the default routes at creation time. | <code>bool</code> |  | <code>false</code> |
@@ -586,17 +624,18 @@ module "vpc" {
 | [firewall_policy_enforcement_order](variables.tf#L67) | Order that Firewall Rules and Firewall Policies are evaluated. Can be either 'BEFORE_CLASSIC_FIREWALL' or 'AFTER_CLASSIC_FIREWALL'. | <code>string</code> |  | <code>&#34;AFTER_CLASSIC_FIREWALL&#34;</code> |
 | [ipv6_config](variables.tf#L79) | Optional IPv6 configuration for this network. | <code title="object&#40;&#123;&#10;  enable_ula_internal &#61; optional&#40;bool&#41;&#10;  internal_range      &#61; optional&#40;string&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [mtu](variables.tf#L89) | Maximum Transmission Unit in bytes. The minimum value for this field is 1460 (the default) and the maximum value is 1500 bytes. | <code>number</code> |  | <code>null</code> |
-| [peering_config](variables.tf#L100) | VPC peering configuration. | <code title="object&#40;&#123;&#10;  peer_vpc_self_link &#61; string&#10;  create_remote_peer &#61; optional&#40;bool, true&#41;&#10;  export_routes      &#61; optional&#40;bool&#41;&#10;  import_routes      &#61; optional&#40;bool&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [policy_based_routes](variables.tf#L111) | Policy based routes, keyed by name. | <code title="map&#40;object&#40;&#123;&#10;  description         &#61; optional&#40;string, &#34;Terraform-managed.&#34;&#41;&#10;  labels              &#61; optional&#40;map&#40;string&#41;&#41;&#10;  priority            &#61; optional&#40;number&#41;&#10;  next_hop_ilb_ip     &#61; optional&#40;string&#41;&#10;  use_default_routing &#61; optional&#40;bool, false&#41;&#10;  filter &#61; optional&#40;object&#40;&#123;&#10;    ip_protocol &#61; optional&#40;string&#41;&#10;    dest_range  &#61; optional&#40;string&#41;&#10;    src_range   &#61; optional&#40;string&#41;&#10;  &#125;&#41;, &#123;&#125;&#41;&#10;  target &#61; optional&#40;object&#40;&#123;&#10;    interconnect_attachment &#61; optional&#40;string&#41;&#10;    tags                    &#61; optional&#40;list&#40;string&#41;&#41;&#10;  &#125;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [psa_config](variables.tf#L164) | The Private Service Access configuration for Service Networking. | <code title="object&#40;&#123;&#10;  ranges         &#61; map&#40;string&#41;&#10;  export_routes  &#61; optional&#40;bool, false&#41;&#10;  import_routes  &#61; optional&#40;bool, false&#41;&#10;  peered_domains &#61; optional&#40;list&#40;string&#41;, &#91;&#93;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [routes](variables.tf#L175) | Network routes, keyed by name. | <code title="map&#40;object&#40;&#123;&#10;  description   &#61; optional&#40;string, &#34;Terraform-managed.&#34;&#41;&#10;  dest_range    &#61; string&#10;  next_hop_type &#61; string &#35; gateway, instance, ip, vpn_tunnel, ilb&#10;  next_hop      &#61; string&#10;  priority      &#61; optional&#40;number&#41;&#10;  tags          &#61; optional&#40;list&#40;string&#41;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [routing_mode](variables.tf#L196) | The network routing mode (default 'GLOBAL'). | <code>string</code> |  | <code>&#34;GLOBAL&#34;</code> |
-| [shared_vpc_host](variables.tf#L206) | Enable shared VPC for this project. | <code>bool</code> |  | <code>false</code> |
-| [shared_vpc_service_projects](variables.tf#L212) | Shared VPC service projects to register with this host. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
-| [subnets](variables.tf#L218) | Subnet configuration. | <code title="list&#40;object&#40;&#123;&#10;  name                  &#61; string&#10;  ip_cidr_range         &#61; string&#10;  region                &#61; string&#10;  description           &#61; optional&#40;string&#41;&#10;  enable_private_access &#61; optional&#40;bool, true&#41;&#10;  flow_logs_config &#61; optional&#40;object&#40;&#123;&#10;    aggregation_interval &#61; optional&#40;string&#41;&#10;    filter_expression    &#61; optional&#40;string&#41;&#10;    flow_sampling        &#61; optional&#40;number&#41;&#10;    metadata             &#61; optional&#40;string&#41;&#10;    metadata_fields &#61; optional&#40;list&#40;string&#41;&#41;&#10;  &#125;&#41;&#41;&#10;  ipv6 &#61; optional&#40;object&#40;&#123;&#10;    access_type &#61; optional&#40;string, &#34;INTERNAL&#34;&#41;&#10;  &#125;&#41;&#41;&#10;  secondary_ip_ranges &#61; optional&#40;map&#40;string&#41;&#41;&#10;&#10;&#10;  iam &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;  iam_bindings &#61; optional&#40;map&#40;object&#40;&#123;&#10;    role    &#61; string&#10;    members &#61; list&#40;string&#41;&#10;    condition &#61; optional&#40;object&#40;&#123;&#10;      expression  &#61; string&#10;      title       &#61; string&#10;      description &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;  iam_bindings_additive &#61; optional&#40;map&#40;object&#40;&#123;&#10;    member &#61; string&#10;    role   &#61; string&#10;    condition &#61; optional&#40;object&#40;&#123;&#10;      expression  &#61; string&#10;      title       &#61; string&#10;      description &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;&#41;">list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
-| [subnets_proxy_only](variables.tf#L265) | List of proxy-only subnets for Regional HTTPS or Internal HTTPS load balancers. Note: Only one proxy-only subnet for each VPC network in each region can be active. | <code title="list&#40;object&#40;&#123;&#10;  name          &#61; string&#10;  ip_cidr_range &#61; string&#10;  region        &#61; string&#10;  description   &#61; optional&#40;string&#41;&#10;  active        &#61; optional&#40;bool, true&#41;&#10;  global        &#61; optional&#40;bool, false&#41;&#10;&#10;&#10;  iam &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;  iam_bindings &#61; optional&#40;map&#40;object&#40;&#123;&#10;    role    &#61; string&#10;    members &#61; list&#40;string&#41;&#10;    condition &#61; optional&#40;object&#40;&#123;&#10;      expression  &#61; string&#10;      title       &#61; string&#10;      description &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;  iam_bindings_additive &#61; optional&#40;map&#40;object&#40;&#123;&#10;    member &#61; string&#10;    role   &#61; string&#10;    condition &#61; optional&#40;object&#40;&#123;&#10;      expression  &#61; string&#10;      title       &#61; string&#10;      description &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;&#41;">list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
-| [subnets_psc](variables.tf#L299) | List of subnets for Private Service Connect service producers. | <code title="list&#40;object&#40;&#123;&#10;  name          &#61; string&#10;  ip_cidr_range &#61; string&#10;  region        &#61; string&#10;  description   &#61; optional&#40;string&#41;&#10;&#10;&#10;  iam &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;  iam_bindings &#61; optional&#40;map&#40;object&#40;&#123;&#10;    role    &#61; string&#10;    members &#61; list&#40;string&#41;&#10;    condition &#61; optional&#40;object&#40;&#123;&#10;      expression  &#61; string&#10;      title       &#61; string&#10;      description &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;  iam_bindings_additive &#61; optional&#40;map&#40;object&#40;&#123;&#10;    member &#61; string&#10;    role   &#61; string&#10;    condition &#61; optional&#40;object&#40;&#123;&#10;      expression  &#61; string&#10;      title       &#61; string&#10;      description &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;&#41;">list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
-| [vpc_create](variables.tf#L331) | Create VPC. When set to false, uses a data source to reference existing VPC. | <code>bool</code> |  | <code>true</code> |
+| [network_attachments](variables.tf#L100) | PSC network attachments, names as keys. | <code title="map&#40;object&#40;&#123;&#10;  subnet                &#61; string&#10;  automatic_connection  &#61; optional&#40;bool, false&#41;&#10;  description           &#61; optional&#40;string, &#34;Terraform-managed.&#34;&#41;&#10;  producer_accept_lists &#61; optional&#40;list&#40;string&#41;&#41;&#10;  producer_reject_lists &#61; optional&#40;list&#40;string&#41;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [peering_config](variables.tf#L113) | VPC peering configuration. | <code title="object&#40;&#123;&#10;  peer_vpc_self_link &#61; string&#10;  create_remote_peer &#61; optional&#40;bool, true&#41;&#10;  export_routes      &#61; optional&#40;bool&#41;&#10;  import_routes      &#61; optional&#40;bool&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [policy_based_routes](variables.tf#L124) | Policy based routes, keyed by name. | <code title="map&#40;object&#40;&#123;&#10;  description         &#61; optional&#40;string, &#34;Terraform-managed.&#34;&#41;&#10;  labels              &#61; optional&#40;map&#40;string&#41;&#41;&#10;  priority            &#61; optional&#40;number&#41;&#10;  next_hop_ilb_ip     &#61; optional&#40;string&#41;&#10;  use_default_routing &#61; optional&#40;bool, false&#41;&#10;  filter &#61; optional&#40;object&#40;&#123;&#10;    ip_protocol &#61; optional&#40;string&#41;&#10;    dest_range  &#61; optional&#40;string&#41;&#10;    src_range   &#61; optional&#40;string&#41;&#10;  &#125;&#41;, &#123;&#125;&#41;&#10;  target &#61; optional&#40;object&#40;&#123;&#10;    interconnect_attachment &#61; optional&#40;string&#41;&#10;    tags                    &#61; optional&#40;list&#40;string&#41;&#41;&#10;  &#125;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [psa_config](variables.tf#L177) | The Private Service Access configuration for Service Networking. | <code title="object&#40;&#123;&#10;  ranges         &#61; map&#40;string&#41;&#10;  export_routes  &#61; optional&#40;bool, false&#41;&#10;  import_routes  &#61; optional&#40;bool, false&#41;&#10;  peered_domains &#61; optional&#40;list&#40;string&#41;, &#91;&#93;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [routes](variables.tf#L188) | Network routes, keyed by name. | <code title="map&#40;object&#40;&#123;&#10;  description   &#61; optional&#40;string, &#34;Terraform-managed.&#34;&#41;&#10;  dest_range    &#61; string&#10;  next_hop_type &#61; string &#35; gateway, instance, ip, vpn_tunnel, ilb&#10;  next_hop      &#61; string&#10;  priority      &#61; optional&#40;number&#41;&#10;  tags          &#61; optional&#40;list&#40;string&#41;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [routing_mode](variables.tf#L209) | The network routing mode (default 'GLOBAL'). | <code>string</code> |  | <code>&#34;GLOBAL&#34;</code> |
+| [shared_vpc_host](variables.tf#L219) | Enable shared VPC for this project. | <code>bool</code> |  | <code>false</code> |
+| [shared_vpc_service_projects](variables.tf#L225) | Shared VPC service projects to register with this host. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
+| [subnets](variables.tf#L231) | Subnet configuration. | <code title="list&#40;object&#40;&#123;&#10;  name                  &#61; string&#10;  ip_cidr_range         &#61; string&#10;  region                &#61; string&#10;  description           &#61; optional&#40;string&#41;&#10;  enable_private_access &#61; optional&#40;bool, true&#41;&#10;  flow_logs_config &#61; optional&#40;object&#40;&#123;&#10;    aggregation_interval &#61; optional&#40;string&#41;&#10;    filter_expression    &#61; optional&#40;string&#41;&#10;    flow_sampling        &#61; optional&#40;number&#41;&#10;    metadata             &#61; optional&#40;string&#41;&#10;    metadata_fields &#61; optional&#40;list&#40;string&#41;&#41;&#10;  &#125;&#41;&#41;&#10;  ipv6 &#61; optional&#40;object&#40;&#123;&#10;    access_type &#61; optional&#40;string, &#34;INTERNAL&#34;&#41;&#10;  &#125;&#41;&#41;&#10;  secondary_ip_ranges &#61; optional&#40;map&#40;string&#41;&#41;&#10;&#10;&#10;  iam &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;  iam_bindings &#61; optional&#40;map&#40;object&#40;&#123;&#10;    role    &#61; string&#10;    members &#61; list&#40;string&#41;&#10;    condition &#61; optional&#40;object&#40;&#123;&#10;      expression  &#61; string&#10;      title       &#61; string&#10;      description &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;  iam_bindings_additive &#61; optional&#40;map&#40;object&#40;&#123;&#10;    member &#61; string&#10;    role   &#61; string&#10;    condition &#61; optional&#40;object&#40;&#123;&#10;      expression  &#61; string&#10;      title       &#61; string&#10;      description &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;&#41;">list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
+| [subnets_proxy_only](variables.tf#L278) | List of proxy-only subnets for Regional HTTPS or Internal HTTPS load balancers. Note: Only one proxy-only subnet for each VPC network in each region can be active. | <code title="list&#40;object&#40;&#123;&#10;  name          &#61; string&#10;  ip_cidr_range &#61; string&#10;  region        &#61; string&#10;  description   &#61; optional&#40;string&#41;&#10;  active        &#61; optional&#40;bool, true&#41;&#10;  global        &#61; optional&#40;bool, false&#41;&#10;&#10;&#10;  iam &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;  iam_bindings &#61; optional&#40;map&#40;object&#40;&#123;&#10;    role    &#61; string&#10;    members &#61; list&#40;string&#41;&#10;    condition &#61; optional&#40;object&#40;&#123;&#10;      expression  &#61; string&#10;      title       &#61; string&#10;      description &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;  iam_bindings_additive &#61; optional&#40;map&#40;object&#40;&#123;&#10;    member &#61; string&#10;    role   &#61; string&#10;    condition &#61; optional&#40;object&#40;&#123;&#10;      expression  &#61; string&#10;      title       &#61; string&#10;      description &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;&#41;">list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
+| [subnets_psc](variables.tf#L312) | List of subnets for Private Service Connect service producers. | <code title="list&#40;object&#40;&#123;&#10;  name          &#61; string&#10;  ip_cidr_range &#61; string&#10;  region        &#61; string&#10;  description   &#61; optional&#40;string&#41;&#10;&#10;&#10;  iam &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;  iam_bindings &#61; optional&#40;map&#40;object&#40;&#123;&#10;    role    &#61; string&#10;    members &#61; list&#40;string&#41;&#10;    condition &#61; optional&#40;object&#40;&#123;&#10;      expression  &#61; string&#10;      title       &#61; string&#10;      description &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;  iam_bindings_additive &#61; optional&#40;map&#40;object&#40;&#123;&#10;    member &#61; string&#10;    role   &#61; string&#10;    condition &#61; optional&#40;object&#40;&#123;&#10;      expression  &#61; string&#10;      title       &#61; string&#10;      description &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;&#41;">list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
+| [vpc_create](variables.tf#L344) | Create VPC. When set to false, uses a data source to reference existing VPC. | <code>bool</code> |  | <code>true</code> |
 
 ## Outputs
 
@@ -606,15 +645,16 @@ module "vpc" {
 | [internal_ipv6_range](outputs.tf#L29) | ULA range. |  |
 | [name](outputs.tf#L34) | Network name. |  |
 | [network](outputs.tf#L46) | Network resource. |  |
-| [project_id](outputs.tf#L58) | Project ID containing the network. Use this when you need to create resources *after* the VPC is fully set up (e.g. subnets created, shared VPC service projects attached, Private Service Networking configured). |  |
-| [self_link](outputs.tf#L71) | Network self link. |  |
-| [subnet_ids](outputs.tf#L83) | Map of subnet IDs keyed by name. |  |
-| [subnet_ips](outputs.tf#L92) | Map of subnet address ranges keyed by name. |  |
-| [subnet_ipv6_external_prefixes](outputs.tf#L99) | Map of subnet external IPv6 prefixes keyed by name. |  |
-| [subnet_regions](outputs.tf#L107) | Map of subnet regions keyed by name. |  |
-| [subnet_secondary_ranges](outputs.tf#L114) | Map of subnet secondary ranges keyed by name. |  |
-| [subnet_self_links](outputs.tf#L125) | Map of subnet self links keyed by name. |  |
-| [subnets](outputs.tf#L134) | Subnet resources. |  |
-| [subnets_proxy_only](outputs.tf#L143) | L7 ILB or L7 Regional LB subnet resources. |  |
-| [subnets_psc](outputs.tf#L148) | Private Service Connect subnet resources. |  |
+| [network_attachment_ids](outputs.tf#L58) | IDs of network attachments. |  |
+| [project_id](outputs.tf#L66) | Project ID containing the network. Use this when you need to create resources *after* the VPC is fully set up (e.g. subnets created, shared VPC service projects attached, Private Service Networking configured). |  |
+| [self_link](outputs.tf#L79) | Network self link. |  |
+| [subnet_ids](outputs.tf#L91) | Map of subnet IDs keyed by name. |  |
+| [subnet_ips](outputs.tf#L100) | Map of subnet address ranges keyed by name. |  |
+| [subnet_ipv6_external_prefixes](outputs.tf#L107) | Map of subnet external IPv6 prefixes keyed by name. |  |
+| [subnet_regions](outputs.tf#L115) | Map of subnet regions keyed by name. |  |
+| [subnet_secondary_ranges](outputs.tf#L122) | Map of subnet secondary ranges keyed by name. |  |
+| [subnet_self_links](outputs.tf#L133) | Map of subnet self links keyed by name. |  |
+| [subnets](outputs.tf#L142) | Subnet resources. |  |
+| [subnets_proxy_only](outputs.tf#L151) | L7 ILB or L7 Regional LB subnet resources. |  |
+| [subnets_psc](outputs.tf#L156) | Private Service Connect subnet resources. |  |
 <!-- END TFDOC -->

--- a/modules/net-vpc/README.md
+++ b/modules/net-vpc/README.md
@@ -331,13 +331,13 @@ module "vpc" {
   network_attachments = {
     prod-ew1 = {
       subnet = "europe-west1/production"
+      producer_accept_lists = [
+        "my-project-1"
+      ]
     }
     prod-ew2 = {
       subnet               = "europe-west2/production"
       automatic_connection = true
-      producer_accept_lists = [
-        "my-project-1"
-      ]
     }
   }
   subnets = [

--- a/modules/net-vpc/outputs.tf
+++ b/modules/net-vpc/outputs.tf
@@ -55,6 +55,14 @@ output "network" {
   ]
 }
 
+output "network_attachment_ids" {
+  description = "IDs of network attachments."
+  value = {
+    for k, v in google_compute_network_attachment.default :
+    k => v.id
+  }
+}
+
 output "project_id" {
   description = "Project ID containing the network. Use this when you need to create resources *after* the VPC is fully set up (e.g. subnets created, shared VPC service projects attached, Private Service Networking configured)."
   value       = var.project_id

--- a/modules/net-vpc/subnets.tf
+++ b/modules/net-vpc/subnets.tf
@@ -252,13 +252,12 @@ resource "google_compute_subnetwork_iam_member" "bindings" {
   }
 }
 
-
 resource "google_compute_network_attachment" "default" {
   provider    = google-beta
   for_each    = var.network_attachments
   project     = var.project_id
-  name        = each.key
   region      = google_compute_subnetwork.subnetwork[each.value.subnet].region
+  name        = each.key
   description = each.value.description
   connection_preference = (
     each.value.automatic_connection ? "ACCEPT_AUTOMATIC" : "ACCEPT_MANUAL"

--- a/modules/net-vpc/subnets.tf
+++ b/modules/net-vpc/subnets.tf
@@ -251,3 +251,21 @@ resource "google_compute_subnetwork_iam_member" "bindings" {
     }
   }
 }
+
+
+resource "google_compute_network_attachment" "default" {
+  provider    = google-beta
+  for_each    = var.network_attachments
+  project     = var.project_id
+  name        = each.key
+  region      = google_compute_subnetwork.subnetwork[each.value.subnet].region
+  description = each.value.description
+  connection_preference = (
+    each.value.automatic_connection ? "ACCEPT_AUTOMATIC" : "ACCEPT_MANUAL"
+  )
+  subnetworks = [
+    google_compute_subnetwork.subnetwork[each.value.subnet].self_link
+  ]
+  producer_accept_lists = each.value.producer_accept_lists
+  producer_reject_lists = each.value.producer_reject_lists
+}

--- a/modules/net-vpc/variables.tf
+++ b/modules/net-vpc/variables.tf
@@ -97,6 +97,19 @@ variable "name" {
   type        = string
 }
 
+variable "network_attachments" {
+  description = "PSC network attachments, names as keys."
+  type = map(object({
+    subnet                = string
+    automatic_connection  = optional(bool, false)
+    description           = optional(string, "Terraform-managed.")
+    producer_accept_lists = optional(list(string))
+    producer_reject_lists = optional(list(string))
+  }))
+  nullable = false
+  default  = {}
+}
+
 variable "peering_config" {
   description = "VPC peering configuration."
   type = object({

--- a/tests/modules/net_address/examples/network-attachments.yaml
+++ b/tests/modules/net_address/examples/network-attachments.yaml
@@ -14,7 +14,7 @@
 
 values:
   module.addresses.google_compute_network_attachment.default["gce-0"]:
-    connection_preference: ACCEPT_AUTOMATIC
+    connection_preference: ACCEPT_MANUAL
     description: Terraform-managed.
     name: gce-0
     producer_accept_lists:

--- a/tests/modules/net_address/examples/network-attachments.yaml
+++ b/tests/modules/net_address/examples/network-attachments.yaml
@@ -1,0 +1,34 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values:
+  module.addresses.google_compute_network_attachment.default["gce-0"]:
+    connection_preference: ACCEPT_AUTOMATIC
+    description: Terraform-managed.
+    name: gce-0
+    producer_accept_lists:
+    - project-id
+    producer_reject_lists: null
+    project: project-id
+    region: europe-west8
+    subnetworks:
+    - https://www.googleapis.com/compute/v1/projects/net-host/regions/europe-west8/subnetworks/gce
+    timeouts: null
+
+counts:
+  google_compute_network_attachment: 1
+  modules: 1
+  resources: 1
+
+outputs: {}

--- a/tests/modules/net_vpc/examples/network-attachments.yaml
+++ b/tests/modules/net_vpc/examples/network-attachments.yaml
@@ -13,21 +13,12 @@
 # limitations under the License.
 
 values:
-  module.vpc.google_compute_network.network[0]:
-    auto_create_subnetworks: false
-    delete_default_routes_on_create: false
-    description: Terraform-managed.
-    enable_ula_internal_ipv6: null
-    name: my-network
-    network_firewall_policy_enforcement_order: AFTER_CLASSIC_FIREWALL
-    project: project-id
-    routing_mode: GLOBAL
-    timeouts: null
   module.vpc.google_compute_network_attachment.default["prod-ew1"]:
     connection_preference: ACCEPT_MANUAL
     description: Terraform-managed.
     name: prod-ew1
-    producer_accept_lists: null
+    producer_accept_lists:
+    - my-project-1
     producer_reject_lists: null
     project: project-id
     region: europe-west1
@@ -36,59 +27,10 @@ values:
     connection_preference: ACCEPT_AUTOMATIC
     description: Terraform-managed.
     name: prod-ew2
-    producer_accept_lists:
-    - my-project-1
+    producer_accept_lists: null
     producer_reject_lists: null
     project: project-id
     region: europe-west2
-    timeouts: null
-  module.vpc.google_compute_route.gateway["private-googleapis"]:
-    description: Terraform-managed.
-    dest_range: 199.36.153.8/30
-    name: my-network-private-googleapis
-    next_hop_gateway: default-internet-gateway
-    next_hop_ilb: null
-    next_hop_instance: null
-    next_hop_vpn_tunnel: null
-    priority: 1000
-    project: project-id
-    tags: null
-    timeouts: null
-  module.vpc.google_compute_route.gateway["restricted-googleapis"]:
-    description: Terraform-managed.
-    dest_range: 199.36.153.4/30
-    name: my-network-restricted-googleapis
-    next_hop_gateway: default-internet-gateway
-    next_hop_ilb: null
-    next_hop_instance: null
-    next_hop_vpn_tunnel: null
-    priority: 1000
-    project: project-id
-    tags: null
-    timeouts: null
-  module.vpc.google_compute_subnetwork.subnetwork["europe-west1/production"]:
-    description: Terraform-managed.
-    ip_cidr_range: 10.0.0.0/24
-    ipv6_access_type: null
-    log_config: []
-    name: production
-    private_ip_google_access: true
-    project: project-id
-    region: europe-west1
-    role: null
-    secondary_ip_range: []
-    timeouts: null
-  module.vpc.google_compute_subnetwork.subnetwork["europe-west2/production"]:
-    description: Terraform-managed.
-    ip_cidr_range: 10.0.16.0/24
-    ipv6_access_type: null
-    log_config: []
-    name: production
-    private_ip_google_access: true
-    project: project-id
-    region: europe-west2
-    role: null
-    secondary_ip_range: []
     timeouts: null
 
 counts:

--- a/tests/modules/net_vpc/examples/network-attachments.yaml
+++ b/tests/modules/net_vpc/examples/network-attachments.yaml
@@ -1,0 +1,102 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values:
+  module.vpc.google_compute_network.network[0]:
+    auto_create_subnetworks: false
+    delete_default_routes_on_create: false
+    description: Terraform-managed.
+    enable_ula_internal_ipv6: null
+    name: my-network
+    network_firewall_policy_enforcement_order: AFTER_CLASSIC_FIREWALL
+    project: project-id
+    routing_mode: GLOBAL
+    timeouts: null
+  module.vpc.google_compute_network_attachment.default["prod-ew1"]:
+    connection_preference: ACCEPT_MANUAL
+    description: Terraform-managed.
+    name: prod-ew1
+    producer_accept_lists: null
+    producer_reject_lists: null
+    project: project-id
+    region: europe-west1
+    timeouts: null
+  module.vpc.google_compute_network_attachment.default["prod-ew2"]:
+    connection_preference: ACCEPT_AUTOMATIC
+    description: Terraform-managed.
+    name: prod-ew2
+    producer_accept_lists:
+    - my-project-1
+    producer_reject_lists: null
+    project: project-id
+    region: europe-west2
+    timeouts: null
+  module.vpc.google_compute_route.gateway["private-googleapis"]:
+    description: Terraform-managed.
+    dest_range: 199.36.153.8/30
+    name: my-network-private-googleapis
+    next_hop_gateway: default-internet-gateway
+    next_hop_ilb: null
+    next_hop_instance: null
+    next_hop_vpn_tunnel: null
+    priority: 1000
+    project: project-id
+    tags: null
+    timeouts: null
+  module.vpc.google_compute_route.gateway["restricted-googleapis"]:
+    description: Terraform-managed.
+    dest_range: 199.36.153.4/30
+    name: my-network-restricted-googleapis
+    next_hop_gateway: default-internet-gateway
+    next_hop_ilb: null
+    next_hop_instance: null
+    next_hop_vpn_tunnel: null
+    priority: 1000
+    project: project-id
+    tags: null
+    timeouts: null
+  module.vpc.google_compute_subnetwork.subnetwork["europe-west1/production"]:
+    description: Terraform-managed.
+    ip_cidr_range: 10.0.0.0/24
+    ipv6_access_type: null
+    log_config: []
+    name: production
+    private_ip_google_access: true
+    project: project-id
+    region: europe-west1
+    role: null
+    secondary_ip_range: []
+    timeouts: null
+  module.vpc.google_compute_subnetwork.subnetwork["europe-west2/production"]:
+    description: Terraform-managed.
+    ip_cidr_range: 10.0.16.0/24
+    ipv6_access_type: null
+    log_config: []
+    name: production
+    private_ip_google_access: true
+    project: project-id
+    region: europe-west2
+    role: null
+    secondary_ip_range: []
+    timeouts: null
+
+counts:
+  google_compute_network: 1
+  google_compute_network_attachment: 2
+  google_compute_route: 2
+  google_compute_subnetwork: 2
+  modules: 1
+  resources: 7
+
+outputs: {}


### PR DESCRIPTION
This PR implements support for PSC network attachments and interfaces. The design moves from Fabric principles, and

- implements support for network attachments in the `net-vpc` module, to allow network owners to directly define them
- implements support for network attachments in the `net-address` module, to allow the use case of creating attachments from Shared VPC service projects
- implements support for network attached interfaces in the `compute-vm` module

At a lower level, the design choice on where and how to implement support (apart from the obvious choice of the vm module), moves from a few simple considerations.

The `net-vpc` variable design uses a separate variable, as network attachments have a 1:1 relationship with subnets (single subnet per attachment), and subnets have a 1:n relationship with attachments (multiple attachments possible per subnet). 
Implementing support directly in the subnets variable would have made it overly verbose; using a separate variable for attachments keeps the variable types simpler, and follows the same design principle used for proxy only and psc subnets, which allows to clearly identify a family of resources in variables at a glance (as opposed to IAM which we consider a resource configuration).

The choice of implementing support for attachment creation in service projects in the `net-address` module moves from the fact that at a high level, a network attachment is not entirely dissimilar from reserving subnet addresses (*"If a network attachment accepts a connection from a Private Service Connect interface, Google Cloud allocates to the interface an internal IP address from a consumer subnet that's specified by the network attachment"* from the GCP docs). Implementing the same in the `net-vpc` module would have resulted in weird configurations, where the project passed to the module did not match the one where the resource needs to be created (host vs service), and subnets would still have to be specified by full URL without being internally referenced by the module who would not be managing them.

The `compute-vm` module support for attached interfaces has been implemented via a dedicated variable, as the type is radically different from regular network interfaces, and would have resulted in a very intricate variable with lots of corner cases to be addressed in validation. This choice also makes it obvious that at least one regular network interface is still required even when attached interfaces are used.

The module changes have been tested with actual apply commands in my own setup.
