### PR TITLE
Fix handling of SSL certificates in external load balancer modules

### DIFF
--- a/modules/net-lb-app-ext-regional/main.tf
+++ b/modules/net-lb-app-ext-regional/main.tf
@@ -80,7 +80,7 @@ resource "google_compute_region_target_https_proxy" "default" {
   region                           = var.region
   description                      = var.description
   certificate_manager_certificates = var.https_proxy_config.certificate_manager_certificates
-  ssl_certificates                 = local.proxy_ssl_certificates
+  ssl_certificates                 = length(local.proxy_ssl_certificates) == 0 ? null : local.proxy_ssl_certificates
   ssl_policy                       = var.https_proxy_config.ssl_policy
   url_map                          = google_compute_region_url_map.default.id
 }

--- a/modules/net-lb-app-ext/main.tf
+++ b/modules/net-lb-app-ext/main.tf
@@ -83,7 +83,7 @@ resource "google_compute_target_https_proxy" "default" {
   certificate_map                  = var.https_proxy_config.certificate_map
   certificate_manager_certificates = var.https_proxy_config.certificate_manager_certificates
   quic_override                    = var.https_proxy_config.quic_override
-  ssl_certificates                 = local.proxy_ssl_certificates
+  ssl_certificates                 = length(local.proxy_ssl_certificates) == 0 ? null : local.proxy_ssl_certificates
   ssl_policy                       = var.https_proxy_config.ssl_policy
   url_map                          = google_compute_url_map.default.id
   server_tls_policy                = var.https_proxy_config.mtls_policy

--- a/modules/net-lb-app-int/main.tf
+++ b/modules/net-lb-app-int/main.tf
@@ -108,16 +108,12 @@ resource "google_compute_region_target_http_proxy" "default" {
 }
 
 resource "google_compute_region_target_https_proxy" "default" {
-  count       = var.protocol == "HTTPS" ? 1 : 0
-  project     = var.project_id
-  region      = var.region
-  name        = var.name
-  description = var.description
-  ssl_certificates = (
-    length(local.proxy_ssl_certificates) == 0
-    ? null
-    : local.proxy_ssl_certificates
-  )
+  count                            = var.protocol == "HTTPS" ? 1 : 0
+  project                          = var.project_id
+  region                           = var.region
+  name                             = var.name
+  description                      = var.description
+  ssl_certificates                 = length(local.proxy_ssl_certificates) == 0 ? null : local.proxy_ssl_certificates
   ssl_policy                       = var.https_proxy_config.ssl_policy
   url_map                          = google_compute_region_url_map.default.id
   certificate_manager_certificates = var.https_proxy_config.certificate_manager_certificates


### PR DESCRIPTION
An empty `ssl_certificates` list will conflict with a user-defined `certificate_manager_certificates` value, so exclude it.

This was fixed in https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/pull/2764, but only for the `net-lb-app-int` module and not for the `net-lb-app-ext` or `net-lb-app-ext-regional` modules.

I'm not sure why `net-lb-app-int-cross-region` doesn't allow a user to set a value for `ssl_certificates`, but I'm going to leave it alone.

Screenshot from https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/issues/2760
![](https://private-user-images.githubusercontent.com/77838077/394778512-4325ed0b-dab1-4765-b4b1-2ecec1fa6e40.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MzQ3MjU3NzIsIm5iZiI6MTczNDcyNTQ3MiwicGF0aCI6Ii83NzgzODA3Ny8zOTQ3Nzg1MTItNDMyNWVkMGItZGFiMS00NzY1LWI0YjEtMmVjZWMxZmE2ZTQwLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDEyMjAlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQxMjIwVDIwMTExMlomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTZlNTNlYzViZDQ4MDRhOWI1MzUxODI1ZGYwODQwNWMzOWI2YzVhZTYyMWQ1NTdiODY0NjI5MmRhNzkyNzQxZjAmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.frzXg7oneJXH4XQP8YxnTUQiz00rrgPonSDtI4rCY2w)

<!-- Put a description of what this PR is for here -->

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [x] Made sure all relevant tests pass
