### PR TITLE
Allow manage existing SSM instance

### DIFF
--- a/modules/secure-source-manager-instance/README.md
+++ b/modules/secure-source-manager-instance/README.md
@@ -41,9 +41,7 @@ module "ssm_instance" {
   location    = var.region
   kms_key     = "projects/another-project-id/locations/${var.region}/keyRings/my-key-ring/cryptoKeys/my-key"
   repositories = {
-    my-repository = {
-      location = var.region
-    }
+    my-repository = {}
   }
 }
 # tftest modules=1 resources=2 inventory=public-instance-with-cmek.yaml
@@ -59,9 +57,7 @@ module "ssm_instance" {
   location    = var.region
   ca_pool     = "projects/another-project/locations/${var.region}/caPools/my-ca-pool"
   repositories = {
-    my-repository = {
-      location = var.region
-    }
+    my-repository = {}
   }
 }
 # tftest modules=1 resources=2 inventory=private-instance.yaml
@@ -82,7 +78,6 @@ module "ssm_instance" {
   }
   repositories = {
     my-repository = {
-      location = var.region
       iam = {
         "roles/securesourcemanager.repoAdmin" = [
           "group:my-repo-admins@myorg.com"
@@ -109,7 +104,6 @@ module "ssm_instance" {
   }
   repositories = {
     my-repository = {
-      location = var.region
       iam_bindings_additive = {
         my-repository-admin = {
           role   = "roles/securesourcemanager.repoAdmin"
@@ -138,7 +132,6 @@ module "ssm_instance" {
   }
   repositories = {
     my-repository = {
-      location = var.region
       iam_bindings = {
         my-repository-admin = {
           role = "roles/securesourcemanager.repoAdmin"
@@ -157,16 +150,17 @@ module "ssm_instance" {
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [instance_id](variables.tf#L23) | Instance ID. | <code>string</code> | ✓ |  |
-| [location](variables.tf#L40) | Location. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L45) | Project ID. | <code>string</code> | ✓ |  |
-| [repositories](variables.tf#L50) | Repositories. | <code title="map&#40;object&#40;&#123;&#10;  description &#61; optional&#40;string&#41;&#10;  iam         &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;  iam_bindings &#61; optional&#40;map&#40;object&#40;&#123;&#10;    role    &#61; string&#10;    members &#61; list&#40;string&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;  iam_bindings_additive &#61; optional&#40;map&#40;object&#40;&#123;&#10;    role   &#61; string&#10;    member &#61; string&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;  initial_config &#61; optional&#40;object&#40;&#123;&#10;    default_branch &#61; optional&#40;string&#41;&#10;    gitignores     &#61; optional&#40;string&#41;&#10;    license        &#61; optional&#40;string&#41;&#10;    readme         &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;  location &#61; string&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> | ✓ |  |
+| [instance_id](variables.tf#L29) | Instance ID. | <code>string</code> | ✓ |  |
+| [location](variables.tf#L46) | Location. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L51) | Project ID. | <code>string</code> | ✓ |  |
+| [repositories](variables.tf#L56) | Repositories. | <code title="map&#40;object&#40;&#123;&#10;  description &#61; optional&#40;string&#41;&#10;  iam         &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;  iam_bindings &#61; optional&#40;map&#40;object&#40;&#123;&#10;    role    &#61; string&#10;    members &#61; list&#40;string&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;  iam_bindings_additive &#61; optional&#40;map&#40;object&#40;&#123;&#10;    role   &#61; string&#10;    member &#61; string&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;  initial_config &#61; optional&#40;object&#40;&#123;&#10;    default_branch &#61; optional&#40;string&#41;&#10;    gitignores     &#61; optional&#40;string&#41;&#10;    license        &#61; optional&#40;string&#41;&#10;    readme         &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> | ✓ |  |
 | [ca_pool](variables.tf#L17) | CA pool. | <code>string</code> |  | <code>null</code> |
 | [iam](variables-iam.tf#L17) | IAM bindings. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_bindings](variables-iam.tf#L23) | IAM bindings. | <code title="map&#40;object&#40;&#123;&#10;  role    &#61; string&#10;  members &#61; list&#40;string&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_bindings_additive](variables-iam.tf#L32) | IAM bindings. | <code title="map&#40;object&#40;&#123;&#10;  role   &#61; string&#10;  member &#61; string&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [kms_key](variables.tf#L28) | KMS key. | <code>string</code> |  | <code>null</code> |
-| [labels](variables.tf#L34) | Instance labels. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [instance_create](variables.tf#L23) | Create SSM Instance. When set to false, uses instance_id to reference existing SSM instance. | <code>bool</code> |  | <code>true</code> |
+| [kms_key](variables.tf#L34) | KMS key. | <code>string</code> |  | <code>null</code> |
+| [labels](variables.tf#L40) | Instance labels. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
 
 ## Outputs
 

--- a/modules/secure-source-manager-instance/README.md
+++ b/modules/secure-source-manager-instance/README.md
@@ -160,7 +160,7 @@ module "ssm_instance" {
 | [iam_bindings_additive](variables-iam.tf#L32) | IAM bindings. | <code title="map&#40;object&#40;&#123;&#10;  role   &#61; string&#10;  member &#61; string&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [instance_create](variables.tf#L23) | Create SSM Instance. When set to false, uses instance_id to reference existing SSM instance. | <code>bool</code> |  | <code>true</code> |
 | [kms_key](variables.tf#L34) | KMS key. | <code>string</code> |  | <code>null</code> |
-| [labels](variables.tf#L40) | Instance labels. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [labels](variables.tf#L40) | Instance labels. | <code>map&#40;string&#41;</code> |  | <code>null</code> |
 
 ## Outputs
 

--- a/modules/secure-source-manager-instance/iam.tf
+++ b/modules/secure-source-manager-instance/iam.tf
@@ -33,19 +33,18 @@ locals {
 
 resource "google_secure_source_manager_instance_iam_binding" "authoritative" {
   for_each    = var.iam
-  project     = var.project_id
-  location    = var.location
-  instance_id = var.instance_id
+  project     = try(google_secure_source_manager_instance.instance.project, var.project_id)
+  location    = try(google_secure_source_manager_instance.instance.location, var.location)
+  instance_id = try(google_secure_source_manager_instance.instance.instance_id, var.instance_id)
   role        = each.key
   members     = each.value
-  depends_on  = [google_secure_source_manager_instance.instance]
 }
 
 resource "google_secure_source_manager_instance_iam_binding" "bindings" {
   for_each    = var.iam_bindings
-  project     = var.project_id
-  location    = var.location
-  instance_id = var.instance_id
+  project     = try(google_secure_source_manager_instance.instance.project, var.project_id)
+  location    = try(google_secure_source_manager_instance.instance.location, var.location)
+  instance_id = try(google_secure_source_manager_instance.instance.instance_id, var.instance_id)
   role        = each.value.role
   members     = each.value.members
   depends_on  = [google_secure_source_manager_instance.instance]
@@ -53,9 +52,9 @@ resource "google_secure_source_manager_instance_iam_binding" "bindings" {
 
 resource "google_secure_source_manager_instance_iam_member" "bindings" {
   for_each    = var.iam_bindings_additive
-  project     = var.project_id
-  location    = var.location
-  instance_id = var.instance_id
+  project     = try(google_secure_source_manager_instance.instance.project, var.project_id)
+  location    = try(google_secure_source_manager_instance.instance.location, var.location)
+  instance_id = try(google_secure_source_manager_instance.instance.instance_id, var.instance_id)
   role        = each.value.role
   member      = each.value.member
   depends_on  = [google_secure_source_manager_instance.instance]

--- a/modules/secure-source-manager-instance/iam.tf
+++ b/modules/secure-source-manager-instance/iam.tf
@@ -29,35 +29,39 @@ locals {
     "${k1}.${k2}" => merge(v2, {
       repository = k1
   }) }]...)
+
+  iam_instance_values = {
+    project     = var.instance_create ? google_secure_source_manager_instance.instance[0].project : var.project_id
+    location    = var.instance_create ? google_secure_source_manager_instance.instance[0].location : var.location
+    instance_id = var.instance_create ? google_secure_source_manager_instance.instance[0].instance_id : var.instance_id
+  }
 }
 
 resource "google_secure_source_manager_instance_iam_binding" "authoritative" {
   for_each    = var.iam
-  project     = try(google_secure_source_manager_instance.instance[0].project, var.project_id)
-  location    = try(google_secure_source_manager_instance.instance[0].location, var.location)
-  instance_id = try(google_secure_source_manager_instance.instance[0].instance_id, var.instance_id)
+  project     = local.iam_instance_values["project"]
+  location    = local.iam_instance_values["location"]
+  instance_id = local.iam_instance_values["instance_id"]
   role        = each.key
   members     = each.value
 }
 
 resource "google_secure_source_manager_instance_iam_binding" "bindings" {
   for_each    = var.iam_bindings
-  project     = try(google_secure_source_manager_instance.instance[0].project, var.project_id)
-  location    = try(google_secure_source_manager_instance.instance[0].location, var.location)
-  instance_id = try(google_secure_source_manager_instance.instance[0].instance_id, var.instance_id)
+  project     = local.iam_instance_values["project"]
+  location    = local.iam_instance_values["location"]
+  instance_id = local.iam_instance_values["instance_id"]
   role        = each.value.role
   members     = each.value.members
-  depends_on  = [google_secure_source_manager_instance.instance]
 }
 
 resource "google_secure_source_manager_instance_iam_member" "bindings" {
   for_each    = var.iam_bindings_additive
-  project     = try(google_secure_source_manager_instance.instance[0].project, var.project_id)
-  location    = try(google_secure_source_manager_instance.instance[0].location, var.location)
-  instance_id = try(google_secure_source_manager_instance.instance[0].instance_id, var.instance_id)
+  project     = local.iam_instance_values["project"]
+  location    = local.iam_instance_values["location"]
+  instance_id = local.iam_instance_values["instance_id"]
   role        = each.value.role
   member      = each.value.member
-  depends_on  = [google_secure_source_manager_instance.instance]
 }
 
 resource "google_secure_source_manager_repository_iam_binding" "authoritative" {

--- a/modules/secure-source-manager-instance/iam.tf
+++ b/modules/secure-source-manager-instance/iam.tf
@@ -33,18 +33,18 @@ locals {
 
 resource "google_secure_source_manager_instance_iam_binding" "authoritative" {
   for_each    = var.iam
-  project     = try(google_secure_source_manager_instance.instance.project, var.project_id)
-  location    = try(google_secure_source_manager_instance.instance.location, var.location)
-  instance_id = try(google_secure_source_manager_instance.instance.instance_id, var.instance_id)
+  project     = try(google_secure_source_manager_instance.instance[0].project, var.project_id)
+  location    = try(google_secure_source_manager_instance.instance[0].location, var.location)
+  instance_id = try(google_secure_source_manager_instance.instance[0].instance_id, var.instance_id)
   role        = each.key
   members     = each.value
 }
 
 resource "google_secure_source_manager_instance_iam_binding" "bindings" {
   for_each    = var.iam_bindings
-  project     = try(google_secure_source_manager_instance.instance.project, var.project_id)
-  location    = try(google_secure_source_manager_instance.instance.location, var.location)
-  instance_id = try(google_secure_source_manager_instance.instance.instance_id, var.instance_id)
+  project     = try(google_secure_source_manager_instance.instance[0].project, var.project_id)
+  location    = try(google_secure_source_manager_instance.instance[0].location, var.location)
+  instance_id = try(google_secure_source_manager_instance.instance[0].instance_id, var.instance_id)
   role        = each.value.role
   members     = each.value.members
   depends_on  = [google_secure_source_manager_instance.instance]
@@ -52,9 +52,9 @@ resource "google_secure_source_manager_instance_iam_binding" "bindings" {
 
 resource "google_secure_source_manager_instance_iam_member" "bindings" {
   for_each    = var.iam_bindings_additive
-  project     = try(google_secure_source_manager_instance.instance.project, var.project_id)
-  location    = try(google_secure_source_manager_instance.instance.location, var.location)
-  instance_id = try(google_secure_source_manager_instance.instance.instance_id, var.instance_id)
+  project     = try(google_secure_source_manager_instance.instance[0].project, var.project_id)
+  location    = try(google_secure_source_manager_instance.instance[0].location, var.location)
+  instance_id = try(google_secure_source_manager_instance.instance[0].instance_id, var.instance_id)
   role        = each.value.role
   member      = each.value.member
   depends_on  = [google_secure_source_manager_instance.instance]

--- a/modules/secure-source-manager-instance/iam.tf
+++ b/modules/secure-source-manager-instance/iam.tf
@@ -33,29 +33,32 @@ locals {
 
 resource "google_secure_source_manager_instance_iam_binding" "authoritative" {
   for_each    = var.iam
-  project     = google_secure_source_manager_instance.instance.project
-  location    = google_secure_source_manager_instance.instance.location
-  instance_id = google_secure_source_manager_instance.instance.instance_id
+  project     = var.project_id
+  location    = var.location
+  instance_id = var.instance_id
   role        = each.key
   members     = each.value
+  depends_on  = [google_secure_source_manager_instance.instance]
 }
 
 resource "google_secure_source_manager_instance_iam_binding" "bindings" {
   for_each    = var.iam_bindings
-  project     = google_secure_source_manager_instance.instance.project
-  location    = google_secure_source_manager_instance.instance.location
-  instance_id = google_secure_source_manager_instance.instance.instance_id
+  project     = var.project_id
+  location    = var.location
+  instance_id = var.instance_id
   role        = each.value.role
   members     = each.value.members
+  depends_on  = [google_secure_source_manager_instance.instance]
 }
 
 resource "google_secure_source_manager_instance_iam_member" "bindings" {
   for_each    = var.iam_bindings_additive
-  project     = google_secure_source_manager_instance.instance.project
-  location    = google_secure_source_manager_instance.instance.location
-  instance_id = google_secure_source_manager_instance.instance.instance_id
+  project     = var.project_id
+  location    = var.location
+  instance_id = var.instance_id
   role        = each.value.role
   member      = each.value.member
+  depends_on  = [google_secure_source_manager_instance.instance]
 }
 
 resource "google_secure_source_manager_repository_iam_binding" "authoritative" {

--- a/modules/secure-source-manager-instance/main.tf
+++ b/modules/secure-source-manager-instance/main.tf
@@ -15,6 +15,7 @@
  */
 
 resource "google_secure_source_manager_instance" "instance" {
+  count       = var.instance_create ? 1 : 0
   instance_id = var.instance_id
   project     = var.project_id
   location    = var.location
@@ -32,9 +33,10 @@ resource "google_secure_source_manager_instance" "instance" {
 resource "google_secure_source_manager_repository" "repositories" {
   for_each      = var.repositories
   repository_id = each.key
-  instance      = google_secure_source_manager_instance.instance.name
+  instance      = try(google_secure_source_manager_instance.instance[0].name, "projects/${var.project_id}/locations/${var.location}/instances/${var.instance_id}")
   project       = var.project_id
-  location      = each.value.location
+  location      = var.location
+  description   = each.value.description
   dynamic "initial_config" {
     for_each = each.value.initial_config == null ? [] : [""]
     content {

--- a/modules/secure-source-manager-instance/outputs.tf
+++ b/modules/secure-source-manager-instance/outputs.tf
@@ -16,12 +16,12 @@
 
 output "instance" {
   description = "Instance."
-  value       = google_secure_source_manager_instance.instance
+  value       = try(google_secure_source_manager_instance.instance[0], null)
 }
 
 output "instance_id" {
   description = "Instance id."
-  value       = google_secure_source_manager_instance.instance.id
+  value       = try(google_secure_source_manager_instance.instance[0].id, null)
 }
 
 output "repositories" {

--- a/modules/secure-source-manager-instance/variables.tf
+++ b/modules/secure-source-manager-instance/variables.tf
@@ -40,7 +40,7 @@ variable "kms_key" {
 variable "labels" {
   description = "Instance labels."
   type        = map(string)
-  default     = {}
+  default     = null
 }
 
 variable "location" {

--- a/modules/secure-source-manager-instance/variables.tf
+++ b/modules/secure-source-manager-instance/variables.tf
@@ -20,6 +20,12 @@ variable "ca_pool" {
   default     = null
 }
 
+variable "instance_create" {
+  description = "Create SSM Instance. When set to false, uses instance_id to reference existing SSM instance."
+  type        = bool
+  default     = true
+}
+
 variable "instance_id" {
   description = "Instance ID."
   type        = string
@@ -66,6 +72,5 @@ variable "repositories" {
       license        = optional(string)
       readme         = optional(string)
     }))
-    location = string
   }))
 }

--- a/tests/modules/secure_source_manager_instance/examples/iam-bindings-additive.yaml
+++ b/tests/modules/secure_source_manager_instance/examples/iam-bindings-additive.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 values:
-  module.ssm_instance.google_secure_source_manager_instance.instance:
+  module.ssm_instance.google_secure_source_manager_instance.instance[0]:
     effective_labels:
       goog-terraform-provisioned: 'true'
     instance_id: my-instance

--- a/tests/modules/secure_source_manager_instance/examples/iam-bindings.yaml
+++ b/tests/modules/secure_source_manager_instance/examples/iam-bindings.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 values:
-  module.ssm_instance.google_secure_source_manager_instance.instance:
+  module.ssm_instance.google_secure_source_manager_instance.instance[0]:
     effective_labels:
       goog-terraform-provisioned: 'true'
     instance_id: my-instance

--- a/tests/modules/secure_source_manager_instance/examples/iam.yaml
+++ b/tests/modules/secure_source_manager_instance/examples/iam.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 values:
-  module.ssm_instance.google_secure_source_manager_instance.instance:
+  module.ssm_instance.google_secure_source_manager_instance.instance[0]:
     effective_labels:
       goog-terraform-provisioned: 'true'
     instance_id: my-instance

--- a/tests/modules/secure_source_manager_instance/examples/private-instance.yaml
+++ b/tests/modules/secure_source_manager_instance/examples/private-instance.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 values:
-  module.ssm_instance.google_secure_source_manager_instance.instance:
+  module.ssm_instance.google_secure_source_manager_instance.instance[0]:
     effective_labels:
       goog-terraform-provisioned: 'true'
     instance_id: my-instance

--- a/tests/modules/secure_source_manager_instance/examples/public-instance-with-cmek.yaml
+++ b/tests/modules/secure_source_manager_instance/examples/public-instance-with-cmek.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 values:
-  module.ssm_instance.google_secure_source_manager_instance.instance:
+  module.ssm_instance.google_secure_source_manager_instance.instance[0]:
     effective_labels:
       goog-terraform-provisioned: 'true'
     instance_id: my-instance

--- a/tests/modules/secure_source_manager_instance/examples/public-instance.yaml
+++ b/tests/modules/secure_source_manager_instance/examples/public-instance.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 values:
-  module.ssm_instance.google_secure_source_manager_instance.instance:
+  module.ssm_instance.google_secure_source_manager_instance.instance[0]:
     effective_labels:
       goog-terraform-provisioned: 'true'
     instance_id: my-instance


### PR DESCRIPTION
Modified the secure-source-manager-instance module to allow management of an existing instance (eg create repos and manage IAM). Also removed the location attr from the repositories var as it needs to be the same as the instance, so this would save having to enter a location for each repo being created.

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
