### PR TITLE
feat(net-cloudnat): add `tcp_time_wait` to `config_timeouts`

### DIFF
--- a/modules/net-cloudnat/README.md
+++ b/modules/net-cloudnat/README.md
@@ -62,26 +62,25 @@ module "nat" {
 }
 # tftest modules=2 resources=5 inventory=rules.yaml e2e
 ```
-
 <!-- BEGIN TFDOC -->
 ## Variables
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [name](variables.tf#L63) | Name of the Cloud NAT resource. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L68) | Project where resources will be created. | <code>string</code> | ✓ |  |
-| [region](variables.tf#L73) | Region where resources will be created. | <code>string</code> | ✓ |  |
+| [name](variables.tf#L64) | Name of the Cloud NAT resource. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L69) | Project where resources will be created. | <code>string</code> | ✓ |  |
+| [region](variables.tf#L74) | Region where resources will be created. | <code>string</code> | ✓ |  |
 | [addresses](variables.tf#L17) | Optional list of external address self links. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
 | [config_port_allocation](variables.tf#L23) | Configuration for how to assign ports to virtual machines. min_ports_per_vm and max_ports_per_vm have no effect unless enable_dynamic_port_allocation is set to 'true'. | <code title="object&#40;&#123;&#10;  enable_endpoint_independent_mapping &#61; optional&#40;bool, true&#41;&#10;  enable_dynamic_port_allocation      &#61; optional&#40;bool, false&#41;&#10;  min_ports_per_vm                    &#61; optional&#40;number, 64&#41;&#10;  max_ports_per_vm                    &#61; optional&#40;number, 65536&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [config_source_subnets](variables.tf#L39) | Subnetwork configuration (ALL_SUBNETWORKS_ALL_IP_RANGES, ALL_SUBNETWORKS_ALL_PRIMARY_IP_RANGES, LIST_OF_SUBNETWORKS). | <code>string</code> |  | <code>&#34;ALL_SUBNETWORKS_ALL_IP_RANGES&#34;</code> |
-| [config_timeouts](variables.tf#L45) | Timeout configurations. | <code title="object&#40;&#123;&#10;  icmp            &#61; optional&#40;number, 30&#41;&#10;  tcp_established &#61; optional&#40;number, 1200&#41;&#10;  tcp_transitory  &#61; optional&#40;number, 30&#41;&#10;  udp             &#61; optional&#40;number, 30&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [logging_filter](variables.tf#L57) | Enables logging if not null, value is one of 'ERRORS_ONLY', 'TRANSLATIONS_ONLY', 'ALL'. | <code>string</code> |  | <code>null</code> |
-| [router_asn](variables.tf#L78) | Router ASN used for auto-created router. | <code>number</code> |  | <code>null</code> |
-| [router_create](variables.tf#L84) | Create router. | <code>bool</code> |  | <code>true</code> |
-| [router_name](variables.tf#L90) | Router name, leave blank if router will be created to use auto generated name. | <code>string</code> |  | <code>null</code> |
-| [router_network](variables.tf#L96) | Name of the VPC used for auto-created router. | <code>string</code> |  | <code>null</code> |
-| [rules](variables.tf#L102) | List of rules associated with this NAT. | <code title="list&#40;object&#40;&#123;&#10;  description &#61; optional&#40;string&#41;,&#10;  match       &#61; string&#10;  source_ips  &#61; list&#40;string&#41;&#10;&#125;&#41;&#41;">list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
-| [subnetworks](variables.tf#L113) | Subnetworks to NAT, only used when config_source_subnets equals LIST_OF_SUBNETWORKS. | <code title="list&#40;object&#40;&#123;&#10;  self_link            &#61; string,&#10;  config_source_ranges &#61; list&#40;string&#41;&#10;  secondary_ranges     &#61; list&#40;string&#41;&#10;&#125;&#41;&#41;">list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
+| [config_timeouts](variables.tf#L45) | Timeout configurations. | <code title="object&#40;&#123;&#10;  icmp            &#61; optional&#40;number, 30&#41;&#10;  tcp_established &#61; optional&#40;number, 1200&#41;&#10;  tcp_time_wait   &#61; optional&#40;number, 120&#41;&#10;  tcp_transitory  &#61; optional&#40;number, 30&#41;&#10;  udp             &#61; optional&#40;number, 30&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [logging_filter](variables.tf#L58) | Enables logging if not null, value is one of 'ERRORS_ONLY', 'TRANSLATIONS_ONLY', 'ALL'. | <code>string</code> |  | <code>null</code> |
+| [router_asn](variables.tf#L79) | Router ASN used for auto-created router. | <code>number</code> |  | <code>null</code> |
+| [router_create](variables.tf#L85) | Create router. | <code>bool</code> |  | <code>true</code> |
+| [router_name](variables.tf#L91) | Router name, leave blank if router will be created to use auto generated name. | <code>string</code> |  | <code>null</code> |
+| [router_network](variables.tf#L97) | Name of the VPC used for auto-created router. | <code>string</code> |  | <code>null</code> |
+| [rules](variables.tf#L103) | List of rules associated with this NAT. | <code title="list&#40;object&#40;&#123;&#10;  description &#61; optional&#40;string&#41;,&#10;  match       &#61; string&#10;  source_ips  &#61; list&#40;string&#41;&#10;&#125;&#41;&#41;">list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
+| [subnetworks](variables.tf#L114) | Subnetworks to NAT, only used when config_source_subnets equals LIST_OF_SUBNETWORKS. | <code title="list&#40;object&#40;&#123;&#10;  self_link            &#61; string,&#10;  config_source_ranges &#61; list&#40;string&#41;&#10;  secondary_ranges     &#61; list&#40;string&#41;&#10;&#125;&#41;&#41;">list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
 
 ## Outputs
 

--- a/modules/net-cloudnat/main.tf
+++ b/modules/net-cloudnat/main.tf
@@ -48,6 +48,7 @@ resource "google_compute_router_nat" "nat" {
   icmp_idle_timeout_sec               = var.config_timeouts.icmp
   udp_idle_timeout_sec                = var.config_timeouts.udp
   tcp_established_idle_timeout_sec    = var.config_timeouts.tcp_established
+  tcp_time_wait_timeout_sec           = var.config_timeouts.tcp_time_wait
   tcp_transitory_idle_timeout_sec     = var.config_timeouts.tcp_transitory
   enable_endpoint_independent_mapping = var.config_port_allocation.enable_endpoint_independent_mapping
   enable_dynamic_port_allocation      = var.config_port_allocation.enable_dynamic_port_allocation

--- a/modules/net-cloudnat/variables.tf
+++ b/modules/net-cloudnat/variables.tf
@@ -47,6 +47,7 @@ variable "config_timeouts" {
   type = object({
     icmp            = optional(number, 30)
     tcp_established = optional(number, 1200)
+    tcp_time_wait   = optional(number, 120)
     tcp_transitory  = optional(number, 30)
     udp             = optional(number, 30)
   })


### PR DESCRIPTION
Closes #2165

This PR adds an additional variable to configure the
`tcp_time_wait_timeout_sec` as exposed by the provider.

<!-- Put a description of what this PR is for here -->

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass
