### PR TITLE
Add optional automated MD5 generation to net-vlan-attachment module

### DIFF
--- a/blueprints/networking/ha-vpn-over-interconnect/README.md
+++ b/blueprints/networking/ha-vpn-over-interconnect/README.md
@@ -171,5 +171,5 @@ module "test" {
     }
   }
 }
-# tftest modules=5 resources=39
+# tftest modules=5 resources=41
 ```

--- a/modules/net-vlan-attachment/main.tf
+++ b/modules/net-vlan-attachment/main.tf
@@ -21,6 +21,7 @@ locals {
     ? local.ipsec_enabled ? try(google_compute_router.encrypted[0].name, null) : try(google_compute_router.unencrypted[0].name, null)
     : var.router_config.name
   )
+  secret = random_id.secret.b64_url
 }
 
 resource "google_compute_address" "default" {
@@ -147,11 +148,15 @@ resource "google_compute_router_peer" "default" {
     for_each = var.router_config.md5_authentication_key != null ? [var.router_config.md5_authentication_key] : []
     content {
       name = md5_authentication_key.value.name
-      key  = md5_authentication_key.value.key
+      key  = coalesce(md5_authentication_key.value.key, local.secret)
     }
   }
 
   depends_on = [
     google_compute_router_interface.default
   ]
+}
+
+resource "random_id" "secret" {
+  byte_length = 12
 }

--- a/modules/net-vlan-attachment/outputs.tf
+++ b/modules/net-vlan-attachment/outputs.tf
@@ -24,6 +24,17 @@ output "id" {
   value       = google_compute_interconnect_attachment.default.id
 }
 
+output "md5_configuration" {
+  description = "MD5 configuration."
+  value = (
+    var.router_config.md5_authentication_key != null
+    ? {
+      name = var.router_config.md5_authentication_key.name
+      key  = coalesce(var.router_config.md5_authentication_key.key, local.secret)
+    } : {}
+  )
+}
+
 output "name" {
   description = "The name of the VLAN attachment created."
   value       = google_compute_interconnect_attachment.default.name

--- a/modules/net-vlan-attachment/variables.tf
+++ b/modules/net-vlan-attachment/variables.tf
@@ -103,7 +103,7 @@ variable "router_config" {
     }))
     md5_authentication_key = optional(object({
       name = string
-      key  = string
+      key  = optional(string)
     }))
     keepalive = optional(number)
     name      = optional(string, "router")


### PR DESCRIPTION
Add ability to automatically generate MD5 keys in VLAN attachments module.

---

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
