### PR TITLE
Fix tutorial error.

### DIFF
--- a/blueprints/gke/patterns/batch/tutorial.md
+++ b/blueprints/gke/patterns/batch/tutorial.md
@@ -92,7 +92,7 @@ cluster_name   = "gke-patterns-cluster"
 cluster_create = {
   deletion_protection = false
   labels = {
-    pattern = "kafka"
+    pattern = "batch"
   }
 }
 region         = "europe-west1"

--- a/blueprints/gke/patterns/batch/versions_override.tf
+++ b/blueprints/gke/patterns/batch/versions_override.tf
@@ -1,0 +1,22 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = ">= 1.7.0"
+    }
+  }
+}


### PR DESCRIPTION
Without versions override it fails with:
 Error: Failed to query available provider packages
│
│ Could not retrieve the list of available versions for provider hashicorp/kubectl: provider registry registry.terraform.io does not have a provider named registry.terraform.io/hashicorp/kubectl │
│ All modules should specify their required_providers so that external consumers will get the correct providers when using a module. To see which modules are currently depending on hashicorp/kubectl, run the following command:
│     terraform providers

<!-- Put a description of what this PR is for here -->

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [ ] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [ ] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass
