### PR TITLE
Make project iam viewer name consistent with GCP naming

### DIFF
--- a/fast/stages/0-bootstrap/data/custom-roles/project_iam_viewer.yaml
+++ b/fast/stages/0-bootstrap/data/custom-roles/project_iam_viewer.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 # yaml-language-server: $schema=../../schemas/custom-role.schema.json
 # this is used by the plan-only admin SA
 
-name: projectIAMViewer
+name: projectIamViewer
 includedPermissions:
 - iam.policybindings.get
 - iam.policybindings.list

--- a/tests/fast/stages/s0_bootstrap/simple.yaml
+++ b/tests/fast/stages/s0_bootstrap/simple.yaml
@@ -56,7 +56,7 @@ outputs:
     ngfw_enterprise_viewer: organizations/123456789012/roles/ngfwEnterpriseViewer
     organization_admin_viewer: organizations/123456789012/roles/organizationAdminViewer
     organization_iam_admin: organizations/123456789012/roles/organizationIamAdmin
-    project_iam_viewer: organizations/123456789012/roles/projectIAMViewer
+    project_iam_viewer: organizations/123456789012/roles/projectIamViewer
     service_project_network_admin: organizations/123456789012/roles/serviceProjectNetworkAdmin
     storage_viewer: organizations/123456789012/roles/storageViewer
     tag_viewer: organizations/123456789012/roles/tagViewer

--- a/tests/fast/stages/s1_resman/simple.tfvars
+++ b/tests/fast/stages/s1_resman/simple.tfvars
@@ -61,7 +61,7 @@ custom_roles = {
   ngfw_enterprise_admin            = "organizations/123456789012/roles/ngfwEnterpriseAdmin"
   ngfw_enterprise_viewer           = "organizations/123456789012/roles/ngfwEnterpriseViewer"
   organization_admin_viewer        = "organizations/123456789012/roles/organizationAdminViewer"
-  project_iam_viewer               = "organizations/123456789012/roles/projectIAMViewer"
+  project_iam_viewer               = "organizations/123456789012/roles/projectIamViewer"
   service_project_network_admin    = "organizations/123456789012/roles/xpnServiceAdmin"
   storage_viewer                   = "organizations/123456789012/roles/storageViewer"
 }


### PR DESCRIPTION
GCP roles only capitalize the first letter of IAM:

![image](https://github.com/user-attachments/assets/1125b6c6-11bc-4c17-addd-47f3b610c19a)
