### PR TITLE
Add pre-commit hook configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,8 @@ repos:
     language: system
     entry: tools/check_boilerplate.py
     pass_filenames: true
+    args:
+    -  --scan-files
   - id: tflint-fast
     name: Checking FAST code with tflint
     entry: tools/tflint-fast.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,80 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+repos:
+- repo: https://github.com/antonbabenko/pre-commit-terraform
+  rev: v1.86.0
+  hooks:
+  - id: terraform_fmt
+  - id: terraform_tflint
+    args:
+    - --args=--config=__GIT_WORKING_DIR__/.tflint.hcl
+    files: ^modules/
+    exclude: (tests/fixtures/|tools/lockfile/)
+  # - id: terraform_validate
+  #   args:
+  #   - --hook-config=--retry-once-with-cleanup=true
+- repo: local
+  hooks:
+  - id: cff-readme
+    name: Regenerate README.md with tfdoc.py
+    entry: tools/pre-commit-tfdoc.sh
+    language: script
+    #types: [terraform]
+    files: ^(modules|fast).*(tf|README.md)$
+    pass_filenames: true
+    require_serial: true
+  - id: licenese
+    name: Check license presence and other boilerplate checks
+    language: system
+    entry: tools/check_boilerplate.py
+    pass_filenames: true
+  - id: tflint-fast
+    name: Checking FAST code with tflint
+    entry: tools/tflint-fast.py
+    language: system
+    pass_filenames: false
+    require_serial: true
+    files: ^fast/.*tf
+
+# - repo: https://github.com/adrienverge/yamllint
+#   rev: v1.34.0
+#   hooks:
+#   - id: yamllint
+#     args: [-c=.yamllint, --no-warnings]
+#     exclude: (/templates/|modules/cloud-config-container/)
+
+- repo: https://github.com/jumanjihouse/pre-commit-hooks
+  rev: "3.0.0"
+  hooks:
+  - id: script-must-have-extension
+  - id: shellcheck
+  - id: shfmt
+    exclude: ".*tpl"
+
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.5.0
+  hooks:
+  - id: end-of-file-fixer
+  - id: trailing-whitespace
+  - id: check-yaml
+    args:
+    - --allow-multiple-documents
+    exclude: (/templates/|modules/cloud-config-container/)
+
+- repo: https://github.com/google/yapf/
+  rev: v0.40.2
+  hooks:
+  - id: yapf

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,16 @@
+---
+
+yaml-files:
+- '*.yaml'
+- '*.yml'
+- '.yamllint'
+
+extends: default
+
+rules:
+  indentation:
+    indent-sequences: consistent
+  line-length:
+    max: 120
+    level: warning
+  braces: disable

--- a/blueprints/apigee/bigquery-analytics/send-requests.sh
+++ b/blueprints/apigee/bigquery-analytics/send-requests.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,18 +13,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
- 
-#!/bin/bash
 
 if [ $# -lt 2 ]; then
-    echo "Usage: $0 ENVGROUP_HOSTNAME NUM_REQUESTS"
-    exit 1
-fi    
+	echo "Usage: $0 ENVGROUP_HOSTNAME NUM_REQUESTS"
+	exit 1
+fi
 
 ENVGROUP_HOSTNAME=$1
 NUM_REQUESTS=$2
 
-for i in $(seq 1 $NUM_REQUESTS)
-do
-curl -v https://$ENVGROUP_HOSTNAME/httpbin/headers
+# shellcheck disable=SC2034
+for i in $(seq 1 "$NUM_REQUESTS"); do
+	curl -v "https://$ENVGROUP_HOSTNAME/httpbin/headers"
 done

--- a/blueprints/cloud-operations/workload-identity-federation/setup.sh
+++ b/blueprints/cloud-operations/workload-identity-federation/setup.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
- 
-#!/bin/bash
 
 sudo apt -y update
 sudo apt -y install apt-transport-https ca-certificates gnupg jq

--- a/tests/modules/artifact_registry/examples/cleanup-policies.yaml
+++ b/tests/modules/artifact_registry/examples/cleanup-policies.yaml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 values:
-values:
   module.registry-docker.google_artifact_registry_repository.registry:
     cleanup_policies:
     - id: keep-tagged-release
@@ -38,7 +37,7 @@ values:
     mode: STANDARD_REPOSITORY
     project: project-id
     repository_id: docker-cleanup-policies
-    
+
 
 counts:
   google_artifact_registry_repository: 1

--- a/tests/modules/gcs/examples/iam-authoritative.yaml
+++ b/tests/modules/gcs/examples/iam-authoritative.yaml
@@ -14,7 +14,6 @@
 
 values:
   module.bucket.google_storage_bucket.bucket:
-    autoclass: []
     cors: []
     custom_placement_config: []
     default_event_based_hold: null

--- a/tests/modules/gcs/examples/iam-bindings-additive.yaml
+++ b/tests/modules/gcs/examples/iam-bindings-additive.yaml
@@ -14,7 +14,6 @@
 
 values:
   module.bucket.google_storage_bucket.bucket:
-    autoclass: []
     cors: []
     custom_placement_config: []
     default_event_based_hold: null

--- a/tests/modules/gcs/examples/iam-bindings.yaml
+++ b/tests/modules/gcs/examples/iam-bindings.yaml
@@ -14,7 +14,6 @@
 
 values:
   module.bucket.google_storage_bucket.bucket:
-    autoclass: []
     cors: []
     custom_placement_config: []
     default_event_based_hold: null

--- a/tests/modules/secret_manager/examples/secret-cmek.yaml
+++ b/tests/modules/secret_manager/examples/secret-cmek.yaml
@@ -71,5 +71,3 @@ counts:
   resources: 11
 
 outputs: {}
-
-outputs: {}

--- a/tools/pre-commit-tfdoc.sh
+++ b/tools/pre-commit-tfdoc.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -ev
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+
+files=("$@")
+declare -A directories
+
+for file in "${files[@]}"; do
+	dir=$(dirname "${file}")
+	if [ -f "${dir}/README.md" ] && [ -f "${dir}/main.tf" ]; then
+		directories["${dir}"]=1
+	fi
+done
+
+for dir in "${!directories[@]}"; do # iterate over keys in directories
+	echo python "${SCRIPT_DIR}/tfdoc.py" "${dir}"
+	python "${SCRIPT_DIR}/tfdoc.py" "${dir}"
+done

--- a/tools/pre-commit-tfdoc.sh
+++ b/tools/pre-commit-tfdoc.sh
@@ -1,6 +1,20 @@
 #!/bin/bash
 
-set -ev
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 

--- a/tools/tflint-fast.py
+++ b/tools/tflint-fast.py
@@ -42,8 +42,11 @@ def main(junit):
         args += ['--format=junit']
       args += [
           '--chdir',
-          str((BASEDIR / module_path).absolute()), '--var-file',
-          str((BASEDIR / var_path).absolute())
+          str((BASEDIR / module_path).absolute()),
+          '--var-file',
+          str((BASEDIR / var_path).absolute()),
+          '--config',
+          str((BASEDIR / ".tflint.hcl").absolute()),
       ]
       print(' '.join(args))
       if junit:


### PR DESCRIPTION
Adding this for those who are forgetful as me, to run `terraform fmt` or `tools/tfdoc.py` on changed files.

As of now configuration includes following linters.
* Terraform:
  * terraform fmt
  * terraform tflint
* Python specific:
  * yapf
* Shell scripts
  * shellcheck
  * shfmt
* YAML files:
  * yamllint (disabled as of now)
  * check-yaml
* Other:
  * end-of-file-fixer
  * trailing-whitespace fixer
* Fabric specific
  * tools/tfdoc.py
  * tools/check_boilerplate.py


The checks that are raising most issues in our repo are:
- end-of-file-fixer
- trailing-whitespace fixer
- shellfmt
- shellcheck

Out of those, only shellcheck requires manual fixes, all other 3 above just apply the fix themselves. Shellcheck is controversial so we may want to disable it. 

If you want to check the changes the linters introduce run `pre-commit run -a` to see all effect on the whole repo. When installed, pre-commit hook runs only on changed files in the commit.

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [ ] :grin: Ran `terraform fmt` on all modified files 
- [ ] :grin: Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass
