### PR TITLE
Add perimeter ids in vpc-sc module outputs, fix vpc-sc in project factory module

### DIFF
--- a/fast/stages/2-security/README.md
+++ b/fast/stages/2-security/README.md
@@ -256,7 +256,7 @@ Some references that might be useful in setting up this stage:
 
 | name | description | sensitive | consumers |
 |---|---|:---:|---|
-| [kms_keys](outputs.tf#L55) | KMS key ids. |  |  |
-| [tfvars](outputs.tf#L60) | Terraform variable files for the following stages. | ✓ |  |
-| [vpc_sc_perimeter_default](outputs.tf#L66) | Raw default perimeter resource. | ✓ |  |
+| [kms_keys](outputs.tf#L65) | KMS key ids. |  |  |
+| [tfvars](outputs.tf#L70) | Terraform variable files for the following stages. | ✓ |  |
+| [vpc_sc_perimeter_default](outputs.tf#L76) | Raw default perimeter resource. | ✓ |  |
 <!-- END TFDOC -->

--- a/fast/stages/2-security/outputs.tf
+++ b/fast/stages/2-security/outputs.tf
@@ -36,6 +36,16 @@ locals {
   output_kms_keys = { for k in local._output_kms_keys : k.key => k.id }
   tfvars = {
     kms_keys = local.output_kms_keys
+    vpc_sc = {
+      perimeters = {
+        for k, v in try(module.vpc-sc[0].service_perimeters_regular, {}) :
+        k => v.id
+      }
+      perimeters_bridge = {
+        for k, v in try(module.vpc-sc[0].service_perimeters_bridge, {}) :
+        k => v.id
+      }
+    }
   }
 }
 

--- a/modules/project-factory/factory-projects.tf
+++ b/modules/project-factory/factory-projects.tf
@@ -117,7 +117,14 @@ locals {
       vpc_sc = (
         var.data_overrides.vpc_sc != null
         ? var.data_overrides.vpc_sc
-        : try(v.vpc_sc, var.data_defaults.vpc_sc, null)
+        : (
+          try(v.vpc_sc, null) != null
+          ? merge({
+            perimeter_bridges = []
+            is_dry_run        = false
+          }, v.vpc_sc)
+          : var.data_defaults.vpc_sc
+        )
       )
       # non-project resources
       service_accounts = try(v.service_accounts, {})


### PR DESCRIPTION
Two small fixes that enable using VPC-SC via the project factory module and FAST stage.