### PR TITLE
Added BGP priority variable for dedicated interconnect because it was…

### DIFF
--- a/modules/net-vlan-attachment/README.md
+++ b/modules/net-vlan-attachment/README.md
@@ -646,19 +646,19 @@ module "example-va-b" {
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [description](variables.tf#L35) | VLAN attachment description. | <code>string</code> | ✓ |  |
-| [name](variables.tf#L52) | The common resources name, used after resource type prefix and suffix. | <code>string</code> | ✓ |  |
-| [network](variables.tf#L57) | The VPC name to which resources are associated to. | <code>string</code> | ✓ |  |
-| [peer_asn](variables.tf#L74) | The on-premises underlay router ASN. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L79) | The project id where resources are created. | <code>string</code> | ✓ |  |
-| [region](variables.tf#L84) | The region where resources are created. | <code>string</code> | ✓ |  |
-| [router_config](variables.tf#L89) | Cloud Router configuration for the VPN. If you want to reuse an existing router, set create to false and use name to specify the desired router. | <code title="object&#40;&#123;&#10;  create &#61; optional&#40;bool, true&#41;&#10;  asn    &#61; optional&#40;number, 65001&#41;&#10;  bfd &#61; optional&#40;object&#40;&#123;&#10;    min_receive_interval        &#61; optional&#40;number&#41;&#10;    min_transmit_interval       &#61; optional&#40;number&#41;&#10;    multiplier                  &#61; optional&#40;number&#41;&#10;    session_initialization_mode &#61; optional&#40;string, &#34;ACTIVE&#34;&#41;&#10;  &#125;&#41;&#41;&#10;  custom_advertise &#61; optional&#40;object&#40;&#123;&#10;    all_subnets &#61; bool&#10;    ip_ranges   &#61; map&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;  md5_authentication_key &#61; optional&#40;object&#40;&#123;&#10;    name &#61; string&#10;    key  &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;  keepalive &#61; optional&#40;number&#41;&#10;  name      &#61; optional&#40;string, &#34;router&#34;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
+| [description](variables.tf#L36) | VLAN attachment description. | <code>string</code> | ✓ |  |
+| [name](variables.tf#L53) | The common resources name, used after resource type prefix and suffix. | <code>string</code> | ✓ |  |
+| [network](variables.tf#L58) | The VPC name to which resources are associated to. | <code>string</code> | ✓ |  |
+| [peer_asn](variables.tf#L75) | The on-premises underlay router ASN. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L80) | The project id where resources are created. | <code>string</code> | ✓ |  |
+| [region](variables.tf#L85) | The region where resources are created. | <code>string</code> | ✓ |  |
+| [router_config](variables.tf#L90) | Cloud Router configuration for the VPN. If you want to reuse an existing router, set create to false and use name to specify the desired router. | <code title="object&#40;&#123;&#10;  create &#61; optional&#40;bool, true&#41;&#10;  asn    &#61; optional&#40;number, 65001&#41;&#10;  bfd &#61; optional&#40;object&#40;&#123;&#10;    min_receive_interval        &#61; optional&#40;number&#41;&#10;    min_transmit_interval       &#61; optional&#40;number&#41;&#10;    multiplier                  &#61; optional&#40;number&#41;&#10;    session_initialization_mode &#61; optional&#40;string, &#34;ACTIVE&#34;&#41;&#10;  &#125;&#41;&#41;&#10;  custom_advertise &#61; optional&#40;object&#40;&#123;&#10;    all_subnets &#61; bool&#10;    ip_ranges   &#61; map&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;  md5_authentication_key &#61; optional&#40;object&#40;&#123;&#10;    name &#61; string&#10;    key  &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;  keepalive &#61; optional&#40;number&#41;&#10;  name      &#61; optional&#40;string, &#34;router&#34;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
 | [admin_enabled](variables.tf#L17) | Whether the VLAN attachment is enabled. | <code>bool</code> |  | <code>true</code> |
-| [dedicated_interconnect_config](variables.tf#L23) | Partner interconnect configuration. | <code title="object&#40;&#123;&#10;  bandwidth    &#61; optional&#40;string, &#34;BPS_10G&#34;&#41;&#10;  bgp_range    &#61; optional&#40;string, &#34;169.254.128.0&#47;29&#34;&#41;&#10;  interconnect &#61; string&#10;  vlan_tag     &#61; string&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [ipsec_gateway_ip_ranges](variables.tf#L40) | IPSec Gateway IP Ranges. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
-| [mtu](variables.tf#L46) | The MTU associated to the VLAN attachment (1440 / 1500). | <code>number</code> |  | <code>1500</code> |
-| [partner_interconnect_config](variables.tf#L62) | Partner interconnect configuration. | <code title="object&#40;&#123;&#10;  edge_availability_domain &#61; string&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [vpn_gateways_ip_range](variables.tf#L114) | The IP range (cidr notation) to be used for the GCP VPN gateways. If null IPSec over Interconnect is not enabled. | <code>string</code> |  | <code>null</code> |
+| [dedicated_interconnect_config](variables.tf#L23) | Dedicated interconnect configuration. | <code title="object&#40;&#123;&#10;  bandwidth    &#61; optional&#40;string, &#34;BPS_10G&#34;&#41;&#10;  bgp_range    &#61; optional&#40;string&#41;&#10;  bgp_priority &#61; optional&#40;number&#41;&#10;  interconnect &#61; string&#10;  vlan_tag     &#61; string&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [ipsec_gateway_ip_ranges](variables.tf#L41) | IPSec Gateway IP Ranges. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [mtu](variables.tf#L47) | The MTU associated to the VLAN attachment (1440 / 1500). | <code>number</code> |  | <code>1500</code> |
+| [partner_interconnect_config](variables.tf#L63) | Partner interconnect configuration. | <code title="object&#40;&#123;&#10;  edge_availability_domain &#61; string&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [vpn_gateways_ip_range](variables.tf#L115) | The IP range (cidr notation) to be used for the GCP VPN gateways. If null IPSec over Interconnect is not enabled. | <code>string</code> |  | <code>null</code> |
 
 ## Outputs
 

--- a/modules/net-vlan-attachment/main.tf
+++ b/modules/net-vlan-attachment/main.tf
@@ -123,7 +123,7 @@ resource "google_compute_router_peer" "default" {
   peer_ip_address           = split("/", google_compute_interconnect_attachment.default.customer_router_ip_address)[0]
   peer_asn                  = var.peer_asn
   interface                 = google_compute_router_interface.default[0].name
-  advertised_route_priority = 100
+  advertised_route_priority = var.dedicated_interconnect_config.bgp_priority
   advertise_mode            = "CUSTOM"
 
   dynamic "advertised_ip_ranges" {

--- a/modules/net-vlan-attachment/variables.tf
+++ b/modules/net-vlan-attachment/variables.tf
@@ -21,11 +21,12 @@ variable "admin_enabled" {
 }
 
 variable "dedicated_interconnect_config" {
-  description = "Partner interconnect configuration."
+  description = "Dedicated interconnect configuration."
   type = object({
     # Possible values @ https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_interconnect_attachment#bandwidth  
     bandwidth    = optional(string, "BPS_10G")
-    bgp_range    = optional(string, "169.254.128.0/29")
+    bgp_range    = optional(string)
+    bgp_priority = optional(number)
     interconnect = string
     vlan_tag     = string
   })


### PR DESCRIPTION
Added BGP priority variable for dedicated interconnect because it was harcoded to 100 and removed default bgp range, so it can be automatically picked up if not specified

<!-- Put a description of what this PR is for here -->

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
