### PR TITLE
Add documentation for load balancer changes

### DIFF
--- a/modules/net-lb-app-ext-regional/README.md
+++ b/modules/net-lb-app-ext-regional/README.md
@@ -25,6 +25,7 @@ The variable space of this module closely mirrors that of  [net-lb-app-ext](../n
     - [Serverless NEG creation](#serverless-neg-creation)
   - [URL Map](#url-map)
   - [Complex example](#complex-example)
+- [Deploying changes to load balancer configurations](#deploying-changes-to-load-balancer-configurations)
 - [Files](#files)
 - [Variables](#variables)
 - [Outputs](#outputs)
@@ -692,6 +693,8 @@ module "ralb-0" {
 }
 # tftest modules=3 resources=18 fixtures=fixtures/compute-vm-group-bc.tf e2e
 ```
+## Deploying changes to load balancer configurations
+For deploying changes to load balancer configuration please refer to [net-lb-app-ext README.md](../net-lb-app-ext/README.md#deploying-changes-to-load-balancer-configurations)
 
 <!-- TFDOC OPTS files:1 -->
 <!-- BEGIN TFDOC -->

--- a/modules/net-lb-app-ext/main.tf
+++ b/modules/net-lb-app-ext/main.tf
@@ -53,9 +53,6 @@ resource "google_compute_ssl_certificate" "default" {
   name        = "${var.name}-${each.key}"
   certificate = trimspace(each.value.certificate)
   private_key = trimspace(each.value.private_key)
-  lifecycle {
-    create_before_destroy = true
-  }
 }
 
 resource "google_compute_managed_ssl_certificate" "default" {
@@ -65,9 +62,6 @@ resource "google_compute_managed_ssl_certificate" "default" {
   description = each.value.description
   managed {
     domains = each.value.domains
-  }
-  lifecycle {
-    create_before_destroy = true
   }
 }
 

--- a/modules/net-lb-app-int-cross-region/README.md
+++ b/modules/net-lb-app-int-cross-region/README.md
@@ -19,6 +19,7 @@ Due to the complexity of the underlying resources, changes to the configuration 
     - [Private Service Connect NEG creation](#private-service-connect-neg-creation)
   - [URL Map](#url-map)
   - [Complex example](#complex-example)
+- [Deploying changes to load balancer configurations](#deploying-changes-to-load-balancer-configurations)
 - [Recipes](#recipes)
 - [Files](#files)
 - [Variables](#variables)
@@ -719,6 +720,9 @@ module "ilb-l7" {
 }
 # tftest modules=1 resources=19
 ```
+
+## Deploying changes to load balancer configurations
+For deploying changes to load balancer configuration please refer to [net-lb-app-ext README.md](../net-lb-app-ext/README.md#deploying-changes-to-load-balancer-configurations)
 
 <!-- TFDOC OPTS files:1 -->
 <!-- BEGIN TFDOC -->

--- a/modules/net-lb-app-int/README.md
+++ b/modules/net-lb-app-int/README.md
@@ -22,6 +22,7 @@ Due to the complexity of the underlying resources, changes to the configuration 
   - [SSL Certificates](#ssl-certificates)
   - [PSC service attachment](#psc-service-attachment)
   - [Complex example](#complex-example)
+- [Deploying changes to load balancer configurations](#deploying-changes-to-load-balancer-configurations)
 - [Files](#files)
 - [Variables](#variables)
 - [Outputs](#outputs)
@@ -711,6 +712,9 @@ module "ilb-l7" {
 }
 # tftest modules=1 resources=14
 ```
+
+## Deploying changes to load balancer configurations
+For deploying changes to load balancer configuration please refer to [net-lb-app-ext README.md](../net-lb-app-ext/README.md#deploying-changes-to-load-balancer-configurations)
 
 <!-- TFDOC OPTS files:1 -->
 <!-- BEGIN TFDOC -->

--- a/modules/net-lb-ext/README.md
+++ b/modules/net-lb-ext/README.md
@@ -194,6 +194,10 @@ module "nlb" {
 }
 # tftest modules=3 resources=7 inventory=e2e.yaml e2e
 ```
+
+## Deploying changes to load balancer configurations
+For deploying changes to load balancer configuration please refer to [net-lb-app-ext README.md](../net-lb-app-ext/README.md#deploying-changes-to-load-balancer-configurations)
+
 <!-- BEGIN TFDOC -->
 ## Variables
 

--- a/modules/net-lb-int/README.md
+++ b/modules/net-lb-int/README.md
@@ -11,6 +11,7 @@ This module allows managing a GCE Internal Load Balancer and integrates the forw
   - [Dual stack (IPv4 and IPv6)](#dual-stack-ipv4-and-ipv6)
   - [PSC service attachments](#psc-service-attachments)
   - [End to end example](#end-to-end-example)
+- [Deploying changes to load balancer configurations](#deploying-changes-to-load-balancer-configurations)
 - [Issues](#issues)
 - [Variables](#variables)
 - [Outputs](#outputs)
@@ -346,6 +347,10 @@ module "ilb" {
 }
 # tftest modules=3 resources=7 e2e
 ```
+
+## Deploying changes to load balancer configurations
+For deploying changes to load balancer configuration please refer to [net-lb-app-ext README.md](../net-lb-app-ext/README.md#deploying-changes-to-load-balancer-configurations)
+
 
 ## Issues
 

--- a/modules/net-lb-proxy-int/README.md
+++ b/modules/net-lb-proxy-int/README.md
@@ -16,6 +16,7 @@ Due to the complexity of the underlying resources, changes to the configuration 
     - [Hybrid NEG creation](#hybrid-neg-creation)
     - [Private Service Connect NEG creation](#private-service-connect-neg-creation)
     - [Internet NEG creation](#internet-neg-creation)
+- [Deploying changes to load balancer configurations](#deploying-changes-to-load-balancer-configurations)
 - [Files](#files)
 - [Variables](#variables)
 - [Outputs](#outputs)
@@ -312,6 +313,8 @@ module "ilb-l7" {
 # tftest modules=1 resources=6 inventory=internet-neg.yaml e2e
 ```
 
+## Deploying changes to load balancer configurations
+For deploying changes to load balancer configuration please refer to [net-lb-app-ext README.md](../net-lb-app-ext/README.md#deploying-changes-to-load-balancer-configurations)
 
 <!-- TFDOC OPTS files:1 -->
 <!-- BEGIN TFDOC -->


### PR DESCRIPTION
lifecycle create_before_destroy on SSL certificates is not working, as with such strategy alreadyExists error is thrown when creating new certificate.

Closes #2093
<!-- Put a description of what this PR is for here -->

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [ ] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [ ] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass
