### PR TITLE
Refactor data catalog tag template module

### DIFF
--- a/modules/data-catalog-tag-template/README.md
+++ b/modules/data-catalog-tag-template/README.md
@@ -2,25 +2,31 @@
 
 This module allows managing [Data Catalog Tag Templates](https://cloud.google.com/data-catalog/docs/tags-and-tag-templates).
 
-## Examples
+<!-- BEGIN TOC -->
+- [Simple Tag Template](#simple-tag-template)
+- [Tag Template with IAM](#tag-template-with-iam)
+- [Factory](#factory)
+- [Variables](#variables)
+- [Outputs](#outputs)
+<!-- END TOC -->
 
-### Simple Tag Template
+## Simple Tag Template
 
 ```hcl
 module "data-catalog-tag-template" {
   source     = "./fabric/modules/data-catalog-tag-template"
   project_id = "my-project"
+  region     = "europe-west1"
   tag_templates = {
     demo_var = {
-      region       = "europe-west1"
       display_name = "Demo Tag Template"
       fields = {
         source = {
           display_name = "Source of data asset"
+          is_required  = true
           type = {
             primitive_type = "STRING"
           }
-          is_required = true
         }
       }
     }
@@ -29,124 +35,50 @@ module "data-catalog-tag-template" {
 # tftest modules=1 resources=1
 ```
 
-### Tag Template with IAM
+## Tag Template with IAM
+
+The module conforms to our standard IAM interface and implements the `iam`, `iam_bindings` and `iam_bindings_additive` variables.
 
 ```hcl
 module "data-catalog-tag-template" {
   source     = "./fabric/modules/data-catalog-tag-template"
   project_id = "my-project"
+  region     = "europe-west1"
   tag_templates = {
     demo_var = {
-      region       = "europe-west1"
       display_name = "Demo Tag Template"
+      is_required  = true
       fields = {
         source = {
           display_name = "Source of data asset"
           type = {
             primitive_type = "STRING"
           }
-          is_required = true
         }
       }
+      iam = {
+        "roles/datacatalog.tagTemplateOwner" = [
+          "group:data-governance@example.com"
+        ]
+        "roles/datacatalog.tagTemplateUser" = [
+          "group:data-product-eng@example.com"
+        ]
+      }
     }
-  }
-  iam = {
-    "roles/datacatalog.tagTemplateOwner" = ["group:data-governance@example.com"]
-    "roles/datacatalog.tagTemplateUser"  = ["group:data-product-eng@example.com"]
   }
 }
 # tftest modules=1 resources=3
 ```
 
-```hcl
-module "data-catalog-tag-template" {
-  source     = "./fabric/modules/data-catalog-tag-template"
-  project_id = var.project_id
-  tag_templates = {
-    demo_var = {
-      region       = "europe-west1"
-      display_name = "Demo Tag Template"
-      fields = {
-        source = {
-          display_name = "Source of data asset"
-          type = {
-            primitive_type = "STRING"
-          }
-          is_required = true
-        }
-      }
-    }
-  }
-  iam_bindings = {
-    admin-with-delegated_roles = {
-      role    = "roles/datacatalog.tagTemplateOwner"
-      members = ["group:data-governance@example.com"]
-      condition = {
-        title = "delegated-role-grants"
-        expression = format(
-          "api.getAttribute('iam.googleapis.com/modifiedGrantsByRole', []).hasOnly([%s])",
-          join(",", formatlist("'%s'",
-            [
-              "roles/datacatalog.tagTemplateOwner"
-            ]
-          ))
-        )
-      }
-    }
-  }
-}
-# tftest modules=1 resources=2
-```
-
-```hcl
-module "data-catalog-tag-template" {
-  source     = "./fabric/modules/data-catalog-tag-template"
-  project_id = var.project_id
-  tag_templates = {
-    demo_var = {
-      region       = "europe-west1"
-      display_name = "Demo Tag Template"
-      fields = {
-        source = {
-          display_name = "Source of data asset"
-          type = {
-            primitive_type = "STRING"
-          }
-          is_required = true
-        }
-      }
-    }
-  }
-  iam_bindings_additive = {
-    admin-with-delegated_roles = {
-      role   = "roles/datacatalog.tagTemplateOwner"
-      member = "group:data-governance@example.com"
-      condition = {
-        title = "delegated-role-grants"
-        expression = format(
-          "api.getAttribute('iam.googleapis.com/modifiedGrantsByRole', []).hasOnly([%s])",
-          join(",", formatlist("'%s'",
-            [
-              "roles/datacatalog.tagTemplateOwner"
-            ]
-          ))
-        )
-      }
-    }
-  }
-}
-# tftest modules=1 resources=2
-```
-
-### Factory
+## Factory
 
 Similarly to other modules, a rules factory (see [Resource Factories](../../blueprints/factories/)) is also included here to allow tag template management via descriptive configuration files.
 
-Factory configuration is via one optional attributes in the `factory_config_path` variable specifying the path where tag template files are stored.
+Factory configuration is done via a single optional attribute in the `factory_config_path` variable specifying the path where tag template files are stored.
 
-Factory tag templates are merged with rules declared in code, with the latter taking precedence where both use the same key.
+Factory tag templates are merged with rules declared in code, with the latter taking precedence if both use the same key.
 
-The name of the file will be used as `tag_template_id` field.
+The name of the file will be used as the `tag_template_id` field.
 
 This is an example of a simple factory:
 
@@ -154,17 +86,17 @@ This is an example of a simple factory:
 module "data-catalog-tag-template" {
   source     = "./fabric/modules/data-catalog-tag-template"
   project_id = "my-project"
+  region     = "europe-west1"
   tag_templates = {
     demo_var = {
-      region       = "europe-west1"
       display_name = "Demo Tag Template"
       fields = {
         source = {
           display_name = "Source of data asset"
+          is_required  = true
           type = {
             primitive_type = "STRING"
           }
-          is_required = true
         }
       }
     }
@@ -179,18 +111,17 @@ module "data-catalog-tag-template" {
 ```yaml
 # tftest-file id=demo_tag path=data/demo.yaml
 
-region: europe-west2
 display_name: Demo Tag Template
 fields:
   source:
       display_name: Source of data asset
+      is_required: true
       type:
         primitive_type: STRING
-      is_required: true
   pii_type:
       display_name: PII type
       type:
-        enum_type:
+        enum_type_values:
           - EMAIL
           - SOCIAL SECURITY NUMBER
           - NONE
@@ -200,17 +131,15 @@ fields:
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [project_id](variables.tf#L62) | Id of the project where Tag Templates will be created. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L26) | Id of the project where Tag Templates will be created. | <code>string</code> | ✓ |  |
+| [region](variables.tf#L31) | Default region for tag templates. | <code>string</code> | ✓ |  |
 | [factories_config](variables.tf#L17) | Paths to data files and folders that enable factory functionality. | <code title="object&#40;&#123;&#10;  tag_templates &#61; optional&#40;string&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [iam](variables.tf#L26) | IAM bindings in {ROLE => [MEMBERS]} format. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [iam_bindings](variables.tf#L32) | Authoritative IAM bindings in {KEY => {role = ROLE, members = [], condition = {}}}. Keys are arbitrary. | <code title="map&#40;object&#40;&#123;&#10;  members &#61; list&#40;string&#41;&#10;  role    &#61; string&#10;  condition &#61; optional&#40;object&#40;&#123;&#10;    expression  &#61; string&#10;    title       &#61; string&#10;    description &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [iam_bindings_additive](variables.tf#L47) | Individual additive IAM bindings. Keys are arbitrary. | <code title="map&#40;object&#40;&#123;&#10;  member &#61; string&#10;  role   &#61; string&#10;  condition &#61; optional&#40;object&#40;&#123;&#10;    expression  &#61; string&#10;    title       &#61; string&#10;    description &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [tag_templates](variables.tf#L67) | Tag templates definitions in the form {TAG_TEMPLATE_ID => TEMPLATE_DEFINITION}. | <code title="map&#40;object&#40;&#123;&#10;  display_name &#61; optional&#40;string&#41;&#10;  force_delete &#61; optional&#40;bool, false&#41;&#10;  region       &#61; string&#10;  fields &#61; map&#40;object&#40;&#123;&#10;    display_name &#61; optional&#40;string&#41;&#10;    description  &#61; optional&#40;string&#41;&#10;    type &#61; object&#40;&#123;&#10;      primitive_type &#61; optional&#40;string&#41;&#10;      enum_type &#61; optional&#40;list&#40;object&#40;&#123;&#10;        allowed_values &#61; object&#40;&#123;&#10;          display_name &#61; string&#10;        &#125;&#41;&#10;      &#125;&#41;&#41;, null&#41;&#10;    &#125;&#41;&#10;    is_required &#61; optional&#40;bool, false&#41;&#10;    order       &#61; optional&#40;number&#41;&#10;  &#125;&#41;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [tag_templates](variables.tf#L36) | Tag templates definitions in the form {TAG_TEMPLATE_ID => TEMPLATE_DEFINITION}. | <code title="map&#40;object&#40;&#123;&#10;  display_name &#61; optional&#40;string&#41;&#10;  force_delete &#61; optional&#40;bool, false&#41;&#10;  region       &#61; optional&#40;string&#41;&#10;  fields &#61; map&#40;object&#40;&#123;&#10;    display_name &#61; optional&#40;string&#41;&#10;    description  &#61; optional&#40;string&#41;&#10;    is_required  &#61; optional&#40;bool, false&#41;&#10;    order        &#61; optional&#40;number&#41;&#10;    type &#61; object&#40;&#123;&#10;      primitive_type   &#61; optional&#40;string&#41;&#10;      enum_type_values &#61; optional&#40;list&#40;string&#41;&#41;&#10;    &#125;&#41;&#10;  &#125;&#41;&#41;&#10;  iam &#61; optional&#40;map&#40;list&#40;string&#41;&#41;, &#123;&#125;&#41;&#10;  iam_bindings &#61; optional&#40;map&#40;object&#40;&#123;&#10;    members &#61; list&#40;string&#41;&#10;    role    &#61; string&#10;    condition &#61; optional&#40;object&#40;&#123;&#10;      expression  &#61; string&#10;      title       &#61; string&#10;      description &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;  iam_bindings_additive &#61; optional&#40;map&#40;object&#40;&#123;&#10;    member &#61; string&#10;    role   &#61; string&#10;    condition &#61; optional&#40;object&#40;&#123;&#10;      expression  &#61; string&#10;      title       &#61; string&#10;      description &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 
 ## Outputs
 
 | name | description | sensitive |
 |---|---|:---:|
 | [data_catalog_tag_template_ids](outputs.tf#L17) | Data catalog tag template ids. |  |
-| [data_catalog_tag_templates](outputs.tf#L22) | Data catalog tag templates. |  |
+| [data_catalog_tag_templates](outputs.tf#L25) | Data catalog tag templates. |  |
 <!-- END TFDOC -->

--- a/modules/data-catalog-tag-template/outputs.tf
+++ b/modules/data-catalog-tag-template/outputs.tf
@@ -16,10 +16,16 @@
 
 output "data_catalog_tag_template_ids" {
   description = "Data catalog tag template ids."
-  value       = { for k, v in google_data_catalog_tag_template.tag_template : v.tag_template_id => v.id }
+  value = {
+    for k, v in google_data_catalog_tag_template.default :
+    v.tag_template_id => v.id
+  }
 }
 
 output "data_catalog_tag_templates" {
   description = "Data catalog tag templates."
-  value       = { for k, v in google_data_catalog_tag_template.tag_template : v.tag_template_id => v }
+  value = {
+    for k, v in google_data_catalog_tag_template.default :
+    v.tag_template_id => v
+  }
 }

--- a/modules/data-catalog-tag-template/schemas/tag-template.schema.json
+++ b/modules/data-catalog-tag-template/schemas/tag-template.schema.json
@@ -1,0 +1,176 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Data Catalog Tag Template",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "display_name": {
+      "type": "string"
+    },
+    "force_delete": {
+      "type": "boolean",
+      "default": false
+    },
+    "region": {
+      "type": "string",
+      "required": true
+    },
+    "fields": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "display_name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "is_required": {
+          "type": "boolean",
+          "default": false
+        },
+        "order": {
+          "type": "number"
+        },
+        "type": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "primitive_type": {
+              "enum": [
+                "DOUBLE",
+                "STRING",
+                "BOOL",
+                "TIMESTAMP"
+              ]
+            },
+            "enum_type_values": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam": {
+      "$ref": "#/$defs/iam"
+    },
+    "iam_bindings": {
+      "$ref": "#/$defs/iam_bindings"
+    },
+    "iam_bindings_additive": {
+      "$ref": "#/$defs/iam_bindings_additive"
+    }
+  },
+  "$defs": {
+    "iam": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^roles/": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^(?:domain:|group:|serviceAccount:|user:|principal:|principalSet:|[a-z])"
+          }
+        }
+      }
+    },
+    "iam_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "members": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "pattern": "^(?:domain:|group:|serviceAccount:|user:|principal:|principalSet:|[a-z])"
+              }
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^roles/"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_bindings_additive": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "member": {
+              "type": "string",
+              "pattern": "^(?:domain:|group:|serviceAccount:|user:|principal:|principalSet:|[a-z])"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^roles/"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_by_principals": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^(?:domain:|group:|serviceAccount:|user:|principal:|principalSet:|[a-z])": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^roles/"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is a prerequisite for the new data foundation design, and implements support for tag-level IAM. It also refactors a few bits to improve the module interface, and adds a json schema for the factory.