### PR TITLE
Update id and project_id outputs for project module

### DIFF
--- a/modules/project/outputs.tf
+++ b/modules/project/outputs.tf
@@ -40,7 +40,10 @@ output "default_service_accounts" {
 
 output "id" {
   description = "Project id."
-  value       = "${local.prefix}${var.name}"
+  value       = coalesce(
+    try(google_project.project.0.project_id, null),
+    try(data.google_project.project.0.project_id, null)
+  )
   depends_on = [
     google_project.project,
     data.google_project.project,
@@ -105,10 +108,11 @@ output "number" {
 
 output "project_id" {
   description = "Project id."
-  value       = "${local.prefix}${var.name}"
+  value       = coalesce(
+    try(google_project.project.0.project_id, null),
+    try(data.google_project.project.0.project_id, null)
+  )
   depends_on = [
-    google_project.project,
-    data.google_project.project,
     google_org_policy_policy.default,
     google_project_service.project_services,
     google_compute_shared_vpc_host_project.shared_vpc_host,


### PR DESCRIPTION
Update project module outputs for id and project_id to fix implicit dependency issues when referencing projects to be created with given module.

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [] Made sure all relevant tests pass
