### PR TITLE
Adding resource_manager_tags to the NodePool module

### DIFF
--- a/modules/gke-nodepool/README.md
+++ b/modules/gke-nodepool/README.md
@@ -77,6 +77,9 @@ module "cluster-1-nodepool-1" {
   location     = "europe-west1-b"
   name         = "nodepool-1"
   labels       = { environment = "dev" }
+  resource_manager_tags = {
+      "tagKeys/12345678901234" = "tagValues/43210987654321"
+  }
   service_account = {
     create       = true
     email        = "nodepool-1" # optional
@@ -159,6 +162,7 @@ module "cluster-1-nodepool-gpu-1" {
 | [sole_tenant_nodegroup](variables.tf#L196) | Sole tenant node group. | <code>string</code> |  | <code>null</code> |
 | [tags](variables.tf#L202) | Network tags applied to nodes. | <code>list&#40;string&#41;</code> |  | <code>null</code> |
 | [taints](variables.tf#L208) | Kubernetes taints applied to all nodes. | <code title="map&#40;object&#40;&#123;&#10;  value  &#61; string&#10;  effect &#61; string&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [resource_manager_tags](variables.tf#L226) | Resource Manager Secure Tags bindings for the Nodes in the pool, can be used for Firewall rules, in tag key => tag value format.  | <code>map&#40;string&#41;</code> |  | <code>null</code> |
 
 ## Outputs
 

--- a/modules/gke-nodepool/README.md
+++ b/modules/gke-nodepool/README.md
@@ -162,7 +162,7 @@ module "cluster-1-nodepool-gpu-1" {
 | [sole_tenant_nodegroup](variables.tf#L196) | Sole tenant node group. | <code>string</code> |  | <code>null</code> |
 | [tags](variables.tf#L202) | Network tags applied to nodes. | <code>list&#40;string&#41;</code> |  | <code>null</code> |
 | [taints](variables.tf#L208) | Kubernetes taints applied to all nodes. | <code title="map&#40;object&#40;&#123;&#10;  value  &#61; string&#10;  effect &#61; string&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [resource_manager_tags](variables.tf#L226) | Resource Manager Secure Tags bindings for the Nodes in the pool, can be used for Firewall rules, in tag key => tag value format.  | <code>map&#40;string&#41;</code> |  | <code>null</code> |
+| [resource_manager_tags](variables.tf#L226) | A map of resource manager tag keys and values to be attached to the nodes for managing Compute Engine firewalls using Network Firewall Policies. Tags must be according to specifications found here. A maximum of 5 tag key-value pairs can be specified. Existing tags will be replaced with new values. Tags must be in one of the following formats ([KEY]=[VALUE])  &nbsp;  1. tagKeys/{tag_key_id}=tagValues/{tag_value_id} &nbsp; 2. {org_id}/{tag_key_name}={tag_value_name} &nbsp; 3. {project_id}/{tag_key_name}={tag_value_name}.  | <code>map&#40;string&#41;</code> |  | <code>null</code> |
 
 ## Outputs
 

--- a/modules/gke-nodepool/main.tf
+++ b/modules/gke-nodepool/main.tf
@@ -147,6 +147,7 @@ resource "google_container_node_pool" "nodepool" {
       var.node_config.spot == true && var.node_config.preemptible != true
     )
     tags = var.tags
+    resource_manager_tags = var.resource_manager_tags
 
     dynamic "ephemeral_storage_config" {
       for_each = var.node_config.ephemeral_ssd_count != null ? [""] : []

--- a/modules/gke-nodepool/main.tf
+++ b/modules/gke-nodepool/main.tf
@@ -146,7 +146,7 @@ resource "google_container_node_pool" "nodepool" {
     spot = (
       var.node_config.spot == true && var.node_config.preemptible != true
     )
-    tags = var.tags
+    tags                  = var.tags
     resource_manager_tags = var.resource_manager_tags
 
     dynamic "ephemeral_storage_config" {

--- a/modules/gke-nodepool/variables.tf
+++ b/modules/gke-nodepool/variables.tf
@@ -221,3 +221,10 @@ variable "taints" {
     error_message = "Invalid taint effect."
   }
 }
+
+
+variable "resource_manager_tags" {
+  description = "Resource Manage Secure Tags bindings for the Nodes in the pool, in tag key => tag value format."
+  type        = map(string)
+  default     = null
+}

--- a/modules/gke-nodepool/variables.tf
+++ b/modules/gke-nodepool/variables.tf
@@ -224,7 +224,7 @@ variable "taints" {
 
 
 variable "resource_manager_tags" {
-  description = "Resource Manage Secure Tags bindings for the Nodes in the pool, in tag key => tag value format."
+  description = " A map of resource manager tag keys and values to be attached to the nodes for managing Compute Engine firewalls using Network Firewall Policies. Tags must be according to specifications found here. A maximum of 5 tag key-value pairs can be specified. Existing tags will be replaced with new values. Tags must be in one of the following formats ([KEY]=[VALUE]) 1. tagKeys/{tag_key_id}=tagValues/{tag_value_id} 2. {org_id}/{tag_key_name}={tag_value_name} 3. {project_id}/{tag_key_name}={tag_value_name}."
   type        = map(string)
   default     = null
 }


### PR DESCRIPTION
Adding resource_manager_tags to the NodePool module at modules/gke-nodepool

---

I applicable, I acknowledge that I have:
- [ X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [ X ] Ran `terraform fmt` on all modified files
- [ X ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ X ] Made sure all relevant tests pass
