### PR TITLE
remove symbolic links

### DIFF
--- a/blueprints/gke/shared-vpc-gke
+++ b/blueprints/gke/shared-vpc-gke
@@ -1,1 +1,0 @@
-../networking/shared-vpc-gke

--- a/fast/stages/3-data-platform/dev/demo
+++ b/fast/stages/3-data-platform/dev/demo
@@ -1,1 +1,0 @@
-../../../../blueprints/data-solutions/data-platform-foundations/demo/


### PR DESCRIPTION
Can we please remove these two symbolic links? They are messing with git submodule usage.

I was not able to find what (if anything) would be broken by removing them.