### PR TITLE
Added missing identity when connectors API is enabled

### DIFF
--- a/modules/project/service-agents.yaml
+++ b/modules/project/service-agents.yaml
@@ -121,6 +121,7 @@
   service_agent: "service-%s@gcp-sa-anthossupport.iam.gserviceaccount.com"
 - name: "connectors"
   service_agent: "service-%s@gcp-sa-connectors.iam.gserviceaccount.com"
+  jit: true
 - name: "contactcenteraiplatform"
   service_agent: "service-%s@gcp-sa-ccaip.iam.gserviceaccount.com"
 - name: "contactcenterinsights"


### PR DESCRIPTION
Enabling the `connectors.googleapis.com` service is insufficient to create the `service-<project_number>@gcp-sa-connectors.iam.gserviceaccount.com` service account.

In a Shared VPC architecture, we are unable to assign the role of dns.peer to this service account, as outlined in the [integration documentation](
https://cloud.google.com/integration-connectors/docs/create-endpoint-attachment#create-ep-hostname)


---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass
