### PR TITLE
[FAST] Fix stage 2 simple NVA wrong location - causing test failures

### DIFF
--- a/fast/stages/2-networking-b-nva/nva-simple.tf
+++ b/fast/stages/2-networking-b-nva/nva-simple.tf
@@ -104,7 +104,7 @@ module "nva-simple-mig" {
   for_each          = (var.network_mode == "simple") ? local.nva_locality : {}
   source            = "../../../modules/compute-mig"
   project_id        = module.landing-project.project_id
-  location          = each.value.zone
+  location          = "${each.value.region}-${each.value.zone}"
   name              = "nva-cos-${each.key}"
   instance_template = module.nva-simple-template[each.key].template.self_link
   target_size       = 1


### PR DESCRIPTION
Fixes FAST stage 2-b (simple NVA) wrong location setting on MIGs, which is causing test failures.

---
**Checklist**

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
