### PR TITLE
Make PSA connection more robust

### DIFF
--- a/modules/net-vpc/psa.tf
+++ b/modules/net-vpc/psa.tf
@@ -68,6 +68,7 @@ resource "google_service_networking_connection" "psa_connection" {
   service                 = each.key
   reserved_peering_ranges = formatlist("${each.value.key}%s", keys(each.value.ranges))
   deletion_policy         = each.value.deletion_policy
+  depends_on              = [google_compute_global_address.psa_ranges]
 }
 
 resource "google_compute_network_peering_routes_config" "psa_routes" {


### PR DESCRIPTION
Sometimes [E2E tests](https://github.com/GoogleCloudPlatform/fast-e2e/actions/runs/12500889107) fail with:
```
Error: Error waiting for Create Service Networking Connection: Error code 9, message: Allocated IP range \'servicenetworking-googleapis-com-cloud-sql\' not found in network.
```

This should prevent this (and make PSA connection creation more reliable).

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [ ] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [ ] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass
