### PR TITLE
Add ca pool object to certification-authority-service module

### DIFF
--- a/modules/certificate-authority-service/README.md
+++ b/modules/certificate-authority-service/README.md
@@ -120,6 +120,7 @@ module "cas" {
 | name | description | sensitive |
 |---|---|:---:|
 | [ca_ids](outputs.tf#L17) | The CA ids. |  |
-| [ca_pool_id](outputs.tf#L25) | The CA pool id. |  |
-| [cas](outputs.tf#L30) | The CAs. |  |
+| [ca_pool](outputs.tf#L25) | The CA pool. |  |
+| [ca_pool_id](outputs.tf#L30) | The CA pool id. |  |
+| [cas](outputs.tf#L35) | The CAs. |  |
 <!-- END TFDOC -->

--- a/modules/certificate-authority-service/outputs.tf
+++ b/modules/certificate-authority-service/outputs.tf
@@ -22,6 +22,11 @@ output "ca_ids" {
   }
 }
 
+output "ca_pool" {
+  description = "The CA pool."
+  value       = try(google_privateca_ca_pool.ca_pool[0], null)
+}
+
 output "ca_pool_id" {
   description = "The CA pool id."
   value       = local.ca_pool_id


### PR DESCRIPTION
Adds the `ca_pool` output object to certification-authority-service module.

---
**Checklist**

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
