### PR TITLE
FAST top-level folder profiles

### DIFF
--- a/fast/stages/1-resman/billing.tf
+++ b/fast/stages/1-resman/billing.tf
@@ -23,6 +23,11 @@ locals {
       module.branch-network-sa.iam_email,
       module.branch-security-sa.iam_email,
     ],
+    # folder profiles
+    [
+      for k, v in local.folder_profile_iam :
+      module.top-level-sa[k].iam_email
+    ],
     local.branch_optional_sa_lists.dp-dev,
     local.branch_optional_sa_lists.dp-prod,
     local.branch_optional_sa_lists.gke-dev,

--- a/fast/stages/1-resman/iam.tf
+++ b/fast/stages/1-resman/iam.tf
@@ -18,6 +18,21 @@
 
 locals {
   iam_bindings_additive = merge(
+    # folder profiles
+    {
+      for v in local.folder_profile_org_iam : v.key => {
+        condition = v.condition
+        member    = module.top-level-sa[v.folder].iam_email
+        role      = v.role
+      }
+    },
+    # folder profile billing
+    local.billing_mode != "org" ? {} : {
+      for k, v in local.folder_profile_iam : "${k}-billing" => {
+        member = module.top-level-sa[k].iam_email
+        role   = "roles/billing.user"
+      }
+    },
     # network and security
     {
       sa_net_fw_policy_admin = {

--- a/fast/stages/1-resman/top-level-folder-profiles.tf
+++ b/fast/stages/1-resman/top-level-folder-profiles.tf
@@ -1,0 +1,114 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# tfdoc:file:description Top-level folders IAM profiles.
+
+locals {
+  # derive folder-level bindings from role names
+  folder_profile_iam = {
+    for k, v in local._folder_profile_iam_roles : k => {
+      # get the set of combined role names
+      for role in distinct(concat(v.ro, v.rw, v.user)) : role => distinct(concat(
+        # combine user principals with ro and rw sa
+        try(local.top_level_folders[k]["iam"][role], []),
+        !contains(v.ro, role) ? [] : [module.top-level-r-sa[k].iam_email],
+        !contains(v.rw, role) ? [] : [module.top-level-sa[k].iam_email],
+      ))
+    }
+  }
+  # derive org-level bindings from roles names
+  folder_profile_org_iam = flatten([
+    for k, v in local._folder_profile_iam_roles : [
+      for binding in v.rw_org : {
+        condition = (
+          try(binding.condition, null) == null
+          ? null
+          : {
+            description = "${binding.condition.description} ${k}."
+            expression  = binding.condition.expression
+            title       = "${binding.condition.title}_${k}"
+          }
+        )
+        folder = k
+        key    = "${k}-${binding.role}"
+        role   = binding.role
+      }
+    ]
+  ])
+  # recombine all role names at folder level
+  _folder_profile_iam_roles = {
+    for k, v in local.top_level_folders : k => {
+      ro = concat(
+        try(local._folder_profile_tpl_folder["_BASE"]["ro"], []),
+        try(local._folder_profile_tpl_folder[v.fast_profile.type]["ro"], [])
+      )
+      rw = concat(
+        try(local._folder_profile_tpl_folder["_BASE"]["rw"], []),
+        try(local._folder_profile_tpl_folder[v.fast_profile.type]["rw"], [])
+      )
+      rw_org = concat(
+        try(local._folder_profile_tpl_org["_BASE"], []),
+        try(local._folder_profile_tpl_org[v.fast_profile.type], [])
+      )
+      user = keys(v.iam)
+    } if v.fast_profile != null
+  }
+  # IAM template for folder-level roles
+  _folder_profile_tpl_folder = {
+    _BASE = {
+      ro = [
+        "roles/viewer",
+        "roles/resourcemanager.folderViewer"
+      ]
+      rw = [
+        "roles/logging.admin",
+        "roles/owner",
+        "roles/resourcemanager.folderAdmin",
+        "roles/resourcemanager.projectCreator",
+        var.custom_roles.service_project_network_admin
+      ]
+    }
+    NETWORKING = {
+      rw = [
+        "roles/compute.xpnAdmin"
+      ]
+    }
+  }
+  # IAM template for rw sa org-level roles
+  _folder_profile_tpl_org = {
+    NETWORKING = [
+      { role = "roles/cloudasset.viewer" },
+      { role = "roles/compute.orgFirewallPolicyAdmin" },
+      { role = "roles/compute.xpnAdmin" }
+    ]
+    PROJECT_FACTORY = [
+      {
+        role = "roles/orgpolicy.policyAdmin"
+        condition = {
+          title       = "pf_org_policy_admin"
+          description = "Project factory org policy admin for"
+          expression  = <<-END
+            resource.matchTag('${local.tag_root}/${var.tag_names.context}', 'project-factory')
+          END
+        }
+      }
+    ]
+    SECURITY = [
+      { role = "roles/accesscontextmanager.policyAdmin" },
+      { role = "roles/cloudasset.viewer" }
+    ]
+  }
+}

--- a/fast/stages/1-resman/variables.tf
+++ b/fast/stages/1-resman/variables.tf
@@ -201,6 +201,15 @@ variable "top_level_folders" {
       sa_impersonation_principals = optional(list(string), [])
     }), {})
     contacts = optional(map(list(string)), {})
+    fast_profile = optional(object({
+      type = string
+      cicd_config = optional(object({
+        name              = string
+        type              = string
+        branch            = optional(string)
+        identity_provider = optional(string)
+      }))
+    }))
     firewall_policy = optional(object({
       name   = string
       policy = string
@@ -267,4 +276,14 @@ variable "top_level_folders" {
   }))
   nullable = false
   default  = {}
+  validation {
+    condition = alltrue([
+      for k, v in var.top_level_folders :
+      v.fast_profile == null ||
+      try(v.fast_profile.type, "-") == "NETWORKING" ||
+      try(v.fast_profile.type, "-") == "SECURITY" ||
+      try(v.fast_profile.type, "-") == "PROJECT_FACTORY"
+    ])
+    error_message = "available FAST folder profile types: NETWORKING, SECURITY, PROJECT_FACTORY"
+  }
 }


### PR DESCRIPTION
This is a work in progress PR that implements a core change in resource management discussed with @juliocc and originating from an insight by @eliamaldini.

The core features implemented here are

- [ ] make project factory a stage 2
- [x] support for "FAST folder profiles" in top-level folders, that allow users to flag arbitrary folders so that FAST makes them ready to support any stage 2 (IAM bindings, automation, optional CI/CD)
- [ ] support for CI/CD in top-level folders

Once the above features are complete, the plan is to drop direct support in code for stage 2s from the resource management stage (the `branch_xxx` files), and replace it with YAML folder definitions that implement the same resources. This will allow users to rename, remove, or add additional stage 2 folders.

Stage 3s will follow the same pattern, it remains to see how to properly implement them. One idea would be to depend them on the project factory, which would remove the need of assigning billing and project creator roles to their service accounts.
