### PR TITLE
Add support for sqlAssertion AutoDQ rule type in dataplex-datascan

### DIFF
--- a/blueprints/gke/patterns/autopilot-cluster/versions.tf
+++ b/blueprints/gke/patterns/autopilot-cluster/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/blueprints/gke/patterns/batch/versions.tf
+++ b/blueprints/gke/patterns/batch/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/blueprints/gke/patterns/kafka/versions.tf
+++ b/blueprints/gke/patterns/kafka/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/blueprints/gke/patterns/kong-cloudrun/versions.tf
+++ b/blueprints/gke/patterns/kong-cloudrun/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/blueprints/gke/patterns/mysql/versions.tf
+++ b/blueprints/gke/patterns/mysql/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/blueprints/gke/patterns/redis-cluster/versions.tf
+++ b/blueprints/gke/patterns/redis-cluster/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/default-versions.tf
+++ b/default-versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/__experimental_deprecated/alloydb-instance/versions.tf
+++ b/modules/__experimental_deprecated/alloydb-instance/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/__experimental_deprecated/net-neg/versions.tf
+++ b/modules/__experimental_deprecated/net-neg/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/__experimental_deprecated/project-iam-magic/versions.tf
+++ b/modules/__experimental_deprecated/project-iam-magic/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/alloydb/versions.tf
+++ b/modules/alloydb/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/analytics-hub/versions.tf
+++ b/modules/analytics-hub/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/api-gateway/versions.tf
+++ b/modules/api-gateway/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/apigee/versions.tf
+++ b/modules/apigee/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/artifact-registry/versions.tf
+++ b/modules/artifact-registry/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/bigquery-dataset/versions.tf
+++ b/modules/bigquery-dataset/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/bigtable-instance/versions.tf
+++ b/modules/bigtable-instance/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/billing-account/versions.tf
+++ b/modules/billing-account/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/binauthz/versions.tf
+++ b/modules/binauthz/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/certificate-manager/versions.tf
+++ b/modules/certificate-manager/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/__need_fixing/onprem/versions.tf
+++ b/modules/cloud-config-container/__need_fixing/onprem/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/__need_fixing/squid/versions.tf
+++ b/modules/cloud-config-container/__need_fixing/squid/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/bindplane/versions.tf
+++ b/modules/cloud-config-container/bindplane/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/coredns/versions.tf
+++ b/modules/cloud-config-container/coredns/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/cos-generic-metadata/versions.tf
+++ b/modules/cloud-config-container/cos-generic-metadata/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/envoy-sni-dyn-fwd-proxy/versions.tf
+++ b/modules/cloud-config-container/envoy-sni-dyn-fwd-proxy/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/envoy-traffic-director/versions.tf
+++ b/modules/cloud-config-container/envoy-traffic-director/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/mysql/versions.tf
+++ b/modules/cloud-config-container/mysql/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/nginx-tls/versions.tf
+++ b/modules/cloud-config-container/nginx-tls/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/nginx/versions.tf
+++ b/modules/cloud-config-container/nginx/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/cloud-config-container/simple-nva/versions.tf
+++ b/modules/cloud-config-container/simple-nva/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/cloud-function-v1/versions.tf
+++ b/modules/cloud-function-v1/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/cloud-function-v2/versions.tf
+++ b/modules/cloud-function-v2/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/cloud-identity-group/versions.tf
+++ b/modules/cloud-identity-group/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/cloud-run-v2/versions.tf
+++ b/modules/cloud-run-v2/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/cloud-run/versions.tf
+++ b/modules/cloud-run/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/cloudsql-instance/versions.tf
+++ b/modules/cloudsql-instance/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/compute-mig/versions.tf
+++ b/modules/compute-mig/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/compute-vm/versions.tf
+++ b/modules/compute-vm/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/container-registry/versions.tf
+++ b/modules/container-registry/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/data-catalog-policy-tag/versions.tf
+++ b/modules/data-catalog-policy-tag/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/data-catalog-tag-template/versions.tf
+++ b/modules/data-catalog-tag-template/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/data-catalog-tag/versions.tf
+++ b/modules/data-catalog-tag/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/dataform-repository/versions.tf
+++ b/modules/dataform-repository/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/datafusion/versions.tf
+++ b/modules/datafusion/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/dataplex-datascan/README.md
+++ b/modules/dataplex-datascan/README.md
@@ -3,15 +3,14 @@
 This module manages the creation of Dataplex DataScan resources.
 
 <!-- BEGIN TOC -->
-- [Dataplex DataScan](#dataplex-datascan)
-  - [Data Profiling](#data-profiling)
-  - [Data Quality](#data-quality)
-  - [Data Source](#data-source)
-  - [Execution Schedule](#execution-schedule)
-  - [IAM](#iam)
-  - [TODO](#todo)
-  - [Variables](#variables)
-  - [Outputs](#outputs)
+- [Data Profiling](#data-profiling)
+- [Data Quality](#data-quality)
+- [Data Source](#data-source)
+- [Execution Schedule](#execution-schedule)
+- [IAM](#iam)
+- [TODO](#todo)
+- [Variables](#variables)
+- [Outputs](#outputs)
 <!-- END TOC -->
 
 ## Data Profiling

--- a/modules/dataplex-datascan/README.md
+++ b/modules/dataplex-datascan/README.md
@@ -3,14 +3,15 @@
 This module manages the creation of Dataplex DataScan resources.
 
 <!-- BEGIN TOC -->
-- [Data Profiling](#data-profiling)
-- [Data Quality](#data-quality)
-- [Data Source](#data-source)
-- [Execution Schedule](#execution-schedule)
-- [IAM](#iam)
-- [TODO](#todo)
-- [Variables](#variables)
-- [Outputs](#outputs)
+- [Dataplex DataScan](#dataplex-datascan)
+  - [Data Profiling](#data-profiling)
+  - [Data Quality](#data-quality)
+  - [Data Source](#data-source)
+  - [Execution Schedule](#execution-schedule)
+  - [IAM](#iam)
+  - [TODO](#todo)
+  - [Variables](#variables)
+  - [Outputs](#outputs)
 <!-- END TOC -->
 
 ## Data Profiling
@@ -43,7 +44,7 @@ module "dataplex-datascan" {
 
 To create an Data Quality scan, provide the `data_quality_spec` input arguments as documented in <https://cloud.google.com/dataplex/docs/reference/rest/v1/DataQualitySpec>.
 
-Documentation for the supported rule types and rule specifications can be found in <https://cloud.example.com/dataplex/docs/reference/rest/v1/DataQualityRule>.
+Documentation for the supported rule types and rule specifications can be found in <https://cloud.google.com/dataplex/docs/reference/rest/v1/DataQualityRule>.
 
 This example shows how to create a Data Quality scan.
 

--- a/modules/dataplex-datascan/README.md
+++ b/modules/dataplex-datascan/README.md
@@ -141,7 +141,7 @@ module "dataplex-datascan" {
       {
         dimension = "VALIDITY"
         sql_assertion = {
-          sql_statement = <<EOT
+          sql_statement = <<-EOT
             SELECT
               city_asset_number, council_district
             FROM $${data()}
@@ -240,7 +240,7 @@ rules:
       sql_expression: COUNT(*) > 0
   - dimension: VALIDITY
     sql_assertion:
-      sql_statement: >
+      sql_statement: |
         SELECT
           city_asset_number, council_district
         FROM ${data()}
@@ -332,7 +332,7 @@ rules:
       sqlExpression: COUNT(*) > 0
   - dimension: VALIDITY
     sqlAssertion:
-      sqlStatement: >
+      sqlStatement: |
         SELECT
           city_asset_number, council_district
         FROM ${data()}

--- a/modules/dataplex-datascan/README.md
+++ b/modules/dataplex-datascan/README.md
@@ -137,6 +137,19 @@ module "dataplex-datascan" {
         table_condition_expectation = {
           sql_expression = "COUNT(*) > 0"
         }
+      },
+      {
+        dimension = "VALIDITY"
+        sql_assertion = {
+          sql_statement = <<EOT
+            SELECT
+              city_asset_number, council_district
+            FROM $${data()}
+            WHERE city_asset_number IS NOT NULL
+            GROUP BY 1,2
+            HAVING COUNT(*) > 1
+          EOT
+        }
       }
     ]
   }
@@ -225,6 +238,15 @@ rules:
   - dimension: VALIDITY
     table_condition_expectation:
       sql_expression: COUNT(*) > 0
+  - dimension: VALIDITY
+    sql_assertion:
+      sql_statement: >
+        SELECT
+          city_asset_number, council_district
+        FROM ${data()}
+        WHERE city_asset_number IS NOT NULL
+        GROUP BY 1,2
+        HAVING COUNT(*) > 1
 ```
 
 While the module only accepts input in snake_case, the YAML file provided to the `data_quality_spec_file` variable can use either camelCase or snake_case. This example below should also produce the same DataScan configuration as the previous examples.
@@ -308,6 +330,15 @@ rules:
   - dimension: VALIDITY
     tableConditionExpectation:
       sqlExpression: COUNT(*) > 0
+  - dimension: VALIDITY
+    sqlAssertion:
+      sqlStatement: >
+        SELECT
+          city_asset_number, council_district
+        FROM ${data()}
+        WHERE city_asset_number IS NOT NULL
+        GROUP BY 1,2
+        HAVING COUNT(*) > 1
 ```
 
 ## Data Source
@@ -431,21 +462,21 @@ module "dataplex-datascan" {
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
 | [data](variables.tf#L17) | The data source for DataScan. The source can be either a Dataplex `entity` or a BigQuery `resource`. | <code title="object&#40;&#123;&#10;  entity   &#61; optional&#40;string&#41;&#10;  resource &#61; optional&#40;string&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
-| [name](variables.tf#L119) | Name of Dataplex Scan. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L130) | The ID of the project where the Dataplex DataScan will be created. | <code>string</code> | ✓ |  |
-| [region](variables.tf#L135) | Region for the Dataplex DataScan. | <code>string</code> | ✓ |  |
+| [name](variables.tf#L122) | Name of Dataplex Scan. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L133) | The ID of the project where the Dataplex DataScan will be created. | <code>string</code> | ✓ |  |
+| [region](variables.tf#L138) | Region for the Dataplex DataScan. | <code>string</code> | ✓ |  |
 | [data_profile_spec](variables.tf#L29) | DataProfileScan related setting. Variable descriptions are provided in https://cloud.google.com/dataplex/docs/reference/rest/v1/DataProfileSpec. | <code title="object&#40;&#123;&#10;  sampling_percent &#61; optional&#40;number&#41;&#10;  row_filter       &#61; optional&#40;string&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [data_quality_spec](variables.tf#L38) | DataQualityScan related setting. Variable descriptions are provided in https://cloud.google.com/dataplex/docs/reference/rest/v1/DataQualitySpec. | <code title="object&#40;&#123;&#10;  sampling_percent &#61; optional&#40;number&#41;&#10;  row_filter       &#61; optional&#40;string&#41;&#10;  post_scan_actions &#61; optional&#40;object&#40;&#123;&#10;    bigquery_export &#61; optional&#40;object&#40;&#123;&#10;      results_table &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;&#41;&#10;  rules &#61; list&#40;object&#40;&#123;&#10;    column               &#61; optional&#40;string&#41;&#10;    ignore_null          &#61; optional&#40;bool, null&#41;&#10;    dimension            &#61; string&#10;    threshold            &#61; optional&#40;number&#41;&#10;    non_null_expectation &#61; optional&#40;object&#40;&#123;&#125;&#41;&#41;&#10;    range_expectation &#61; optional&#40;object&#40;&#123;&#10;      min_value          &#61; optional&#40;number&#41;&#10;      max_value          &#61; optional&#40;number&#41;&#10;      strict_min_enabled &#61; optional&#40;bool&#41;&#10;      strict_max_enabled &#61; optional&#40;bool&#41;&#10;    &#125;&#41;&#41;&#10;    regex_expectation &#61; optional&#40;object&#40;&#123;&#10;      regex &#61; string&#10;    &#125;&#41;&#41;&#10;    set_expectation &#61; optional&#40;object&#40;&#123;&#10;      values &#61; list&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;    uniqueness_expectation &#61; optional&#40;object&#40;&#123;&#125;&#41;&#41;&#10;    statistic_range_expectation &#61; optional&#40;object&#40;&#123;&#10;      statistic          &#61; string&#10;      min_value          &#61; optional&#40;number&#41;&#10;      max_value          &#61; optional&#40;number&#41;&#10;      strict_min_enabled &#61; optional&#40;bool&#41;&#10;      strict_max_enabled &#61; optional&#40;bool&#41;&#10;    &#125;&#41;&#41;&#10;    row_condition_expectation &#61; optional&#40;object&#40;&#123;&#10;      sql_expression &#61; string&#10;    &#125;&#41;&#41;&#10;    table_condition_expectation &#61; optional&#40;object&#40;&#123;&#10;      sql_expression &#61; string&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [description](variables.tf#L85) | Custom description for DataScan. | <code>string</code> |  | <code>null</code> |
-| [execution_schedule](variables.tf#L91) | Schedule DataScan to run periodically based on a cron schedule expression. If not specified, the DataScan is created with `on_demand` schedule, which means it will not run until the user calls `dataScans.run` API. | <code>string</code> |  | <code>null</code> |
-| [factories_config](variables.tf#L97) | Paths to data files and folders that enable factory functionality. | <code title="object&#40;&#123;&#10;  data_quality_spec &#61; optional&#40;string&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [data_quality_spec](variables.tf#L38) | DataQualityScan related setting. Variable descriptions are provided in https://cloud.google.com/dataplex/docs/reference/rest/v1/DataQualitySpec. | <code title="object&#40;&#123;&#10;  sampling_percent &#61; optional&#40;number&#41;&#10;  row_filter       &#61; optional&#40;string&#41;&#10;  post_scan_actions &#61; optional&#40;object&#40;&#123;&#10;    bigquery_export &#61; optional&#40;object&#40;&#123;&#10;      results_table &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;&#41;&#10;  rules &#61; list&#40;object&#40;&#123;&#10;    column               &#61; optional&#40;string&#41;&#10;    ignore_null          &#61; optional&#40;bool, null&#41;&#10;    dimension            &#61; string&#10;    threshold            &#61; optional&#40;number&#41;&#10;    non_null_expectation &#61; optional&#40;object&#40;&#123;&#125;&#41;&#41;&#10;    range_expectation &#61; optional&#40;object&#40;&#123;&#10;      min_value          &#61; optional&#40;number&#41;&#10;      max_value          &#61; optional&#40;number&#41;&#10;      strict_min_enabled &#61; optional&#40;bool&#41;&#10;      strict_max_enabled &#61; optional&#40;bool&#41;&#10;    &#125;&#41;&#41;&#10;    regex_expectation &#61; optional&#40;object&#40;&#123;&#10;      regex &#61; string&#10;    &#125;&#41;&#41;&#10;    set_expectation &#61; optional&#40;object&#40;&#123;&#10;      values &#61; list&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;    uniqueness_expectation &#61; optional&#40;object&#40;&#123;&#125;&#41;&#41;&#10;    statistic_range_expectation &#61; optional&#40;object&#40;&#123;&#10;      statistic          &#61; string&#10;      min_value          &#61; optional&#40;number&#41;&#10;      max_value          &#61; optional&#40;number&#41;&#10;      strict_min_enabled &#61; optional&#40;bool&#41;&#10;      strict_max_enabled &#61; optional&#40;bool&#41;&#10;    &#125;&#41;&#41;&#10;    row_condition_expectation &#61; optional&#40;object&#40;&#123;&#10;      sql_expression &#61; string&#10;    &#125;&#41;&#41;&#10;    table_condition_expectation &#61; optional&#40;object&#40;&#123;&#10;      sql_expression &#61; string&#10;    &#125;&#41;&#41;&#10;    sql_assertion &#61; optional&#40;object&#40;&#123;&#10;      sql_statement &#61; string&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [description](variables.tf#L88) | Custom description for DataScan. | <code>string</code> |  | <code>null</code> |
+| [execution_schedule](variables.tf#L94) | Schedule DataScan to run periodically based on a cron schedule expression. If not specified, the DataScan is created with `on_demand` schedule, which means it will not run until the user calls `dataScans.run` API. | <code>string</code> |  | <code>null</code> |
+| [factories_config](variables.tf#L100) | Paths to data files and folders that enable factory functionality. | <code title="object&#40;&#123;&#10;  data_quality_spec &#61; optional&#40;string&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam](variables-iam.tf#L24) | Dataplex DataScan IAM bindings in {ROLE => [MEMBERS]} format. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_bindings](variables-iam.tf#L31) | Authoritative IAM bindings in {KEY => {role = ROLE, members = [], condition = {}}}. Keys are arbitrary. | <code title="map&#40;object&#40;&#123;&#10;  members &#61; list&#40;string&#41;&#10;  role    &#61; string&#10;  condition &#61; optional&#40;object&#40;&#123;&#10;    expression  &#61; string&#10;    title       &#61; string&#10;    description &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_bindings_additive](variables-iam.tf#L46) | Individual additive IAM bindings. Keys are arbitrary. | <code title="map&#40;object&#40;&#123;&#10;  member &#61; string&#10;  role   &#61; string&#10;  condition &#61; optional&#40;object&#40;&#123;&#10;    expression  &#61; string&#10;    title       &#61; string&#10;    description &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_by_principals](variables-iam.tf#L17) | Authoritative IAM binding in {PRINCIPAL => [ROLES]} format. Principals need to be statically defined to avoid cycle errors. Merged internally with the `iam` variable. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [incremental_field](variables.tf#L106) | The unnested field (of type Date or Timestamp) that contains values which monotonically increase over time. If not specified, a data scan will run for all data in the table. | <code>string</code> |  | <code>null</code> |
-| [labels](variables.tf#L112) | Resource labels. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
-| [prefix](variables.tf#L124) | Optional prefix used to generate Dataplex DataScan ID. | <code>string</code> |  | <code>null</code> |
+| [incremental_field](variables.tf#L109) | The unnested field (of type Date or Timestamp) that contains values which monotonically increase over time. If not specified, a data scan will run for all data in the table. | <code>string</code> |  | <code>null</code> |
+| [labels](variables.tf#L115) | Resource labels. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [prefix](variables.tf#L127) | Optional prefix used to generate Dataplex DataScan ID. | <code>string</code> |  | <code>null</code> |
 
 ## Outputs
 

--- a/modules/dataplex-datascan/factory.tf
+++ b/modules/dataplex-datascan/factory.tf
@@ -139,6 +139,17 @@ locals {
           }
           : null
         )
+        sql_assertion = (
+          can(rule.sqlAssertion) || can(rule.sql_assertion)
+          ? {
+            sql_statement = try(
+              rule.sqlAssertion.sqlStatement,
+              rule.sql_assertion.sql_statement,
+              null
+            )
+          }
+          : null
+        )
       }
     ]
     sampling_percent = try(

--- a/modules/dataplex-datascan/main.tf
+++ b/modules/dataplex-datascan/main.tf
@@ -203,6 +203,15 @@ resource "google_dataplex_datascan" "datascan" {
             }
           }
 
+          dynamic "sql_assertion" {
+            for_each = (
+              try(rules.value.sql_assertion, null) != null ? [""] : []
+            )
+            content {
+              sql_statement = rules.value.sql_assertion.sql_statement
+            }
+          }
+
         }
       }
     }
@@ -240,10 +249,11 @@ resource "google_dataplex_datascan" "datascan" {
             "uniqueness_expectation",
             "statistic_range_expectation",
             "row_condition_expectation",
-            "table_condition_expectation"
+            "table_condition_expectation",
+            "sql_assertion"
           ], k) && v != null
       ]) == 1])
-      error_message = "Datascan rule must contain a key that is one of ['non_null_expectation', 'range_expectation', 'regex_expectation', 'set_expectation', 'uniqueness_expectation', 'statistic_range_expectation', 'row_condition_expectation', 'table_condition_expectation]."
+      error_message = "Datascan rule must contain a key that is one of ['non_null_expectation', 'range_expectation', 'regex_expectation', 'set_expectation', 'uniqueness_expectation', 'statistic_range_expectation', 'row_condition_expectation', 'table_condition_expectation', 'sql_assertion']."
     }
   }
 }

--- a/modules/dataplex-datascan/variables.tf
+++ b/modules/dataplex-datascan/variables.tf
@@ -78,6 +78,9 @@ variable "data_quality_spec" {
       table_condition_expectation = optional(object({
         sql_expression = string
       }))
+      sql_assertion = optional(object({
+        sql_statement = string
+      }))
     }))
   })
 }

--- a/modules/dataplex-datascan/versions.tf
+++ b/modules/dataplex-datascan/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/dataplex/versions.tf
+++ b/modules/dataplex/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/dataproc/versions.tf
+++ b/modules/dataproc/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/dns-response-policy/versions.tf
+++ b/modules/dns-response-policy/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/dns/versions.tf
+++ b/modules/dns/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/endpoints/versions.tf
+++ b/modules/endpoints/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/firestore/versions.tf
+++ b/modules/firestore/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/folder/versions.tf
+++ b/modules/folder/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/gcs/versions.tf
+++ b/modules/gcs/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/gcve-private-cloud/versions.tf
+++ b/modules/gcve-private-cloud/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/gke-cluster-autopilot/versions.tf
+++ b/modules/gke-cluster-autopilot/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/gke-cluster-standard/versions.tf
+++ b/modules/gke-cluster-standard/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/gke-hub/versions.tf
+++ b/modules/gke-hub/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/gke-nodepool/versions.tf
+++ b/modules/gke-nodepool/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/iam-service-account/versions.tf
+++ b/modules/iam-service-account/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/kms/versions.tf
+++ b/modules/kms/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/logging-bucket/versions.tf
+++ b/modules/logging-bucket/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/ncc-spoke-ra/versions.tf
+++ b/modules/ncc-spoke-ra/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/net-address/versions.tf
+++ b/modules/net-address/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/net-cloudnat/versions.tf
+++ b/modules/net-cloudnat/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/net-firewall-policy/versions.tf
+++ b/modules/net-firewall-policy/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/net-ipsec-over-interconnect/versions.tf
+++ b/modules/net-ipsec-over-interconnect/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/net-lb-app-ext-regional/versions.tf
+++ b/modules/net-lb-app-ext-regional/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/net-lb-app-ext/versions.tf
+++ b/modules/net-lb-app-ext/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/net-lb-app-int-cross-region/versions.tf
+++ b/modules/net-lb-app-int-cross-region/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/net-lb-app-int/versions.tf
+++ b/modules/net-lb-app-int/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/net-lb-ext/versions.tf
+++ b/modules/net-lb-ext/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/net-lb-int/versions.tf
+++ b/modules/net-lb-int/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/net-lb-proxy-int/versions.tf
+++ b/modules/net-lb-proxy-int/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/net-swp/versions.tf
+++ b/modules/net-swp/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/net-vlan-attachment/versions.tf
+++ b/modules/net-vlan-attachment/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/net-vpc-firewall/versions.tf
+++ b/modules/net-vpc-firewall/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/net-vpc-peering/versions.tf
+++ b/modules/net-vpc-peering/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/net-vpc/versions.tf
+++ b/modules/net-vpc/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/net-vpn-dynamic/versions.tf
+++ b/modules/net-vpn-dynamic/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/net-vpn-ha/versions.tf
+++ b/modules/net-vpn-ha/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/net-vpn-static/versions.tf
+++ b/modules/net-vpn-static/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/organization/versions.tf
+++ b/modules/organization/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/project/versions.tf
+++ b/modules/project/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/projects-data-source/versions.tf
+++ b/modules/projects-data-source/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/pubsub/versions.tf
+++ b/modules/pubsub/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/secret-manager/versions.tf
+++ b/modules/secret-manager/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/service-directory/versions.tf
+++ b/modules/service-directory/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/source-repository/versions.tf
+++ b/modules/source-repository/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/spanner-instance/versions.tf
+++ b/modules/spanner-instance/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/vpc-sc/versions.tf
+++ b/modules/vpc-sc/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/modules/workstation-cluster/versions.tf
+++ b/modules/workstation-cluster/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/tests/examples_e2e/setup_module/versions.tf
+++ b/tests/examples_e2e/setup_module/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.34.0, < 6.0.0" # tftest
+      version = ">= 5.37.0, < 6.0.0" # tftest
     }
   }
 }

--- a/tests/modules/dataplex_datascan/datascan_test_inputs.tfvars
+++ b/tests/modules/dataplex_datascan/datascan_test_inputs.tfvars
@@ -111,6 +111,19 @@ data_quality_spec = {
       table_condition_expectation = {
         sql_expression = "COUNT(*) > 0"
       }
+    },
+    {
+      dimension = "VALIDITY"
+      sql_assertion = {
+        sql_statement = <<-EOT
+          SELECT
+            city_asset_number, council_district
+          FROM $${data()}
+          WHERE city_asset_number IS NOT NULL
+          GROUP BY 1,2
+          HAVING COUNT(*) > 1
+        EOT
+      }
     }
   ]
 }

--- a/tests/modules/dataplex_datascan/datascan_test_inputs.yaml
+++ b/tests/modules/dataplex_datascan/datascan_test_inputs.yaml
@@ -32,6 +32,7 @@ values:
         regex_expectation: []
         row_condition_expectation: []
         set_expectation: []
+        sql_assertion: []
         statistic_range_expectation: []
         table_condition_expectation: []
         threshold: 0.99
@@ -50,6 +51,7 @@ values:
         regex_expectation: []
         row_condition_expectation: []
         set_expectation: []
+        sql_assertion: []
         statistic_range_expectation: []
         table_condition_expectation: []
         threshold: 0.9
@@ -68,6 +70,7 @@ values:
         regex_expectation: []
         row_condition_expectation: []
         set_expectation: []
+        sql_assertion: []
         statistic_range_expectation: []
         table_condition_expectation: []
         threshold: 0.8
@@ -83,6 +86,7 @@ values:
         - regex: .*solar.*
         row_condition_expectation: []
         set_expectation: []
+        sql_assertion: []
         statistic_range_expectation: []
         table_condition_expectation: []
         threshold: null
@@ -100,6 +104,7 @@ values:
         - values:
           - sidewalk
           - parkland
+        sql_assertion: []
         statistic_range_expectation: []
         table_condition_expectation: []
         threshold: null
@@ -114,6 +119,7 @@ values:
         regex_expectation: []
         row_condition_expectation: []
         set_expectation: []
+        sql_assertion: []
         statistic_range_expectation: []
         table_condition_expectation: []
         threshold: null
@@ -129,6 +135,7 @@ values:
         regex_expectation: []
         row_condition_expectation: []
         set_expectation: []
+        sql_assertion: []
         statistic_range_expectation:
         - max_value: '15'
           min_value: '5'
@@ -149,6 +156,7 @@ values:
         row_condition_expectation:
         - sql_expression: footprint_length > 0 AND footprint_length <= 10
         set_expectation: []
+        sql_assertion: []
         statistic_range_expectation: []
         table_condition_expectation: []
         threshold: null
@@ -163,9 +171,32 @@ values:
         regex_expectation: []
         row_condition_expectation: []
         set_expectation: []
+        sql_assertion: []
         statistic_range_expectation: []
         table_condition_expectation:
         - sql_expression: COUNT(*) > 0
+        threshold: null
+        uniqueness_expectation: []
+      - column: null
+        name: null
+        description: null
+        dimension: VALIDITY
+        ignore_null: null
+        non_null_expectation: []
+        range_expectation: []
+        regex_expectation: []
+        row_condition_expectation: []
+        set_expectation: []
+        sql_assertion:
+        - sql_statement: |
+            SELECT
+              city_asset_number, council_district
+            FROM ${data()}
+            WHERE city_asset_number IS NOT NULL
+            GROUP BY 1,2
+            HAVING COUNT(*) > 1
+        statistic_range_expectation: []
+        table_condition_expectation: []
         threshold: null
         uniqueness_expectation: []
       sampling_percent: 100

--- a/tests/modules/dataplex_datascan/examples/datascan_dq.yaml
+++ b/tests/modules/dataplex_datascan/examples/datascan_dq.yaml
@@ -32,6 +32,7 @@ values:
         regex_expectation: []
         row_condition_expectation: []
         set_expectation: []
+        sql_assertion: []
         statistic_range_expectation: []
         table_condition_expectation: []
         threshold: 0.99
@@ -50,6 +51,7 @@ values:
         regex_expectation: []
         row_condition_expectation: []
         set_expectation: []
+        sql_assertion: []
         statistic_range_expectation: []
         table_condition_expectation: []
         threshold: 0.9
@@ -68,6 +70,7 @@ values:
         regex_expectation: []
         row_condition_expectation: []
         set_expectation: []
+        sql_assertion: []
         statistic_range_expectation: []
         table_condition_expectation: []
         threshold: 0.8
@@ -83,6 +86,7 @@ values:
         - regex: .*solar.*
         row_condition_expectation: []
         set_expectation: []
+        sql_assertion: []
         statistic_range_expectation: []
         table_condition_expectation: []
         threshold: null
@@ -100,6 +104,7 @@ values:
         - values:
           - sidewalk
           - parkland
+        sql_assertion: []
         statistic_range_expectation: []
         table_condition_expectation: []
         threshold: null
@@ -114,6 +119,7 @@ values:
         regex_expectation: []
         row_condition_expectation: []
         set_expectation: []
+        sql_assertion: []
         statistic_range_expectation: []
         table_condition_expectation: []
         threshold: null
@@ -129,6 +135,7 @@ values:
         regex_expectation: []
         row_condition_expectation: []
         set_expectation: []
+        sql_assertion: []
         statistic_range_expectation:
         - max_value: '15'
           min_value: '5'
@@ -149,6 +156,7 @@ values:
         row_condition_expectation:
         - sql_expression: footprint_length > 0 AND footprint_length <= 10
         set_expectation: []
+        sql_assertion: []
         statistic_range_expectation: []
         table_condition_expectation: []
         threshold: null
@@ -163,9 +171,32 @@ values:
         regex_expectation: []
         row_condition_expectation: []
         set_expectation: []
+        sql_assertion: []
         statistic_range_expectation: []
         table_condition_expectation:
         - sql_expression: COUNT(*) > 0
+        threshold: null
+        uniqueness_expectation: []
+      - column: null
+        name: null
+        description: null
+        dimension: VALIDITY
+        ignore_null: null
+        non_null_expectation: []
+        range_expectation: []
+        regex_expectation: []
+        row_condition_expectation: []
+        set_expectation: []
+        sql_assertion:
+        - sql_statement: |
+            SELECT
+              city_asset_number, council_district
+            FROM ${data()}
+            WHERE city_asset_number IS NOT NULL
+            GROUP BY 1,2
+            HAVING COUNT(*) > 1
+        statistic_range_expectation: []
+        table_condition_expectation: []
         threshold: null
         uniqueness_expectation: []
       sampling_percent: 100


### PR DESCRIPTION
`terraform-google-provider` [v5.37.0](https://github.com/hashicorp/terraform-provider-google/releases/tag/v5.37.0) now has support for [`SqlAssertion`](https://cloud.google.com/dataplex/docs/reference/rest/v1/DataQualityRule#sqlassertion) DataQualityRule introduced by [`terraform-google-provider` #18559](https://github.com/hashicorp/terraform-provider-google/pull/18559).

This PR extends the existing `dataplex-datascan` module to support the new `SqlAssertion` DataQualityRule type.

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [x] Made sure all relevant tests pass
