### PR TITLE
Fix failing e2e tests for Cloud Run CMEK

### DIFF
--- a/modules/cloud-run-v2/README.md
+++ b/modules/cloud-run-v2/README.md
@@ -188,7 +188,7 @@ module "cloud_run" {
 
 ### Using Customer-Managed Encryption Key
 
-Deploy a Cloud Run service with environment variables encrypted using a Customer-Managed Encryption Key. Ensure you specify the encryption_key with the full resource identifier of your Cloud KMS CryptoKey. This setup adds an extra layer of security by utilizing your own encryption keys.
+Deploy a Cloud Run service with environment variables encrypted using a Customer-Managed Encryption Key (CMEK). Ensure you specify the encryption_key with the full resource identifier of your Cloud KMS CryptoKey and that Cloud Run Service agent (`service-<PROJECT_NUMBER>@serverless-robot-prod.iam.gserviceaccount.com`) has permission to use the key, for example `roles/cloudkms.cryptoKeyEncrypterDecrypter` IAM role. This setup adds an extra layer of security by utilizing your own encryption keys.
 
 ```hcl
 module "cloud_run" {
@@ -203,7 +203,7 @@ module "cloud_run" {
     }
   }
 }
-# tftest modules=1 resources=1 e2e
+# tftest modules=1 resources=2 fixtures=fixtures/cloud-run-kms-iam-grant.tf e2e
 ```
 
 ### Eventarc triggers
@@ -424,6 +424,7 @@ module "cloud_run" {
 
 ## Fixtures
 
+- [cloud-run-kms-iam-grant.tf](../../tests/fixtures/cloud-run-kms-iam-grant.tf)
 - [iam-service-account.tf](../../tests/fixtures/iam-service-account.tf)
 - [pubsub.tf](../../tests/fixtures/pubsub.tf)
 - [secret-credentials.tf](../../tests/fixtures/secret-credentials.tf)

--- a/tests/fixtures/cloud-run-kms-iam-grant.tf
+++ b/tests/fixtures/cloud-run-kms-iam-grant.tf
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_kms_crypto_key_iam_binding" "encrypt_decrypt" {
+  crypto_key_id = var.kms_key.id
+  members = [
+    "serviceAccount:service-${var.project_number}@serverless-robot-prod.iam.gserviceaccount.com"
+  ]
+  role = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+}


### PR DESCRIPTION
* create a fixture adding IAM grants to Cloud Run service agent
* add to README.md information about required grant

Decided to add ths as a fixture though it may not be reused so:
* grant is not polluting the example
* grant is fairly easy discoverable from README.md
* setup_module is not burdened with additional grant which is used only for this example

<!-- Put a description of what this PR is for here -->

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [x] Made sure all relevant tests pass
