### PR TITLE
Update SWP

### DIFF
--- a/modules/net-swp/main.tf
+++ b/modules/net-swp/main.tf
@@ -15,7 +15,10 @@
  */
 
 locals {
-  create_url_lists = { for k, v in var.policy_rules.url_lists : v.url_list => v if v.values != null }
+  create_url_lists = {
+    for k, v in var.policy_rules.url_lists
+    : v.url_list => v if v.values != null
+  }
 }
 
 moved {
@@ -24,12 +27,14 @@ moved {
 }
 
 resource "google_network_security_gateway_security_policy" "default" {
-  provider              = google-beta
-  project               = var.project_id
-  name                  = var.name
-  location              = var.region
-  description           = var.description
-  tls_inspection_policy = var.tls_inspection_config != null ? google_network_security_tls_inspection_policy.default[0].id : null
+  project     = var.project_id
+  name        = var.name
+  location    = var.region
+  description = var.description
+  tls_inspection_policy = try(coalesce(
+    var.tls_inspection_config.id,
+    try(google_network_security_tls_inspection_policy.default[0].id, null)
+  ), null)
 }
 
 moved {
@@ -38,19 +43,17 @@ moved {
 }
 
 resource "google_network_security_tls_inspection_policy" "default" {
-  count                 = var.tls_inspection_config != null ? 1 : 0
-  provider              = google
+  count                 = var.tls_inspection_config.create_config != null ? 1 : 0
   project               = var.project_id
   name                  = var.name
   location              = var.region
-  description           = coalesce(var.tls_inspection_config.description, var.description)
-  ca_pool               = var.tls_inspection_config.ca_pool
-  exclude_public_ca_set = var.tls_inspection_config.exclude_public_ca_set
+  description           = coalesce(var.tls_inspection_config.create_config.description, var.description)
+  ca_pool               = var.tls_inspection_config.create_config.ca_pool
+  exclude_public_ca_set = var.tls_inspection_config.create_config.exclude_public_ca_set
 }
 
 resource "google_network_security_gateway_security_policy_rule" "secure_tag_rules" {
   for_each                = var.policy_rules.secure_tags
-  provider                = google
   project                 = var.project_id
   name                    = each.key
   location                = var.region
@@ -69,7 +72,6 @@ resource "google_network_security_gateway_security_policy_rule" "secure_tag_rule
 
 resource "google_network_security_gateway_security_policy_rule" "url_list_rules" {
   for_each                = var.policy_rules.url_lists
-  provider                = google
   project                 = var.project_id
   name                    = each.key
   location                = var.region
@@ -93,7 +95,6 @@ resource "google_network_security_gateway_security_policy_rule" "url_list_rules"
 resource "google_network_security_gateway_security_policy_rule" "custom_rules" {
   for_each                = var.policy_rules.custom
   project                 = var.project_id
-  provider                = google
   name                    = each.key
   location                = var.region
   description             = coalesce(each.value.description, var.description)
@@ -112,7 +113,6 @@ moved {
 }
 resource "google_network_security_url_lists" "default" {
   for_each    = local.create_url_lists
-  provider    = google
   project     = var.project_id
   name        = each.key
   location    = var.region
@@ -126,7 +126,6 @@ moved {
 }
 
 resource "google_network_services_gateway" "default" {
-  provider                             = google
   project                              = var.project_id
   name                                 = var.name
   location                             = var.region

--- a/modules/net-swp/main.tf
+++ b/modules/net-swp/main.tf
@@ -27,6 +27,7 @@ moved {
 }
 
 resource "google_network_security_gateway_security_policy" "default" {
+  provider    = google-beta
   project     = var.project_id
   name        = var.name
   location    = var.region

--- a/modules/net-swp/variables.tf
+++ b/modules/net-swp/variables.tf
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-
-
 variable "addresses" {
   description = "One or more IP addresses to be used for Secure Web Proxy."
   type        = list(string)
@@ -156,9 +154,20 @@ variable "subnetwork" {
 variable "tls_inspection_config" {
   description = "TLS inspection configuration."
   type = object({
-    ca_pool               = optional(string, null)
-    exclude_public_ca_set = optional(bool, false)
-    description           = optional(string)
+    create_config = optional(object({
+      ca_pool               = optional(string, null)
+      description           = optional(string, null)
+      exclude_public_ca_set = optional(bool, false)
+    }), null)
+    id = optional(string, null)
   })
-  default = null
+  nullable = false
+  default  = {}
+  validation {
+    condition = !(
+      var.tls_inspection_config.create_config != null &&
+      var.tls_inspection_config.id != null
+    )
+    error_message = "You can't assign values both to `create.config.ca_pool` and `id`."
+  }
 }

--- a/tests/modules/net_swp/examples/tls-no-ip.yaml
+++ b/tests/modules/net_swp/examples/tls-no-ip.yaml
@@ -1,0 +1,59 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# file: tests/modules/net_swp/examples/tls.yaml
+values:
+  module.secure-web-proxy.google_network_security_gateway_security_policy.default:
+    description: Managed by Terraform.
+    location: europe-west4
+    name: secure-web-proxy
+    project: my-project
+    timeouts: null
+    tls_inspection_policy: projects/another-project/locations/europe-west1/tlsInspectionPolicies/tls-ip-0
+  module.secure-web-proxy.google_network_security_gateway_security_policy_rule.custom_rules["custom-rule-1"]:
+    application_matcher: request.path.contains('generate_204')
+    basic_profile: ALLOW
+    description: Managed by Terraform.
+    enabled: true
+    location: europe-west4
+    name: custom-rule-1
+    priority: 1000
+    project: my-project
+    session_matcher: host() == 'google.com'
+    timeouts: null
+    tls_inspection_enabled: true
+  module.secure-web-proxy.google_network_services_gateway.default:
+    addresses:
+    - 10.142.68.3
+    certificate_urls:
+    - projects/my-project/locations/europe-west4/certificates/secure-web-proxy-cert
+    delete_swg_autogen_router_on_destroy: true
+    description: Managed by Terraform.
+    labels: null
+    location: europe-west4
+    name: secure-web-proxy
+    network: projects/my-project/global/networks/my-network
+    ports:
+    - 443
+    project: my-project
+    scope: ''
+    server_tls_policy: null
+    subnetwork: projects/my-project/regions/europe-west4/subnetworks/my-subnetwork
+    timeouts: null
+    type: SECURE_WEB_GATEWAY
+  
+counts:
+  google_network_security_gateway_security_policy: 1
+  google_network_services_gateway: 1
+  google_network_security_gateway_security_policy_rule: 1


### PR DESCRIPTION
- Removes `google-beta` provider references
- Make TLS inspection policy creation optional (vs pass id to existing TLS inspection policies)

---
**Checklist**

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
