### PR TITLE
Add generic URL output to modules/artifiact-registry

### DIFF
--- a/blueprints/gke/patterns/autopilot-cluster/outputs.tf
+++ b/blueprints/gke/patterns/autopilot-cluster/outputs.tf
@@ -25,7 +25,7 @@ output "created_resources" {
       vpc_id    = module.vpc[0].id
     },
     !var.registry_create ? {} : {
-      registry = module.registry[0].docker_image_path
+      registry = module.registry[0].url
     },
     !local.cluster_create ? {} : {
       cluster              = module.cluster[0].id

--- a/modules/artifact-registry/README.md
+++ b/modules/artifact-registry/README.md
@@ -230,8 +230,8 @@ module "registry-docker" {
 
 | name | description | sensitive |
 |---|---|:---:|
-| [docker_image_path](outputs.tf#L17) | Repository path for Docker images. |  |
-| [id](outputs.tf#L27) | Fully qualified repository id. |  |
-| [name](outputs.tf#L32) | Repository name. |  |
-| [repository](outputs.tf#L37) | Repository object. |  |
+| [id](outputs.tf#L17) | Fully qualified repository id. |  |
+| [name](outputs.tf#L22) | Repository name. |  |
+| [repository](outputs.tf#L27) | Repository object. |  |
+| [url](outputs.tf#L32) | Repository URL. |  |
 <!-- END TFDOC -->

--- a/modules/artifact-registry/outputs.tf
+++ b/modules/artifact-registry/outputs.tf
@@ -14,16 +14,6 @@
  * limitations under the License.
  */
 
-output "docker_image_path" {
-  description = "Repository path for Docker images."
-  value = join("/", [
-    "${var.location}-${local.format_string}.pkg.dev",
-    var.project_id,
-    var.name
-  ])
-  depends_on = [google_artifact_registry_repository.registry]
-}
-
 output "id" {
   description = "Fully qualified repository id."
   value       = google_artifact_registry_repository.registry.id
@@ -37,4 +27,14 @@ output "name" {
 output "repository" {
   description = "Repository object."
   value       = google_artifact_registry_repository.registry
+}
+
+output "url" {
+  description = "Repository URL."
+  value = join("/", [
+    "${var.location}-${local.format_string}.pkg.dev",
+    var.project_id,
+    var.name
+  ])
+  depends_on = [google_artifact_registry_repository.registry]
 }


### PR DESCRIPTION
All formats follow the same naming convention "$region-$format.pkg.dev". This PR simply renames the existing `docker_image_path` output to `url`.