### PR TITLE
Use the `google_tags_location_tag_binding` Terraform resource to bind tags on KMS key rings

### DIFF
--- a/modules/kms/tags.tf
+++ b/modules/kms/tags.tf
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-resource "google_tags_tag_binding" "binding" {
+resource "google_tags_location_tag_binding" "binding" {
   for_each  = var.tag_bindings
   parent    = "//cloudkms.googleapis.com/${local.keyring.id}"
   tag_value = each.value
+  location  = var.keyring.location
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here -->
<p>
The current version of the KMS Terraform module uses the `google_tags_tag_binding` resource to bind tags to KMS key rings. However, according to the Terraform documentation, this resource is only applicable to projects, folders, and organizations. For non-global resources, such as KMS key rings, the correct resource to use is `google_tags_location_tag_binding`.

Moreover, through multiple tests on a corporate Terraform project, tag bindings using `google_tags_location_tag_binding` have been successful, whereas attempts with `google_tags_tag_binding` have not worked.
</p>
---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [x] Made sure all relevant tests pass
