### PR TITLE
Add required enabled field introduced in Terraform version 5.41.0

### DIFF
--- a/modules/gke-hub/main.tf
+++ b/modules/gke-hub/main.tf
@@ -106,6 +106,7 @@ resource "google_gke_hub_feature_membership" "default" {
       content {
         prevent_drift = each.value.config_sync.prevent_drift
         source_format = each.value.config_sync.source_format
+        enabled       = true
         dynamic "git" {
           for_each = (
             try(each.value.config_sync.git, null) == null ? {} : { 1 = 1 }


### PR DESCRIPTION
Fixes issue with current module where enabling Config Sync does not work because of missing `enabled=true` field.

---
**Checklist**

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [x] Made sure all relevant tests pass
