### PR TITLE
remove default location in tag value - cloud-run-v2 tags.tf

### DIFF
--- a/modules/cloud-run-v2/tags.tf
+++ b/modules/cloud-run-v2/tags.tf
@@ -17,7 +17,7 @@
 resource "google_tags_location_tag_binding" "binding" {
   for_each = var.create_job ? {} : var.tag_bindings
   parent = (
-    "//run.googleapis.com/projects/${var.project_id}/locations/europe-west1/services/${google_cloud_run_v2_service.service[0].name}"
+    "//run.googleapis.com/projects/${var.project_id}/locations/${var.region}/services/${google_cloud_run_v2_service.service[0].name}"
   )
   tag_value = each.value
   location  = var.region


### PR DESCRIPTION
Fixes: #2754

The google_tags_location_tag_binding resource has a default to europe-west1 when it should use the same region/location as the cloud-run module is configured for

Changed to use the var.region instead of europe-west1

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [ ] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [ ] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass
