### PR TITLE
Support for Gke standard workload vulnerability

### DIFF
--- a/modules/gke-cluster-standard/main.tf
+++ b/modules/gke-cluster-standard/main.tf
@@ -477,6 +477,12 @@ resource "google_container_cluster" "cluster" {
       enabled = var.enable_features.pod_security_policy
     }
   }
+  dynamic "protect_config" {
+    for_each = var.enable_features.protect_config ? [""] : []
+    content {
+      workload_vulnerability_mode = "BASIC"
+    }
+  }
   dynamic "release_channel" {
     for_each = var.release_channel != null ? [""] : []
     content {

--- a/modules/gke-cluster-standard/variables.tf
+++ b/modules/gke-cluster-standard/variables.tf
@@ -197,6 +197,7 @@ variable "enable_features" {
     l4_ilb_subsetting    = optional(bool, false)
     mesh_certificates    = optional(bool)
     pod_security_policy  = optional(bool, false)
+    protect_config       = optional(bool, false)
     resource_usage_export = optional(object({
       dataset                              = string
       enable_network_egress_metering       = optional(bool)


### PR DESCRIPTION
Added the support for protect_config [workload_vulnerability_mode]
[https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#workload_vulnerability_mode](url)
---

I applicable, I acknowledge that I have:
- [ x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x ] Ran `terraform fmt` on all modified files
- [x ] Made sure all relevant tests pass
