### PR TITLE
Added data_cache_config settings for cloudsql-instance module

### DIFF
--- a/modules/cloudsql-instance/main.tf
+++ b/modules/cloudsql-instance/main.tf
@@ -67,6 +67,13 @@ resource "google_sql_database_instance" "primary" {
     collation                   = var.collation
     connector_enforcement       = var.connector_enforcement
     time_zone                   = var.time_zone
+    
+    dynamic "data_cache_config" {
+      for_each = var.edition == "ENTERPRISE_PLUS" ? [1] : []
+      content {
+        data_cache_enabled = var.data_cache_enabled
+      }
+    }
 
     ip_configuration {
       ipv4_enabled       = var.network_config.connectivity.public_ipv4

--- a/modules/cloudsql-instance/variables.tf
+++ b/modules/cloudsql-instance/variables.tf
@@ -196,6 +196,13 @@ variable "network_config" {
   }
 }
 
+variable "data_cache_enabled" {
+  description = "Whether data cache is enabled for the instance. Defaults to false. Can be used with MYSQL and PostgreSQL only."
+  type = bool
+  default = false
+  nullable    = false
+}
+
 
 variable "prefix" {
   description = "Optional prefix used to generate instance names."

--- a/modules/cloudsql-instance/versions.tf
+++ b/modules/cloudsql-instance/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.18.0, < 6.0.0" # tftest
+      version = ">= 5.23.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.18.0, < 6.0.0" # tftest
+      version = ">= 5.23.0, < 6.0.0" # tftest
     }
   }
 }


### PR DESCRIPTION
Added data_cache_config settings for cloudsql-instance module

---
**Checklist**

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
