### PR TITLE
Add basename to SWP policy rules factory

### DIFF
--- a/modules/net-swp/policy-rules.tf
+++ b/modules/net-swp/policy-rules.tf
@@ -18,7 +18,7 @@ locals {
   _policy_rules_path = try(pathexpand(var.factories_config.policy_rules), null)
   _policy_rules = {
     for f in try(fileset(local._policy_rules_path, "**/*.yaml"), []) :
-    trimsuffix(f, ".yaml") => yamldecode(file(
+    basename(trimsuffix(f, ".yaml")) => yamldecode(file(
       "${local._policy_rules_path}/${f}"
     ))
   }


### PR DESCRIPTION
Adds basename to SWP policy rules factory

---
**Checklist**

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
