### PR TITLE
Fix for plan not in sync when creating billing budgets in project factory #2365

### DIFF
--- a/modules/project-factory/factory-budgets.tf
+++ b/modules/project-factory/factory-budgets.tf
@@ -51,7 +51,7 @@ locals {
           try(v.projects, []),
           [
             for p in lookup(local.project_budgets, k, []) :
-            "projects/${module.projects[p].project_id}"
+            "projects/${module.projects[p].number}"
           ]
         )
         resource_ancestors = try(v.filter.resource_ancestors, null)


### PR DESCRIPTION
Fixes #2365 . 
Using project id for the projects in the filter is not correct and the [project number is expected](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/billing_budget#projects). This fixes  that.

<!-- Put a description of what this PR is for here -->
---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [x] Made sure all relevant tests pass
