### PR TITLE
Run tests and linting when pushing to master or fast-dev

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -18,6 +18,10 @@ on:
     branches:
       - master
       - fast-dev
+  push:
+    branches:
+      - master
+      - fast-dev
 
 jobs:
   linting:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,10 @@ name: "Tests"
 on:
   # schedule:
   #   - cron: "45 2 * * *"
+  push:
+    branches:
+      - master
+      - fast-dev
   pull_request:
     branches:
       - master


### PR DESCRIPTION
Maintainers occasionally force push to these branches. This will allow tests to run without the need for a dummy PR
