### PR TITLE
Fixed e2e tests for alloydb module

### DIFF
--- a/modules/alloydb/README.md
+++ b/modules/alloydb/README.md
@@ -1,6 +1,6 @@
 # AlloyDB module
 
-This module manages the creation of an AlloyDB cluster. It also supports cross-region replication scenario by setting up a secondary cluster. 
+This module manages the creation of an AlloyDB cluster. It also supports cross-region replication scenario by setting up a secondary cluster.
 It can also create an initial set of users via the `users` variable.
 
 Note that this module assumes that some options are the same for both the primary instance and the secondary one in case of cross regional replication configuration.
@@ -44,7 +44,6 @@ module "vpc" {
   # need only one - psa_config or subnets_psc
   psa_configs = [{
     ranges          = { alloydb = "10.60.0.0/16" }
-    deletion_policy = "ABANDON"
   }]
   subnets_psc = [{
     ip_cidr_range = "10.0.3.0/24"
@@ -86,7 +85,7 @@ module "alloydb" {
 # tftest modules=1 resources=4 inventory=cross_region_replication.yaml e2e
 ```
 
-In a cross-region replication scenario (like in the previous example) this module also supports [promoting the secondary instance](https://cloud.google.com/alloydb/docs/cross-region-replication/work-with-cross-region-replication#promote-secondary-cluster) to become a primary instance via the `var.cross_region_replication.promote_secondary` flag.  
+In a cross-region replication scenario (like in the previous example) this module also supports [promoting the secondary instance](https://cloud.google.com/alloydb/docs/cross-region-replication/work-with-cross-region-replication#promote-secondary-cluster) to become a primary instance via the `var.cross_region_replication.promote_secondary` flag.
 
 ### Custom flags and users definition
 
@@ -137,7 +136,7 @@ module "alloydb" {
   }
 }
 
-# tftest modules=1 resources=2 inventory=cmek.yaml e2e
+# tftest modules=1 resources=2 fixtures=fixtures/alloydb-kms-iam-grant.tf inventory=cmek.yaml e2e
 ```
 <!-- BEGIN TFDOC -->
 ## Variables
@@ -188,4 +187,8 @@ module "alloydb" {
 | [secondary_id](outputs.tf#L68) | Fully qualified primary instance id. |  |
 | [secondary_ip](outputs.tf#L73) | IP address of the primary instance. |  |
 | [user_passwords](outputs.tf#L78) | Map of containing the password of all users created through terraform. | ✓ |
+
+## Fixtures
+
+- [alloydb-kms-iam-grant.tf](../../tests/fixtures/alloydb-kms-iam-grant.tf)
 <!-- END TFDOC -->

--- a/modules/alloydb/README.md
+++ b/modules/alloydb/README.md
@@ -43,7 +43,7 @@ module "vpc" {
   name       = "my-network"
   # need only one - psa_config or subnets_psc
   psa_configs = [{
-    ranges          = { alloydb = "10.60.0.0/16" }
+    ranges = { alloydb = "10.60.0.0/16" }
   }]
   subnets_psc = [{
     ip_cidr_range = "10.0.3.0/24"
@@ -136,7 +136,7 @@ module "alloydb" {
   }
 }
 
-# tftest modules=1 resources=2 fixtures=fixtures/alloydb-kms-iam-grant.tf inventory=cmek.yaml e2e
+# tftest modules=1 resources=3 fixtures=fixtures/alloydb-kms-iam-grant.tf inventory=cmek.yaml e2e
 ```
 <!-- BEGIN TFDOC -->
 ## Variables

--- a/modules/alloydb/main.tf
+++ b/modules/alloydb/main.tf
@@ -139,6 +139,12 @@ resource "google_alloydb_cluster" "primary" {
       }
     }
   }
+  # waiting to fix this issue https://github.com/hashicorp/terraform-provider-google/issues/14944
+  lifecycle {
+    ignore_changes = [
+      display_name
+    ]
+  }
 }
 
 resource "google_alloydb_instance" "primary" {
@@ -193,6 +199,13 @@ resource "google_alloydb_instance" "primary" {
       record_client_address   = var.query_insights_config.record_client_address
       query_plans_per_minute  = var.query_insights_config.query_plans_per_minute
     }
+  }
+
+  # waiting to fix this issue https://github.com/hashicorp/terraform-provider-google/issues/14944
+  lifecycle {
+    ignore_changes = [
+      network_config
+    ]
   }
 }
 
@@ -299,13 +312,19 @@ resource "google_alloydb_cluster" "secondary" {
   }
 
   dynamic "secondary_config" {
-    for_each = var.cross_region_replication.promote_secondary ? [""] : []
+    for_each = var.cross_region_replication.promote_secondary ? [] : [""]
     content {
       primary_cluster_name = google_alloydb_cluster.primary.id
     }
   }
 
   depends_on = [google_alloydb_instance.primary]
+  # waiting to fix this issue https://github.com/hashicorp/terraform-provider-google/issues/14944
+  lifecycle {
+    ignore_changes = [
+      display_name
+    ]
+  }
 }
 
 resource "google_alloydb_instance" "secondary" {
@@ -362,6 +381,13 @@ resource "google_alloydb_instance" "secondary" {
       query_plans_per_minute  = var.query_insights_config.query_plans_per_minute
     }
   }
+
+  # waiting to fix this issue https://github.com/hashicorp/terraform-provider-google/issues/14944
+  lifecycle {
+    ignore_changes = [
+      network_config
+    ]
+  }
 }
 
 resource "random_password" "passwords" {
@@ -381,4 +407,5 @@ resource "google_alloydb_user" "users" {
   user_type      = each.value.type
   password       = each.value.password
   database_roles = each.value.roles
+  depends_on     = [google_alloydb_instance.primary]
 }

--- a/tests/examples_e2e/setup_module/main.tf
+++ b/tests/examples_e2e/setup_module/main.tf
@@ -15,6 +15,7 @@
 locals {
   prefix = "${var.prefix}-${var.timestamp}${var.suffix}"
   jit_services = [
+    "alloydb.googleapis.com",  # no permissions granted by default
     "storage.googleapis.com",  # no permissions granted by default
     "sqladmin.googleapis.com", # roles/cloudsql.serviceAgent
   ]
@@ -164,6 +165,13 @@ resource "google_kms_crypto_key" "key" {
   name            = "crypto-key-example"
   key_ring        = google_kms_key_ring.keyring.id
   rotation_period = "100000s"
+}
+
+resource "google_kms_crypto_key_iam_member" "crypto_key" {
+  crypto_key_id = google_kms_crypto_key.key.id
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:service-${google_project.project.number}@gcp-sa-alloydb.iam.gserviceaccount.com"
+  depends_on    = [google_project_service_identity.jit_si]
 }
 
 resource "google_project_service_identity" "jit_si" {

--- a/tests/examples_e2e/setup_module/main.tf
+++ b/tests/examples_e2e/setup_module/main.tf
@@ -167,13 +167,6 @@ resource "google_kms_crypto_key" "key" {
   rotation_period = "100000s"
 }
 
-resource "google_kms_crypto_key_iam_member" "crypto_key" {
-  crypto_key_id = google_kms_crypto_key.key.id
-  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member        = "serviceAccount:service-${google_project.project.number}@gcp-sa-alloydb.iam.gserviceaccount.com"
-  depends_on    = [google_project_service_identity.jit_si]
-}
-
 resource "google_project_service_identity" "jit_si" {
   for_each   = toset(local.jit_services)
   provider   = google-beta

--- a/tests/fixtures/alloydb-kms-iam-grant.tf
+++ b/tests/fixtures/alloydb-kms-iam-grant.tf
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_kms_crypto_key_iam_member" "alloydb_encrypt_decrypt" {
+  crypto_key_id = var.kms_key.id
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:service-${var.project_number}@gcp-sa-alloydb.iam.gserviceaccount.com"
+}

--- a/tests/modules/alloydb/examples/cmek.yaml
+++ b/tests/modules/alloydb/examples/cmek.yaml
@@ -65,6 +65,6 @@ counts:
   google_alloydb_cluster: 1
   google_alloydb_instance: 1
   modules: 1
-  resources: 2
+  resources: 3
 
 outputs: {}

--- a/tests/modules/alloydb/examples/cross_region_replication.yaml
+++ b/tests/modules/alloydb/examples/cross_region_replication.yaml
@@ -61,7 +61,7 @@ values:
     project: project-id
     restore_backup_source: []
     restore_continuous_backup_source: []
-    secondary_config: []
+    secondary_config: [{}]
     timeouts: null
   module.alloydb.google_alloydb_instance.primary:
     annotations: null

--- a/tests/modules/alloydb/examples/simple.yaml
+++ b/tests/modules/alloydb/examples/simple.yaml
@@ -152,7 +152,6 @@ values:
     role: null
     timeouts: null
   module.vpc.google_service_networking_connection.psa_connection["servicenetworking.googleapis.com"]:
-    deletion_policy: ABANDON
     reserved_peering_ranges:
       - servicenetworking-googleapis-com-alloydb
     service: servicenetworking.googleapis.com


### PR DESCRIPTION
Fixed issue with AlloyDB e2e tests. I had to add ignore_changes due to a bug in the API (not yet managed in the provider) causing an attribute not being set and plan never aligned with infrastructure state. 

---

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [x] Made sure all relevant tests pass
