### PR TITLE
Fix the location of the GCS and NFS attributes

### DIFF
--- a/modules/cloud-run-v2/job.tf
+++ b/modules/cloud-run-v2/job.tf
@@ -130,16 +130,16 @@ resource "google_cloud_run_v2_job" "job" {
           dynamic "gcs" {
             for_each = volumes.value.gcs == null ? [] : [""]
             content {
-              bucket    = volumes.value.bucket
-              read_only = volumes.value.is_read_only
+              bucket    = volumes.value.gcs.bucket
+              read_only = volumes.value.gcs.is_read_only
             }
           }
           dynamic "nfs" {
             for_each = volumes.value.nfs == null ? [] : [""]
             content {
-              server    = volumes.value.server
-              path      = volumes.value.path
-              read_only = volumes.value.is_read_only
+              server    = volumes.value.nfs.server
+              path      = volumes.value.nfs.path
+              read_only = volumes.value.nfs.is_read_only
             }
           }
         }


### PR DESCRIPTION
When attempting to mount GCS or NFS volumes, the following error message would appear:

```
│ Error: Unsupported attribute
│
│   on .terraform/modules/deploy_backfill_tmdb/modules/cloud-run-v2/job.tf line 133, in resource "google_cloud_run_v2_job" "job":
│  133:               bucket    = volumes.value.bucket
│     ├────────────────
│     │ volumes.value is object with 5 attributes
│
│ This object does not have an attribute named "bucket".
╵
╷
│ Error: Unsupported attribute
│
│   on .terraform/modules/deploy_backfill_tmdb/modules/cloud-run-v2/job.tf line 134, in resource "google_cloud_run_v2_job" "job":
│  134:               read_only = volumes.value.is_read_only
│     ├────────────────
│     │ volumes.value is object with 5 attributes
│
│ This object does not have an attribute named "is_read_only".
```

This fixes the above.