### PR TITLE
Firewall policy module factory schema

### DIFF
--- a/fast/stages/3-network-security/data/firewall-policy-rules/dev/egress.yaml
+++ b/fast/stages/3-network-security/data/firewall-policy-rules/dev/egress.yaml
@@ -1,12 +1,16 @@
 # skip boilerplate check
 ---
+# start of document (---) avoids errors if the file only contains comments
+
+# yaml-language-server: $schema=../../../schemas/firewall-policy-rules.schema.json
+
 egress-allow-rfc1918:
   description: "Allow all hosts to RFC-1918"
   priority: 2147483546
   match:
    destination_ranges:
    - rfc1918
-  action: "allow"
+  action: allow
 
 egress-inspect-internet:
   description: "Inspect egress traffic from all dev hosts to Internet"

--- a/fast/stages/3-network-security/data/firewall-policy-rules/dev/ingress.yaml
+++ b/fast/stages/3-network-security/data/firewall-policy-rules/dev/ingress.yaml
@@ -1,6 +1,10 @@
 # skip boilerplate check
 ---
-# Following are some NGFW Enterprise ingress rules examples
+# start of document (---) avoids errors if the file only contains comments
+
+# yaml-language-server: $schema=../../../schemas/firewall-policy-rules.schema.json
+
+# sample NGFW Enterprise ingress rules
 
 # ingress-allow-inspect-cross:
 #   description: "Allow and inspect cross-env traffic from prod."

--- a/fast/stages/3-network-security/schemas/firewall-policy-rules.schema.json
+++ b/fast/stages/3-network-security/schemas/firewall-policy-rules.schema.json
@@ -1,0 +1,1 @@
+../../../../modules/net-firewall-policy/schemas/firewall-policy-rules.schema.json

--- a/modules/net-firewall-policy/README.md
+++ b/modules/net-firewall-policy/README.md
@@ -204,17 +204,16 @@ module "firewall-policy" {
 ```
 
 ```yaml
-# tftest-file id=cidrs path=configs/cidrs.yaml
 rfc1918:
   - 10.0.0.0/8
   - 172.16.0.0/12
   - 192.168.0.0/24
 gke-nodes-range:
   - 10.0.1.0/24
+# tftest-file id=cidrs path=configs/cidrs.yaml
 ```
 
 ```yaml
-# tftest-file id=egress path=configs/egress.yaml
 smtp:
   priority: 900
   match:
@@ -224,10 +223,10 @@ smtp:
    - protocol: tcp
      ports:
      - 25
+# tftest-file id=egress path=configs/egress.yaml schema=firewall-policy-rules.schema.json
 ```
 
 ```yaml
-# tftest-file id=ingress path=configs/ingress.yaml
 icmp:
   priority: 1000
   match:
@@ -252,6 +251,7 @@ issue-1995:
       ports:
       - 1-65535
     - protocol: icmp
+# tftest-file id=ingress path=configs/ingress.yaml schema=firewall-policy-rules.schema.json
 ```
 
 You might need to reference external security profile groups in your firewall rules, using their Terraform ids. For example, `//networksecurity.googleapis.com/${google_network_security_security_profile_group.security_profile_group.id}`. To do so, list your security profile groups in the `security_profile_group_ids` map variable. Then reference them by key from your factories.

--- a/modules/net-firewall-policy/schemas/firewall-policy-rules.schema.json
+++ b/modules/net-firewall-policy/schemas/firewall-policy-rules.schema.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Firewall Rules",
+  "type": "object",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^[a-z0-9_-]+$": {
+      "$ref": "#/$defs/rule"
+    }
+  },
+  "$defs": {
+    "rule": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "priority"
+      ],
+      "properties": {
+        "priority": {
+          "type": "number"
+        },
+        "action": {
+          "enum": [
+            "allow",
+            "deny",
+            "goto_next",
+            "apply_security_profile_group"
+          ]
+        },
+        "description": {
+          "type": "string"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "enable_logging": {
+          "type": "boolean"
+        },
+        "security_profile_group": {
+          "type": "string"
+        },
+        "target_resources": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "target_service_accounts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "target_tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tls_inspect": {
+          "type": "boolean"
+        },
+        "match": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "address_groups": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "fqdns": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "region_codes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "threat_intelligences": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "destination_ranges": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "source_ranges": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "source_tags": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "layer4_configs": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "protocol": {
+                    "type": "string"
+                  },
+                  "ports": {
+                    "type": "array"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/modules/net-vpc-firewall/README.md
+++ b/modules/net-vpc-firewall/README.md
@@ -14,7 +14,7 @@ The predefined rules are enabled by default and set to the ranges of the GCP hea
   - [Controlling or turning off default rules](#controlling-or-turning-off-default-rules)
     - [Overriding default tags and ranges](#overriding-default-tags-and-ranges)
     - [Disabling predefined rules](#disabling-predefined-rules)
-  - [Including source & destination ranges](#including-source-destination-ranges)
+  - [Including source and destination ranges](#including-source-and-destination-ranges)
   - [Rules Factory](#rules-factory)
 - [Variables](#variables)
 - [Outputs](#outputs)
@@ -149,7 +149,7 @@ module "firewall" {
 # tftest modules=0 resources=0 inventory=no-default-rules.yaml e2e
 ```
 
-### Including source & destination ranges
+### Including source and destination ranges
 
 Custom rules now support including both source & destination ranges in ingress and egress rules:
 
@@ -229,7 +229,7 @@ egress:
         ports:
           - 23
 
-# tftest-file id=lbs path=configs/firewall/rules/load_balancers.yaml
+# tftest-file id=lbs path=configs/firewall/rules/load_balancers.yaml schema=firewall-rules.schema.json
 ```
 
 ```yaml

--- a/modules/net-vpc-firewall/schemas/firewall-rules.schema.json
+++ b/modules/net-vpc-firewall/schemas/firewall-rules.schema.json
@@ -4,6 +4,15 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "egress": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "$ref": "#/$defs/rule"
+        }
+      }
+    },
     "ingress": {
       "type": "object",
       "additionalProperties": false,


### PR DESCRIPTION
This completes the schemas used in FAST factories. Also fixes VPC firewall schema merged in previous PR to include egress rules.