### PR TITLE
Strip bucket name from bundle URI in cloud function modules

### DIFF
--- a/modules/cloud-function-v1/main.tf
+++ b/modules/cloud-function-v1/main.tf
@@ -65,7 +65,7 @@ resource "google_cloudfunctions_function" "function" {
   source_archive_bucket = local.bucket
   source_archive_object = (
     local.bundle_type == "gcs"
-    ? var.bundle_config.path
+    ? replace(var.bundle_config.path, "/^gs:\\/\\/[^\\/]+\\//", "")
     : google_storage_bucket_object.bundle[0].name
   )
   labels                       = var.labels

--- a/modules/cloud-function-v2/main.tf
+++ b/modules/cloud-function-v2/main.tf
@@ -76,7 +76,7 @@ resource "google_cloudfunctions2_function" "function" {
         bucket = local.bucket
         object = (
           local.bundle_type == "gcs"
-          ? var.bundle_config.path
+          ? replace(var.bundle_config.path, "/^gs:\\/\\/[^\\/]+\\//", "")
           : google_storage_bucket_object.bundle[0].name
         )
       }


### PR DESCRIPTION
Fixes the changes introduced with #2361