### PR TITLE
Fix 0-bootstrap iam_by_principals not taking into account all principals

### DIFF
--- a/fast/stages/0-bootstrap/organization.tf
+++ b/fast/stages/0-bootstrap/organization.tf
@@ -138,8 +138,14 @@ module "organization" {
   organization_id = module.organization-logging.id
   # human (groups) IAM bindings
   iam_by_principals = {
-    for k, v in local.iam_principals :
-    k => distinct(concat(v, lookup(var.iam_by_principals, k, [])))
+    for key in distinct(concat(
+      keys(local.iam_principals),
+      keys(var.iam_by_principals),
+    )) :
+    key => distinct(concat(
+      lookup(local.iam_principals, key, []),
+      lookup(var.iam_by_principals, key, []),
+    ))
   }
   # machine (service accounts) IAM bindings
   iam = merge(

--- a/tests/collectors.py
+++ b/tests/collectors.py
@@ -92,7 +92,7 @@ class FabricTestItem(pytest.Item):
                              self.tf_var_files, self.extra_files)
     except AssertionError:
       def full_paths(x):
-        return [(self.parent.path.parent / x ) for x in x]
+        return [str(self.parent.path.parent / x ) for x in x]
       print(f'Error in inventory file: {" ".join(full_paths(self.inventory))}')
       print(f'To regenerate inventory run: python tools/plan_summary.py {self.module} {" ".join(full_paths(self.tf_var_files))}')
       raise

--- a/tests/fast/stages/s0_bootstrap/iam_by_principals.tfvars
+++ b/tests/fast/stages/s0_bootstrap/iam_by_principals.tfvars
@@ -1,0 +1,20 @@
+organization = {
+  domain      = "fast.example.com"
+  id          = 123456789012
+  customer_id = "C00000000"
+}
+billing_account = {
+  id = "000000-111111-222222"
+}
+essential_contacts = "gcp-organization-admins@fast.example.com"
+iam_by_principals = {
+  "user:other@fast.example.com" = ["roles/browser"]
+}
+prefix = "fast"
+org_policies_config = {
+  import_defaults = false
+}
+outputs_location = "/fast-config"
+groups = {
+  gcp-support = "group:gcp-support@example.com"
+}

--- a/tests/fast/stages/s0_bootstrap/iam_by_principals.yaml
+++ b/tests/fast/stages/s0_bootstrap/iam_by_principals.yaml
@@ -1,4 +1,3 @@
-# skip boilerplate check
 # Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,17 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-module: fast/stages/0-bootstrap
-
-tests:
-  checklist:
-    extra_files:
-      - ../../../tests/fast/stages/s0_bootstrap/data/checklist-data.json
-      - ../../../tests/fast/stages/s0_bootstrap/data/checklist-org-iam.json
-  simple:
-    inventory:
-      - simple.yaml
-      - simple_projects.yaml
-      - simple_sas.yaml
-  
-  iam_by_principals:
+values:
+  module.organization.google_organization_iam_binding.authoritative["roles/browser"]:
+    condition: []
+    members:
+    - domain:fast.example.com
+    - user:other@fast.example.com
+    org_id: '123456789012'
+    role: roles/browser


### PR DESCRIPTION
<!-- Put a description of what this PR is for here -->

When I provide `iam_by_principals` to bootstrap stage, not all entries are taken into account, as only principals listed `local.iam_principals` were used. For example, if using this to grant permissions to non-FAST defined groups, this would not work.

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass
