### PR TITLE
Add `--extra-files` option to plan_summary.py cmd

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1072,6 +1072,18 @@ outputs:
 
 You can now use this output to create the inventory file for your test. As mentioned before, please only use those values relevant to your test scenario.
 
+You can optionally pass to the command additional files that your plan might need to properly execute.
+
+In this example we pass in two extra files from the organization folder.
+
+```bash
+$ python tools/plan_summary.py modules/organization \
+   tests/modules/organization/common.tfvars \
+   tests/modules/organization/audit_config.tfvars \
+   --extra-files ../my-file-1.tf \
+   --extra-files ../my-file-2.yaml
+```
+
 ### Running end-to-end tests
 
 You can use end-to-end tests to verify your code against GCP API. These tests verify that `terraform apply` succeeds, `terraform plan` is empty afterwards and that `terraform destroy` raises no error.

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -77,6 +77,9 @@ def plan_summary(module_path, basedir, tf_var_files=None, extra_files=None,
   - tf_var_files: set of terraform variable files (tfvars) to pass
     in to terraform
 
+  - extra_files: set of extra terraform files needed during the plan.
+    The path must be relative to the tfvars file path.
+
   Returns a PlanSummary object containing 3 attributes:
   - values: dictionary where the keys are terraform plan addresses
     and values are the JSON representation (converted to python

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -77,8 +77,8 @@ def plan_summary(module_path, basedir, tf_var_files=None, extra_files=None,
   - tf_var_files: set of terraform variable files (tfvars) to pass
     in to terraform
 
-  - extra_files: set of extra terraform files needed during the plan.
-    The path must be relative to the tfvars file path.
+  - extra_files: set of extra files to optionally pass
+    in to terraform
 
   Returns a PlanSummary object containing 3 attributes:
   - values: dictionary where the keys are terraform plan addresses

--- a/tools/plan_summary.py
+++ b/tools/plan_summary.py
@@ -31,9 +31,10 @@ except ImportError:
 
 @click.command()
 @click.option('--example', default=False, is_flag=True)
+@click.option('--extra-files', default=[], multiple=True)
 @click.argument('module', type=click.Path(), nargs=1)
 @click.argument('tfvars', type=click.Path(exists=True), nargs=-1)
-def main(example, module, tfvars):
+def main(example, module, tfvars, extra_files):
   try:
     if example:
       tmp_dir = tempfile.TemporaryDirectory()
@@ -46,7 +47,7 @@ def main(example, module, tfvars):
     else:
       module = BASEDIR / module
 
-    summary = fixtures.plan_summary(module, Path(), tfvars)
+    summary = fixtures.plan_summary(module, Path(), tfvars, extra_files)
     print(yaml.dump({'values': summary.values}))
     print(yaml.dump({'counts': summary.counts}))
     outputs = {


### PR DESCRIPTION
Adds `--extra-files` option to plan_summary.py cmd

---
**Checklist**

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
