### PR TITLE
fix(artifact-registry): fix a move issue with tf>1.7

### DIFF
--- a/modules/artifact-registry/iam.tf
+++ b/modules/artifact-registry/iam.tf
@@ -20,6 +20,7 @@ moved {
 }
 
 resource "google_artifact_registry_repository_iam_binding" "authoritative" {
+  provider   = google-beta
   for_each   = local.iam
   project    = var.project_id
   location   = google_artifact_registry_repository.registry.location


### PR DESCRIPTION
Happy to be the first one to complain 🙂 

As mentionned by @juliocc in https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/pull/2606 the move is failing if we transfer the resource to the non-beta provider:

```
│ The "google_artifact_registry_repository_iam_binding" resource type does
│ not support moving resource state across resource types.
```

The TF 1.8 has introduced a new feature that makes the move failing (I was testing with 1.7 in #2606):
> Providers can now transfer the ownership of a remote object between resources of different types, for situations where there are two different resource types that represent the same remote object type.
> This extends the moved block behavior to support moving between two resources of different types only if the provider for the target resource type declares that it can convert from the source resource type. Refer to provider documentation for details on which pairs of resource types are supported.
https://github.com/hashicorp/terraform/blob/v1.8/CHANGELOG.md#180-april-10-2024

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [x] Made sure all relevant tests pass
