### PR TITLE
Key inconsistency in project-factory and fix for null-value

### DIFF
--- a/modules/project-factory/factory-projects.tf
+++ b/modules/project-factory/factory-projects.tf
@@ -31,7 +31,7 @@ locals {
   _projects = merge(
     {
       for f in try(fileset(local._project_path, "**/*.yaml"), []) :
-      trimsuffix(f, ".yaml") => yamldecode(file("${local._project_path}/${f}"))
+      basename(trimsuffix(f, ".yaml")) => yamldecode(file("${local._project_path}/${f}"))
     },
     local._hierarchy_projects
   )


### PR DESCRIPTION
This Pull Request addresses two issues I stumbled upon, while working with your nice and shiny framework.

# Inconsistent Map Keys for Project Files

Projects configured in `folders_data_path` have their filename as key (see [code](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/modules/project-factory/factory-projects.tf#L23), do note the use of `basename()` to get **only** the filename), whereas those from `projects_data_path` have their entire path, relative to `projects_data_path`, as key (see [code](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/modules/project-factory/factory-projects.tf#L34), do note the absence of `basename()`).

This causes project files from the two sources to be key'ed differently, which has some implications down the line.

1. When `local.projects` is eventually constructed [here](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/modules/project-factory/factory-projects.tf#L50), the `name` attribute each YAML file is looked up. If not set, the function resorts to the map-key, which is the filename for project files from `folders_data_path` and the full relative path for project files from `projects_data_path`.
2. Moving project files around in the folder hierarchy causes the path of the file to change, which would change the key for projects files from `projects_data_path`, unless `name` was specified in the file. As `local.projects` is used as map for invoking `module.projects`, this key-change destroys and re-creates projects. This does not happen, if the project file resides anywhere in `folders_data_path`, since their key is only the filename (`basename()` was used).
3. Invoking `module.projects` on a project YAML from `projects_data_path` without specified `name` attribute will cause a mis-construction of the `project_id`. Module `project` will be handed the map-key as `name` for the project, which is used together with `prefix` as `project_id`. But if the project YAML file happens to reside in a sub-directory, the path will not only contain its filename, but also its parent-folder separated by a `/`. This causes an error (admittedly in the `tf plan` stage) which outputs that the `project_id` is invalid (it may look like this `prefix-subdir/projectname`). However, this error is not very verbose and unintuitive in this case, since omitting `name` in project files from `folders_data_path` works perfectly fine, as the key is always just the filename and a perfectly fine `name`/`project_id`.

## Solution

The PR uses `basename()` for files from `projects_data_path` too, causing the behavior to be identical and `name` to be an optional setting, just like with files from `folders_data_path`, which is consistent, in my opinion.

One implication is, that files from `folders_data_path` can now overwrite entries fetched from `projects_data_path`, if they happen to use the same `name` (or filename, in case no `name` is specified), due to the merge-order, see [this `merge()`-call](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/modules/project-factory/factory-projects.tf#L31).

# Null when decoding empty YAML files

Another minor detail I noticed was that Terraform returns `null` when using `yamldecode()` on a file that only contains `---` to indicate the start of the YAML document. An empty project YAML is a perfectly fine configuration, since the filename is used as `name` and everything else may be added by default values or overrides. 

However, parsing an empty YAML document will place `null` as value in [factory-projects.tf:25](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/modules/project-factory/factory-projects.tf#L25) and [factory-projects.tf:34](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/modules/project-factory/factory-projects.tf#L34). This causes an error, when this value is used in `lookup()` at [factory-projects.tf:50](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/modules/project-factory/factory-projects.tf#L50), since `lookup()` does not accept `null` as parameter `InputMap`.

Interestingly enough, this also happens **only** to project files from `projects_data_path`, since those from `folders_data_path` are `merge()`d with `{parent = dirname(f) ...}` at [factory-projects.tf:24](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/modules/project-factory/factory-projects.tf#L24). `merge()` actually accepts `null` as argument, treating it as `{ }`, so there is always at least a map/object present as value for those project files. This is inconsistent behavior, in my opinion and YAML objects from project files should be sanitized to be at least `{ }` instead of `null`, allowing empty project files for both `folders_data_path` and `projects_data_path`.

## Solution

I added a second commit to my PR, which wraps `yamldecode()` in `coalesce()` resorting to `{ }` should the `yamldecode()` invocation return `null`, making the behavior consistent for both cases.

---
**Checklist**

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
