### PR TITLE
Add coalesce to factory fw policies to support empty yaml files

### DIFF
--- a/modules/net-firewall-policy/factory.tf
+++ b/modules/net-firewall-policy/factory.tf
@@ -15,16 +15,20 @@
  */
 
 locals {
-  _factory_egress_rules = try(
-    yamldecode(file(pathexpand(var.factories_config.egress_rules_file_path))),
-    {}
+  _factory_egress_rules = coalesce(
+    try(
+      yamldecode(file(pathexpand(var.factories_config.egress_rules_file_path))),
+    {}), {}
   )
-  _factory_ingress_rules = try(
-    yamldecode(file(pathexpand(var.factories_config.ingress_rules_file_path))),
-    {}
+  _factory_ingress_rules = coalesce(
+    try(
+      yamldecode(file(pathexpand(var.factories_config.ingress_rules_file_path))),
+    {}), {}
   )
-  factory_cidrs = try(
-    yamldecode(file(pathexpand(var.factories_config.cidr_file_path))), {}
+  factory_cidrs = coalesce(
+    try(
+      yamldecode(file(pathexpand(var.factories_config.cidr_file_path))),
+    {}), {}
   )
   factory_egress_rules = {
     for k, v in local._factory_egress_rules : "egress/${k}" => {

--- a/modules/net-firewall-policy/factory.tf
+++ b/modules/net-firewall-policy/factory.tf
@@ -18,12 +18,12 @@ locals {
   _factory_egress_rules = coalesce(
     try(
       yamldecode(file(pathexpand(var.factories_config.egress_rules_file_path))),
-    {}), {}
+    {}), tomap({})
   )
   _factory_ingress_rules = coalesce(
     try(
       yamldecode(file(pathexpand(var.factories_config.ingress_rules_file_path))),
-    {}), {}
+    {}), tomap({})
   )
   factory_cidrs = coalesce(
     try(


### PR DESCRIPTION
Add coalesce to factory net-firewall-policies to support empty yaml files.

---
**Checklist**

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
