### PR TITLE
Allow networking stage to be disabled

### DIFF
--- a/fast/stages/1-resman/stage-2-security.tf
+++ b/fast/stages/1-resman/stage-2-security.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,10 +51,13 @@ module "sec-folder" {
       "roles/owner"                          = [module.sec-sa-rw[0].iam_email]
       "roles/resourcemanager.folderAdmin"    = [module.sec-sa-rw[0].iam_email]
       "roles/resourcemanager.projectCreator" = [module.sec-sa-rw[0].iam_email]
-      "roles/resourcemanager.tagUser"        = [module.net-sa-rw[0].iam_email]
       "roles/viewer"                         = [module.sec-sa-ro[0].iam_email]
       "roles/resourcemanager.folderViewer"   = [module.sec-sa-ro[0].iam_email]
-      "roles/resourcemanager.tagViewer"      = [module.net-sa-ro[0].iam_email]
+    },
+    # networking service accounts
+    (var.fast_stage_2.networking.enabled) != true ? {} : {
+      "roles/resourcemanager.tagUser"   = [module.net-sa-rw[0].iam_email]
+      "roles/resourcemanager.tagViewer" = [module.net-sa-ro[0].iam_email]
     },
     # project factory service accounts
     (var.fast_stage_2.project_factory.enabled) != true ? {} : {


### PR DESCRIPTION
This fix prevents
```
╷
│ Error: Invalid index
│
│   on stage-2-security.tf line 54, in module "sec-folder":
│   54:       "roles/resourcemanager.tagUser"        = [module.net-sa-rw[0].iam_email]
│     ├────────────────
│     │ module.net-sa-rw is empty tuple
│
│ The given key does not identify an element in this collection value: the collection has no elements.
╵
╷
│ Error: Invalid index
│
│   on stage-2-security.tf line 57, in module "sec-folder":
│   57:       "roles/resourcemanager.tagViewer"      = [module.net-sa-ro[0].iam_email]
│     ├────────────────
│     │ module.net-sa-ro is empty tuple
```
when 
```tfvars
fast_stage_2 = {
  networking = { enabled = false }
}
```