### PR TITLE
Add missing permission to org viewer custom role in FAST stage 0

### DIFF
--- a/fast/stages/0-bootstrap/data/custom-roles/organization_admin_viewer.yaml
+++ b/fast/stages/0-bootstrap/data/custom-roles/organization_admin_viewer.yaml
@@ -17,6 +17,7 @@ name: organizationAdminViewer
 includedPermissions:
   - essentialcontacts.contacts.get
   - essentialcontacts.contacts.list
+  - logging.settings.get
   - orgpolicy.constraints.list
   - orgpolicy.policies.list
   - orgpolicy.policy.get

--- a/fast/stages/0-bootstrap/templates/workflow-github.yaml
+++ b/fast/stages/0-bootstrap/templates/workflow-github.yaml
@@ -30,7 +30,7 @@ env:
   SSH_AUTH_SOCK: /tmp/ssh_agent.sock
   TF_PROVIDERS_FILE: ${tf_providers_files.apply}
   TF_PROVIDERS_FILE_PLAN: ${tf_providers_files.plan}
-  TF_VERSION: 1.6.5
+  TF_VERSION: 1.7.4
 
 jobs:
   fast-pr:
@@ -43,7 +43,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # set up SSH key authentication to the modules repository
 
@@ -100,7 +100,7 @@ jobs:
 
       - id: tf-setup
         name: Set up Terraform
-        uses: hashicorp/setup-terraform@v2.0.3
+        uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: $${{env.TF_VERSION}}
 

--- a/fast/stages/0-bootstrap/templates/workflow-sourcerepo.yaml
+++ b/fast/stages/0-bootstrap/templates/workflow-sourcerepo.yaml
@@ -95,4 +95,4 @@ substitutions:
   _FAST_OUTPUTS_BUCKET: ${outputs_bucket}
   _TF_PROVIDERS_FILE: ${tf_providers_files.apply}
   _TF_VAR_FILES: ${tf_var_files == [] ? "''" : join("\n    ", tf_var_files)}
-  _TF_VERSION: 1.4.4
+  _TF_VERSION: 1.7.6

--- a/fast/stages/1-resman/templates/workflow-github.yaml
+++ b/fast/stages/1-resman/templates/workflow-github.yaml
@@ -30,7 +30,7 @@ env:
   SSH_AUTH_SOCK: /tmp/ssh_agent.sock
   TF_PROVIDERS_FILE: ${tf_providers_files.apply}
   TF_PROVIDERS_FILE_PLAN: ${tf_providers_files.plan}
-  TF_VERSION: 1.6.5
+  TF_VERSION: 1.7.4
 
 jobs:
   fast-pr:
@@ -43,7 +43,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # set up SSH key authentication to the modules repository
 
@@ -100,7 +100,7 @@ jobs:
 
       - id: tf-setup
         name: Set up Terraform
-        uses: hashicorp/setup-terraform@v2.0.3
+        uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: $${{env.TF_VERSION}}
 

--- a/fast/stages/1-resman/templates/workflow-sourcerepo.yaml
+++ b/fast/stages/1-resman/templates/workflow-sourcerepo.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -93,6 +93,6 @@ options:
   logging: CLOUD_LOGGING_ONLY
 substitutions:
   _FAST_OUTPUTS_BUCKET: ${outputs_bucket}
-  _TF_PROVIDERS_FILE: ${tf_providers_file}
+  _TF_PROVIDERS_FILE: ${tf_providers_files.apply}
   _TF_VAR_FILES: ${tf_var_files == [] ? "''" : join("\n    ", tf_var_files)}
-  _TF_VERSION: 1.4.4
+  _TF_VERSION: 1.7.6


### PR DESCRIPTION
The missing permissions is a consequence of #2139.

This also bumps the Terraform version in our workflow files, to support recent language features. Fixes #2176 