### PR TITLE
Update list of imported org policies

### DIFF
--- a/fast/stages/0-bootstrap/organization.tf
+++ b/fast/stages/0-bootstrap/organization.tf
@@ -112,7 +112,8 @@ import {
       "iam.allowedPolicyMemberDomains",
       "essentialcontacts.allowedContactDomains",
       "storage.uniformBucketLevelAccess",
-      # "compute.setNewProjectDefaultToZonalDNSOnly", # not confirmed, that this is already live
+      "compute.setNewProjectDefaultToZonalDNSOnly", # Verified as of 2024-09-13
+      # "constraints/compute.restrictProtocolForwardingCreationForTypes", # Officially be applied starting 2024-08-15, but still MIA as of 2024-09-13
     ])
   )
   id = "organizations/${var.organization.id}/policies/${each.key}"


### PR DESCRIPTION
Adding `compute.setNewProjectDefaultToZonalDNSOnly`, and `compute.restrictProtocolForwardingCreationForTypes` (as commented out code) to the list of importable policies for `bootstrap`

This is the list of automatically created org policies on a new organization as of 2024-09-13.

```bash
admin_@cloudshell:~$ gcloud resource-manager org-policies list --organization=xxxx --format=yaml
---
booleanPolicy:
  enforced: true
constraint: constraints/compute.setNewProjectDefaultToZonalDNSOnly
etag: CJi8j7cGELi0htYC
updateTime: '2024-09-13T06:39:20.717331Z'
---
constraint: constraints/essentialcontacts.allowedContactDomains
etag: CJi8j7cGEODs29cC
listPolicy:
  allowedValues:
  - '@xxxxx.tld'
updateTime: '2024-09-13T06:39:20.720828Z'
---
constraint: constraints/iam.allowedPolicyMemberDomains
etag: CJi8j7cGENCggdkC
listPolicy:
  allowedValues:
  - C02ga8d4b
updateTime: '2024-09-13T06:39:20.723538Z'
---
booleanPolicy:
  enforced: true
constraint: constraints/iam.disableServiceAccountKeyUpload
etag: CJi8j7cGEJjKntYC
updateTime: '2024-09-13T06:39:20.717727Z'
---
booleanPolicy:
  enforced: true
constraint: constraints/iam.disableServiceAccountKeyCreation
etag: CJi8j7cGEIi-6t8C
updateTime: '2024-09-13T06:39:20.737845Z'
---
booleanPolicy:
  enforced: true
constraint: constraints/iam.automaticIamGrantsForDefaultServiceAccounts
etag: CJi8j7cGEOD2rtcC
updateTime: '2024-09-13T06:39:20.720092Z'
---
booleanPolicy:
  enforced: true
constraint: constraints/storage.uniformBucketLevelAccess
etag: CJi8j7cGEMDz-9YC
updateTime: '2024-09-13T06:39:20.719256Z'
```