### PR TITLE
Remove alpha from gcloud storage cp as it moved to GA

### DIFF
--- a/fast/assets/templates/workflow-github.yaml
+++ b/fast/assets/templates/workflow-github.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -97,10 +97,10 @@ jobs:
       - id: tf-config-provider
         name: Copy Terraform provider file
         run: |
-          gcloud alpha storage cp -r \
+          gcloud storage cp -r \
             "gs://${outputs_bucket}/providers/$${{env.provider_file}}" ./
           %{~ for f in tf_var_files ~}
-          gcloud alpha storage cp -r \
+          gcloud storage cp -r \
             "gs://${outputs_bucket}/tfvars/${f}" ./
           %{~ endfor ~}
 

--- a/fast/assets/templates/workflow-gitlab.yaml
+++ b/fast/assets/templates/workflow-gitlab.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -70,9 +70,9 @@ gcp-setup:
         --output-file=$GOOGLE_CREDENTIALS \
         --credential-source-file=token.txt
     - gcloud config set auth/credential_file_override $GOOGLE_CREDENTIALS
-    - gcloud alpha storage cp -r "gs://$FAST_OUTPUTS_BUCKET/providers/$TF_PROVIDERS_FILE" ./providers.tf
+    - gcloud storage cp -r "gs://$FAST_OUTPUTS_BUCKET/providers/$TF_PROVIDERS_FILE" ./providers.tf
     %{~ for f in tf_var_files ~}
-    - gcloud alpha storage cp gs://$FAST_OUTPUTS_BUCKET/tfvars/${f} ./
+    - gcloud storage cp gs://$FAST_OUTPUTS_BUCKET/tfvars/${f} ./
     %{~ endfor ~}
 
 

--- a/fast/extras/0-cicd-gitlab/README.md
+++ b/fast/extras/0-cicd-gitlab/README.md
@@ -326,7 +326,7 @@ Set the newly created personal access as `gitlab_config.access_token` variable
 and then issue the following commands:
 
 ```bash
-gcloud alpha storage cp gs://${prefix}-prod-iac-core-outputs-0/workflows/*-workflow.yaml ./workflows/
+gcloud storage cp gs://${prefix}-prod-iac-core-outputs-0/workflows/*-workflow.yaml ./workflows/
 ```
 
 This will download Gitlab CICD workflow files generated during 0-bootstrap stage

--- a/fast/stage-links.sh
+++ b/fast/stage-links.sh
@@ -32,7 +32,7 @@ END
 fi
 
 if [[ "$1" == "gs://"* ]]; then
-  CMD="gcloud alpha storage cp $1"
+  CMD="gcloud storage cp $1"
   CP_CMD=$CMD
 elif [ ! -d "$1" ]; then
   echo "folder $1 not found"

--- a/fast/stages/0-bootstrap/README.md
+++ b/fast/stages/0-bootstrap/README.md
@@ -405,7 +405,7 @@ ln -s ~/fast-config/providers/0-bootstrap-providers.tf ./
 
 # copy and paste the following commands for '0-bootstrap'
 
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/providers/0-bootstrap-providers.tf ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/providers/0-bootstrap-providers.tf ./
 ```
 
 Copy/paste the command returned by the script to link or copy the provider file, then migrate state with `terraform init` and run `terraform apply`. If your organization was created with "Secure by Default Org Policy", that is with some of the org policies enabled, add `-var 'org_policies_config={"import_defaults": true}'` to `terraform apply`:

--- a/fast/stages/0-bootstrap/templates/workflow-github.yaml
+++ b/fast/stages/0-bootstrap/templates/workflow-github.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -97,10 +97,10 @@ jobs:
       - id: tf-config-provider
         name: Copy Terraform provider file
         run: |
-          gcloud alpha storage cp -r \
+          gcloud storage cp -r \
             "gs://${outputs_bucket}/providers/$${{env.provider_file}}" ./
           %{~ for f in tf_var_files ~}
-          gcloud alpha storage cp -r \
+          gcloud storage cp -r \
             "gs://${outputs_bucket}/tfvars/${f}" ./
           %{~ endfor ~}
 

--- a/fast/stages/0-bootstrap/templates/workflow-gitlab.yaml
+++ b/fast/stages/0-bootstrap/templates/workflow-gitlab.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -70,9 +70,9 @@ gcp-setup:
         --output-file=$GOOGLE_CREDENTIALS \
         --credential-source-file=token.txt
     - gcloud config set auth/credential_file_override $GOOGLE_CREDENTIALS
-    - gcloud alpha storage cp -r "gs://$FAST_OUTPUTS_BUCKET/providers/$TF_PROVIDERS_FILE" ./providers.tf
+    - gcloud storage cp -r "gs://$FAST_OUTPUTS_BUCKET/providers/$TF_PROVIDERS_FILE" ./providers.tf
     %{~ for f in tf_var_files ~}
-    - gcloud alpha storage cp gs://$FAST_OUTPUTS_BUCKET/tfvars/${f} ./
+    - gcloud storage cp gs://$FAST_OUTPUTS_BUCKET/tfvars/${f} ./
     %{~ endfor ~}
 
 

--- a/fast/stages/1-resman/README.md
+++ b/fast/stages/1-resman/README.md
@@ -103,9 +103,9 @@ ln -s ~/fast-config/tfvars/0-bootstrap.auto.tfvars.json ./
 
 # copy and paste the following commands for '1-resman'
 
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/providers/1-resman-providers.tf ./
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/0-globals.auto.tfvars.json ./
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/0-bootstrap.auto.tfvars.json ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/providers/1-resman-providers.tf ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/0-globals.auto.tfvars.json ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/0-bootstrap.auto.tfvars.json ./
 ```
 
 ### Impersonating the automation service account

--- a/fast/stages/1-resman/templates/workflow-github.yaml
+++ b/fast/stages/1-resman/templates/workflow-github.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -97,10 +97,10 @@ jobs:
       - id: tf-config-provider
         name: Copy Terraform provider file
         run: |
-          gcloud alpha storage cp -r \
+          gcloud storage cp -r \
             "gs://${outputs_bucket}/providers/$${{env.provider_file}}" ./
           %{~ for f in tf_var_files ~}
-          gcloud alpha storage cp -r \
+          gcloud storage cp -r \
             "gs://${outputs_bucket}/tfvars/${f}" ./
           %{~ endfor ~}
 

--- a/fast/stages/1-resman/templates/workflow-gitlab.yaml
+++ b/fast/stages/1-resman/templates/workflow-gitlab.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -70,9 +70,9 @@ gcp-setup:
         --output-file=$GOOGLE_CREDENTIALS \
         --credential-source-file=token.txt
     - gcloud config set auth/credential_file_override $GOOGLE_CREDENTIALS
-    - gcloud alpha storage cp -r "gs://$FAST_OUTPUTS_BUCKET/providers/$TF_PROVIDERS_FILE" ./providers.tf
+    - gcloud storage cp -r "gs://$FAST_OUTPUTS_BUCKET/providers/$TF_PROVIDERS_FILE" ./providers.tf
     %{~ for f in tf_var_files ~}
-    - gcloud alpha storage cp gs://$FAST_OUTPUTS_BUCKET/tfvars/${f} ./
+    - gcloud storage cp gs://$FAST_OUTPUTS_BUCKET/tfvars/${f} ./
     %{~ endfor ~}
 
 

--- a/fast/stages/1-tenant-factory/README.md
+++ b/fast/stages/1-tenant-factory/README.md
@@ -107,9 +107,9 @@ ln -s ~/fast-config/tfvars/0-bootstrap.auto.tfvars.json ./
 
 # copy and paste the following commands for '1-tenant-factory'
 
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/providers/1-tenant-factory-providers.tf ./
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/0-globals.auto.tfvars.json ./
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/0-bootstrap.auto.tfvars.json ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/providers/1-tenant-factory-providers.tf ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/0-globals.auto.tfvars.json ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/0-bootstrap.auto.tfvars.json ./
 ```
 
 ### Impersonating the automation service account
@@ -276,9 +276,9 @@ ln -s ~/fast-config/tenants/tenant-a/tfvars/0-bootstrap.auto.tfvars.json ./
 
 # copy and paste the following commands for 'tenant-a/1-resman'
 
-gcloud alpha storage cp gs://{prefix}-{tenant-shortname}-prod-iac-core-0/providers/1-tenant-factory-providers.tf ./
-gcloud alpha storage cp gs://{prefix}-{tenant-shortname}-prod-iac-core-0/tfvars/0-globals.auto.tfvars.json ./
-gcloud alpha storage cp gs://{prefix}-{tenant-shortname}-prod-iac-core-0/tfvars/0-bootstrap.auto.tfvars.json ./
+gcloud storage cp gs://{prefix}-{tenant-shortname}-prod-iac-core-0/providers/1-tenant-factory-providers.tf ./
+gcloud storage cp gs://{prefix}-{tenant-shortname}-prod-iac-core-0/tfvars/0-globals.auto.tfvars.json ./
+gcloud storage cp gs://{prefix}-{tenant-shortname}-prod-iac-core-0/tfvars/0-bootstrap.auto.tfvars.json ./
 ```
 
 <!-- TFDOC OPTS files:1 show_extra:1 -->

--- a/fast/stages/1-tenant-factory/templates/workflow-github.yaml
+++ b/fast/stages/1-tenant-factory/templates/workflow-github.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -97,10 +97,10 @@ jobs:
       - id: tf-config-provider
         name: Copy Terraform provider file
         run: |
-          gcloud alpha storage cp -r \
+          gcloud storage cp -r \
             "gs://${outputs_bucket}/providers/$${{env.provider_file}}" ./
           %{~ for f in tf_var_files ~}
-          gcloud alpha storage cp -r \
+          gcloud storage cp -r \
             "gs://${outputs_bucket}/tfvars/${f}" ./
           %{~ endfor ~}
 

--- a/fast/stages/1-tenant-factory/templates/workflow-gitlab.yaml
+++ b/fast/stages/1-tenant-factory/templates/workflow-gitlab.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -70,9 +70,9 @@ gcp-setup:
         --output-file=$GOOGLE_CREDENTIALS \
         --credential-source-file=token.txt
     - gcloud config set auth/credential_file_override $GOOGLE_CREDENTIALS
-    - gcloud alpha storage cp -r "gs://$FAST_OUTPUTS_BUCKET/providers/$TF_PROVIDERS_FILE" ./providers.tf
+    - gcloud storage cp -r "gs://$FAST_OUTPUTS_BUCKET/providers/$TF_PROVIDERS_FILE" ./providers.tf
     %{~ for f in tf_var_files ~}
-    - gcloud alpha storage cp gs://$FAST_OUTPUTS_BUCKET/tfvars/${f} ./
+    - gcloud storage cp gs://$FAST_OUTPUTS_BUCKET/tfvars/${f} ./
     %{~ endfor ~}
 
 

--- a/fast/stages/2-networking-a-simple/README.md
+++ b/fast/stages/2-networking-a-simple/README.md
@@ -272,10 +272,10 @@ ln -s ~/fast-config/tfvars/1-resman.auto.tfvars.json ./
 
 # copy and paste the following commands for '2-networking-*'
 
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/providers/2-networking-providers.tf ./
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/0-globals.auto.tfvars.json ./
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/0-bootstrap.auto.tfvars.json ./
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/1-resman.auto.tfvars.json ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/providers/2-networking-providers.tf ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/0-globals.auto.tfvars.json ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/0-bootstrap.auto.tfvars.json ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/1-resman.auto.tfvars.json ./
 ```
 
 ### Impersonating the automation service account

--- a/fast/stages/2-networking-b-nva/README.md
+++ b/fast/stages/2-networking-b-nva/README.md
@@ -347,10 +347,10 @@ ln -s ~/fast-config/tfvars/1-resman.auto.tfvars.json ./
 
 # copy and paste the following commands for '2-networking-*'
 
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/providers/2-networking-providers.tf ./
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/0-globals.auto.tfvars.json ./
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/0-bootstrap.auto.tfvars.json ./
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/1-resman.auto.tfvars.json ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/providers/2-networking-providers.tf ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/0-globals.auto.tfvars.json ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/0-bootstrap.auto.tfvars.json ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/1-resman.auto.tfvars.json ./
 ```
 
 ### Impersonating the automation service account

--- a/fast/stages/2-networking-c-separate-envs/README.md
+++ b/fast/stages/2-networking-c-separate-envs/README.md
@@ -193,10 +193,10 @@ ln -s ~/fast-config/tfvars/1-resman.auto.tfvars.json ./
 
 # copy and paste the following commands for '2-networking-*'
 
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/providers/2-networking-providers.tf ./
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/0-globals.auto.tfvars.json ./
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/0-bootstrap.auto.tfvars.json ./
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/1-resman.auto.tfvars.json ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/providers/2-networking-providers.tf ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/0-globals.auto.tfvars.json ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/0-bootstrap.auto.tfvars.json ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/1-resman.auto.tfvars.json ./
 ```
 
 ### Impersonating the automation service account

--- a/fast/stages/2-security/README.md
+++ b/fast/stages/2-security/README.md
@@ -86,10 +86,10 @@ ln -s ~/fast-config/tfvars/1-resman.auto.tfvars.json ./
 
 # copy and paste the following commands for '2-security'
 
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/providers/2-security-providers.tf ./
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/0-globals.auto.tfvars.json ./
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/0-bootstrap.auto.tfvars.json ./
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/1-resman.auto.tfvars.json ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/providers/2-security-providers.tf ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/0-globals.auto.tfvars.json ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/0-bootstrap.auto.tfvars.json ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/1-resman.auto.tfvars.json ./
 ```
 
 ### Impersonating the automation service account

--- a/fast/stages/3-data-platform/dev/README.md
+++ b/fast/stages/3-data-platform/dev/README.md
@@ -108,12 +108,12 @@ ln -s ~/fast-config/tfvars/2-security.auto.tfvars.json ./
 
 # copy and paste the following commands for '3-data-platform'
 
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/providers/3-data-platform-providers.tf ./
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/0-globals.auto.tfvars.json ./
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/0-bootstrap.auto.tfvars.json ./
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/1-resman.auto.tfvars.json ./
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/2-networking.auto.tfvars.json ./
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/2-security.auto.tfvars.json ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/providers/3-data-platform-providers.tf ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/0-globals.auto.tfvars.json ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/0-bootstrap.auto.tfvars.json ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/1-resman.auto.tfvars.json ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/2-networking.auto.tfvars.json ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/2-security.auto.tfvars.json ./
 ```
 
 ### Impersonating the automation service account

--- a/fast/stages/3-gcve/prod/README.md
+++ b/fast/stages/3-gcve/prod/README.md
@@ -39,11 +39,11 @@ ln -s ~/fast-config/tfvars/2-networking.auto.tfvars.json ./
 
 # copy and paste the following commands for '3-gcve'
 
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/providers/3-gcve-dev-providers.tf ./
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/0-globals.auto.tfvars.json ./
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/0-bootstrap.auto.tfvars.json ./
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/1-resman.auto.tfvars.json ./
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/2-networking.auto.tfvars.json ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/providers/3-gcve-dev-providers.tf ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/0-globals.auto.tfvars.json ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/0-bootstrap.auto.tfvars.json ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/1-resman.auto.tfvars.json ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/2-networking.auto.tfvars.json ./
 ```
 
 ### Impersonating the automation service account

--- a/fast/stages/3-gke-multitenant/dev/README.md
+++ b/fast/stages/3-gke-multitenant/dev/README.md
@@ -85,12 +85,12 @@ ln -s /home/ludomagno/fast-config/tfvars/2-security.auto.tfvars.json ./
 
 # copy and paste the following commands for '3-gke-multitenant'
 
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/providers/3-gke-multitenant-providers.tf ./
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/0-globals.auto.tfvars.json ./
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/0-bootstrap.auto.tfvars.json ./
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/1-resman.auto.tfvars.json ./
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/2-networking.auto.tfvars.json ./
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/2-security.auto.tfvars.json ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/providers/3-gke-multitenant-providers.tf ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/0-globals.auto.tfvars.json ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/0-bootstrap.auto.tfvars.json ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/1-resman.auto.tfvars.json ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/2-networking.auto.tfvars.json ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/2-security.auto.tfvars.json ./
 ```
 
 ### Impersonating the automation service account

--- a/fast/stages/3-project-factory/dev/README.md
+++ b/fast/stages/3-project-factory/dev/README.md
@@ -45,12 +45,12 @@ ln -s ~/fast-config/tfvars/2-security.auto.tfvars.json ./
 
 # copy and paste the following commands for '3-project-factory'
 
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/providers/3-project-factory-providers.tf ./
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/0-globals.auto.tfvars.json ./
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/0-bootstrap.auto.tfvars.json ./
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/1-resman.auto.tfvars.json ./
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/2-networking.auto.tfvars.json ./
-gcloud alpha storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/2-security.auto.tfvars.json ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/providers/3-project-factory-providers.tf ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/0-globals.auto.tfvars.json ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/0-bootstrap.auto.tfvars.json ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/1-resman.auto.tfvars.json ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/2-networking.auto.tfvars.json ./
+gcloud storage cp gs://xxx-prod-iac-core-outputs-0/tfvars/2-security.auto.tfvars.json ./
 ```
 
 If you're not using FAST, refer to the [Variables](#variables) table at the bottom of this document for a full list of variables, their origin (e.g., a stage or specific to this one), and descriptions explaining their meaning.


### PR DESCRIPTION
Removes `alpha` from `gcloud storage cp`, as it moved to GA.

---
**Checklist**

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
