### PR TITLE
Adding DNS for GKE control plane to private google access APIs

### DIFF
--- a/fast/stages/2-networking-a-simple/data/dns-policy-rules.yaml
+++ b/fast/stages/2-networking-a-simple/data/dns-policy-rules.yaml
@@ -64,6 +64,9 @@ gcr:
 gcr-all:
   dns_name: "*.gcr.io."
   local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
+gke-all:
+  dns_name: "*.gke.goog."
+  local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
 googleapis-all:
   dns_name: "*.googleapis.com."
   local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }

--- a/fast/stages/2-networking-b-nva/data/dns-policy-rules.yaml
+++ b/fast/stages/2-networking-b-nva/data/dns-policy-rules.yaml
@@ -64,6 +64,9 @@ gcr:
 gcr-all:
   dns_name: "*.gcr.io."
   local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
+gke-all:
+  dns_name: "*.gke.goog."
+  local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
 googleapis-all:
   dns_name: "*.googleapis.com."
   local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }

--- a/fast/stages/2-networking-c-separate-envs/data/dns-policy-rules.yaml
+++ b/fast/stages/2-networking-c-separate-envs/data/dns-policy-rules.yaml
@@ -64,6 +64,9 @@ gcr:
 gcr-all:
   dns_name: "*.gcr.io."
   local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
+gke-all:
+  dns_name: "*.gke.goog."
+  local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
 googleapis-all:
   dns_name: "*.googleapis.com."
   local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }

--- a/tests/fast/stages/s2_networking_a_simple/ncc.yaml
+++ b/tests/fast/stages/s2_networking_a_simple/ncc.yaml
@@ -43,4 +43,4 @@ counts:
   google_storage_bucket_object: 2
   google_vpc_access_connector: 2
   modules: 24
-  resources: 173
+  resources: 174

--- a/tests/fast/stages/s2_networking_a_simple/ncc.yaml
+++ b/tests/fast/stages/s2_networking_a_simple/ncc.yaml
@@ -27,7 +27,7 @@ counts:
   google_dns_policy: 3
   google_dns_record_set: 3
   google_dns_response_policy: 1
-  google_dns_response_policy_rule: 38
+  google_dns_response_policy_rule: 39
   google_essential_contacts_contact: 1
   google_folder: 1
   google_monitoring_alert_policy: 2

--- a/tests/fast/stages/s2_networking_a_simple/simple.yaml
+++ b/tests/fast/stages/s2_networking_a_simple/simple.yaml
@@ -33,7 +33,7 @@ counts:
   google_dns_policy: 3
   google_dns_record_set: 3
   google_dns_response_policy: 1
-  google_dns_response_policy_rule: 38
+  google_dns_response_policy_rule: 39
   google_essential_contacts_contact: 1
   google_folder: 1
   google_monitoring_alert_policy: 2

--- a/tests/fast/stages/s2_networking_a_simple/simple.yaml
+++ b/tests/fast/stages/s2_networking_a_simple/simple.yaml
@@ -48,4 +48,4 @@ counts:
   google_vpc_access_connector: 2
   modules: 29
   random_id: 1
-  resources: 185
+  resources: 186

--- a/tests/fast/stages/s2_networking_a_simple/vpn.yaml
+++ b/tests/fast/stages/s2_networking_a_simple/vpn.yaml
@@ -46,4 +46,4 @@ counts:
   google_vpc_access_connector: 2
   modules: 31
   random_id: 5
-  resources: 222
+  resources: 223

--- a/tests/fast/stages/s2_networking_a_simple/vpn.yaml
+++ b/tests/fast/stages/s2_networking_a_simple/vpn.yaml
@@ -31,7 +31,7 @@ counts:
   google_dns_policy: 3
   google_dns_record_set: 3
   google_dns_response_policy: 1
-  google_dns_response_policy_rule: 38
+  google_dns_response_policy_rule: 39
   google_essential_contacts_contact: 1
   google_folder: 1
   google_monitoring_alert_policy: 2

--- a/tests/fast/stages/s2_networking_b_nva/ncc-ra.yaml
+++ b/tests/fast/stages/s2_networking_b_nva/ncc-ra.yaml
@@ -34,7 +34,7 @@ counts:
   google_dns_policy: 4
   google_dns_record_set: 3
   google_dns_response_policy: 1
-  google_dns_response_policy_rule: 38
+  google_dns_response_policy_rule: 39
   google_essential_contacts_contact: 1
   google_folder: 1
   google_monitoring_alert_policy: 2

--- a/tests/fast/stages/s2_networking_b_nva/ncc-ra.yaml
+++ b/tests/fast/stages/s2_networking_b_nva/ncc-ra.yaml
@@ -51,4 +51,4 @@ counts:
   google_vpc_access_connector: 2
   modules: 39
   random_id: 2
-  resources: 253
+  resources: 254

--- a/tests/fast/stages/s2_networking_b_nva/regional.yaml
+++ b/tests/fast/stages/s2_networking_b_nva/regional.yaml
@@ -38,7 +38,7 @@ counts:
   google_dns_policy: 6
   google_dns_record_set: 3
   google_dns_response_policy: 1
-  google_dns_response_policy_rule: 38
+  google_dns_response_policy_rule: 39
   google_essential_contacts_contact: 1
   google_folder: 1
   google_monitoring_alert_policy: 2

--- a/tests/fast/stages/s2_networking_b_nva/regional.yaml
+++ b/tests/fast/stages/s2_networking_b_nva/regional.yaml
@@ -52,4 +52,4 @@ counts:
   google_storage_bucket_object: 2
   modules: 47
   random_id: 2
-  resources: 258
+  resources: 259

--- a/tests/fast/stages/s2_networking_b_nva/simple.yaml
+++ b/tests/fast/stages/s2_networking_b_nva/simple.yaml
@@ -38,7 +38,7 @@ counts:
   google_dns_policy: 4
   google_dns_record_set: 3
   google_dns_response_policy: 1
-  google_dns_response_policy_rule: 38
+  google_dns_response_policy_rule: 39
   google_essential_contacts_contact: 1
   google_folder: 1
   google_monitoring_alert_policy: 2

--- a/tests/fast/stages/s2_networking_b_nva/simple.yaml
+++ b/tests/fast/stages/s2_networking_b_nva/simple.yaml
@@ -53,4 +53,4 @@ counts:
   google_vpc_access_connector: 2
   modules: 43
   random_id: 2
-  resources: 236
+  resources: 237

--- a/tests/fast/stages/s2_networking_c_separate_envs/simple.yaml
+++ b/tests/fast/stages/s2_networking_c_separate_envs/simple.yaml
@@ -32,7 +32,7 @@ counts:
   google_dns_policy: 2
   google_dns_record_set: 2
   google_dns_response_policy: 2
-  google_dns_response_policy_rule: 76
+  google_dns_response_policy_rule: 78
   google_essential_contacts_contact: 1
   google_folder: 1
   google_monitoring_alert_policy: 4

--- a/tests/fast/stages/s2_networking_c_separate_envs/simple.yaml
+++ b/tests/fast/stages/s2_networking_c_separate_envs/simple.yaml
@@ -46,4 +46,4 @@ counts:
   google_vpc_access_connector: 2
   modules: 22
   random_id: 2
-  resources: 204
+  resources: 206


### PR DESCRIPTION
Adding "*.gke.goog" to private google access default DNS configuration.
This will allow DNS based access to GKE clusters from on-premise and in GCP, solving transitivity issues and allowing more secure GKE control plane access (https://cloud.google.com/kubernetes-engine/docs/how-to/latest/network-isolation#modify_the_control_plane_access).

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [ X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X ] Ran `terraform fmt` on all modified files
- [] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [] Made sure all relevant tests pass
