### PR TITLE
Add location to cert-manager issuance config and fix issuance config reference

### DIFF
--- a/modules/certificate-manager/main.tf
+++ b/modules/certificate-manager/main.tf
@@ -47,7 +47,7 @@ resource "google_certificate_manager_certificate" "certificates" {
     content {
       domains            = each.value.managed.domains
       dns_authorizations = each.value.managed.dns_authorizations
-      issuance_config    = each.value.managed.issuance_config
+      issuance_config    = try(google_certificate_manager_certificate_issuance_config.default[each.value.managed.issuance_config].id, null)
     }
   }
   dynamic "self_managed" {
@@ -80,6 +80,7 @@ resource "google_certificate_manager_certificate_issuance_config" "default" {
     }
   }
   lifetime                   = each.value.lifetime
+  location                   = each.value.location
   rotation_window_percentage = each.value.rotation_window_percentage
   key_algorithm              = each.value.key_algorithm
   labels                     = each.value.labels

--- a/modules/certificate-manager/variables.tf
+++ b/modules/certificate-manager/variables.tf
@@ -71,6 +71,7 @@ variable "issuance_configs" {
     key_algorithm              = string
     labels                     = optional(map(string), {})
     lifetime                   = string
+    location                   = optional(string)
     rotation_window_percentage = number
   }))
   default  = {}

--- a/tests/modules/certificate_manager/examples/map-with-managed-cert-ca-service.yaml
+++ b/tests/modules/certificate_manager/examples/map-with-managed-cert-ca-service.yaml
@@ -96,7 +96,6 @@ values:
     - dns_authorizations: null
       domains:
       - mydomain.mycompany.org
-      issuance_config: my-issuance-config
     name: my-certificate-1
     project: project-id
     scope: null


### PR DESCRIPTION
Add location to cert-manager issuance config and fix issuance config reference.

---
**Checklist**

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
