### PR TITLE
Add mixer to FAST project template

### DIFF
--- a/fast/project-templates/mixer/README.md
+++ b/fast/project-templates/mixer/README.md
@@ -1,0 +1,37 @@
+# Mixer
+
+Mixer is a collection of ready to use (and customize) recipes to create platform blueprints.
+Mixer enables well known scenarios in the area of AI, data and application modernization.
+
+## How to use
+
+- Setup a project with [project factory]() (optional)
+Create a project using the `*-prj.yaml` recipe in the `recipes` folder. If you don't
+execute this step we expect you to have a project already setup with the same
+characteristics, service accounts, permissions as described in the recipe.
+
+- Setup platform components for your recipe
+
+```shell
+terraform init
+
+terraform apply -var recipe_file=ai-agent-conversational.yaml
+```
+
+## Contribute
+
+You can either add a new recipe based on existing comopnents already integrated
+in mixer, or integrate new components before writing new recipes.
+
+To add new components:
+- create a .tf file in the main folder for the product you want to integrate.
+Similarly to other files, make sure it can either read a yaml file or a variable
+from tfvars
+
+To add a recipe:
+
+- drop a new .yaml receipe file in the receipes folder. You can inspect yaml
+defaults in each product tf file in the main folder.
+- drop another .yaml receipt name as aboved with the prefix `-prj` in the recipes
+folder. This file should be passed to project factory to optionally create the
+project and the "system-level" prerequisites (enable APIs, SA, permissions, ...)

--- a/fast/project-templates/mixer/ai-agent-builder-chat-engine.tf
+++ b/fast/project-templates/mixer/ai-agent-builder-chat-engine.tf
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  # chat engine yaml defaults
+  agent_builder_chat_engines = coalesce({
+    for k, v in local.app.agent_builder.chat_engines : k => {
+      engine_id         = k
+      collection_id     = lookup(v, "collection_id", "default_collection")
+      location          = lookup(v, "location", "eu")
+      display_name      = lookup(v, "display_name", "sample chat engine")
+      industry_vertical = lookup(v, "industry_vertical", "GENERIC")
+      data_store_ids    = lookup(v, "data_store_ids", [])
+
+      common_config = lookup(v, "common_config", null) == null ? null : {
+        company_name = lookup(v, "company_name", null)
+      }
+
+      chat_engine_config = (
+        try(v.chat_engine_config.dialogflow_agent_to_link, null) == null ? {
+          dialogflow_agent_to_link = null
+          agent_creation_config = {
+            business              = try(v.chat_engine_config.agent_creation_config.business, null)
+            default_language_code = try(v.chat_engine_config.agent_creation_config.default_language_code, "en")
+            time_zone             = try(v.chat_engine_config.agent_creation_config.time_zone, "Europe/London")
+            location              = try(v.chat_engine_config.agent_creation_config.location, null)
+          }
+          } : {
+          agent_creation_config    = null
+          dialogflow_agent_to_link = v.chat_engine_config.dialogflow_agent_to_link
+        }
+      )
+    }
+  }, try(var.agent_builder.chat_engines, null))
+}
+
+resource "google_discovery_engine_chat_engine" "chat_engines" {
+  for_each          = local.agent_builder_chat_engines
+  engine_id         = each.key
+  project           = var.project_id
+  collection_id     = each.value.collection_id
+  location          = each.value.location
+  display_name      = each.value.display_name
+  industry_vertical = each.value.industry_vertical
+  data_store_ids = ([
+    for data_store_id in each.value.data_store_ids
+    : try(
+      google_discovery_engine_data_store.data_stores[data_store_id].data_store_id,
+      data_store_id
+    )
+  ])
+
+  dynamic "common_config" {
+    for_each = each.value.common_config == null ? [] : [""]
+    content {
+      company_name = each.value.common_config.company_name
+    }
+  }
+
+  chat_engine_config {
+    dialogflow_agent_to_link = each.value.chat_engine_config.dialogflow_agent_to_link
+    dynamic "agent_creation_config" {
+      for_each = each.value.chat_engine_config.agent_creation_config == null ? [] : [""]
+      content {
+        business              = each.value.chat_engine_config.agent_creation_config.business
+        default_language_code = each.value.chat_engine_config.agent_creation_config.default_language_code
+        location              = each.value.chat_engine_config.agent_creation_config.location
+        time_zone             = each.value.chat_engine_config.agent_creation_config.time_zone
+      }
+    }
+  }
+}

--- a/fast/project-templates/mixer/ai-agent-builder-datastore.tf
+++ b/fast/project-templates/mixer/ai-agent-builder-datastore.tf
@@ -1,0 +1,174 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  # data stores yaml defaults
+  agent_builder_data_stores = coalesce({
+    for k, v in local.app.agent_builder.data_stores : k => {
+      data_store_id                = k
+      display_name                 = lookup(v, "display_name", "sample data store")
+      location                     = lookup(v, "location", "eu")
+      industry_vertical            = lookup(v, "industry_vertical", "GENERIC")
+      content_config               = lookup(v, "content_config", "NO_CONTENT")
+      solution_types               = lookup(v, "solution_types", ["SOLUTION_TYPE_CHAT"])
+      create_advanced_site_search  = lookup(v, "create_advanced_site_search", false)
+      skip_default_schema_creation = lookup(v, "skip_default_schema_creation", false)
+      advanced_site_search_config = (
+        lookup(v, "advanced_site_search_config", null) == null
+        ? null
+        : {
+          disable_automatic_refresh = lookup(
+            v.advanced_site_search_config, "disable_automatic_refresh",
+            false
+          )
+          disable_initial_index = lookup(
+            v.advanced_site_search_config, "disable_initial_index",
+            false
+          )
+        }
+      )
+      document_processing_config = (
+        lookup(v, "document_processing_config", null) == null
+        ? null
+        : {
+          chunking_config = (
+            lookup(v.document_processing_config, "chunking_config", null) == null
+            ? null
+            : {
+              chunk_size                = lookup(v.document_processing_config.chunking_config, "chunk_size", 500)
+              include_ancestor_headings = lookup(v.document_processing_config.chunking_config, "include_ancestor_headings", false)
+            }
+          )
+          default_parsing_config = (
+            lookup(v.document_processing_config, "default_parsing_config", null) == null
+            ? null
+            : {
+              digital_parsing_config = lookup(v.document_processing_config.default_parsing_config, "digital_parsing_config", false)
+              layout_parsing_config  = lookup(v.document_processing_config.default_parsing_config, "layout_parsing_config", false)
+              ocr_parsing_config = (
+                lookup(v.document_processing_config.default_parsing_config, "ocr_parsing_config", null) == null
+                ? null
+                : {
+                  use_native_text = lookup(v.document_processing_config.default_parsing_config.ocr_parsing_config, "use_native_text", false)
+                }
+              )
+            }
+          )
+          parsing_config_overrides = (
+            lookup(v.document_processing_config, "parsing_config_overrides", null) == null
+            ? null
+            : [
+              for override_rule in v.document_processing_config.parsing_config_overrides : {
+                digital_parsing_config = lookup(v.document_processing_config.parsing_config_overrides, "digital_parsing_config", false)
+                file_type              = lookup(v.document_processing_config.parsing_config_overrides, "digital_parsing_config", "pdf")
+                layout_parsing_config  = lookup(v.document_processing_config.parsing_config_overrides, "layout_parsing_config", false)
+                ocr_parsing_config = (
+                  lookup(v.document_processing_config.parsing_config_overrides, "ocr_parsing_config", null) == null
+                  ? null
+                  : {
+                    use_native_text = lookup(v.document_processing_config.parsing_config_overrides.ocr_parsing_config, "use_native_text", false)
+                  }
+                )
+              }
+            ]
+          )
+        }
+      )
+    }
+  }, try(var.agent_builder.data_stores, null))
+}
+
+resource "google_discovery_engine_data_store" "data_stores" {
+  for_each                     = local.agent_builder_data_stores
+  data_store_id                = each.key
+  display_name                 = each.value.display_name
+  project                      = var.project_id
+  location                     = each.value.location
+  industry_vertical            = each.value.industry_vertical
+  content_config               = each.value.content_config
+  solution_types               = each.value.solution_types
+  create_advanced_site_search  = each.value.create_advanced_site_search
+  skip_default_schema_creation = each.value.skip_default_schema_creation
+
+  dynamic "advanced_site_search_config" {
+    for_each = each.value.advanced_site_search_config == null ? [] : [""]
+    content {
+      disable_automatic_refresh = (
+        each.value.advanced_site_search_config.disable_automatic_refresh
+      )
+      disable_initial_index = (
+        each.value.advanced_site_search_config.disable_initial_index
+      )
+    }
+  }
+
+  dynamic "document_processing_config" {
+    for_each = each.value.document_processing_config == null ? [] : [""]
+    content {
+      dynamic "chunking_config" {
+        for_each = try(each.value.document_processing_config.chunking_config, null) == null ? [] : [""]
+        content {
+          dynamic "layout_based_chunking_config" {
+            for_each = each.value.document_processing_config.chunking_config.layout_based_chunking_config == null ? [] : [""]
+            content {
+              chunk_size                = each.value.document_processing_config.chunking_config.layout_based_chunking_config.chunk_size
+              include_ancestor_headings = each.value.document_processing_config.chunking_config.layout_based_chunking_config.include_ancestor_headings
+            }
+          }
+        }
+      }
+      dynamic "default_parsing_config" {
+        for_each = try(each.value.document_processing_config.default_parsing_config, null) == null ? [] : [""]
+        content {
+          dynamic "digital_parsing_config" {
+            for_each = each.value.document_processing_config.default_parsing_config.digital_parsing_config == null ? [] : [""]
+            content {}
+          }
+          dynamic "layout_parsing_config" {
+            for_each = each.value.document_processing_config.default_parsing_config.layout_parsing_config == null ? [] : [""]
+            content {}
+          }
+          dynamic "ocr_parsing_config" {
+            for_each = each.value.document_processing_config.default_parsing_config.ocr_parsing_config == null ? [] : [""]
+            content {
+              use_native_text = each.value.document_processing_config.default_parsing_config.ocr_parsing_config.use_native_text
+            }
+          }
+        }
+      }
+      dynamic "parsing_config_overrides" {
+        for_each = try(each.value.document_processing_config.parsing_config_overrides, [])
+        content {
+          file_type = each.value.document_processing_config.parsing_config_overrides.file_type
+          dynamic "digital_parsing_config" {
+            for_each = each.value.document_processing_config.parsing_config_overrides.digital_parsing_config == null ? [] : [""]
+            content {}
+          }
+          dynamic "layout_parsing_config" {
+            for_each = each.value.document_processing_config.parsing_config_overrides.layout_parsing_config == null ? [] : [""]
+            content {}
+          }
+          dynamic "ocr_parsing_config" {
+            for_each = each.value.document_processing_config.parsing_config_overrides.ocr_parsing_config == null ? [] : [""]
+            content {
+              use_native_text = each.value.document_processing_config.parsing_config_overrides.ocr_parsing_config.use_native_text
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/fast/project-templates/mixer/main.tf
+++ b/fast/project-templates/mixer/main.tf
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  app = yamldecode(file(pathexpand("${var.recipes_path}/${var.recipe_file}")))
+}
+
+provider "google" {
+  user_project_override = true
+}

--- a/fast/project-templates/mixer/recipes/ai-agent-conversational-prj.yaml
+++ b/fast/project-templates/mixer/recipes/ai-agent-conversational-prj.yaml
@@ -1,0 +1,22 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# yaml-language-server: $schema=../../stages/2-project-factory/schemas/project.schema.json
+
+# TODO: edit and uncomment the following line to create the project in a folder
+# parent: shared
+
+name: ai-agent-cnv-0
+services:
+  - discoveryengine.googleapis.com

--- a/fast/project-templates/mixer/recipes/ai-agent-conversational.yaml
+++ b/fast/project-templates/mixer/recipes/ai-agent-conversational.yaml
@@ -1,0 +1,10 @@
+# abilita discoveryengine.googleapis.com
+# permessi per creare agent builder? permessi service account agent builder?
+
+agent_builder:
+  chat_engines:
+    chat_engine_0:
+      data_store_ids:
+        - data_store_0
+  data_stores:
+    data_store_0: {}

--- a/fast/project-templates/mixer/variables-ai-agent-builder.tf
+++ b/fast/project-templates/mixer/variables-ai-agent-builder.tf
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "agent_builder" {
+  type = object({
+    chat_engines = map(object({
+      collection_id     = optional(string, "default_collection")
+      location          = optional(string, "eu")
+      display_name      = optional(string, "sample chat engine")
+      industry_vertical = optional(string, "GENERIC")
+      data_store_ids    = optional(list(string), [])
+      common_config = optional(object({
+        company_name = optional(string)
+      }))
+      chat_engine_config = optional(object({
+        dialogflow_agent_to_link = optional(string)
+        agent_creation_config = optional(object({
+          business              = optional(string)
+          default_language_code = optional(string, "en")
+          time_zone             = optional(string, "Europe/London")
+          location              = optional(string)
+        }))
+      }))
+    }))
+    data_stores = map(object({
+      content_config               = optional(string, "NO_CONTENT")
+      create_advanced_site_search  = optional(bool, false)
+      display_name                 = optional(string, "sample data store")
+      industry_vertical            = optional(string, "GENERIC")
+      location                     = optional(string, "eu")
+      solution_types               = optional(list(string), ["SOLUTION_TYPE_CHAT"])
+      skip_default_schema_creation = optional(bool, false)
+      advanced_site_search_config = optional(object({
+        disable_automatic_refresh = optional(bool, false)
+        disable_initial_index     = optional(bool, false)
+      }))
+      document_processing_config = optional(object({
+        chunking_config = optional(object({
+          chunk_size                = optional(number, 500)
+          include_ancestor_headings = optional(bool, false)
+        }))
+        default_parsing_config = optional(object({
+          digital_parsing_config = optional(bool, false)
+          layout_parsing_config  = optional(bool, false)
+          ocr_parsing_config = optional(object({
+            use_native_text = optional(bool, false)
+          }))
+        }))
+        defaultparsing_config_overrides = optional(object({
+          digital_parsing_config = optional(bool, false)
+          file_type              = optional(string, "pdf")
+          layout_parsing_config  = optional(bool, false)
+          ocr_parsing_config = optional(object({
+            use_native_text = optional(bool, false)
+          }))
+        }))
+      }))
+    }))
+  })
+  default = null
+}

--- a/fast/project-templates/mixer/variables.tf
+++ b/fast/project-templates/mixer/variables.tf
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "recipes_path" {
+  description = "The path to the recipe yaml file."
+  default     = "./recipes"
+}
+
+variable "recipe_file" {
+  description = "The path to the recipe yaml file."
+  default     = "app.yaml"
+}
+
+variable "project_id" {
+  description = "Project ID."
+  type        = string
+}


### PR DESCRIPTION
Adding mixer to FAST project template. Mixer allows user to bring up ai/data/application blueprints using yaml and following best practices.

---
**Checklist**

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass

** Upgrade Notes **

```upgrade-note
fast/project-template: Adds mixer to create templates for applications deployment
```