### PR TITLE
Fix bug from output typo in new project-factory module

### DIFF
--- a/modules/project-factory/outputs.tf
+++ b/modules/project-factory/outputs.tf
@@ -16,7 +16,7 @@
 
 output "folders" {
   description = "Folder ids."
-  value       = local.folders
+  value       = local.hierarchy
 }
 
 output "projects" {


### PR DESCRIPTION
`local.folders` is [just a map of var-based keys to string manipulations on those keys](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/modules/project-factory/factory-folders.tf#L32), while `local.hierarchy` is [the seemingly-intended map of var-based keys to generated IDs/numbers](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/modules/project-factory/factory-folders.tf#L39). Access to the actual generated IDs/numbers is necessary for practical use of this module.

I tested this by modifying a clone, but I haven't actually run your tests.

Thank you for recently developing this convenient module!

---

I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass
