### PR TITLE
Change tfdoc pre-commit hook script to use while read

### DIFF
--- a/tools/pre-commit-tfdoc.sh
+++ b/tools/pre-commit-tfdoc.sh
@@ -19,6 +19,9 @@ set -e
 SCRIPT_DIR=$(dirname -- "$(readlink -f -- "$0")")
 TFDOC_CMD="${SCRIPT_DIR}/tfdoc.py"
 CHECKDOC_CMD="${SCRIPT_DIR}/check_documentation.py"
+if [ -z "$PYTHON" ]; then
+	PYTHON=python
+fi
 
 for file in "$@"; do
 	if [ -d "${file}" ]; then
@@ -30,4 +33,4 @@ for file in "$@"; do
 		echo "${dir}"
 	fi
 
-done | sort | uniq | xargs -I {} /bin/sh -c "echo python \"${TFDOC_CMD}\" {} ; python \"${TFDOC_CMD}\" {} ; echo python \"${CHECKDOC_CMD}\" {} ; python \"${CHECKDOC_CMD}\" {}"
+done | sort | uniq | while read -r line; do /bin/sh -c "echo ${PYTHON} \"${TFDOC_CMD}\" \"$line\" ; ${PYTHON} \"${TFDOC_CMD}\" \"$line\" ; echo ${PYTHON} \"${CHECKDOC_CMD}\" \"$line\" ; ${PYTHON} \"${CHECKDOC_CMD}\" \"$line\""; done


### PR DESCRIPTION
Use read line instead of xargs. While probably a bit slower, this works reliably on Linux and OS X. (BSD and GNU xargs are unfortunately with different arguments) Also added option to set Python binary (eg. export PYTHON=python3). pre-commit.com hooks stash uncommitted changes, so patching it locally isn't really a good option.

On OS X:
```
Regenerate README.md with tfdoc.py........................................Failed
- hook id: cff-readme
- exit code: 1

xargs: command line cannot be assembled, too long
```

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
