### PR TITLE
Add bucket IAM policy read

### DIFF
--- a/fast/stages/0-bootstrap/data/custom-roles/organization_admin_viewer.yaml
+++ b/fast/stages/0-bootstrap/data/custom-roles/organization_admin_viewer.yaml
@@ -31,3 +31,4 @@ includedPermissions:
   - resourcemanager.projects.get
   - resourcemanager.projects.getIamPolicy
   - resourcemanager.projects.list
+  - storage.buckets.getIamPolicy

--- a/fast/stages/1-resman/data/top-level-folders/teams.yaml
+++ b/fast/stages/1-resman/data/top-level-folders/teams.yaml
@@ -26,7 +26,16 @@ iam_by_principals:
     - roles/viewer
     - roles/resourcemanager.folderViewer
     - roles/resourcemanager.tagViewer
-
+iam_bindings:
+  pf_viewer:
+    role: organization_admin_viewer
+    members:
+      - project-factory-ro
+    condition:
+      title: project-factory-scoped
+      description: Allow to check buckets and contact policies
+      expression: |
+        resource.matchTag('${organization.id}/${tag_names.context}', 'project-factory')
 # don't create a context tag since this uses the pf tag
 is_fast_context: false
 tag_bindings:

--- a/tests/fast/stages/s1_resman/simple.yaml
+++ b/tests/fast/stages/s1_resman/simple.yaml
@@ -14,7 +14,7 @@
 
 counts:
   google_folder: 12
-  google_folder_iam_binding: 50
+  google_folder_iam_binding: 51
   google_org_policy_policy: 2
   google_organization_iam_member: 15
   google_project_iam_member: 13
@@ -29,7 +29,7 @@ counts:
   google_tags_tag_value: 12
   google_tags_tag_value_iam_binding: 4
   modules: 32
-  resources: 194
+  resources: 195
 
 outputs:
   cicd_repositories:


### PR DESCRIPTION
Allow the Project factory read only SA to retrieve buckets IAM policy for buckets created by the PF

<!-- Put a description of what this PR is for here -->

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
