### PR TITLE
Add missing role to FAST stage 0 org-level delegated IAM grants

### DIFF
--- a/fast/stages/0-bootstrap/organization.tf
+++ b/fast/stages/0-bootstrap/organization.tf
@@ -162,6 +162,7 @@ module "organization" {
                 "roles/resourcemanager.organizationViewer"
               ]))
               , join(",", formatlist("'%s'", [
+                module.organization.custom_role_id["billing_viewer"],
                 module.organization.custom_role_id["network_firewall_policies_admin"],
                 module.organization.custom_role_id["ngfw_enterprise_admin"],
                 module.organization.custom_role_id["ngfw_enterprise_viewer"],


### PR DESCRIPTION
We cannot run apply with org-level billing accounts, and this was only caught after releasing.