### PR TITLE
Allow attaching PSA for multiple services

### DIFF
--- a/modules/net-vpc/README.md
+++ b/modules/net-vpc/README.md
@@ -13,6 +13,7 @@ This module allows creation and management of VPC networks including subnetworks
   - [Shared VPC](#shared-vpc)
   - [Private Service Networking](#private-service-networking)
   - [Private Service Networking with peering routes and peered Cloud DNS domains](#private-service-networking-with-peering-routes-and-peered-cloud-dns-domains)
+  - [Private Service Networking with multiple service providers](#private-service-networking-with-multiple-service-providers)
   - [Subnets for Private Service Connect, Proxy-only subnets](#subnets-for-private-service-connect-proxy-only-subnets)
   - [PSC Network Attachments](#psc-network-attachments)
   - [DNS Policies](#dns-policies)
@@ -149,7 +150,7 @@ module "vpc" {
 
 ### Peering
 
-A single peering can be configured for the VPC, so as to allow management of simple scenarios, and more complex configurations like hub and spoke by defining the peering configuration on the spoke VPCs. Care must be taken so as a single peering is created/changed/destroyed at a time, due to the specific behaviour of the peering API calls.
+A single peering can be configured for the VPC, to allow management of simple scenarios, and more complex configurations like hub and spoke by defining the peering configuration on the spoke VPCs. Care must be taken so as a single peering is created/changed/destroyed at a time, due to the specific behaviour of the peering API calls.
 
 If you only want to create the "local" side of the peering, use `peering_create_remote_end` to `false`. This is useful if you don't have permissions on the remote project/VPC to create peerings.
 
@@ -179,7 +180,7 @@ module "vpc-spoke-1" {
     import_routes      = true
   }
 }
-# tftest modules=2 resources=10 inventory=peering.yaml
+# tftest modules=2 resources=10 inventory=peering.yaml e2e
 ```
 
 ### Shared VPC
@@ -247,9 +248,11 @@ module "vpc" {
       region        = "europe-west1"
     }
   ]
-  psa_config = {
-    ranges = { myrange = "10.0.1.0/24" }
-  }
+  psa_config = [
+    {
+      ranges = { myrange = "10.0.1.0/24" }
+    }
+  ]
 }
 # tftest modules=1 resources=7 inventory=psa.yaml e2e
 ```
@@ -270,14 +273,44 @@ module "vpc" {
       region        = "europe-west1"
     }
   ]
-  psa_config = {
-    ranges         = { myrange = "10.0.1.0/24" }
-    export_routes  = true
-    import_routes  = true
-    peered_domains = ["gcp.example.com."]
-  }
+  psa_config = [
+    {
+      ranges         = { myrange = "10.0.1.0/24" }
+      export_routes  = true
+      import_routes  = true
+      peered_domains = ["gcp.example.com."]
+    }
+  ]
 }
 # tftest modules=1 resources=8 inventory=psa-routes.yaml e2e
+```
+
+### Private Service Networking with multiple service providers
+
+```hcl
+module "vpc" {
+  source     = "./fabric/modules/net-vpc"
+  project_id = var.project_id
+  name       = "my-network"
+  subnets = [
+    {
+      ip_cidr_range = "10.0.0.0/24"
+      name          = "production"
+      region        = "europe-west1"
+    }
+  ]
+  psa_config = [
+    {
+      ranges = { myrange = "10.0.1.0/24" }
+      # service_producer = "servicenetworking.googleapis.com" # default value
+    },
+    {
+      ranges           = { netapp = "10.0.2.0/24" }
+      service_producer = "netapp.servicenetworking.goog"
+    }
+  ]
+}
+# tftest modules=1 resources=10 inventory=psa-multiple-providers.yaml e2e
 ```
 
 ### Subnets for Private Service Connect, Proxy-only subnets
@@ -627,15 +660,15 @@ module "vpc" {
 | [network_attachments](variables.tf#L100) | PSC network attachments, names as keys. | <code title="map&#40;object&#40;&#123;&#10;  subnet                &#61; string&#10;  automatic_connection  &#61; optional&#40;bool, false&#41;&#10;  description           &#61; optional&#40;string, &#34;Terraform-managed.&#34;&#41;&#10;  producer_accept_lists &#61; optional&#40;list&#40;string&#41;&#41;&#10;  producer_reject_lists &#61; optional&#40;list&#40;string&#41;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [peering_config](variables.tf#L113) | VPC peering configuration. | <code title="object&#40;&#123;&#10;  peer_vpc_self_link &#61; string&#10;  create_remote_peer &#61; optional&#40;bool, true&#41;&#10;  export_routes      &#61; optional&#40;bool&#41;&#10;  import_routes      &#61; optional&#40;bool&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
 | [policy_based_routes](variables.tf#L124) | Policy based routes, keyed by name. | <code title="map&#40;object&#40;&#123;&#10;  description         &#61; optional&#40;string, &#34;Terraform-managed.&#34;&#41;&#10;  labels              &#61; optional&#40;map&#40;string&#41;&#41;&#10;  priority            &#61; optional&#40;number&#41;&#10;  next_hop_ilb_ip     &#61; optional&#40;string&#41;&#10;  use_default_routing &#61; optional&#40;bool, false&#41;&#10;  filter &#61; optional&#40;object&#40;&#123;&#10;    ip_protocol &#61; optional&#40;string&#41;&#10;    dest_range  &#61; optional&#40;string&#41;&#10;    src_range   &#61; optional&#40;string&#41;&#10;  &#125;&#41;, &#123;&#125;&#41;&#10;  target &#61; optional&#40;object&#40;&#123;&#10;    interconnect_attachment &#61; optional&#40;string&#41;&#10;    tags                    &#61; optional&#40;list&#40;string&#41;&#41;&#10;  &#125;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [psa_config](variables.tf#L177) | The Private Service Access configuration. | <code title="object&#40;&#123;&#10;  ranges           &#61; map&#40;string&#41;&#10;  export_routes    &#61; optional&#40;bool, false&#41;&#10;  import_routes    &#61; optional&#40;bool, false&#41;&#10;  peered_domains   &#61; optional&#40;list&#40;string&#41;, &#91;&#93;&#41;&#10;  service_producer &#61; optional&#40;string, &#34;servicenetworking.googleapis.com&#34;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [routes](variables.tf#L189) | Network routes, keyed by name. | <code title="map&#40;object&#40;&#123;&#10;  description   &#61; optional&#40;string, &#34;Terraform-managed.&#34;&#41;&#10;  dest_range    &#61; string&#10;  next_hop_type &#61; string &#35; gateway, instance, ip, vpn_tunnel, ilb&#10;  next_hop      &#61; string&#10;  priority      &#61; optional&#40;number&#41;&#10;  tags          &#61; optional&#40;list&#40;string&#41;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [routing_mode](variables.tf#L210) | The network routing mode (default 'GLOBAL'). | <code>string</code> |  | <code>&#34;GLOBAL&#34;</code> |
-| [shared_vpc_host](variables.tf#L220) | Enable shared VPC for this project. | <code>bool</code> |  | <code>false</code> |
-| [shared_vpc_service_projects](variables.tf#L226) | Shared VPC service projects to register with this host. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
-| [subnets](variables.tf#L232) | Subnet configuration. | <code title="list&#40;object&#40;&#123;&#10;  name                  &#61; string&#10;  ip_cidr_range         &#61; string&#10;  region                &#61; string&#10;  description           &#61; optional&#40;string&#41;&#10;  enable_private_access &#61; optional&#40;bool, true&#41;&#10;  flow_logs_config &#61; optional&#40;object&#40;&#123;&#10;    aggregation_interval &#61; optional&#40;string&#41;&#10;    filter_expression    &#61; optional&#40;string&#41;&#10;    flow_sampling        &#61; optional&#40;number&#41;&#10;    metadata             &#61; optional&#40;string&#41;&#10;    metadata_fields &#61; optional&#40;list&#40;string&#41;&#41;&#10;  &#125;&#41;&#41;&#10;  ipv6 &#61; optional&#40;object&#40;&#123;&#10;    access_type &#61; optional&#40;string, &#34;INTERNAL&#34;&#41;&#10;  &#125;&#41;&#41;&#10;  secondary_ip_ranges &#61; optional&#40;map&#40;string&#41;&#41;&#10;&#10;&#10;  iam &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;  iam_bindings &#61; optional&#40;map&#40;object&#40;&#123;&#10;    role    &#61; string&#10;    members &#61; list&#40;string&#41;&#10;    condition &#61; optional&#40;object&#40;&#123;&#10;      expression  &#61; string&#10;      title       &#61; string&#10;      description &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;  iam_bindings_additive &#61; optional&#40;map&#40;object&#40;&#123;&#10;    member &#61; string&#10;    role   &#61; string&#10;    condition &#61; optional&#40;object&#40;&#123;&#10;      expression  &#61; string&#10;      title       &#61; string&#10;      description &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;&#41;">list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
-| [subnets_proxy_only](variables.tf#L279) | List of proxy-only subnets for Regional HTTPS or Internal HTTPS load balancers. Note: Only one proxy-only subnet for each VPC network in each region can be active. | <code title="list&#40;object&#40;&#123;&#10;  name          &#61; string&#10;  ip_cidr_range &#61; string&#10;  region        &#61; string&#10;  description   &#61; optional&#40;string&#41;&#10;  active        &#61; optional&#40;bool, true&#41;&#10;  global        &#61; optional&#40;bool, false&#41;&#10;&#10;&#10;  iam &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;  iam_bindings &#61; optional&#40;map&#40;object&#40;&#123;&#10;    role    &#61; string&#10;    members &#61; list&#40;string&#41;&#10;    condition &#61; optional&#40;object&#40;&#123;&#10;      expression  &#61; string&#10;      title       &#61; string&#10;      description &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;  iam_bindings_additive &#61; optional&#40;map&#40;object&#40;&#123;&#10;    member &#61; string&#10;    role   &#61; string&#10;    condition &#61; optional&#40;object&#40;&#123;&#10;      expression  &#61; string&#10;      title       &#61; string&#10;      description &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;&#41;">list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
-| [subnets_psc](variables.tf#L313) | List of subnets for Private Service Connect service producers. | <code title="list&#40;object&#40;&#123;&#10;  name          &#61; string&#10;  ip_cidr_range &#61; string&#10;  region        &#61; string&#10;  description   &#61; optional&#40;string&#41;&#10;&#10;&#10;  iam &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;  iam_bindings &#61; optional&#40;map&#40;object&#40;&#123;&#10;    role    &#61; string&#10;    members &#61; list&#40;string&#41;&#10;    condition &#61; optional&#40;object&#40;&#123;&#10;      expression  &#61; string&#10;      title       &#61; string&#10;      description &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;  iam_bindings_additive &#61; optional&#40;map&#40;object&#40;&#123;&#10;    member &#61; string&#10;    role   &#61; string&#10;    condition &#61; optional&#40;object&#40;&#123;&#10;      expression  &#61; string&#10;      title       &#61; string&#10;      description &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;&#41;">list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
-| [vpc_create](variables.tf#L345) | Create VPC. When set to false, uses a data source to reference existing VPC. | <code>bool</code> |  | <code>true</code> |
+| [psa_config](variables.tf#L177) | The Private Service Access configuration. | <code title="list&#40;object&#40;&#123;&#10;  ranges           &#61; map&#40;string&#41;&#10;  export_routes    &#61; optional&#40;bool, false&#41;&#10;  import_routes    &#61; optional&#40;bool, false&#41;&#10;  peered_domains   &#61; optional&#40;list&#40;string&#41;, &#91;&#93;&#41;&#10;  service_producer &#61; optional&#40;string, &#34;servicenetworking.googleapis.com&#34;&#41;&#10;&#125;&#41;&#41;">list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
+| [routes](variables.tf#L201) | Network routes, keyed by name. | <code title="map&#40;object&#40;&#123;&#10;  description   &#61; optional&#40;string, &#34;Terraform-managed.&#34;&#41;&#10;  dest_range    &#61; string&#10;  next_hop_type &#61; string &#35; gateway, instance, ip, vpn_tunnel, ilb&#10;  next_hop      &#61; string&#10;  priority      &#61; optional&#40;number&#41;&#10;  tags          &#61; optional&#40;list&#40;string&#41;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [routing_mode](variables.tf#L222) | The network routing mode (default 'GLOBAL'). | <code>string</code> |  | <code>&#34;GLOBAL&#34;</code> |
+| [shared_vpc_host](variables.tf#L232) | Enable shared VPC for this project. | <code>bool</code> |  | <code>false</code> |
+| [shared_vpc_service_projects](variables.tf#L238) | Shared VPC service projects to register with this host. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
+| [subnets](variables.tf#L244) | Subnet configuration. | <code title="list&#40;object&#40;&#123;&#10;  name                  &#61; string&#10;  ip_cidr_range         &#61; string&#10;  region                &#61; string&#10;  description           &#61; optional&#40;string&#41;&#10;  enable_private_access &#61; optional&#40;bool, true&#41;&#10;  flow_logs_config &#61; optional&#40;object&#40;&#123;&#10;    aggregation_interval &#61; optional&#40;string&#41;&#10;    filter_expression    &#61; optional&#40;string&#41;&#10;    flow_sampling        &#61; optional&#40;number&#41;&#10;    metadata             &#61; optional&#40;string&#41;&#10;    metadata_fields &#61; optional&#40;list&#40;string&#41;&#41;&#10;  &#125;&#41;&#41;&#10;  ipv6 &#61; optional&#40;object&#40;&#123;&#10;    access_type &#61; optional&#40;string, &#34;INTERNAL&#34;&#41;&#10;  &#125;&#41;&#41;&#10;  secondary_ip_ranges &#61; optional&#40;map&#40;string&#41;&#41;&#10;&#10;&#10;  iam &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;  iam_bindings &#61; optional&#40;map&#40;object&#40;&#123;&#10;    role    &#61; string&#10;    members &#61; list&#40;string&#41;&#10;    condition &#61; optional&#40;object&#40;&#123;&#10;      expression  &#61; string&#10;      title       &#61; string&#10;      description &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;  iam_bindings_additive &#61; optional&#40;map&#40;object&#40;&#123;&#10;    member &#61; string&#10;    role   &#61; string&#10;    condition &#61; optional&#40;object&#40;&#123;&#10;      expression  &#61; string&#10;      title       &#61; string&#10;      description &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;&#41;">list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
+| [subnets_proxy_only](variables.tf#L291) | List of proxy-only subnets for Regional HTTPS or Internal HTTPS load balancers. Note: Only one proxy-only subnet for each VPC network in each region can be active. | <code title="list&#40;object&#40;&#123;&#10;  name          &#61; string&#10;  ip_cidr_range &#61; string&#10;  region        &#61; string&#10;  description   &#61; optional&#40;string&#41;&#10;  active        &#61; optional&#40;bool, true&#41;&#10;  global        &#61; optional&#40;bool, false&#41;&#10;&#10;&#10;  iam &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;  iam_bindings &#61; optional&#40;map&#40;object&#40;&#123;&#10;    role    &#61; string&#10;    members &#61; list&#40;string&#41;&#10;    condition &#61; optional&#40;object&#40;&#123;&#10;      expression  &#61; string&#10;      title       &#61; string&#10;      description &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;  iam_bindings_additive &#61; optional&#40;map&#40;object&#40;&#123;&#10;    member &#61; string&#10;    role   &#61; string&#10;    condition &#61; optional&#40;object&#40;&#123;&#10;      expression  &#61; string&#10;      title       &#61; string&#10;      description &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;&#41;">list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
+| [subnets_psc](variables.tf#L325) | List of subnets for Private Service Connect service producers. | <code title="list&#40;object&#40;&#123;&#10;  name          &#61; string&#10;  ip_cidr_range &#61; string&#10;  region        &#61; string&#10;  description   &#61; optional&#40;string&#41;&#10;&#10;&#10;  iam &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;  iam_bindings &#61; optional&#40;map&#40;object&#40;&#123;&#10;    role    &#61; string&#10;    members &#61; list&#40;string&#41;&#10;    condition &#61; optional&#40;object&#40;&#123;&#10;      expression  &#61; string&#10;      title       &#61; string&#10;      description &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;  iam_bindings_additive &#61; optional&#40;map&#40;object&#40;&#123;&#10;    member &#61; string&#10;    role   &#61; string&#10;    condition &#61; optional&#40;object&#40;&#123;&#10;      expression  &#61; string&#10;      title       &#61; string&#10;      description &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;&#41;">list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
+| [vpc_create](variables.tf#L357) | Create VPC. When set to false, uses a data source to reference existing VPC. | <code>bool</code> |  | <code>true</code> |
 
 ## Outputs
 

--- a/tests/modules/net_vpc/examples/psa-multiple-providers.yaml
+++ b/tests/modules/net_vpc/examples/psa-multiple-providers.yaml
@@ -23,32 +23,28 @@ values:
   module.vpc.google_compute_network.network[0]:
     name: my-network
     project: project-id
-    routing_mode: GLOBAL
   module.vpc.google_compute_network_peering_routes_config.psa_routes["servicenetworking.googleapis.com"]:
-    export_custom_routes: true
-    import_custom_routes: true
+    export_custom_routes: false
+    import_custom_routes: false
     project: project-id
   module.vpc.google_compute_subnetwork.subnetwork["europe-west1/production"]:
     ip_cidr_range: 10.0.0.0/24
     name: production
-    private_ip_google_access: true
     project: project-id
-    region: europe-west1
-    secondary_ip_range: []
   module.vpc.google_service_networking_connection.psa_connection["servicenetworking.googleapis.com"]:
     reserved_peering_ranges:
-    - myrange
+      - myrange
     service: servicenetworking.googleapis.com
-  module.vpc.google_service_networking_peered_dns_domain.name["servicenetworking.googleapis.com-gcp.example.com."]:
-    dns_suffix: gcp.example.com.
-    name: servicenetworking-googleapis-com-gcp-example-com
-    project: project-id
-    service: servicenetworking.googleapis.com
+  module.vpc.google_service_networking_connection.psa_connection["netapp.servicenetworking.goog"]:
+    reserved_peering_ranges:
+      - netapp
+    service: netapp.servicenetworking.goog
 
 counts:
-  google_compute_global_address: 1
+  google_compute_global_address: 2
   google_compute_network: 1
-  google_compute_network_peering_routes_config: 1
+  google_compute_network_peering_routes_config: 2
   google_compute_subnetwork: 1
-  google_service_networking_connection: 1
-  google_service_networking_peered_dns_domain: 1
+  google_service_networking_connection: 2
+
+outputs: {}

--- a/tests/modules/net_vpc/examples/psa.yaml
+++ b/tests/modules/net_vpc/examples/psa.yaml
@@ -23,7 +23,7 @@ values:
   module.vpc.google_compute_network.network[0]:
     name: my-network
     project: project-id
-  module.vpc.google_compute_network_peering_routes_config.psa_routes[0]:
+  module.vpc.google_compute_network_peering_routes_config.psa_routes["servicenetworking.googleapis.com"]:
     export_custom_routes: false
     import_custom_routes: false
     project: project-id
@@ -31,7 +31,7 @@ values:
     ip_cidr_range: 10.0.0.0/24
     name: production
     project: project-id
-  module.vpc.google_service_networking_connection.psa_connection[0]:
+  module.vpc.google_service_networking_connection.psa_connection["servicenetworking.googleapis.com"]:
     reserved_peering_ranges:
     - myrange
     service: servicenetworking.googleapis.com

--- a/tests/modules/net_vpc/psa_routes_export.tfvars
+++ b/tests/modules/net_vpc/psa_routes_export.tfvars
@@ -1,7 +1,9 @@
-psa_config = {
-  ranges = {
-    bar = "172.16.100.0/24"
+psa_config = [
+  {
+    ranges = {
+      bar = "172.16.100.0/24"
+    }
+    export_routes = true
+    import_routes = false
   }
-  export_routes = true
-  import_routes = false
-}
+]

--- a/tests/modules/net_vpc/psa_routes_export.yaml
+++ b/tests/modules/net_vpc/psa_routes_export.yaml
@@ -30,11 +30,11 @@ values:
     name: test
     project: test-project
     routing_mode: GLOBAL
-  google_compute_network_peering_routes_config.psa_routes[0]:
+  google_compute_network_peering_routes_config.psa_routes["servicenetworking.googleapis.com"]:
     export_custom_routes: true
     import_custom_routes: false
     project: test-project
-  google_service_networking_connection.psa_connection[0]:
+  google_service_networking_connection.psa_connection["servicenetworking.googleapis.com"]:
     reserved_peering_ranges:
     - bar
     service: servicenetworking.googleapis.com

--- a/tests/modules/net_vpc/psa_routes_import.tfvars
+++ b/tests/modules/net_vpc/psa_routes_import.tfvars
@@ -1,7 +1,9 @@
-psa_config = {
-  ranges = {
-    bar = "172.16.100.0/24"
+psa_config = [
+  {
+    ranges = {
+      bar = "172.16.100.0/24"
+    }
+    export_routes = false
+    import_routes = true
   }
-  export_routes = false
-  import_routes = true
-}
+]

--- a/tests/modules/net_vpc/psa_routes_import.yaml
+++ b/tests/modules/net_vpc/psa_routes_import.yaml
@@ -30,11 +30,11 @@ values:
     name: test
     project: test-project
     routing_mode: GLOBAL
-  google_compute_network_peering_routes_config.psa_routes[0]:
+  google_compute_network_peering_routes_config.psa_routes["servicenetworking.googleapis.com"]:
     export_custom_routes: false
     import_custom_routes: true
     project: test-project
-  google_service_networking_connection.psa_connection[0]:
+  google_service_networking_connection.psa_connection["servicenetworking.googleapis.com"]:
     reserved_peering_ranges:
     - bar
     service: servicenetworking.googleapis.com

--- a/tests/modules/net_vpc/psa_routes_import_export.tfvars
+++ b/tests/modules/net_vpc/psa_routes_import_export.tfvars
@@ -1,7 +1,9 @@
-psa_config = {
-  ranges = {
-    bar = "172.16.100.0/24"
+psa_config = [
+  {
+    ranges = {
+      bar = "172.16.100.0/24"
+    }
+    export_routes = true
+    import_routes = true
   }
-  export_routes = true
-  import_routes = true
-}
+]

--- a/tests/modules/net_vpc/psa_routes_import_export.yaml
+++ b/tests/modules/net_vpc/psa_routes_import_export.yaml
@@ -30,11 +30,11 @@ values:
     name: test
     project: test-project
     routing_mode: GLOBAL
-  google_compute_network_peering_routes_config.psa_routes[0]:
+  google_compute_network_peering_routes_config.psa_routes["servicenetworking.googleapis.com"]:
     export_custom_routes: true
     import_custom_routes: true
     project: test-project
-  google_service_networking_connection.psa_connection[0]:
+  google_service_networking_connection.psa_connection["servicenetworking.googleapis.com"]:
     reserved_peering_ranges:
     - bar
     service: servicenetworking.googleapis.com


### PR DESCRIPTION
<!-- Put a description of what this PR is for here -->
This allows defining PSA connectivity for multiple providers in one module call.

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass
