### PR TITLE
example testing improvements

### DIFF
--- a/tests/examples/conftest.py
+++ b/tests/examples/conftest.py
@@ -13,36 +13,14 @@
 # limitations under the License.
 """Pytest configuration for testing code examples."""
 
-import collections
-import re
 from pathlib import Path
+
+from .utils import get_tftest_directive, Example, File
 
 import marko
 import pytest
 
 FABRIC_ROOT = Path(__file__).parents[2]
-Directive = collections.namedtuple('Directive', 'name args kwargs')
-Example = collections.namedtuple(
-    'Example', 'name code module files fixtures type directive')
-File = collections.namedtuple('File', 'path content')
-
-
-def get_tftest_directive(s):
-  """Scan a code block and return a Directive object if there are any
-  tftest directives"""
-  regexp = rf"^ *# *(tftest\S*)(.*)$"
-  if match := re.search(regexp, s, re.M):
-    name, body = match.groups()
-    args = []
-    kwargs = {}
-    for arg in body.split():
-      if '=' in arg:
-        l, r = arg.split('=', 1)
-        kwargs[l] = r
-      else:
-        args.append(arg)
-    return Directive(name, args, kwargs)
-  return None
 
 
 def pytest_generate_tests(metafunc, test_group='example',

--- a/tests/examples/conftest.py
+++ b/tests/examples/conftest.py
@@ -13,12 +13,13 @@
 # limitations under the License.
 """Pytest configuration for testing code examples."""
 
+import collections
 from pathlib import Path
-
-from .utils import get_tftest_directive, Example, File
 
 import marko
 import pytest
+
+from .utils import Example, File, get_tftest_directive
 
 FABRIC_ROOT = Path(__file__).parents[2]
 

--- a/tests/examples/conftest.py
+++ b/tests/examples/conftest.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Pytest configuration for testing code examples."""
 
-from dataclasses import dataclass
 import collections
 import re
 from pathlib import Path
@@ -22,16 +21,10 @@ import marko
 import pytest
 
 FABRIC_ROOT = Path(__file__).parents[2]
-Example = collections.namedtuple('Example',
-                                 'name code module files fixtures type')
+Directive = collections.namedtuple('Directive', 'name args kwargs')
+Example = collections.namedtuple(
+    'Example', 'name code module files fixtures type directive')
 File = collections.namedtuple('File', 'path content')
-
-
-@dataclass(frozen=True)
-class Directive:
-  name: str
-  args: list
-  kwargs: dict
 
 
 def get_tftest_directive(s):
@@ -109,7 +102,7 @@ def pytest_generate_tests(metafunc, test_group='example',
             marks = [pytest.mark.xdist_group('serial')
                     ] if 'serial' in directive.args else []
             example = Example(name, code, path, files[last_header], fixtures,
-                              child.lang)
+                              child.lang, directive)
             examples.append(pytest.param(example, marks=marks))
         elif isinstance(child, marko.block.Heading):
           last_header = child.children[0].children

--- a/tests/examples/test_plan.py
+++ b/tests/examples/test_plan.py
@@ -87,9 +87,11 @@ def test_example(plan_validator, example):
     counts = summary.counts
     num_modules, num_resources = counts['modules'], counts['resources']
 
-    if expected_modules := int(directive.kwargs['modules']):
+    if expected_modules := directive.kwargs.get('modules'):
+      expected_modules = int(expected_modules)
       assert expected_modules == num_modules, 'wrong number of modules'
-    if expected_resources := int(directive.kwargs['resources']):
+    if expected_resources := directive.kwargs.get('resources'):
+      expected_resources = int(expected_resources)
       assert expected_resources == num_resources, 'wrong number of resources'
 
     # TODO(jccb): this should probably be done in check_documentation

--- a/tests/examples/test_plan.py
+++ b/tests/examples/test_plan.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 import re
-import subprocess
-import yaml
 import shutil
+import subprocess
 import tempfile
 from pathlib import Path
+
+import yaml
 
 BASE_PATH = Path(__file__).parent
 

--- a/tests/examples/test_plan.py
+++ b/tests/examples/test_plan.py
@@ -19,8 +19,6 @@ import shutil
 import tempfile
 from pathlib import Path
 
-from .conftest import get_tftest_directive
-
 BASE_PATH = Path(__file__).parent
 
 
@@ -47,8 +45,7 @@ def prepare_files(example, test_path, files, fixtures):
 
 
 def test_example(plan_validator, example):
-  directive = get_tftest_directive(example.code)
-  assert directive is not None, "can't find tftest directive"
+  directive = example.directive
 
   # for tfvars-based tests, create the temporary directory with the
   # same parent as the original module

--- a/tests/examples/test_plan.py
+++ b/tests/examples/test_plan.py
@@ -19,12 +19,9 @@ import shutil
 import tempfile
 from pathlib import Path
 
+from .conftest import get_tftest_directive
+
 BASE_PATH = Path(__file__).parent
-COUNT_TEST_RE = re.compile(
-    r'# tftest +modules=(?P<modules>\d+) +resources=(?P<resources>\d+)' +
-    r'(?: +files=(?P<files>[\w@,_-]+))?' +
-    r'(?: +fixtures=(?P<fixtures>[\w@,_/.-]+))?' +
-    r'(?: +inventory=(?P<inventory>[\w\-.]+))?')
 
 
 def prepare_files(example, test_path, files, fixtures):
@@ -50,58 +47,57 @@ def prepare_files(example, test_path, files, fixtures):
 
 
 def test_example(plan_validator, example):
-  if match := COUNT_TEST_RE.search(example.code):
-    # for tfvars-based tests, create the temporary directory with the
-    # same parent as the original module
-    directory = example.module.parent if example.type == 'tfvars' else None
-    prefix = f'pytest-{example.module.name}'
-    with tempfile.TemporaryDirectory(prefix=prefix, dir=directory) as tmp_path:
-      tmp_path = Path(tmp_path)
-      tf_var_files = []
-      if example.type == 'hcl':
-        (tmp_path / 'fabric').symlink_to(BASE_PATH.parents[1])
-        (tmp_path / 'variables.tf').symlink_to(BASE_PATH / 'variables.tf')
-        (tmp_path / 'main.tf').write_text(example.code)
-        assets_path = (BASE_PATH.parent /
-                       str(example.module).replace('-', '_') / 'assets')
-        if assets_path.exists():
-          (tmp_path / 'assets').symlink_to(assets_path)
+  directive = get_tftest_directive(example.code)
+  assert directive is not None, "can't find tftest directive"
 
-        prepare_files(example, tmp_path, match.group('files'),
-                      match.group('fixtures'))
-      elif example.type == 'tfvars':
-        (tmp_path / 'terraform.auto.tfvars').write_text(example.code)
-        shutil.copytree(example.module, tmp_path, dirs_exist_ok=True)
-        tf_var_files = [(tmp_path / 'terraform.auto.tfvars').resolve()]
+  # for tfvars-based tests, create the temporary directory with the
+  # same parent as the original module
+  directory = example.module.parent if example.type == 'tfvars' else None
+  prefix = f'pytest-{example.module.name}'
+  with tempfile.TemporaryDirectory(prefix=prefix, dir=directory) as tmp_path:
+    tmp_path = Path(tmp_path)
+    tf_var_files = []
+    if example.type == 'hcl':
+      (tmp_path / 'fabric').symlink_to(BASE_PATH.parents[1])
+      (tmp_path / 'variables.tf').symlink_to(BASE_PATH / 'variables.tf')
+      (tmp_path / 'main.tf').write_text(example.code)
+      assets_path = (BASE_PATH.parent / str(example.module).replace('-', '_') /
+                     'assets')
+      if assets_path.exists():
+        (tmp_path / 'assets').symlink_to(assets_path)
 
-      expected_modules = int(match.group('modules'))
-      expected_resources = int(match.group('resources'))
+      prepare_files(example, tmp_path, directive.kwargs.get('files'),
+                    directive.kwargs.get('fixtures'))
+    elif example.type == 'tfvars':
+      (tmp_path / 'terraform.auto.tfvars').write_text(example.code)
+      shutil.copytree(example.module, tmp_path, dirs_exist_ok=True)
+      tf_var_files = [(tmp_path / 'terraform.auto.tfvars').resolve()]
 
-      inventory = []
-      if match.group('inventory') is not None:
-        python_test_path = str(example.module).replace('-', '_')
-        inventory = BASE_PATH.parent / python_test_path / 'examples'
-        inventory = inventory / match.group('inventory')
+    inventory = []
+    if directive.kwargs.get('inventory') is not None:
+      python_test_path = str(example.module).replace('-', '_')
+      inventory = BASE_PATH.parent / python_test_path / 'examples'
+      inventory = inventory / directive.kwargs['inventory']
 
-      summary = plan_validator(module_path=tmp_path, inventory_paths=inventory,
-                               tf_var_files=tf_var_files)
+    summary = plan_validator(module_path=tmp_path, inventory_paths=inventory,
+                             tf_var_files=tf_var_files)
 
-      print('\n')
-      print(yaml.dump({'values': summary.values}))
-      print(yaml.dump({'counts': summary.counts}))
-      print(yaml.dump({'outputs': summary.outputs}))
+    print('\n')
+    print(yaml.dump({'values': summary.values}))
+    print(yaml.dump({'counts': summary.counts}))
+    print(yaml.dump({'outputs': summary.outputs}))
 
-      counts = summary.counts
-      num_modules, num_resources = counts['modules'], counts['resources']
+    counts = summary.counts
+    num_modules, num_resources = counts['modules'], counts['resources']
+
+    if expected_modules := int(directive.kwargs['modules']):
       assert expected_modules == num_modules, 'wrong number of modules'
+    if expected_resources := int(directive.kwargs['resources']):
       assert expected_resources == num_resources, 'wrong number of resources'
 
-      # TODO(jccb): this should probably be done in check_documentation
-      # but we already have all the data here.
-      result = subprocess.run(
-          'terraform fmt -check -diff -no-color main.tf'.split(), cwd=tmp_path,
-          stdout=subprocess.PIPE, encoding='utf-8')
-      assert result.returncode == 0, f'terraform code not formatted correctly\n{result.stdout}'
-
-  else:
-    assert False, "can't find tftest directive"
+    # TODO(jccb): this should probably be done in check_documentation
+    # but we already have all the data here.
+    result = subprocess.run(
+        'terraform fmt -check -diff -no-color main.tf'.split(), cwd=tmp_path,
+        stdout=subprocess.PIPE, encoding='utf-8')
+    assert result.returncode == 0, f'terraform code not formatted correctly\n{result.stdout}'

--- a/tests/examples/utils.py
+++ b/tests/examples/utils.py
@@ -1,0 +1,39 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import collections
+import re
+
+Directive = collections.namedtuple('Directive', 'name args kwargs')
+Example = collections.namedtuple(
+    'Example', 'name code module files fixtures type directive')
+File = collections.namedtuple('File', 'path content')
+
+
+def get_tftest_directive(s):
+  """Scan a code block and return a Directive object if there are any
+  tftest directives"""
+  regexp = rf"^ *# *(tftest\S*)(.*)$"
+  if match := re.search(regexp, s, re.M):
+    name, body = match.groups()
+    args = []
+    kwargs = {}
+    for arg in body.split():
+      if '=' in arg:
+        l, r = arg.split('=', 1)
+        kwargs[l] = r
+      else:
+        args.append(arg)
+    return Directive(name, args, kwargs)
+  return None

--- a/tests/examples_e2e/conftest.py
+++ b/tests/examples_e2e/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,8 @@
 # limitations under the License.
 """Pytest configuration for testing code examples."""
 
-from ..examples.conftest import pytest_generate_tests as _examples_generate_test
+from ..examples.conftest import \
+    pytest_generate_tests as _examples_generate_test
 
 
 def pytest_generate_tests(metafunc):

--- a/tests/examples_e2e/test_plan.py
+++ b/tests/examples_e2e/test_plan.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,10 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import re
 
 from pathlib import Path
-from ..examples.test_plan import COUNT_TEST_RE, prepare_files
+from ..examples.test_plan import prepare_files
+from ..examples.conftest import get_tftest_directive
 
 BASE_PATH = Path(__file__).parent
 
@@ -31,9 +31,10 @@ def test_example(e2e_validator, tmp_path, examples_e2e, e2e_tfvars_path):
   (tmp_path / 'terraform.tfvars').symlink_to(e2e_tfvars_path)
 
   # add files the same way as it is done for examples
-  if match := COUNT_TEST_RE.search(examples_e2e.code):
-    prepare_files(examples_e2e, tmp_path, match.group("files"),
-                  match.group('fixtures'))
+  directive, _, kwargs = get_tftest_directive(examples_e2e.code)
+  if directive == 'tftest':
+    prepare_files(examples_e2e, tmp_path, kwargs.get('files'),
+                  kwargs.get('fixtures'))
 
   e2e_validator(module_path=tmp_path, extra_files=[],
                 tf_var_files=[(tmp_path / 'terraform.tfvars')])

--- a/tests/examples_e2e/test_plan.py
+++ b/tests/examples_e2e/test_plan.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from pathlib import Path
+
 from ..examples.test_plan import prepare_files
 from ..examples.utils import get_tftest_directive
 

--- a/tests/examples_e2e/test_plan.py
+++ b/tests/examples_e2e/test_plan.py
@@ -14,7 +14,7 @@
 
 from pathlib import Path
 from ..examples.test_plan import prepare_files
-from ..examples.conftest import get_tftest_directive
+from ..examples.utils import get_tftest_directive
 
 BASE_PATH = Path(__file__).parent
 

--- a/tests/examples_e2e/test_plan.py
+++ b/tests/examples_e2e/test_plan.py
@@ -32,10 +32,10 @@ def test_example(e2e_validator, tmp_path, examples_e2e, e2e_tfvars_path):
   (tmp_path / 'terraform.tfvars').symlink_to(e2e_tfvars_path)
 
   # add files the same way as it is done for examples
-  directive, _, kwargs = get_tftest_directive(examples_e2e.code)
-  if directive == 'tftest':
-    prepare_files(examples_e2e, tmp_path, kwargs.get('files'),
-                  kwargs.get('fixtures'))
+  directive = get_tftest_directive(examples_e2e.code)
+  if directive and directive.name == 'tftest':
+    prepare_files(examples_e2e, tmp_path, directive.kwargs.get('files'),
+                  directive.kwargs.get('fixtures'))
 
   e2e_validator(module_path=tmp_path, extra_files=[],
                 tf_var_files=[(tmp_path / 'terraform.tfvars')])

--- a/tools/tfdoc.py
+++ b/tools/tfdoc.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -45,18 +45,20 @@ import re
 import string
 import sys
 import urllib.parse
+from pathlib import Path
 
 import click
 import marko
 
+try:
+  from examples.conftest import get_tftest_directive
+except ImportError:
+  BASEDIR = Path(__file__).parents[1]
+  sys.path.append(str(BASEDIR / 'tests'))
+  from examples.conftest import get_tftest_directive
+
 __version__ = '2.1.0'
 
-# COUNT_TEST_RE copied from tests/examples/test_plan.py
-COUNT_TEST_RE = re.compile(
-    r'# tftest +modules=(?P<modules>\d+) +resources=(?P<resources>\d+)' +
-    r'(?: +files=(?P<files>[\w@,_-]+))?' +
-    r'(?: +fixtures=(?P<fixtures>[\w@,_/.-]+))?' +
-    r'(?: +inventory=(?P<inventory>[\w\-.]+))?')
 # TODO(ludomagno): decide if we want to support variables*.tf and outputs*.tf
 FILE_DESC_DEFAULTS = {
     'main.tf': 'Module-level locals and resources.',
@@ -390,8 +392,8 @@ def parse_fixtures(basepath, readme):
     if isinstance(child, marko.block.FencedCode):
       if child.lang == 'hcl':
         code = child.children[0].children
-        if match := COUNT_TEST_RE.search(code):
-          if fixtures := match.group('fixtures'):
+        if directive := get_tftest_directive(code):
+          if fixtures := directive.kwargs.get('fixtures'):
             for fixture in fixtures.split(','):
               fixture_full = os.path.join(REPO_ROOT, 'tests', fixture)
               if not os.path.exists(fixture_full):

--- a/tools/tfdoc.py
+++ b/tools/tfdoc.py
@@ -51,11 +51,11 @@ import click
 import marko
 
 try:
-  from examples.conftest import get_tftest_directive
+  from examples.utils import get_tftest_directive
 except ImportError:
   BASEDIR = Path(__file__).parents[1]
   sys.path.append(str(BASEDIR / 'tests'))
-  from examples.conftest import get_tftest_directive
+  from examples.utils import get_tftest_directive
 
 __version__ = '2.1.0'
 


### PR DESCRIPTION
Improved the example testing machinery in anticipation of YAML schema testing. This includes the introduction of a generic `get_tftest_directive` function for parsing directives and their arguments, along with optimizations to avoid redundant directive parsing by storing parsed details within the Example object.