### PR TITLE
FAST: IAM cleanups to reflect PF changes

### DIFF
--- a/fast/stages/2-networking-a-simple/net-dev.tf
+++ b/fast/stages/2-networking-a-simple/net-dev.tf
@@ -46,9 +46,6 @@ module "dev-spoke-project" {
   iam = {
     "roles/dns.admin" = compact([
       try(local.service_accounts.gke-dev, null),
-      try(local.service_accounts.project-factory, null),
-      try(local.service_accounts.project-factory-dev, null),
-      try(local.service_accounts.project-factory-prod, null),
     ])
   }
   # allow specific service accounts to assign a set of roles

--- a/fast/stages/2-networking-a-simple/net-landing.tf
+++ b/fast/stages/2-networking-a-simple/net-landing.tf
@@ -32,16 +32,6 @@ module "landing-project" {
   shared_vpc_host_config = {
     enabled = true
   }
-  iam = {
-    "roles/dns.admin" = compact([
-      try(local.service_accounts.project-factory, null),
-      try(local.service_accounts.project-factory-prod, null)
-    ])
-    (local.custom_roles.service_project_network_admin) = compact([
-      try(local.service_accounts.project-factory, null),
-      try(local.service_accounts.project-factory-prod, null)
-    ])
-  }
 }
 
 module "landing-vpc" {

--- a/fast/stages/2-networking-a-simple/net-prod.tf
+++ b/fast/stages/2-networking-a-simple/net-prod.tf
@@ -46,8 +46,6 @@ module "prod-spoke-project" {
   iam = {
     "roles/dns.admin" = compact([
       try(local.service_accounts.gke-prod, null),
-      try(local.service_accounts.project-factory, null),
-      try(local.service_accounts.project-factory-prod, null),
     ])
   }
   # allow specific service accounts to assign a set of roles

--- a/fast/stages/2-networking-b-nva/net-dev.tf
+++ b/fast/stages/2-networking-b-nva/net-dev.tf
@@ -45,9 +45,6 @@ module "dev-spoke-project" {
   iam = {
     "roles/dns.admin" = compact([
       try(local.service_accounts.gke-dev, null),
-      try(local.service_accounts.project-factory, null),
-      try(local.service_accounts.project-factory-dev, null),
-      try(local.service_accounts.project-factory-prod, null),
     ])
   }
   # allow specific service accounts to assign a set of roles

--- a/fast/stages/2-networking-b-nva/net-landing.tf
+++ b/fast/stages/2-networking-b-nva/net-landing.tf
@@ -38,16 +38,6 @@ module "landing-project" {
   shared_vpc_host_config = {
     enabled = true
   }
-  iam = {
-    "roles/dns.admin" = compact([
-      try(local.service_accounts.project-factory, null),
-      try(local.service_accounts.project-factory-prod, null)
-    ])
-    (local.custom_roles.service_project_network_admin) = compact([
-      try(local.service_accounts.project-factory, null),
-      try(local.service_accounts.project-factory-prod, null)
-    ])
-  }
 }
 
 # DMZ (untrusted) VPC

--- a/fast/stages/2-networking-b-nva/net-prod.tf
+++ b/fast/stages/2-networking-b-nva/net-prod.tf
@@ -45,8 +45,6 @@ module "prod-spoke-project" {
   iam = {
     "roles/dns.admin" = compact([
       try(local.service_accounts.gke-prod, null),
-      try(local.service_accounts.project-factory, null),
-      try(local.service_accounts.project-factory-prod, null),
     ])
   }
   # allow specific service accounts to assign a set of roles

--- a/fast/stages/2-networking-c-separate-envs/net-dev.tf
+++ b/fast/stages/2-networking-c-separate-envs/net-dev.tf
@@ -45,9 +45,6 @@ module "dev-spoke-project" {
   iam = {
     "roles/dns.admin" = compact([
       try(local.service_accounts.gke-dev, null),
-      try(local.service_accounts.project-factory, null),
-      try(local.service_accounts.project-factory-dev, null),
-      try(local.service_accounts.project-factory-prod, null),
     ])
   }
   # allow specific service accounts to assign a set of roles

--- a/fast/stages/2-networking-c-separate-envs/net-prod.tf
+++ b/fast/stages/2-networking-c-separate-envs/net-prod.tf
@@ -45,8 +45,6 @@ module "prod-spoke-project" {
   iam = {
     "roles/dns.admin" = compact([
       try(local.service_accounts.gke-prod, null),
-      try(local.service_accounts.project-factory, null),
-      try(local.service_accounts.project-factory-prod, null)
     ])
   }
   # allow specific service accounts to assign a set of roles

--- a/tests/fast/stages/s2_networking_a_simple/simple.yaml
+++ b/tests/fast/stages/s2_networking_a_simple/simple.yaml
@@ -14,4 +14,4 @@
 
 counts:
   modules: 29
-  resources: 158
+  resources: 156

--- a/tests/fast/stages/s2_networking_a_simple/vpn.yaml
+++ b/tests/fast/stages/s2_networking_a_simple/vpn.yaml
@@ -14,4 +14,4 @@
 
 counts:
   modules: 31
-  resources: 195
+  resources: 193

--- a/tests/fast/stages/s2_networking_b_nva/ncc-ra.yaml
+++ b/tests/fast/stages/s2_networking_b_nva/ncc-ra.yaml
@@ -43,11 +43,11 @@ counts:
   google_network_connectivity_hub: 2
   google_network_connectivity_spoke: 4
   google_project: 3
-  google_project_iam_binding: 6
+  google_project_iam_binding: 4
   google_project_iam_member: 2
   google_project_service: 22
   google_project_service_identity: 5
   google_storage_bucket_object: 2
   modules: 39
   random_id: 2
-  resources: 224
+  resources: 222

--- a/tests/fast/stages/s2_networking_b_nva/simple.yaml
+++ b/tests/fast/stages/s2_networking_b_nva/simple.yaml
@@ -45,7 +45,7 @@ counts:
   google_monitoring_dashboard: 3
   google_monitoring_monitored_project: 2
   google_project: 3
-  google_project_iam_binding: 6
+  google_project_iam_binding: 4
   google_project_iam_member: 2
   google_project_service: 21
   google_project_service_identity: 5
@@ -53,4 +53,4 @@ counts:
   google_vpc_access_connector: 2
   modules: 43
   random_id: 2
-  resources: 209
+  resources: 207


### PR DESCRIPTION
This PR retrospect-fixes a few IAM leftovers on the FAST networking stages.

In particular: 

- the `service_project_network_admin` custom role is assigned to the PF SA by 1-resman at folder level, so the project-level assignment done by 2-net is not needed
- `roles/dns.admin` is not required anymore since the PF doesn't deal with DNS management anymore (even though it could arguably be configured to assign DNS roles to other principals)

