### PR TITLE
added log_sinks to tfvars.logging in 0-bootstrap

### DIFF
--- a/fast/stages/0-bootstrap/README.md
+++ b/fast/stages/0-bootstrap/README.md
@@ -678,16 +678,16 @@ The remaining configuration is manual, as it regards the repositories themselves
 
 | name | description | sensitive | consumers |
 |---|---|:---:|---|
-| [automation](outputs.tf#L146) | Automation resources. |  |  |
-| [billing_dataset](outputs.tf#L151) | BigQuery dataset prepared for billing export. |  |  |
-| [cicd_repositories](outputs.tf#L156) | CI/CD repository configurations. |  |  |
-| [custom_roles](outputs.tf#L168) | Organization-level custom roles. |  |  |
-| [outputs_bucket](outputs.tf#L173) | GCS bucket where generated output files are stored. |  |  |
-| [project_ids](outputs.tf#L178) | Projects created by this stage. |  |  |
-| [providers](outputs.tf#L188) | Terraform provider files for this stage and dependent stages. | ✓ | <code>stage-01</code> |
-| [service_accounts](outputs.tf#L195) | Automation service accounts created by this stage. |  |  |
-| [tfvars](outputs.tf#L213) | Terraform variable files for the following stages. | ✓ |  |
-| [tfvars_globals](outputs.tf#L219) | Terraform Globals variable files for the following stages. | ✓ |  |
-| [workforce_identity_pool](outputs.tf#L225) | Workforce Identity Federation pool. |  |  |
-| [workload_identity_pool](outputs.tf#L234) | Workload Identity Federation pool and providers. |  |  |
+| [automation](outputs.tf#L147) | Automation resources. |  |  |
+| [billing_dataset](outputs.tf#L152) | BigQuery dataset prepared for billing export. |  |  |
+| [cicd_repositories](outputs.tf#L157) | CI/CD repository configurations. |  |  |
+| [custom_roles](outputs.tf#L169) | Organization-level custom roles. |  |  |
+| [outputs_bucket](outputs.tf#L174) | GCS bucket where generated output files are stored. |  |  |
+| [project_ids](outputs.tf#L179) | Projects created by this stage. |  |  |
+| [providers](outputs.tf#L189) | Terraform provider files for this stage and dependent stages. | ✓ | <code>stage-01</code> |
+| [service_accounts](outputs.tf#L196) | Automation service accounts created by this stage. |  |  |
+| [tfvars](outputs.tf#L214) | Terraform variable files for the following stages. | ✓ |  |
+| [tfvars_globals](outputs.tf#L220) | Terraform Globals variable files for the following stages. | ✓ |  |
+| [workforce_identity_pool](outputs.tf#L226) | Workforce Identity Federation pool. |  |  |
+| [workload_identity_pool](outputs.tf#L235) | Workload Identity Federation pool and providers. |  |  |
 <!-- END TFDOC -->

--- a/fast/stages/0-bootstrap/outputs.tf
+++ b/fast/stages/0-bootstrap/outputs.tf
@@ -112,6 +112,7 @@ locals {
     }
     custom_roles = module.organization.custom_role_id
     logging = {
+      log_sinks         = var.log_sinks
       project_id        = module.log-export-project.project_id
       project_number    = module.log-export-project.number
       writer_identities = module.organization.sink_writer_identities


### PR DESCRIPTION
Currently [var.logging 1-resman](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/47e74a1c52c53405dc067ede2bbfcf39337c3f4a/fast/stages/1-resman/variables-fast.tf#L98-L109) has the [logging structure from 1-tenants](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/47e74a1c52c53405dc067ede2bbfcf39337c3f4a/fast/stages/1-tenant-factory/outputs.tf#L99-L120) which includes log_sinks. This change adds var.log_sinks from 0-bootstrap in to local.tfvars.logging to align with 1-resman's expectations. Without this value, this causes issues for using state/tfe_outputs backends but not using the tenant-factory as 1-resman expects logging.log_sink to exist. 

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [x] Made sure all relevant tests pass
