### PR TITLE
add pubsub topic iam viewer role in bootstrap CICD set up

### DIFF
--- a/fast/stages/0-bootstrap/data/custom-roles/pubsub_iam_viewer.yaml
+++ b/fast/stages/0-bootstrap/data/custom-roles/pubsub_iam_viewer.yaml
@@ -1,0 +1,20 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# yaml-language-server: $schema=../../schemas/custom-role.schema.json
+# the following permissions are a descoped version of tagAdm
+
+name: pubsubIamViewer
+includedPermissions:
+  - pubsub.topics.getIamPolicy

--- a/fast/stages/0-bootstrap/log-export.tf
+++ b/fast/stages/0-bootstrap/log-export.tf
@@ -52,6 +52,9 @@ module "log-export-project" {
   iam = {
     "roles/owner"  = [module.automation-tf-bootstrap-sa.iam_email]
     "roles/viewer" = [module.automation-tf-bootstrap-r-sa.iam_email]
+    (module.organization.custom_role_id["pubsub_iam_viewer"]) = [
+      module.automation-tf-bootstrap-r-sa.iam_email
+    ]
   }
   services = [
     # "cloudresourcemanager.googleapis.com",


### PR DESCRIPTION
<!-- Put a description of what this PR is for here -->

Add a custom role in bootstrap phase to allow read-only service account to be able to check IAM policy of pubsub topics on the logExport project.

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [N/A] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
