### PR TITLE
Alloydb variables refactor

### DIFF
--- a/modules/alloydb/README.md
+++ b/modules/alloydb/README.md
@@ -63,8 +63,8 @@ module "alloydb" {
       network = module.vpc.id
     }
   }
-  name     = "db"
-  location = var.region
+  instance_name = "db"
+  location      = var.region
 }
 # tftest modules=3 resources=16 inventory=simple.yaml e2e
 ```
@@ -73,11 +73,11 @@ module "alloydb" {
 
 ```hcl
 module "alloydb" {
-  source       = "./fabric/modules/alloydb"
-  project_id   = var.project_id
-  cluster_name = "db"
-  location     = var.region
-  name         = "db"
+  source        = "./fabric/modules/alloydb"
+  project_id    = var.project_id
+  cluster_name  = "db"
+  location      = var.region
+  instance_name = "db"
   network_config = {
     psa_config = {
       network = var.vpc.id
@@ -98,11 +98,11 @@ In a cross-region replication scenario (like in the previous example) this modul
 
 ```hcl
 module "alloydb" {
-  source       = "./fabric/modules/alloydb"
-  project_id   = var.project_id
-  cluster_name = "db"
-  location     = var.region
-  name         = "db"
+  source        = "./fabric/modules/alloydb"
+  project_id    = var.project_id
+  cluster_name  = "db"
+  location      = var.region
+  instance_name = "db"
   network_config = {
     psc_config = { allowed_consumer_projects = [var.project_number] }
   }
@@ -114,11 +114,11 @@ module "alloydb" {
 
 ```hcl
 module "alloydb" {
-  source       = "./fabric/modules/alloydb"
-  project_id   = var.project_id
-  cluster_name = "primary"
-  location     = var.region
-  name         = "primary"
+  source        = "./fabric/modules/alloydb"
+  project_id    = var.project_id
+  cluster_name  = "primary"
+  location      = var.region
+  instance_name = "primary"
   flags = {
     "alloydb.enable_pgaudit"            = "on"
     "alloydb.iam_authentication"        = "on"
@@ -196,11 +196,11 @@ module "vpc" {
 
 
 module "alloydb" {
-  source       = "./fabric/modules/alloydb"
-  project_id   = module.project.project_id
-  cluster_name = "primary"
-  location     = var.region
-  name         = "primary"
+  source        = "./fabric/modules/alloydb"
+  project_id    = module.project.project_id
+  cluster_name  = "primary"
+  location      = var.region
+  instance_name = "primary"
   network_config = {
     psa_config = {
       network = module.vpc.id
@@ -235,11 +235,11 @@ module "org" {
 }
 
 module "alloydb" {
-  source       = "./fabric/modules/alloydb"
-  project_id   = var.project_id
-  cluster_name = "primary"
-  location     = var.region
-  name         = "primary"
+  source        = "./fabric/modules/alloydb"
+  project_id    = var.project_id
+  cluster_name  = "primary"
+  location      = var.region
+  instance_name = "primary"
   network_config = {
     psa_config = {
       network = var.vpc.id
@@ -257,35 +257,31 @@ module "alloydb" {
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
 | [cluster_name](variables.tf#L99) | Name of the primary cluster. | <code>string</code> | ✓ |  |
-| [location](variables.tf#L186) | Region or zone of the cluster and instance. | <code>string</code> | ✓ |  |
-| [name](variables.tf#L242) | Name of primary instance. | <code>string</code> | ✓ |  |
-| [network_config](variables.tf#L247) | Network configuration for cluster and instance. Only one between psa_config and psc_config can be used. | <code title="object&#40;&#123;&#10;  psa_config &#61; optional&#40;object&#40;&#123;&#10;    network                      &#61; optional&#40;string&#41;&#10;    allocated_ip_range           &#61; optional&#40;string&#41;&#10;    authorized_external_networks &#61; optional&#40;list&#40;string&#41;, &#91;&#93;&#41;&#10;    enable_public_ip             &#61; optional&#40;bool, false&#41;&#10;  &#125;&#41;&#41;&#10;  psc_config &#61; optional&#40;object&#40;&#123;&#10;    allowed_consumer_projects &#61; optional&#40;list&#40;string&#41;, &#91;&#93;&#41;&#10;  &#125;&#41;, null&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
-| [project_id](variables.tf#L290) | The ID of the project where this instances will be created. | <code>string</code> | ✓ |  |
+| [instance_name](variables.tf#L184) | Name of primary instance. | <code>string</code> | ✓ |  |
+| [location](variables.tf#L195) | Region or zone of the cluster and instance. | <code>string</code> | ✓ |  |
+| [network_config](variables.tf#L251) | Network configuration for cluster and instance. Only one between psa_config and psc_config can be used. | <code title="object&#40;&#123;&#10;  psa_config &#61; optional&#40;object&#40;&#123;&#10;    network                      &#61; optional&#40;string&#41;&#10;    allocated_ip_range           &#61; optional&#40;string&#41;&#10;    authorized_external_networks &#61; optional&#40;list&#40;string&#41;, &#91;&#93;&#41;&#10;    enable_public_ip             &#61; optional&#40;bool, false&#41;&#10;  &#125;&#41;&#41;&#10;  psc_config &#61; optional&#40;object&#40;&#123;&#10;    allowed_consumer_projects &#61; optional&#40;list&#40;string&#41;, &#91;&#93;&#41;&#10;  &#125;&#41;, null&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
+| [project_id](variables.tf#L294) | The ID of the project where this instances will be created. | <code>string</code> | ✓ |  |
 | [annotations](variables.tf#L17) | Map FLAG_NAME=>VALUE for annotations which allow client tools to store small amount of arbitrary data. | <code>map&#40;string&#41;</code> |  | <code>null</code> |
 | [automated_backup_configuration](variables.tf#L23) | Automated backup settings for cluster. | <code title="object&#40;&#123;&#10;  enabled       &#61; optional&#40;bool, false&#41;&#10;  backup_window &#61; optional&#40;string, &#34;1800s&#34;&#41;&#10;  location      &#61; optional&#40;string&#41;&#10;  weekly_schedule &#61; optional&#40;object&#40;&#123;&#10;    days_of_week &#61; optional&#40;list&#40;string&#41;, &#91;&#10;      &#34;MONDAY&#34;, &#34;TUESDAY&#34;, &#34;WEDNESDAY&#34;, &#34;THURSDAY&#34;, &#34;FRIDAY&#34;, &#34;SATURDAY&#34;, &#34;SUNDAY&#34;&#10;    &#93;&#41;&#10;    start_times &#61; optional&#40;object&#40;&#123;&#10;      hours   &#61; optional&#40;number, 23&#41;&#10;      minutes &#61; optional&#40;number, 0&#41;&#10;      seconds &#61; optional&#40;number, 0&#41;&#10;      nanos   &#61; optional&#40;number, 0&#41;&#10;    &#125;&#41;, &#123;&#125;&#41;&#10;  &#125;&#41;, &#123;&#125;&#41;&#10;  retention_count  &#61; optional&#40;number, 7&#41;&#10;  retention_period &#61; optional&#40;string, null&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code title="&#123;&#10;  enabled       &#61; false&#10;  backup_window &#61; &#34;1800s&#34;&#10;  location      &#61; null&#10;  weekly_schedule &#61; &#123;&#10;    days_of_week &#61; &#91;&#34;MONDAY&#34;, &#34;TUESDAY&#34;, &#34;WEDNESDAY&#34;, &#34;THURSDAY&#34;, &#34;FRIDAY&#34;, &#34;SATURDAY&#34;, &#34;SUNDAY&#34;&#93;&#10;    start_times &#61; &#123;&#10;      hours   &#61; 23&#10;      minutes &#61; 0&#10;      seconds &#61; 0&#10;      nanos   &#61; 0&#10;    &#125;&#10;  &#125;&#10;  retention_count  &#61; 7&#10;  retention_period &#61; null&#10;&#125;">&#123;&#8230;&#125;</code> |
 | [availability_type](variables.tf#L76) | Availability type for the primary replica. Either `ZONAL` or `REGIONAL`. | <code>string</code> |  | <code>&#34;REGIONAL&#34;</code> |
 | [client_connection_config](variables.tf#L82) | Client connection config. | <code title="object&#40;&#123;&#10;  require_connectors &#61; optional&#40;bool, false&#41;&#10;  ssl_config &#61; optional&#40;object&#40;&#123;&#10;    ssl_mode &#61; string&#10;  &#125;&#41;, null&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
 | [cluster_display_name](variables.tf#L93) | Display name of the primary cluster. | <code>string</code> |  | <code>null</code> |
 | [continuous_backup_configuration](variables.tf#L104) | Continuous backup settings for cluster. | <code title="object&#40;&#123;&#10;  enabled              &#61; optional&#40;bool, false&#41;&#10;  recovery_window_days &#61; optional&#40;number, 14&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code title="&#123;&#10;  enabled              &#61; true&#10;  recovery_window_days &#61; 14&#10;&#125;">&#123;&#8230;&#125;</code> |
-| [cross_region_replication](variables.tf#L117) | Cross region replication config. | <code title="object&#40;&#123;&#10;  enabled           &#61; optional&#40;bool, false&#41;&#10;  promote_secondary &#61; optional&#40;bool, false&#41;&#10;  region            &#61; optional&#40;string, null&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [database_version](variables.tf#L131) | Database type and version to create. | <code>string</code> |  | <code>&#34;POSTGRES_15&#34;</code> |
-| [deletion_policy](variables.tf#L137) | AlloyDB cluster and instance deletion policy. | <code>string</code> |  | <code>null</code> |
-| [display_name](variables.tf#L143) | AlloyDB instance display name. | <code>string</code> |  | <code>null</code> |
-| [encryption_config](variables.tf#L149) | Set encryption configuration. KMS name format: 'projects/[PROJECT]/locations/[REGION]/keyRings/[RING]/cryptoKeys/[KEY_NAME]'. | <code title="object&#40;&#123;&#10;  primary_kms_key_name   &#61; string&#10;  secondary_kms_key_name &#61; optional&#40;string, null&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [flags](variables.tf#L159) | Map FLAG_NAME=>VALUE for database-specific tuning. | <code>map&#40;string&#41;</code> |  | <code>null</code> |
-| [gce_zone](variables.tf#L165) | The GCE zone that the instance should serve from. This can ONLY be specified for ZONAL instances. If present for a REGIONAL instance, an error will be thrown. | <code>string</code> |  | <code>null</code> |
-| [initial_user](variables.tf#L171) | AlloyDB cluster initial user credentials. | <code title="object&#40;&#123;&#10;  user     &#61; optional&#40;string, &#34;root&#34;&#41;&#10;  password &#61; string&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [labels](variables.tf#L180) | Labels to be attached to all instances. | <code>map&#40;string&#41;</code> |  | <code>null</code> |
-| [machine_config](variables.tf#L191) | AlloyDB machine config. | <code title="object&#40;&#123;&#10;  cpu_count &#61; optional&#40;number, 2&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code title="&#123;&#10;  cpu_count &#61; 2&#10;&#125;">&#123;&#8230;&#125;</code> |
-| [maintenance_config](variables.tf#L202) | Set maintenance window configuration. | <code title="object&#40;&#123;&#10;  enabled &#61; optional&#40;bool, false&#41;&#10;  day     &#61; optional&#40;string, &#34;SUNDAY&#34;&#41;&#10;  start_time &#61; optional&#40;object&#40;&#123;&#10;    hours   &#61; optional&#40;number, 23&#41;&#10;    minutes &#61; optional&#40;number, 0&#41;&#10;    seconds &#61; optional&#40;number, 0&#41;&#10;    nanos   &#61; optional&#40;number, 0&#41;&#10;  &#125;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code title="&#123;&#10;  enabled &#61; false&#10;  day     &#61; &#34;SUNDAY&#34;&#10;  start_time &#61; &#123;&#10;    hours   &#61; 23&#10;    minutes &#61; 0&#10;    seconds &#61; 0&#10;    nanos   &#61; 0&#10;  &#125;&#10;&#125;">&#123;&#8230;&#125;</code> |
-| [prefix](variables.tf#L280) | Optional prefix used to generate instance names. | <code>string</code> |  | <code>null</code> |
-| [query_insights_config](variables.tf#L295) | Query insights config. | <code title="object&#40;&#123;&#10;  query_string_length     &#61; optional&#40;number, 1024&#41;&#10;  record_application_tags &#61; optional&#40;bool, true&#41;&#10;  record_client_address   &#61; optional&#40;bool, true&#41;&#10;  query_plans_per_minute  &#61; optional&#40;number, 5&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code title="&#123;&#10;  query_string_length     &#61; 1024&#10;  record_application_tags &#61; true&#10;  record_client_address   &#61; true&#10;  query_plans_per_minute  &#61; 5&#10;&#125;">&#123;&#8230;&#125;</code> |
-| [secondary_cluster_display_name](variables.tf#L311) | Display name of secondary cluster instance. | <code>string</code> |  | <code>null</code> |
-| [secondary_cluster_name](variables.tf#L317) | Name of secondary cluster instance. | <code>string</code> |  | <code>null</code> |
-| [secondary_display_name](variables.tf#L323) | Display name of secondary instance. | <code>string</code> |  | <code>null</code> |
-| [secondary_name](variables.tf#L329) | Name of secondary instance. | <code>string</code> |  | <code>null</code> |
-| [tag_bindings](variables.tf#L335) | Tag bindings for this service, in key => tag value id format. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
-| [users](variables.tf#L342) | Map of users to create in the primary instance (and replicated to other replicas). Set PASSWORD to null if you want to get an autogenerated password. The user types available are: 'ALLOYDB_BUILT_IN' or 'ALLOYDB_IAM_USER'. | <code title="map&#40;object&#40;&#123;&#10;  password &#61; optional&#40;string&#41;&#10;  roles    &#61; optional&#40;list&#40;string&#41;, &#91;&#34;alloydbsuperuser&#34;&#93;&#41;&#10;  type     &#61; optional&#40;string&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>null</code> |
+| [cross_region_replication](variables.tf#L117) | Cross region replication config. | <code title="object&#40;&#123;&#10;  enabled                         &#61; optional&#40;bool, false&#41;&#10;  promote_secondary               &#61; optional&#40;bool, false&#41;&#10;  region                          &#61; optional&#40;string, null&#41;&#10;  secondary_cluster_display_name  &#61; optional&#40;string, null&#41;&#10;  secondary_cluster_name          &#61; optional&#40;string, null&#41;&#10;  secondary_instance_display_name &#61; optional&#40;string, null&#41;&#10;  secondary_instance_name         &#61; optional&#40;string, null&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [database_version](variables.tf#L135) | Database type and version to create. | <code>string</code> |  | <code>&#34;POSTGRES_15&#34;</code> |
+| [deletion_policy](variables.tf#L141) | AlloyDB cluster and instance deletion policy. | <code>string</code> |  | <code>null</code> |
+| [display_name](variables.tf#L147) | AlloyDB instance display name. | <code>string</code> |  | <code>null</code> |
+| [encryption_config](variables.tf#L153) | Set encryption configuration. KMS name format: 'projects/[PROJECT]/locations/[REGION]/keyRings/[RING]/cryptoKeys/[KEY_NAME]'. | <code title="object&#40;&#123;&#10;  primary_kms_key_name   &#61; string&#10;  secondary_kms_key_name &#61; optional&#40;string, null&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [flags](variables.tf#L163) | Map FLAG_NAME=>VALUE for database-specific tuning. | <code>map&#40;string&#41;</code> |  | <code>null</code> |
+| [gce_zone](variables.tf#L169) | The GCE zone that the instance should serve from. This can ONLY be specified for ZONAL instances. If present for a REGIONAL instance, an error will be thrown. | <code>string</code> |  | <code>null</code> |
+| [initial_user](variables.tf#L175) | AlloyDB cluster initial user credentials. | <code title="object&#40;&#123;&#10;  user     &#61; optional&#40;string, &#34;root&#34;&#41;&#10;  password &#61; string&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [labels](variables.tf#L189) | Labels to be attached to all instances. | <code>map&#40;string&#41;</code> |  | <code>null</code> |
+| [machine_config](variables.tf#L200) | AlloyDB machine config. | <code title="object&#40;&#123;&#10;  cpu_count &#61; optional&#40;number, 2&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code title="&#123;&#10;  cpu_count &#61; 2&#10;&#125;">&#123;&#8230;&#125;</code> |
+| [maintenance_config](variables.tf#L211) | Set maintenance window configuration. | <code title="object&#40;&#123;&#10;  enabled &#61; optional&#40;bool, false&#41;&#10;  day     &#61; optional&#40;string, &#34;SUNDAY&#34;&#41;&#10;  start_time &#61; optional&#40;object&#40;&#123;&#10;    hours   &#61; optional&#40;number, 23&#41;&#10;    minutes &#61; optional&#40;number, 0&#41;&#10;    seconds &#61; optional&#40;number, 0&#41;&#10;    nanos   &#61; optional&#40;number, 0&#41;&#10;  &#125;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code title="&#123;&#10;  enabled &#61; false&#10;  day     &#61; &#34;SUNDAY&#34;&#10;  start_time &#61; &#123;&#10;    hours   &#61; 23&#10;    minutes &#61; 0&#10;    seconds &#61; 0&#10;    nanos   &#61; 0&#10;  &#125;&#10;&#125;">&#123;&#8230;&#125;</code> |
+| [prefix](variables.tf#L284) | Optional prefix used to generate instance names. | <code>string</code> |  | <code>null</code> |
+| [query_insights_config](variables.tf#L299) | Query insights config. | <code title="object&#40;&#123;&#10;  query_string_length     &#61; optional&#40;number, 1024&#41;&#10;  record_application_tags &#61; optional&#40;bool, true&#41;&#10;  record_client_address   &#61; optional&#40;bool, true&#41;&#10;  query_plans_per_minute  &#61; optional&#40;number, 5&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code title="&#123;&#10;  query_string_length     &#61; 1024&#10;  record_application_tags &#61; true&#10;  record_client_address   &#61; true&#10;  query_plans_per_minute  &#61; 5&#10;&#125;">&#123;&#8230;&#125;</code> |
+| [tag_bindings](variables.tf#L315) | Tag bindings for this service, in key => tag value id format. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [users](variables.tf#L322) | Map of users to create in the primary instance (and replicated to other replicas). Set PASSWORD to null if you want to get an autogenerated password. The user types available are: 'ALLOYDB_BUILT_IN' or 'ALLOYDB_IAM_USER'. | <code title="map&#40;object&#40;&#123;&#10;  password &#61; optional&#40;string&#41;&#10;  roles    &#61; optional&#40;list&#40;string&#41;, &#91;&#34;alloydbsuperuser&#34;&#93;&#41;&#10;  type     &#61; optional&#40;string&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>null</code> |
 
 ## Outputs
 

--- a/modules/alloydb/main.tf
+++ b/modules/alloydb/main.tf
@@ -20,9 +20,9 @@ locals {
   # secondary instance type is aligned with cluster type unless apply is targeting a promotion, in that
   # case cluster will be 'primary' while instance still 'secondary'.
   primary_cluster_name    = "${local.prefix}${var.cluster_name}"
-  primary_instance_name   = "${local.prefix}${var.name}"
-  secondary_cluster_name  = coalesce(var.secondary_cluster_name, "${var.cluster_name}-sec")
-  secondary_instance_name = coalesce(var.secondary_name, "${var.name}-sec")
+  primary_instance_name   = "${local.prefix}${var.instance_name}"
+  secondary_cluster_name  = coalesce(var.cross_region_replication.secondary_cluster_name, "${var.cluster_name}-sec")
+  secondary_instance_name = coalesce(var.cross_region_replication.secondary_instance_name, "${var.instance_name}-sec")
   secondary_instance_type = try(
     var.cross_region_replication.promote_secondary && google_alloydb_cluster.secondary[0].cluster_type == "SECONDARY"
     ? "SECONDARY"
@@ -231,7 +231,7 @@ resource "google_alloydb_cluster" "secondary" {
   cluster_type     = var.cross_region_replication.promote_secondary ? "PRIMARY" : "SECONDARY"
   database_version = var.database_version
   deletion_policy  = "FORCE"
-  display_name     = coalesce(var.secondary_cluster_display_name, local.secondary_cluster_name)
+  display_name     = coalesce(var.cross_region_replication.secondary_cluster_display_name, local.secondary_cluster_name)
   labels           = var.labels
   location         = var.cross_region_replication.region
 
@@ -353,7 +353,7 @@ resource "google_alloydb_instance" "secondary" {
   availability_type = var.availability_type
   cluster           = google_alloydb_cluster.secondary[0].id
   database_flags    = var.cross_region_replication.promote_secondary ? var.flags : null
-  display_name      = coalesce(var.secondary_display_name, local.secondary_instance_name)
+  display_name      = coalesce(var.cross_region_replication.secondary_instance_name, local.secondary_instance_name)
   gce_zone          = local.is_regional ? null : var.gce_zone
   instance_id       = local.secondary_instance_name
   instance_type     = local.secondary_instance_type

--- a/modules/alloydb/variables.tf
+++ b/modules/alloydb/variables.tf
@@ -117,9 +117,13 @@ variable "continuous_backup_configuration" {
 variable "cross_region_replication" {
   description = "Cross region replication config."
   type = object({
-    enabled           = optional(bool, false)
-    promote_secondary = optional(bool, false)
-    region            = optional(string, null)
+    enabled                         = optional(bool, false)
+    promote_secondary               = optional(bool, false)
+    region                          = optional(string, null)
+    secondary_cluster_display_name  = optional(string, null)
+    secondary_cluster_name          = optional(string, null)
+    secondary_instance_display_name = optional(string, null)
+    secondary_instance_name         = optional(string, null)
   })
   default = {}
   validation {
@@ -175,6 +179,11 @@ variable "initial_user" {
     password = string
   })
   default = null
+}
+
+variable "instance_name" {
+  description = "Name of primary instance."
+  type        = string
 }
 
 variable "labels" {
@@ -239,11 +248,6 @@ variable "maintenance_config" {
   }
 }
 
-variable "name" {
-  description = "Name of primary instance."
-  type        = string
-}
-
 variable "network_config" {
   description = "Network configuration for cluster and instance. Only one between psa_config and psc_config can be used."
   type = object({
@@ -306,30 +310,6 @@ variable "query_insights_config" {
     record_client_address   = true
     query_plans_per_minute  = 5
   }
-}
-
-variable "secondary_cluster_display_name" {
-  description = "Display name of secondary cluster instance."
-  type        = string
-  default     = null
-}
-
-variable "secondary_cluster_name" {
-  description = "Name of secondary cluster instance."
-  type        = string
-  default     = null
-}
-
-variable "secondary_display_name" {
-  description = "Display name of secondary instance."
-  type        = string
-  default     = null
-}
-
-variable "secondary_name" {
-  description = "Name of secondary instance."
-  type        = string
-  default     = null
 }
 
 variable "tag_bindings" {


### PR DESCRIPTION
Include secondary cluster and instance variables in the cross_region_replication one

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
