### PR TITLE
Change shebang on pre-commit checks

### DIFF
--- a/tools/pre-commit-tfdoc.sh
+++ b/tools/pre-commit-tfdoc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2024 Google LLC
 #


### PR DESCRIPTION
<!-- Put a description of what this PR is for here -->
Addresses # 2342

Changes: updates the shebang for the pre-commit hook, specifically `pre-commit-tfdocs.sh`, so that bash is taken from $PATH and not hardcoded. 

```bash
export PATH="/opt/homebrew/bin/bash:$PATH" # This makes our bash version to be selected by the shebang
git commit -m "My great commit!"  # This will trigger the pre-hook using the injected bash version into env
```

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [ ] Ran `terraform fmt` on all modified files -> _Not needed, no TF file was touched/created_
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)  -> _Not needed, no doc file was touched/created_
- [x] Made sure all relevant tests pass ->  _Tested working by issuing a simple commit on a TF file_
