### PR TITLE
Add links to factories doc

### DIFF
--- a/blueprints/factories/README.md
+++ b/blueprints/factories/README.md
@@ -41,39 +41,36 @@ The second factory type is implemented as a standalone module that internally re
 ### Module-level factory interfaces
 
 - **BigQuery Analicts Hub rules**
-  - `analytics-hub`
+  - [`analytics-hub`](../../modules/analytics-hub/README.md#factory)
 - **billing budgets**
-  - `billing-account`
+  - [`billing-account`](../../modules/billing-account/README.md#budget-factory)
 - **Data Catalog tags**
-  - `data-catalog-tag`
+  - [`data-catalog-tag`](../../modules/data-catalog-tag/README.md#factory)
 - **Data Catalog tag templates**
-  - `data-catalog-tag-template`
+  - [`data-catalog-tag-template`](../../modules/data-catalog-tag-template/README.md#factory)
 - **Dataplex Datascan rules**
-  - `dataplex-datascan`
-- **firewall policy rules**
-  - `net-firewall-policy`
-- **hierarchical firewall policies**
-  - `folder`
-  - `project`
+  - [`dataplex-datascan`](../../modules/dataplex-datascan/README.md)
+- **firewall policy**
+  - [`net-firewall-policy`](../../modules/net-firewall-policy/README.md#factory)
 - **IAM custom roles**
-  - `organization`
-  - `project`
+  - [`organization`](../../modules/organization/README.md#custom-roles-factory)
+  - [`project`](../../modules/project/README.md#custom-roles-factory)
 - **organization policies**
-  - `organization`
-  - `folder`
-  - `project`
+  - [`organization`](../../modules/organization/README.md#organization-policy-factory)
+  - [`folder`](../../modules/folder/README.md#organization-policy-factory)
+  - [`project`](../../modules/project/README.md#organization-policy-factory)
 - **organization policy custom constraints**
-  - `organization`
+  - [`organization`](../../modules/organization/README.md#organization-policy-custom-constraints-factory)
 - **DNS response policy rules**
-  - `dns-response-policy`
+  - [`dns-response-policy`](../../modules/dns-response-policy/README.md#define-policy-rules-via-a-factory-file)
 - **VPC firewall rules**
-  - `net-vpc-firewall`
+  - [`net-vpc-firewall`](../../modules/net-vpc-firewall/README.md#rules-factory)
 - **VPC subnets**
-  - `net-vpc`
+  - [`net-vpc`](../../modules/net-vpc/README.md#subnet-factory)
 - **VPC-SC access levels and policies**
-  - `vpc-sc`
+  - [`vpc-sc`](../../modules/vpc-sc/README.md#factories)
 
 ### Standalone factories
 
 - **projects**
-  - `project-factory`
+  - [`project-factory`](../../modules/project-factory/)

--- a/modules/organization/README.md
+++ b/modules/organization/README.md
@@ -24,6 +24,7 @@ To manage organization policies, the `orgpolicy.googleapis.com` service should b
 - [Log Sinks](#log-sinks)
 - [Data Access Logs](#data-access-logs)
 - [Custom Roles](#custom-roles)
+  - [Custom Roles Factory](#custom-roles-factory)
 - [Tags](#tags)
 - [Files](#files)
 - [Variables](#variables)
@@ -387,6 +388,8 @@ module "org" {
 }
 # tftest modules=1 resources=2 inventory=roles.yaml e2e serial
 ```
+
+### Custom Roles Factory
 
 Custom roles can also be specified via a factory in a similar way to organization policies and policy constraints. Each file is mapped to a custom role, where
 

--- a/modules/project/README.md
+++ b/modules/project/README.md
@@ -1096,8 +1096,8 @@ module "bucket" {
 
 | name | description | sensitive |
 |---|---|:---:|
-| [custom_role_id](outputs.tf#L22) | Map of custom role IDs created in the project. |  |
-| [custom_roles](outputs.tf#L17) | Map of custom roles resources created in the project. |  |
+| [custom_role_id](outputs.tf#L17) | Map of custom role IDs created in the project. |  |
+| [custom_roles](outputs.tf#L27) | Map of custom roles resources created in the project. |  |
 | [id](outputs.tf#L32) | Project id. |  |
 | [name](outputs.tf#L51) | Project name. |  |
 | [number](outputs.tf#L63) | Project number. |  |

--- a/modules/project/outputs.tf
+++ b/modules/project/outputs.tf
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-output "custom_role_ids" {
+output "custom_roles" {
+  description = "Map of custom roles resources created in the project."
+  value       = google_project_iam_custom_role.roles
+}
+
+output "custom_role_id" {
   description = "Map of custom role IDs created in the project."
   value = {
     for k, v in google_project_iam_custom_role.roles :

--- a/modules/project/outputs.tf
+++ b/modules/project/outputs.tf
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-output "custom_roles" {
-  description = "Map of custom roles resources created in the project."
-  value       = google_project_iam_custom_role.roles
-}
-
 output "custom_role_id" {
   description = "Map of custom role IDs created in the project."
   value = {
@@ -27,6 +22,11 @@ output "custom_role_id" {
     # keys (useful for folder/organization/project-level iam bindings)
     (k) => "projects/${local.prefix}${var.name}/roles/${local.custom_roles[k].name}"
   }
+}
+
+output "custom_roles" {
+  description = "Map of custom roles resources created in the project."
+  value       = google_project_iam_custom_role.roles
 }
 
 output "id" {


### PR DESCRIPTION
This PR adds deep links to the factories documentation page. It also adds a missing section to the project module README, and reconciles the name of the custom roles outputs with the the one used in the organization module.