### PR TITLE
Disable reserved_internal_range in net-vpc due to provider bug

### DIFF
--- a/blueprints/gke/patterns/autopilot-cluster/versions.tf
+++ b/blueprints/gke/patterns/autopilot-cluster/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/blueprints/gke/patterns/batch/versions.tf
+++ b/blueprints/gke/patterns/batch/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/blueprints/gke/patterns/kafka/versions.tf
+++ b/blueprints/gke/patterns/kafka/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/blueprints/gke/patterns/mysql/versions.tf
+++ b/blueprints/gke/patterns/mysql/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/blueprints/gke/patterns/redis-cluster/versions.tf
+++ b/blueprints/gke/patterns/redis-cluster/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/default-versions.tf
+++ b/default-versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/__experimental_deprecated/alloydb-instance/versions.tf
+++ b/modules/__experimental_deprecated/alloydb-instance/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/__experimental_deprecated/net-neg/versions.tf
+++ b/modules/__experimental_deprecated/net-neg/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/__experimental_deprecated/project-iam-magic/versions.tf
+++ b/modules/__experimental_deprecated/project-iam-magic/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/analytics-hub/versions.tf
+++ b/modules/analytics-hub/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/api-gateway/versions.tf
+++ b/modules/api-gateway/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/apigee/versions.tf
+++ b/modules/apigee/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/artifact-registry/versions.tf
+++ b/modules/artifact-registry/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/bigquery-dataset/versions.tf
+++ b/modules/bigquery-dataset/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/bigtable-instance/versions.tf
+++ b/modules/bigtable-instance/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/billing-account/versions.tf
+++ b/modules/billing-account/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/binauthz/versions.tf
+++ b/modules/binauthz/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/__need_fixing/onprem/versions.tf
+++ b/modules/cloud-config-container/__need_fixing/onprem/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/__need_fixing/squid/versions.tf
+++ b/modules/cloud-config-container/__need_fixing/squid/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/bindplane/versions.tf
+++ b/modules/cloud-config-container/bindplane/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/coredns/versions.tf
+++ b/modules/cloud-config-container/coredns/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/cos-generic-metadata/versions.tf
+++ b/modules/cloud-config-container/cos-generic-metadata/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/envoy-sni-dyn-fwd-proxy/versions.tf
+++ b/modules/cloud-config-container/envoy-sni-dyn-fwd-proxy/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/envoy-traffic-director/versions.tf
+++ b/modules/cloud-config-container/envoy-traffic-director/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/mysql/versions.tf
+++ b/modules/cloud-config-container/mysql/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/nginx-tls/versions.tf
+++ b/modules/cloud-config-container/nginx-tls/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/nginx/versions.tf
+++ b/modules/cloud-config-container/nginx/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/simple-nva/versions.tf
+++ b/modules/cloud-config-container/simple-nva/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/cloud-function-v1/versions.tf
+++ b/modules/cloud-function-v1/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/cloud-function-v2/versions.tf
+++ b/modules/cloud-function-v2/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/cloud-identity-group/versions.tf
+++ b/modules/cloud-identity-group/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/cloud-run-v2/versions.tf
+++ b/modules/cloud-run-v2/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/cloud-run/versions.tf
+++ b/modules/cloud-run/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/cloudsql-instance/versions.tf
+++ b/modules/cloudsql-instance/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/compute-mig/versions.tf
+++ b/modules/compute-mig/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/compute-vm/versions.tf
+++ b/modules/compute-vm/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/container-registry/versions.tf
+++ b/modules/container-registry/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/data-catalog-policy-tag/versions.tf
+++ b/modules/data-catalog-policy-tag/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/data-catalog-tag-template/versions.tf
+++ b/modules/data-catalog-tag-template/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/data-catalog-tag/versions.tf
+++ b/modules/data-catalog-tag/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/dataform-repository/versions.tf
+++ b/modules/dataform-repository/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/datafusion/versions.tf
+++ b/modules/datafusion/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/dataplex-datascan/versions.tf
+++ b/modules/dataplex-datascan/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/dataplex/versions.tf
+++ b/modules/dataplex/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/dataproc/versions.tf
+++ b/modules/dataproc/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/dns-response-policy/versions.tf
+++ b/modules/dns-response-policy/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/dns/versions.tf
+++ b/modules/dns/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/endpoints/versions.tf
+++ b/modules/endpoints/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/folder/versions.tf
+++ b/modules/folder/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/gcs/versions.tf
+++ b/modules/gcs/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/gcve-private-cloud/versions.tf
+++ b/modules/gcve-private-cloud/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/gke-cluster-autopilot/versions.tf
+++ b/modules/gke-cluster-autopilot/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/gke-cluster-standard/versions.tf
+++ b/modules/gke-cluster-standard/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/gke-hub/versions.tf
+++ b/modules/gke-hub/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/gke-nodepool/versions.tf
+++ b/modules/gke-nodepool/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/iam-service-account/versions.tf
+++ b/modules/iam-service-account/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/kms/versions.tf
+++ b/modules/kms/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/logging-bucket/versions.tf
+++ b/modules/logging-bucket/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/ncc-spoke-ra/versions.tf
+++ b/modules/ncc-spoke-ra/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/net-address/versions.tf
+++ b/modules/net-address/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/net-cloudnat/versions.tf
+++ b/modules/net-cloudnat/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/net-firewall-policy/versions.tf
+++ b/modules/net-firewall-policy/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/net-ipsec-over-interconnect/versions.tf
+++ b/modules/net-ipsec-over-interconnect/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/net-lb-app-ext-regional/versions.tf
+++ b/modules/net-lb-app-ext-regional/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/net-lb-app-ext/versions.tf
+++ b/modules/net-lb-app-ext/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/net-lb-app-int-cross-region/versions.tf
+++ b/modules/net-lb-app-int-cross-region/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/net-lb-app-int/versions.tf
+++ b/modules/net-lb-app-int/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/net-lb-ext/versions.tf
+++ b/modules/net-lb-ext/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/net-lb-int/versions.tf
+++ b/modules/net-lb-int/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/net-lb-proxy-int/versions.tf
+++ b/modules/net-lb-proxy-int/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/net-swp/versions.tf
+++ b/modules/net-swp/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/net-vlan-attachment/versions.tf
+++ b/modules/net-vlan-attachment/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/net-vpc-firewall/versions.tf
+++ b/modules/net-vpc-firewall/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/net-vpc-peering/versions.tf
+++ b/modules/net-vpc-peering/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/net-vpc/subnets.tf
+++ b/modules/net-vpc/subnets.tf
@@ -157,17 +157,20 @@ resource "google_compute_subnetwork" "subnetwork" {
   dynamic "secondary_ip_range" {
     for_each = each.value.secondary_ip_ranges == null ? {} : each.value.secondary_ip_ranges
     content {
-      range_name = secondary_ip_range.key
-      ip_cidr_range = (
-        startswith(secondary_ip_range.value, "networkconnectivity.googleapis.com")
-        ? null
-        : secondary_ip_range.value
-      )
-      reserved_internal_range = (
-        startswith(secondary_ip_range.value, "networkconnectivity.googleapis.com")
-        ? secondary_ip_range.value
-        : null
-      )
+      range_name    = secondary_ip_range.key
+      ip_cidr_range = secondary_ip_range.value
+      # TODO(sruffilli): Provider 5.29.1 disabled reserved_internal_range because of a bug.
+      #                  Revert to the following once fixed.
+      # ip_cidr_range = (
+      #   startswith(secondary_ip_range.value, "networkconnectivity.googleapis.com")
+      #   ? null
+      #   : secondary_ip_range.value
+      # )    
+      # reserved_internal_range = (
+      #   startswith(secondary_ip_range.value, "networkconnectivity.googleapis.com")
+      #   ? secondary_ip_range.value
+      #   : null
+      # )
     }
   }
   dynamic "log_config" {

--- a/modules/net-vpc/versions.tf
+++ b/modules/net-vpc/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/net-vpn-dynamic/versions.tf
+++ b/modules/net-vpn-dynamic/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/net-vpn-ha/versions.tf
+++ b/modules/net-vpn-ha/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/net-vpn-static/versions.tf
+++ b/modules/net-vpn-static/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/organization/versions.tf
+++ b/modules/organization/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/project/versions.tf
+++ b/modules/project/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/projects-data-source/versions.tf
+++ b/modules/projects-data-source/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/pubsub/versions.tf
+++ b/modules/pubsub/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/secret-manager/versions.tf
+++ b/modules/secret-manager/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/service-directory/versions.tf
+++ b/modules/service-directory/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/source-repository/versions.tf
+++ b/modules/source-repository/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/vpc-sc/versions.tf
+++ b/modules/vpc-sc/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/workstation-cluster/versions.tf
+++ b/modules/workstation-cluster/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }

--- a/tests/examples_e2e/setup_module/versions.tf
+++ b/tests/examples_e2e/setup_module/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.29.0, < 6.0.0" # tftest
+      version = ">= 5.29.1, < 6.0.0" # tftest
     }
   }
 }


### PR DESCRIPTION
This PR disables `reserved_internal_range` in `google_compute_subnetwork` used by `net-vpc` because of a [provider issue](https://github.com/hashicorp/terraform-provider-google/releases/tag/v5.29.1).

Version bumped to 5.29.1