### PR TITLE
Support automation/controlling projects and resources in project factory

### DIFF
--- a/modules/project-factory/README.md
+++ b/modules/project-factory/README.md
@@ -128,7 +128,7 @@ automation:
         roles/storage.objectViewer:
           - rw
           - ro
-          - "group: devops@example.org"
+          - group:devops@example.org
 ```
 
 ## Billing budgets
@@ -342,7 +342,7 @@ automation:
         roles/storage.objectViewer:
           - rw
           - ro
-          - "group: devops@example.org"
+          - group:devops@example.org
 
 
 # tftest-file id=prj-app-3 path=data/projects/prj-app-3.yaml

--- a/modules/project-factory/automation.tf
+++ b/modules/project-factory/automation.tf
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  automation_buckets = flatten([
+    for k, v in projects : [
+      for ks, kv in try(v.automation.buckets, {}) : merge(kv, {
+        automation_project = v.automation.project
+        name               = ks
+        prefix             = v.prefix
+        project            = k
+      })
+    ]
+  ])
+  automation_sa = flatten([
+    for k, v in projects : [
+      for ks, kv in try(v.automation.service_accounts, {}) : merge(kv, {
+        automation_project = v.automation.project
+        name               = ks
+        prefix             = v.prefix
+        project            = k
+      })
+    ]
+  ])
+}
+
+module "automation-buckets" {
+  source = "../gcs"
+  for_each = {
+    for k in local.automation_buckets : "${k.project}/${k.name}" => k
+  }
+  project_id     = each.value.automation_project
+  prefix         = each.value.prefix
+  name           = "${each.value.project}-${each.value.name}"
+  description    = lookup(each.value, "description", null)
+  encryption_key = lookup(each.value, "encryption_key", null)
+  # try interpolating service accounts by key in principals
+  iam = {
+    for k, v in lookup(each.value, "iam", {}) : k => [
+      for vv in v : try(
+        module.automation-service-accounts["${each.value.project}/${vv}"], vv
+      )
+    ]
+  }
+  iam_bindings = {
+    for k, v in lookup(each.value, "iam_bindings", {}) : k => merge(v, {
+      members = [
+        for vv in v.members : try(
+          module.automation-service-accounts["${each.value.project}/${vv}"], vv
+        )
+      ]
+    })
+  }
+  iam_bindings_additive = {
+    for k, v in lookup(each.value, "iam_bindings_additive", {}) : k => merge(v, {
+      member = try(
+        module.automation-service-accounts["${each.value.project}/${v.member}"],
+        v.member
+      )
+    })
+  }
+  labels                      = lookup(each.value, "labels", {})
+  location                    = lookup(each.value, "location", "EU")
+  storage_class               = lookup(each.value, "storage_class", "MULTI_REGIONAL")
+  uniform_bucket_level_access = lookup(each.value, "uniform_bucket_level_access", true)
+  versioning                  = lookup(each.value, "versioning", false)
+}
+
+module "automation-service-accounts" {
+  source = "../iam-service-account"
+  for_each = {
+    for k in local.automation_sa : "${k.project}/${k.name}" => k
+  }
+  project_id  = each.value.automation_project
+  prefix      = each.value.prefix
+  name        = "${each.value.project}-${each.value.name}"
+  description = lookup(each.value, "description", null)
+  display_name = lookup(
+    each.value,
+    "display_name",
+    "Service account ${each.value.key} for ${each.value.project}."
+  )
+  iam                    = lookup(each.value, "iam", {})
+  iam_bindings           = lookup(each.value, "iam_bindings", {})
+  iam_bindings_additive  = lookup(each.value, "iam_bindings_additive", {})
+  iam_billing_roles      = lookup(each.value, "iam_billing_roles", {})
+  iam_folder_roles       = lookup(each.value, "iam_folder_roles", {})
+  iam_organization_roles = lookup(each.value, "iam_organization_roles", {})
+  iam_project_roles      = lookup(each.value, "iam_project_roles", {})
+  iam_sa_roles           = lookup(each.value, "iam_sa_roles", {})
+  # we don't interpolate buckets here as we can't use a dynamic key
+  iam_storage_roles = lookup(each.value, "iam_storage_roles", {})
+}

--- a/modules/project-factory/factory-budgets.tf
+++ b/modules/project-factory/factory-budgets.tf
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+# tfdoc:file:description Billing budget factory locals.
+
 locals {
   # reimplement the billing account factory here to interpolate projects
   _budget_path = try(pathexpand(var.factories_config.budgets.budgets_data_path), null)

--- a/modules/project-factory/factory-folders.tf
+++ b/modules/project-factory/factory-folders.tf
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+# tfdoc:file:description Folder hierarchy factory locals.
+
 locals {
   _folders_path = try(
     pathexpand(var.factories_config.hierarchy.folders_data_path), null
@@ -50,54 +52,4 @@ check "hierarchy-data" {
     )
     error_message = "No default set for hierarchy parent ids."
   }
-}
-
-module "hierarchy-folder-lvl-1" {
-  source   = "../folder"
-  for_each = { for k, v in local.folders : k => v if v.level == 1 }
-  parent = try(
-    # allow the YAML data to set the parent for this level
-    lookup(
-      var.factories_config.hierarchy.parent_ids,
-      each.value.parent,
-      # use the value as is if it's not in the parents map
-      each.value.parent
-    ),
-    # use the default value in the initial parents map
-    var.factories_config.hierarchy.parent_ids.default
-    # fail if we don't have an explicit parent
-  )
-  name                  = each.value.name
-  iam                   = lookup(each.value, "iam", {})
-  iam_bindings          = lookup(each.value, "iam_bindings", {})
-  iam_bindings_additive = lookup(each.value, "iam_bindings_additive", {})
-  iam_by_principals     = lookup(each.value, "iam_by_principals", {})
-  org_policies          = lookup(each.value, "org_policies", {})
-  tag_bindings          = lookup(each.value, "tag_bindings", {})
-}
-
-module "hierarchy-folder-lvl-2" {
-  source                = "../folder"
-  for_each              = { for k, v in local.folders : k => v if v.level == 2 }
-  parent                = module.hierarchy-folder-lvl-1[each.value.parent_key].id
-  name                  = each.value.name
-  iam                   = lookup(each.value, "iam", {})
-  iam_bindings          = lookup(each.value, "iam_bindings", {})
-  iam_bindings_additive = lookup(each.value, "iam_bindings_additive", {})
-  iam_by_principals     = lookup(each.value, "iam_by_principals", {})
-  org_policies          = lookup(each.value, "org_policies", {})
-  tag_bindings          = lookup(each.value, "tag_bindings", {})
-}
-
-module "hierarchy-folder-lvl-3" {
-  source                = "../folder"
-  for_each              = { for k, v in local.folders : k => v if v.level == 3 }
-  parent                = module.hierarchy-folder-lvl-2[each.value.parent_key].id
-  name                  = each.value.name
-  iam                   = lookup(each.value, "iam", {})
-  iam_bindings          = lookup(each.value, "iam_bindings", {})
-  iam_bindings_additive = lookup(each.value, "iam_bindings_additive", {})
-  iam_by_principals     = lookup(each.value, "iam_by_principals", {})
-  org_policies          = lookup(each.value, "org_policies", {})
-  tag_bindings          = lookup(each.value, "tag_bindings", {})
 }

--- a/modules/project-factory/factory-projects.tf
+++ b/modules/project-factory/factory-projects.tf
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+# tfdoc:file:description Projects factory locals.
+
 locals {
   _hierarchy_projects = (
     {

--- a/modules/project-factory/folders.tf
+++ b/modules/project-factory/folders.tf
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# tfdoc:file:description Folder hierarchy factory resources.
+
+module "hierarchy-folder-lvl-1" {
+  source   = "../folder"
+  for_each = { for k, v in local.folders : k => v if v.level == 1 }
+  parent = try(
+    # allow the YAML data to set the parent for this level
+    lookup(
+      var.factories_config.hierarchy.parent_ids,
+      each.value.parent,
+      # use the value as is if it's not in the parents map
+      each.value.parent
+    ),
+    # use the default value in the initial parents map
+    var.factories_config.hierarchy.parent_ids.default
+    # fail if we don't have an explicit parent
+  )
+  name                  = each.value.name
+  iam                   = lookup(each.value, "iam", {})
+  iam_bindings          = lookup(each.value, "iam_bindings", {})
+  iam_bindings_additive = lookup(each.value, "iam_bindings_additive", {})
+  iam_by_principals     = lookup(each.value, "iam_by_principals", {})
+  org_policies          = lookup(each.value, "org_policies", {})
+  tag_bindings          = lookup(each.value, "tag_bindings", {})
+}
+
+module "hierarchy-folder-lvl-2" {
+  source                = "../folder"
+  for_each              = { for k, v in local.folders : k => v if v.level == 2 }
+  parent                = module.hierarchy-folder-lvl-1[each.value.parent_key].id
+  name                  = each.value.name
+  iam                   = lookup(each.value, "iam", {})
+  iam_bindings          = lookup(each.value, "iam_bindings", {})
+  iam_bindings_additive = lookup(each.value, "iam_bindings_additive", {})
+  iam_by_principals     = lookup(each.value, "iam_by_principals", {})
+  org_policies          = lookup(each.value, "org_policies", {})
+  tag_bindings          = lookup(each.value, "tag_bindings", {})
+}
+
+module "hierarchy-folder-lvl-3" {
+  source                = "../folder"
+  for_each              = { for k, v in local.folders : k => v if v.level == 3 }
+  parent                = module.hierarchy-folder-lvl-2[each.value.parent_key].id
+  name                  = each.value.name
+  iam                   = lookup(each.value, "iam", {})
+  iam_bindings          = lookup(each.value, "iam_bindings", {})
+  iam_bindings_additive = lookup(each.value, "iam_bindings_additive", {})
+  iam_by_principals     = lookup(each.value, "iam_by_principals", {})
+  org_policies          = lookup(each.value, "org_policies", {})
+  tag_bindings          = lookup(each.value, "tag_bindings", {})
+}

--- a/modules/project-factory/main.tf
+++ b/modules/project-factory/main.tf
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+# tfdoc:file:description Projects and billing budgets factory resources.
+
 module "projects" {
   source          = "../project"
   for_each        = local.projects
@@ -31,10 +33,35 @@ module "projects" {
   )
   default_service_account = try(each.value.default_service_account, "keep")
   descriptive_name        = try(each.value.descriptive_name, null)
-  iam                     = try(each.value.iam, {})
-  iam_bindings            = try(each.value.iam_bindings, {})
-  iam_bindings_additive   = try(each.value.iam_bindings_additive, {})
-  iam_by_principals       = try(each.value.iam_by_principals, {})
+  # IAM interpolates automation service accounts
+  iam = {
+    for k, v in lookup(each.value, "iam", {}) : k => [
+      for vv in v : try(
+        module.automation-service-accounts["${each.key}/${vv}"].iam_email,
+        vv
+      )
+    ]
+  }
+  iam_bindings = {
+    for k, v in lookup(each.value, "iam_bindings", {}) : k => merge(v, {
+      members = [
+        for vv in v.members : try(
+          module.automation-service-accounts["${each.key}/${vv}"].iam_email,
+          vv
+        )
+      ]
+    })
+  }
+  iam_bindings_additive = {
+    for k, v in lookup(each.value, "iam_bindings_additive", {}) : k => merge(v, {
+      member = try(
+        module.automation-service-accounts["${each.key}/${v.member}"].iam_email,
+        v.member
+      )
+    })
+  }
+  # IAM principals would trigger dynamic key errors so we don't interpolate
+  iam_by_principals = try(each.value.iam_by_principals, {})
   labels = merge(
     each.value.labels, var.data_merges.labels
   )

--- a/tests/modules/project_factory/examples/example.yaml
+++ b/tests/modules/project_factory/examples/example.yaml
@@ -12,6 +12,107 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+values:
+  module.project-factory.module.automation-buckets["prj-app-3/state"].google_storage_bucket.bucket:
+    autoclass:
+    - enabled: false
+    cors: []
+    custom_placement_config: []
+    default_event_based_hold: null
+    enable_object_retention: null
+    encryption: []
+    force_destroy: false
+    labels: null
+    lifecycle_rule: []
+    location: EU
+    logging: []
+    name: test-pf-prj-app-3-state
+    project: bar-baz-iac-0
+    requester_pays: null
+    retention_policy: []
+    storage_class: MULTI_REGIONAL
+    timeouts: null
+    uniform_bucket_level_access: true
+    versioning:
+    - enabled: false
+  ? module.project-factory.module.automation-buckets["prj-app-3/state"].google_storage_bucket_iam_binding.authoritative["roles/storage.objectCreator"]
+  : bucket: test-pf-prj-app-3-state
+    condition: []
+    members:
+    - serviceAccount:test-pf-prj-app-3-rw@bar-baz-iac-0.iam.gserviceaccount.com
+    role: roles/storage.objectCreator
+  ? module.project-factory.module.automation-buckets["prj-app-3/state"].google_storage_bucket_iam_binding.authoritative["roles/storage.objectViewer"]
+  : bucket: test-pf-prj-app-3-state
+    condition: []
+    members:
+    - 'group: devops@example.org'
+    - serviceAccount:test-pf-prj-app-3-ro@bar-baz-iac-0.iam.gserviceaccount.com
+    - serviceAccount:test-pf-prj-app-3-rw@bar-baz-iac-0.iam.gserviceaccount.com
+    role: roles/storage.objectViewer
+  module.project-factory.module.automation-service-accounts["prj-app-3/ro"].google_service_account.service_account[0]:
+    account_id: test-pf-prj-app-3-ro
+    create_ignore_already_exists: null
+    description: Read-only automation sa for app example 0.
+    disabled: false
+    display_name: Service account ro for prj-app-3.
+    project: bar-baz-iac-0
+    timeouts: null
+  module.project-factory.module.automation-service-accounts["prj-app-3/rw"].google_service_account.service_account[0]:
+    account_id: test-pf-prj-app-3-rw
+    create_ignore_already_exists: null
+    description: Read/write automation sa for app example 0.
+    disabled: false
+    display_name: Service account rw for prj-app-3.
+    project: bar-baz-iac-0
+    timeouts: null
+  module.project-factory.module.hierarchy-folder-lvl-1["bar"].google_folder.folder[0]:
+    display_name: Bar (level 1)
+    parent: folders/4567890
+    timeouts: null
+  module.project-factory.module.hierarchy-folder-lvl-1["foo"].google_folder.folder[0]:
+    display_name: Foo (level 1)
+    parent: folders/12345678
+    timeouts: null
+  module.project-factory.module.hierarchy-folder-lvl-1["foo"].google_folder_iam_binding.authoritative["roles/viewer"]:
+    condition: []
+    members:
+    - group:a@example.com
+    role: roles/viewer
+  module.project-factory.module.hierarchy-folder-lvl-2["bar/baz"].google_folder.folder[0]:
+    display_name: Bar Baz (level 2)
+    timeouts: null
+  module.project-factory.module.hierarchy-folder-lvl-2["foo/baz"].google_folder.folder[0]:
+    display_name: Foo Baz (level 2)
+    timeouts: null
+  module.project-factory.module.projects["bar-baz-iac-0"].data.google_storage_project_service_account.gcs_sa[0]:
+    project: test-pf-bar-baz-iac-0
+    user_project: null
+  module.project-factory.module.projects["prj-app-3"].google_project.project[0]:
+    auto_create_network: false
+    billing_account: 123456-123456-123456
+    effective_labels:
+      environment: test
+    labels:
+      environment: test
+    name: test-pf-prj-app-3
+    project_id: test-pf-prj-app-3
+    skip_delete: false
+    terraform_labels:
+      environment: test
+    timeouts: null
+  module.project-factory.module.projects["prj-app-3"].google_project_iam_binding.authoritative["roles/owner"]:
+    condition: []
+    members:
+    - serviceAccount:test-pf-prj-app-3-rw@bar-baz-iac-0.iam.gserviceaccount.com
+    project: test-pf-prj-app-3
+    role: roles/owner
+  module.project-factory.module.projects["prj-app-3"].google_project_iam_binding.authoritative["roles/viewer"]:
+    condition: []
+    members:
+    - serviceAccount:test-pf-prj-app-3-ro@bar-baz-iac-0.iam.gserviceaccount.com
+    project: test-pf-prj-app-3
+    role: roles/viewer
+
 counts:
   google_billing_budget: 1
   google_compute_shared_vpc_service_project: 1
@@ -23,9 +124,12 @@ counts:
   google_monitoring_notification_channel: 1
   google_org_policy_policy: 1
   google_project: 4
+  google_project_iam_binding: 2
   google_project_iam_member: 6
   google_project_service: 14
-  google_service_account: 3
+  google_service_account: 5
+  google_storage_bucket: 1
+  google_storage_bucket_iam_binding: 2
   google_storage_project_service_account: 4
-  modules: 13
-  resources: 48
+  modules: 16
+  resources: 55

--- a/tests/modules/project_factory/examples/example.yaml
+++ b/tests/modules/project_factory/examples/example.yaml
@@ -45,7 +45,7 @@ values:
   : bucket: test-pf-prj-app-3-state
     condition: []
     members:
-    - 'group: devops@example.org'
+    - group:devops@example.org
     - serviceAccount:test-pf-prj-app-3-ro@bar-baz-iac-0.iam.gserviceaccount.com
     - serviceAccount:test-pf-prj-app-3-rw@bar-baz-iac-0.iam.gserviceaccount.com
     role: roles/storage.objectViewer


### PR DESCRIPTION
This PR adds support for defining controlling (IaC) projects and resources in the project factory. This is an example from the README:

```yaml
# file name: prod-app-example-0
# prefix via factory defaults: foo
# project id: foo-prod-app-example-0
billing_account: 012345-67890A-BCDEF0
parent: folders/12345678
services:
  - compute.googleapis.com
  - stackdriver.googleapis.com
iam:
  roles/owner:
    - rw
  roles/viewer:
    - ro
automation:
  project: foo-prod-iac-core-0
  service_accounts:
    # sa name: foo-prod-app-example-0-rw
    rw:
      description: Read/write automation sa for app example 0.
    # sa name: foo-prod-app-example-0-ro
    ro:
      description: Read-only automation sa for app example 0.
  buckets:
    # bucket name: foo-prod-app-example-0-state
    state:
      description: Terraform state bucket for app example 0.
      iam:
        roles/storage.objectCreator:
          - rw
        roles/storage.objectViewer:
          - rw
          - ro
          - "group: devops@example.org"
```