### PR TITLE
Add org log settings viewer custom role and binding

### DIFF
--- a/fast/stages/0-bootstrap/data/custom-roles/organization_logsettings_viewer.yaml
+++ b/fast/stages/0-bootstrap/data/custom-roles/organization_logsettings_viewer.yaml
@@ -1,0 +1,18 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# this is used by the plan-only admin SA
+name: organizationLogsettingsViewer
+includedPermissions:
+  - logging.settings.get

--- a/fast/stages/0-bootstrap/organization-iam.tf
+++ b/fast/stages/0-bootstrap/organization-iam.tf
@@ -121,7 +121,8 @@ locals {
         "roles/essentialcontacts.viewer",
         "roles/logging.viewer",
         "roles/resourcemanager.folderViewer",
-        "roles/resourcemanager.tagViewer"
+        "roles/resourcemanager.tagViewer",
+        module.organization.custom_role_id["organization_logsettings_viewer"]
       ]
       additive = concat(
         [


### PR DESCRIPTION
This should fix a corner case where the organization logging settings are configured (e.g. by having a regional location in `var.locations.logging`), and the read-only service account can't access the configuration due to missing `logging.settings.get` permission.