### PR TITLE
Fix project-factory SA indirections

### DIFF
--- a/modules/project-factory/main.tf
+++ b/modules/project-factory/main.tf
@@ -120,7 +120,14 @@ module "projects" {
       )
       network_users = [
         for v in try(each.value.shared_vpc_service_config.network_users, []) :
-        lookup(local.context.iam_principals, v, v)
+        try(
+          # automation service account
+          local.context.iam_principals["${each.key}/${v}"],
+          # other context
+          local.context.iam_principals[v],
+          # passthrough
+          v
+        )
       ]
       # TODO: network subnet users
     })


### PR DESCRIPTION
Project factory is unable to lookup for project automation SA when used in network_users arguments 

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass
