### PR TITLE
Fixed reversed bootstrap_user null check in stage 0-bootstrap

### DIFF
--- a/fast/stages/0-bootstrap/organization.tf
+++ b/fast/stages/0-bootstrap/organization.tf
@@ -229,7 +229,7 @@ module "organization" {
   factories_config = {
     custom_roles = var.factories_config.custom_roles
     org_policies = (
-      var.bootstrap_user != null ? null : var.factories_config.org_policy
+      var.bootstrap_user != null ? var.factories_config.org_policy : null
     )
   }
   logging_sinks = {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here -->
This fixes a reversed null check for var.bootstrap_user, so that org-policies are created when deploying stage 0-bootstrap.
---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [N/A] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
