### PR TITLE
Fix wrong expression in compute-mig module

### DIFF
--- a/modules/compute-mig/autoscaler.tf
+++ b/modules/compute-mig/autoscaler.tf
@@ -219,7 +219,7 @@ resource "google_compute_region_autoscaler" "default" {
         duration_sec          = schedule.value.duration_sec
         min_required_replicas = schedule.value.min_required_replicas
         name                  = schedule.value.name
-        schedule              = schedule.cron_schedule
+        schedule              = schedule.value.cron_schedule
         description           = schedule.value.description
         disabled              = schedule.value.disabled
         time_zone             = schedule.value.timezone


### PR DESCRIPTION
Fixed an obvious error.

```
Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: Unsupported attribute
│ 
│   on .terraform/modules/ci-c3d-highcpu-60-build-canva.compute_mig/modules/compute-mig/autoscaler.tf line 222, in resource "google_compute_region_autoscaler" "default":
│  222:         schedule              = schedule.cron_schedule
│ 
│ This object does not have an attribute named "cron_schedule".

```

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [x] Made sure all relevant tests pass
