### PR TITLE
Fix KMS E2E tests

### DIFF
--- a/modules/alloydb/README.md
+++ b/modules/alloydb/README.md
@@ -173,7 +173,7 @@ module "kms" {
   project_id = module.project.project_id
   keyring = {
     location = var.region
-    name     = "keyring"
+    name     = "${var.prefix}-keyring"
   }
   keys = {
     "key-regional" = {

--- a/modules/cloud-function-v1/README.md
+++ b/modules/cloud-function-v1/README.md
@@ -324,7 +324,7 @@ module "kms" {
   project_id = module.project.project_id
   keyring = {
     location = var.regions.secondary
-    name     = "keyring"
+    name     = "${var.prefix}-keyring"
   }
   keys = {
     "key-regional" = {

--- a/modules/cloud-run-v2/README.md
+++ b/modules/cloud-run-v2/README.md
@@ -277,7 +277,7 @@ module "kms" {
   project_id = module.project.project_id
   keyring = {
     location = var.region
-    name     = "keyring"
+    name     = "${var.prefix}-keyring"
   }
   keys = {
     "key-regional" = {

--- a/modules/cloudsql-instance/README.md
+++ b/modules/cloudsql-instance/README.md
@@ -176,7 +176,7 @@ module "kms" {
   project_id = module.project.project_id
   keyring = {
     location = var.region
-    name     = "keyring"
+    name     = "${var.prefix}-keyring"
   }
   keys = {
     "key-regional" = {

--- a/modules/compute-vm/README.md
+++ b/modules/compute-vm/README.md
@@ -565,7 +565,7 @@ module "kms" {
   project_id = module.project.project_id
   keyring = {
     location = var.region
-    name     = "keyring"
+    name     = "${var.prefix}-keyring"
   }
   keys = {
     "key-regional" = {

--- a/modules/dataproc/README.md
+++ b/modules/dataproc/README.md
@@ -109,7 +109,7 @@ module "kms" {
   project_id = module.project.project_id
   keyring = {
     location = var.region
-    name     = "keyring"
+    name     = "${var.prefix}-keyring"
   }
   keys = {
     "key-regional" = {

--- a/modules/gcs/README.md
+++ b/modules/gcs/README.md
@@ -47,7 +47,7 @@ module "kms" {
   project_id = var.project_id
   keyring = {
     location = "europe" # location of the KMS must match location of the bucket
-    name     = "test"
+    name     = "${var.prefix}-test"
   }
   keys = {
     bucket_key = {

--- a/modules/kms/README.md
+++ b/modules/kms/README.md
@@ -30,7 +30,7 @@ module "kms" {
   project_id = var.project_id
   keyring = {
     location = var.region
-    name     = "test-1"
+    name     = "${var.prefix}-test"
   }
   keys = {
     key-a = {
@@ -82,7 +82,7 @@ module "kms" {
   project_id = var.project_id
   keyring = {
     location = var.region
-    name     = "test-2"
+    name     = "${var.prefix}-test"
   }
   keys = {
     key-a = {
@@ -105,7 +105,7 @@ module "kms" {
   project_id = var.project_id
   keyring = {
     location = var.region
-    name     = "test-3"
+    name     = "${var.prefix}-test"
   }
   import_job = {
     id               = "my-import-job"
@@ -141,7 +141,7 @@ module "kms" {
   project_id = var.project_id
   keyring = {
     location = var.region
-    name     = "test-3"
+    name     = "${var.prefix}-test"
   }
   tag_bindings = {
     env-sandbox = module.org.tag_values["environment/sandbox"].id

--- a/modules/project/README.md
+++ b/modules/project/README.md
@@ -804,7 +804,7 @@ module "kms" {
   project_id = var.project_id # KMS is in different project to prevent dependency cycle
   keyring = {
     location = var.region
-    name     = "keyring"
+    name     = "${var.prefix}-keyring"
   }
   keys = {
     "key-regional" = {
@@ -1362,7 +1362,7 @@ module "kms" {
   project_id = var.project_id # Keys come from different project to prevent dependency cycle
   keyring = {
     location = "global"
-    name     = "keyring"
+    name     = "${var.prefix}-keyring"
   }
   keys = {
     "key-global" = {

--- a/modules/secret-manager/README.md
+++ b/modules/secret-manager/README.md
@@ -112,7 +112,7 @@ module "kms-global" {
   project_id = module.project.project_id
   keyring = {
     location = "global"
-    name     = "keyring-global"
+    name     = "${var.prefix}-keyring-global"
   }
   keys = {
     "key-global" = {
@@ -131,7 +131,7 @@ module "kms-primary-region" {
   project_id = module.project.project_id
   keyring = {
     location = var.regions.primary
-    name     = "keyring-regional"
+    name     = "${var.prefix}-keyring-regional"
   }
   keys = {
     "key-regional" = {
@@ -149,7 +149,7 @@ module "kms-secondary-region" {
   project_id = module.project.project_id
   keyring = {
     location = var.regions.secondary
-    name     = "keyring-regional"
+    name     = "${var.prefix}-keyring-regional"
   }
   keys = {
     "key-regional" = {

--- a/tests/modules/kms/examples/basic.yaml
+++ b/tests/modules/kms/examples/basic.yaml
@@ -43,7 +43,7 @@ values:
     role: roles/cloudkms.cryptoKeyEncrypterDecrypter
   module.kms.google_kms_key_ring.default[0]:
     location: europe-west8
-    name: test-1
+    name: test-test
     project: project-id
 
 counts:

--- a/tests/modules/kms/examples/import-job.yaml
+++ b/tests/modules/kms/examples/import-job.yaml
@@ -19,7 +19,7 @@ values:
     protection_level: SOFTWARE
   module.kms.google_kms_key_ring.default[0]:
     location: europe-west8
-    name: test-3
+    name: test-test
     project: project-id
 
 counts:

--- a/tests/modules/kms/examples/purpose.yaml
+++ b/tests/modules/kms/examples/purpose.yaml
@@ -21,7 +21,7 @@ values:
       protection_level: HSM
   module.kms.google_kms_key_ring.default[0]:
     location: europe-west8
-    name: test-2
+    name: test-test
     project: project-id
 
 counts:

--- a/tests/modules/project/examples/data.yaml
+++ b/tests/modules/project/examples/data.yaml
@@ -88,7 +88,7 @@ values:
     timeouts: null
   module.kms.google_kms_key_ring.default[0]:
     location: global
-    name: keyring
+    name: test-keyring
     project: project-id
     timeouts: null
   module.kms.google_kms_key_ring_iam_binding.authoritative["roles/cloudkms.cryptoKeyEncrypterDecrypter"]:

--- a/tools/create_e2e_sandbox.sh
+++ b/tools/create_e2e_sandbox.sh
@@ -38,7 +38,7 @@ mkdir -p "${DEST}" "${INFRA}"
 ln -sfT "${DIR}" "${DEST}/fabric"
 
 SETUP_MODULE="${DIR}/tests/examples_e2e/setup_module"
-cp "${SETUP_MODULE}/main.tf" "${SETUP_MODULE}/variables.tf" "${SETUP_MODULE}/e2e_tests.tfvars.tftpl" "${INFRA}"
+cp "${SETUP_MODULE}"/* "${INFRA}"
 
 cp "${DIR}/tests/examples/variables.tf" "${DEST}"
 
@@ -54,6 +54,7 @@ export | sed -e 's/^declare -x //' | grep '^TFTEST_E2E_' | sed -e 's/^TFTEST_E2E
 	terraform init
 	terraform apply -auto-approve
 	ln -sfT "${INFRA}/e2e_tests.tfvars" "${DEST}/e2e_tests.auto.tfvars"
+	echo "prefix=$(grep timestamp "${INFRA}/randomizer.auto.tfvars" | cut -d '=' -f2)" >"${DEST}/prefix.auto.tfvars"
 )
 
 touch "${DEST}/main.tf"


### PR DESCRIPTION
Add `var.prefix` to keyring names, as they are [not removed](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/kms_key_ring) on destroy. This allows retried E2E tests to complete.

Fix creation of E2E sandbox, so all necessary files are created and random `var.prefix` value is set.

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [ ] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass
