### PR TITLE
port_name must be excluded when serverless NEGs are involved

### DIFF
--- a/modules/net-lb-app-ext/backend-service.tf
+++ b/modules/net-lb-app-ext/backend-service.tf
@@ -62,9 +62,11 @@ resource "google_compute_backend_service" "default" {
   ]
   load_balancing_scheme = var.use_classic_version ? "EXTERNAL" : "EXTERNAL_MANAGED"
   port_name = (
-    each.value.port_name == null
-    ? lower(each.value.protocol == null ? var.protocol : each.value.protocol)
-    : each.value.port_name
+    contains(keys(google_compute_region_network_endpoint_group.serverless), each.key)
+    ? null
+    : each.value.port_name != null
+    ? each.value.port_name
+    : lower(each.value.protocol == null ? var.protocol : each.value.protocol)
   )
   protocol = (
     each.value.protocol == null ? var.protocol : each.value.protocol


### PR DESCRIPTION
Terraform will return the following error without this fix:

> Error: Error creating BackendService: googleapi: Error 400: Invalid value for field 'resource.portName': 'https'. Port name is not supported for a backend service with Serverless network endpoint groups., invalid

<!-- Put a description of what this PR is for here -->

Test output
```
for i in net-lb-app-ext ; do
    echo "Running tests for $i\n\n"
    pytest -k "modules and $i: and not e2e"
    ./tools/tfdoc.py modules/$i
done
Running tests for net-lb-app-ext


========================================================================= test session starts =========================================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/srodriguez/code/github/googlecloudplatform/cloud-foundation-fabric
plugins: xdist-3.6.1
collected 1037 items / 1016 deselected / 21 selected

tests/examples/test_plan.py .....................                                                                                                               [100%]

=========================================================== 21 passed, 1016 deselected in 236.40s (0:03:56) ===========================================================
```

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [x] Made sure all relevant tests pass

<!--
Uncomment and complete the upgrade notes section below (if applicable), following the examples provided.
-->

<!--
** Upgrade Notes **

```upgrade-note
fast/stages/0-boostrap: example upgrade note 1.
```
```upgrade-note
modules/project: example upgrade note 2.
```
-->
