### PR TITLE
Add ability to autogenerate md5 keys in net-vpn-ha

### DIFF
--- a/blueprints/apigee/network-patterns/nb-glb-psc-neg-sb-psc-ilbl7-hybrid-neg/README.md
+++ b/blueprints/apigee/network-patterns/nb-glb-psc-neg-sb-psc-ilbl7-hybrid-neg/README.md
@@ -79,5 +79,5 @@ module "test" {
   onprem_project_id  = "my-onprem-project"
   hostname           = "test.myorg.org"
 }
-# tftest modules=14 resources=80
+# tftest modules=14 resources=84
 ```

--- a/blueprints/networking/private-cloud-function-from-onprem/README.md
+++ b/blueprints/networking/private-cloud-function-from-onprem/README.md
@@ -45,5 +45,5 @@ module "test" {
   }
   project_id = "test-project"
 }
-# tftest modules=11 resources=50
+# tftest modules=11 resources=54
 ```

--- a/blueprints/networking/vpc-connectivity-lab/README.md
+++ b/blueprints/networking/vpc-connectivity-lab/README.md
@@ -108,5 +108,5 @@ module "test" {
   prefix     = "fast-sr0-sbox"
 }
 
-# tftest modules=35 resources=136
+# tftest modules=35 resources=144
 ```

--- a/blueprints/serverless/cloud-run-corporate/README.md
+++ b/blueprints/serverless/cloud-run-corporate/README.md
@@ -253,7 +253,7 @@ module "test" {
   prj_onprem_id = "onprem-project-id"
 }
 
-# tftest modules=15 resources=58
+# tftest modules=15 resources=62
 ```
 
 ```hcl

--- a/modules/net-vpn-ha/README.md
+++ b/modules/net-vpn-ha/README.md
@@ -228,12 +228,13 @@ You can optionally avoid to specify MD5 keys and the module will automatically g
 | [gateway](outputs.tf#L30) | VPN gateway resource (only if auto-created). |  |
 | [id](outputs.tf#L35) | Fully qualified VPN gateway id. |  |
 | [md5_keys](outputs.tf#L42) | BGP tunnels MD5 keys. |  |
-| [name](outputs.tf#L56) | VPN gateway name (only if auto-created). |  |
-| [router](outputs.tf#L61) | Router resource (only if auto-created). |  |
-| [router_name](outputs.tf#L66) | Router name. |  |
-| [self_link](outputs.tf#L71) | HA VPN gateway self link. |  |
-| [shared_secrets](outputs.tf#L76) | IPSEC tunnels shared secrets. |  |
-| [tunnel_names](outputs.tf#L84) | VPN tunnel names. |  |
-| [tunnel_self_links](outputs.tf#L92) | VPN tunnel self links. |  |
-| [tunnels](outputs.tf#L100) | VPN tunnel resources. |  |
+| [name](outputs.tf#L53) | VPN gateway name (only if auto-created). |  |
+| [random_secret](outputs.tf#L58) | Generated secret. |  |
+| [router](outputs.tf#L63) | Router resource (only if auto-created). |  |
+| [router_name](outputs.tf#L68) | Router name. |  |
+| [self_link](outputs.tf#L73) | HA VPN gateway self link. |  |
+| [shared_secrets](outputs.tf#L78) | IPSEC tunnels shared secrets. |  |
+| [tunnel_names](outputs.tf#L86) | VPN tunnel names. |  |
+| [tunnel_self_links](outputs.tf#L94) | VPN tunnel self links. |  |
+| [tunnels](outputs.tf#L102) | VPN tunnel resources. |  |
 <!-- END TFDOC -->

--- a/modules/net-vpn-ha/README.md
+++ b/modules/net-vpn-ha/README.md
@@ -76,7 +76,7 @@ module "vpn-2" {
     }
   }
 }
-# tftest modules=2 resources=18 inventory=gcp-to-gcp.yaml
+# tftest modules=2 resources=22 inventory=gcp-to-gcp.yaml
 ```
 
 Note: When using the `for_each` meta-argument you might experience a Cycle Error due to the multiple `net-vpn-ha` modules referencing each other. To fix this you can create the [google_compute_ha_vpn_gateway](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_ha_vpn_gateway) resources separately and reference them in the `net-vpn-ha` module via the `vpn_gateway` and `peer_gcp_gateway` variables.
@@ -146,7 +146,7 @@ module "vpn_ha" {
     }
   }
 }
-# tftest modules=1 resources=10 inventory=gcp-to-onprem.yaml
+# tftest modules=1 resources=12 inventory=gcp-to-onprem.yaml
 ```
 
 ### IPv6 (dual-stack)
@@ -200,8 +200,11 @@ module "vpn_ha" {
     stack_type = "IPV4_IPV6"
   }
 }
-# tftest modules=1 resources=10 intentory=ipv6.yaml
+# tftest modules=1 resources=12 intentory=ipv6.yaml
 ```
+
+You can optionally avoid to specify MD5 keys and the module will automatically generate them for you.
+
 <!-- BEGIN TFDOC -->
 ## Variables
 

--- a/modules/net-vpn-ha/README.md
+++ b/modules/net-vpn-ha/README.md
@@ -62,7 +62,7 @@ module "vpn-2" {
         asn     = 64514
       }
       bgp_session_range     = "169.254.1.1/30"
-      shared_secret         = module.vpn-1.random_secret
+      shared_secret         = module.vpn-1.shared_secrets["remote-0"]
       vpn_gateway_interface = 0
     }
     remote-1 = {
@@ -71,7 +71,7 @@ module "vpn-2" {
         asn     = 64514
       }
       bgp_session_range     = "169.254.2.1/30"
-      shared_secret         = module.vpn-1.random_secret
+      shared_secret         = module.vpn-1.shared_secrets["remote-1"]
       vpn_gateway_interface = 1
     }
   }
@@ -204,7 +204,6 @@ module "vpn_ha" {
 ```
 
 You can optionally avoid to specify MD5 keys and the module will automatically generate them for you.
-
 <!-- BEGIN TFDOC -->
 ## Variables
 
@@ -216,7 +215,7 @@ You can optionally avoid to specify MD5 keys and the module will automatically g
 | [region](variables.tf#L53) | Region used for resources. | <code>string</code> | ✓ |  |
 | [router_config](variables.tf#L58) | Cloud Router configuration for the VPN. If you want to reuse an existing router, set create to false and use name to specify the desired router. | <code title="object&#40;&#123;&#10;  asn    &#61; number&#10;  create &#61; optional&#40;bool, true&#41;&#10;  custom_advertise &#61; optional&#40;object&#40;&#123;&#10;    all_subnets &#61; bool&#10;    ip_ranges   &#61; map&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;  keepalive     &#61; optional&#40;number&#41;&#10;  name          &#61; optional&#40;string&#41;&#10;  override_name &#61; optional&#40;string&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
 | [peer_gateways](variables.tf#L27) | Configuration of the (external or GCP) peer gateway. | <code title="map&#40;object&#40;&#123;&#10;  external &#61; optional&#40;object&#40;&#123;&#10;    redundancy_type &#61; string&#10;    interfaces      &#61; list&#40;string&#41;&#10;    description     &#61; optional&#40;string, &#34;Terraform managed external VPN gateway&#34;&#41;&#10;    name            &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;  gcp &#61; optional&#40;string&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [tunnels](variables.tf#L74) | VPN tunnel configurations. | <code title="map&#40;object&#40;&#123;&#10;  bgp_peer &#61; object&#40;&#123;&#10;    address        &#61; string&#10;    asn            &#61; number&#10;    route_priority &#61; optional&#40;number, 1000&#41;&#10;    custom_advertise &#61; optional&#40;object&#40;&#123;&#10;      all_subnets &#61; bool&#10;      ip_ranges   &#61; map&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;    md5_authentication_key &#61; optional&#40;object&#40;&#123;&#10;      name &#61; string&#10;      key  &#61; string&#10;    &#125;&#41;&#41;&#10;    ipv6 &#61; optional&#40;object&#40;&#123;&#10;      nexthop_address      &#61; optional&#40;string&#41;&#10;      peer_nexthop_address &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;    name &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#10;  bgp_session_range               &#61; string&#10;  ike_version                     &#61; optional&#40;number, 2&#41;&#10;  name                            &#61; optional&#40;string&#41;&#10;  peer_external_gateway_interface &#61; optional&#40;number&#41;&#10;  peer_router_interface_name      &#61; optional&#40;string&#41;&#10;  peer_gateway                    &#61; optional&#40;string, &#34;default&#34;&#41;&#10;  router                          &#61; optional&#40;string&#41;&#10;  shared_secret                   &#61; optional&#40;string&#41;&#10;  vpn_gateway_interface           &#61; number&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [tunnels](variables.tf#L74) | VPN tunnel configurations. | <code title="map&#40;object&#40;&#123;&#10;  bgp_peer &#61; object&#40;&#123;&#10;    address        &#61; string&#10;    asn            &#61; number&#10;    route_priority &#61; optional&#40;number, 1000&#41;&#10;    custom_advertise &#61; optional&#40;object&#40;&#123;&#10;      all_subnets &#61; bool&#10;      ip_ranges   &#61; map&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;    md5_authentication_key &#61; optional&#40;object&#40;&#123;&#10;      name &#61; string&#10;      key  &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;    ipv6 &#61; optional&#40;object&#40;&#123;&#10;      nexthop_address      &#61; optional&#40;string&#41;&#10;      peer_nexthop_address &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;    name &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#10;  bgp_session_range               &#61; string&#10;  ike_version                     &#61; optional&#40;number, 2&#41;&#10;  name                            &#61; optional&#40;string&#41;&#10;  peer_external_gateway_interface &#61; optional&#40;number&#41;&#10;  peer_router_interface_name      &#61; optional&#40;string&#41;&#10;  peer_gateway                    &#61; optional&#40;string, &#34;default&#34;&#41;&#10;  router                          &#61; optional&#40;string&#41;&#10;  shared_secret                   &#61; optional&#40;string&#41;&#10;  vpn_gateway_interface           &#61; number&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [vpn_gateway](variables.tf#L111) | HA VPN Gateway Self Link for using an existing HA VPN Gateway. Ignored if `vpn_gateway_create` is set to `true`. | <code>string</code> |  | <code>null</code> |
 | [vpn_gateway_create](variables.tf#L117) | Create HA VPN Gateway. Set to null to avoid creation. | <code title="object&#40;&#123;&#10;  description &#61; optional&#40;string, &#34;Terraform managed external VPN gateway&#34;&#41;&#10;  ipv6        &#61; optional&#40;bool, false&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 
@@ -228,12 +227,13 @@ You can optionally avoid to specify MD5 keys and the module will automatically g
 | [external_gateway](outputs.tf#L25) | External VPN gateway resource. |  |
 | [gateway](outputs.tf#L30) | VPN gateway resource (only if auto-created). |  |
 | [id](outputs.tf#L35) | Fully qualified VPN gateway id. |  |
-| [name](outputs.tf#L42) | VPN gateway name (only if auto-created). . |  |
-| [random_secret](outputs.tf#L47) | Generated secret. |  |
-| [router](outputs.tf#L52) | Router resource (only if auto-created). |  |
-| [router_name](outputs.tf#L57) | Router name. |  |
-| [self_link](outputs.tf#L62) | HA VPN gateway self link. |  |
-| [tunnel_names](outputs.tf#L67) | VPN tunnel names. |  |
-| [tunnel_self_links](outputs.tf#L75) | VPN tunnel self links. |  |
-| [tunnels](outputs.tf#L83) | VPN tunnel resources. |  |
+| [md5_keys](outputs.tf#L42) | BGP tunnels MD5 keys. |  |
+| [name](outputs.tf#L56) | VPN gateway name (only if auto-created). |  |
+| [router](outputs.tf#L61) | Router resource (only if auto-created). |  |
+| [router_name](outputs.tf#L66) | Router name. |  |
+| [self_link](outputs.tf#L71) | HA VPN gateway self link. |  |
+| [shared_secrets](outputs.tf#L76) | IPSEC tunnels shared secrets. |  |
+| [tunnel_names](outputs.tf#L84) | VPN tunnel names. |  |
+| [tunnel_self_links](outputs.tf#L92) | VPN tunnel self links. |  |
+| [tunnels](outputs.tf#L100) | VPN tunnel resources. |  |
 <!-- END TFDOC -->

--- a/modules/net-vpn-ha/main.tf
+++ b/modules/net-vpn-ha/main.tf
@@ -17,7 +17,7 @@
 
 locals {
   md5_keys = {
-    for k, v in random_id.md5_key
+    for k, v in random_id.md5_keys
     : k => v.b64_url
   }
   peer_gateways_external = {
@@ -121,7 +121,7 @@ resource "google_compute_router_peer" "bgp_peer" {
     for_each = each.value.bgp_peer.md5_authentication_key != null ? toset([each.value.bgp_peer.md5_authentication_key]) : []
     content {
       name = md5_authentication_key.value.name
-      key  = coalesce(md5_authentication_key.value.key, local.md5_key)
+      key  = coalesce(md5_authentication_key.value.key, local.md5_keys[each.key])
     }
   }
   enable_ipv6               = try(each.value.bgp_peer.ipv6, null) == null ? false : true
@@ -165,7 +165,7 @@ resource "random_id" "secret" {
   byte_length = 8
 }
 
-resource "random_id" "md5_key" {
+resource "random_id" "md5_keys" {
   for_each    = var.tunnels
   byte_length = 12
 }

--- a/modules/net-vpn-ha/main.tf
+++ b/modules/net-vpn-ha/main.tf
@@ -16,6 +16,10 @@
  */
 
 locals {
+  md5_keys = {
+    for k, v in random_id.md5_key
+    : k => v.b64_url
+  }
   peer_gateways_external = {
     for k, v in var.peer_gateways : k => v.external if v.external != null
   }
@@ -117,7 +121,7 @@ resource "google_compute_router_peer" "bgp_peer" {
     for_each = each.value.bgp_peer.md5_authentication_key != null ? toset([each.value.bgp_peer.md5_authentication_key]) : []
     content {
       name = md5_authentication_key.value.name
-      key  = md5_authentication_key.value.key
+      key  = coalesce(md5_authentication_key.value.key, local.md5_key)
     }
   }
   enable_ipv6               = try(each.value.bgp_peer.ipv6, null) == null ? false : true
@@ -159,4 +163,9 @@ resource "google_compute_vpn_tunnel" "tunnels" {
 
 resource "random_id" "secret" {
   byte_length = 8
+}
+
+resource "random_id" "md5_key" {
+  for_each    = var.tunnels
+  byte_length = 12
 }

--- a/modules/net-vpn-ha/outputs.tf
+++ b/modules/net-vpn-ha/outputs.tf
@@ -39,14 +39,25 @@ output "id" {
   )
 }
 
+output "md5_keys" {
+  description = "BGP tunnels MD5 keys."
+  value = {
+    for k, v in var.tunnels
+    : k => coalesce(md5_authentication_key.value.key, local.md5_key)
+  }
+}
+
 output "name" {
-  description = "VPN gateway name (only if auto-created). ."
+  description = "VPN gateway name (only if auto-created)."
   value       = one(google_compute_ha_vpn_gateway.ha_gateway[*].name)
 }
 
-output "random_secret" {
-  description = "Generated secret."
-  value       = local.secret
+output "shared_secrets" {
+  description = "IPSEC tunnels shared secrets."
+  value = {
+    for k, v in var.tunnels
+    : k => coalesce(each.value.shared_secret, local.secret)
+  }
 }
 
 output "router" {

--- a/modules/net-vpn-ha/outputs.tf
+++ b/modules/net-vpn-ha/outputs.tf
@@ -42,20 +42,22 @@ output "id" {
 output "md5_keys" {
   description = "BGP tunnels MD5 keys."
   value = {
-    for k, v in var.tunnels
-    : k => (
-      try(v.bgp_peer.md5_authentication_key) == null
-      ? {} : {
-        key  = coalesce(v.bgp_peer.md5_authentication_key.key, local.md5_keys[k])
-        name = v.bgp_peer.md5_authentication_key.name
-      }
-    )
+    for k, v in var.tunnels :
+    k => try(v.bgp_peer.md5_authentication_key, null) == null ? {} : {
+      key  = coalesce(v.bgp_peer.md5_authentication_key.key, local.md5_keys[k])
+      name = v.bgp_peer.md5_authentication_key.name
+    }
   }
 }
 
 output "name" {
   description = "VPN gateway name (only if auto-created)."
   value       = one(google_compute_ha_vpn_gateway.ha_gateway[*].name)
+}
+
+output "random_secret" {
+  description = "Generated secret."
+  value       = local.secret
 }
 
 output "router" {

--- a/modules/net-vpn-ha/variables.tf
+++ b/modules/net-vpn-ha/variables.tf
@@ -84,7 +84,7 @@ variable "tunnels" {
       }))
       md5_authentication_key = optional(object({
         name = string
-        key  = string
+        key  = optional(string)
       }))
       ipv6 = optional(object({
         nexthop_address      = optional(string)

--- a/tests/fast/stages/s2_networking_a_simple/simple.yaml
+++ b/tests/fast/stages/s2_networking_a_simple/simple.yaml
@@ -47,5 +47,5 @@ counts:
   google_tags_tag_binding: 3
   google_vpc_access_connector: 2
   modules: 29
-  random_id: 1
-  resources: 197
+  random_id: 3
+  resources: 199

--- a/tests/fast/stages/s2_networking_a_simple/vpn.yaml
+++ b/tests/fast/stages/s2_networking_a_simple/vpn.yaml
@@ -45,5 +45,5 @@ counts:
   google_tags_tag_binding: 3
   google_vpc_access_connector: 2
   modules: 31
-  random_id: 5
-  resources: 232
+  random_id: 17
+  resources: 244

--- a/tests/fast/stages/s2_networking_b_nva/ncc-ra.yaml
+++ b/tests/fast/stages/s2_networking_b_nva/ncc-ra.yaml
@@ -50,5 +50,5 @@ counts:
   google_tags_tag_binding: 3
   google_vpc_access_connector: 2
   modules: 39
-  random_id: 2
-  resources: 257
+  random_id: 6
+  resources: 261

--- a/tests/fast/stages/s2_networking_b_nva/regional.yaml
+++ b/tests/fast/stages/s2_networking_b_nva/regional.yaml
@@ -52,5 +52,5 @@ counts:
   google_tags_tag_binding: 3
   google_vpc_access_connector: 2
   modules: 47
-  random_id: 2
-  resources: 265
+  random_id: 6
+  resources: 269

--- a/tests/fast/stages/s2_networking_b_nva/simple.yaml
+++ b/tests/fast/stages/s2_networking_b_nva/simple.yaml
@@ -52,5 +52,5 @@ counts:
   google_tags_tag_binding: 3
   google_vpc_access_connector: 2
   modules: 43
-  random_id: 2
-  resources: 243
+  random_id: 6
+  resources: 247

--- a/tests/fast/stages/s2_networking_c_separate_envs/simple.yaml
+++ b/tests/fast/stages/s2_networking_c_separate_envs/simple.yaml
@@ -45,5 +45,5 @@ counts:
   google_tags_tag_binding: 2
   google_vpc_access_connector: 2
   modules: 22
-  random_id: 2
-  resources: 211
+  random_id: 6
+  resources: 215

--- a/tests/modules/net_vpn_ha/examples/gcp-to-gcp.yaml
+++ b/tests/modules/net_vpn_ha/examples/gcp-to-gcp.yaml
@@ -212,5 +212,5 @@ counts:
   google_compute_router_peer: 4
   google_compute_vpn_tunnel: 4
   modules: 2
-  random_id: 2
-  resources: 18
+  random_id: 6
+  resources: 22

--- a/tests/modules/net_vpn_ha/examples/gcp-to-onprem.yaml
+++ b/tests/modules/net_vpn_ha/examples/gcp-to-onprem.yaml
@@ -126,5 +126,5 @@ counts:
   google_compute_router_peer: 2
   google_compute_vpn_tunnel: 2
   modules: 1
-  random_id: 1
-  resources: 10
+  random_id: 3
+  resources: 12

--- a/tests/modules/net_vpn_ha/examples/ipv6.yaml
+++ b/tests/modules/net_vpn_ha/examples/ipv6.yaml
@@ -131,5 +131,5 @@ counts:
   google_compute_router_peer: 2
   google_compute_vpn_tunnel: 2
   modules: 1
-  random_id: 1
-  resources: 10
+  random_id: 3
+  resources: 12


### PR DESCRIPTION
- Add ability to autogenerate MD5 keys in net-vpn-ha.
- Fix VPN tunnels secret outputs

---
**Checklist**

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
