### PR TITLE
[FAST] Fix permissions for branch network dev - read sa

### DIFF
--- a/fast/stages/1-resman/branch-networking.tf
+++ b/fast/stages/1-resman/branch-networking.tf
@@ -101,10 +101,10 @@ module "branch-network-dev-folder" {
     )
     # read-only (plan) automation service accounts
     "roles/compute.networkViewer" = concat(
-      local.branch_optional_r_sa_lists.dp-prod,
-      local.branch_optional_r_sa_lists.gke-prod,
+      local.branch_optional_r_sa_lists.dp-dev,
+      local.branch_optional_r_sa_lists.gke-dev,
       local.branch_optional_r_sa_lists.gcve-dev,
-      local.branch_optional_r_sa_lists.pf-prod,
+      local.branch_optional_r_sa_lists.pf-dev,
     )
     (local.custom_roles.gcve_network_admin) = local.branch_optional_sa_lists.gcve-dev
   }


### PR DESCRIPTION
Fix permissions for FAST branch network dev for read service accounts.

---
**Checklist**

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
