### PR TITLE
Remove Service Account key generation

### DIFF
--- a/blueprints/cloud-operations/vm-migration/host-target-projects/README.md
+++ b/blueprints/cloud-operations/vm-migration/host-target-projects/README.md
@@ -60,5 +60,5 @@ module "test-target-project" {
   project_create  = true
 }
 
-# tftest modules=5 resources=28
+# tftest modules=5 resources=27
 ```

--- a/blueprints/cloud-operations/vm-migration/host-target-projects/main.tf
+++ b/blueprints/cloud-operations/vm-migration/host-target-projects/main.tf
@@ -55,10 +55,9 @@ module "host-project" {
 }
 
 module "m4ce-service-account" {
-  source       = "../../../../modules/iam-service-account"
-  project_id   = module.host-project.project_id
-  name         = "m4ce-sa"
-  generate_key = true
+  source     = "../../../../modules/iam-service-account"
+  project_id = module.host-project.project_id
+  name       = "m4ce-sa"
 }
 
 module "target-projects" {

--- a/blueprints/cloud-operations/vm-migration/single-project/README.md
+++ b/blueprints/cloud-operations/vm-migration/single-project/README.md
@@ -49,5 +49,5 @@ module "test" {
   migration_admin  = "user:admin@example.com"
   migration_viewer = "user:viewer@example.com"
 }
-# tftest modules=5 resources=27
+# tftest modules=5 resources=26
 ```

--- a/blueprints/cloud-operations/vm-migration/single-project/main.tf
+++ b/blueprints/cloud-operations/vm-migration/single-project/main.tf
@@ -55,10 +55,9 @@ module "landing-project" {
 }
 
 module "m4ce-service-account" {
-  source       = "../../../../modules/iam-service-account"
-  project_id   = module.landing-project.project_id
-  name         = "m4ce-sa"
-  generate_key = true
+  source     = "../../../../modules/iam-service-account"
+  project_id = module.landing-project.project_id
+  name       = "m4ce-sa"
 }
 
 module "landing-vpc" {

--- a/modules/iam-service-account/README.md
+++ b/modules/iam-service-account/README.md
@@ -2,9 +2,7 @@
 
 This module allows simplified creation and management of one a service account and its IAM bindings.
 
-A key can optionally be generated and will be stored in Terraform state. To use it create a sensitive output in your root modules referencing the `key` output, then extract the private key from the JSON formatted outputs.
-
-Alternatively, the `key` can be generated with `openssl` library and only the public part uploaded to the Service Account, for more refer to the [Onprem SA Key Management](../../blueprints/cloud-operations/onprem-sa-key-management/) example.
+The Service Account `key` can be generated with `openssl` library and only the public part uploaded to the Service Account, for more refer to the [Onprem SA Key Management](../../blueprints/cloud-operations/onprem-sa-key-management/) example.
 
 Note that outputs have no dependencies on IAM bindings to prevent resource cycles.
 
@@ -45,23 +43,22 @@ module "myproject-default-service-accounts" {
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [name](variables.tf#L114) | Name of the service account to create. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L129) | Project id where service account will be created. | <code>string</code> | ✓ |  |
+| [name](variables.tf#L108) | Name of the service account to create. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L123) | Project id where service account will be created. | <code>string</code> | ✓ |  |
 | [description](variables.tf#L17) | Optional description. | <code>string</code> |  | <code>null</code> |
 | [display_name](variables.tf#L23) | Display name of the service account to create. | <code>string</code> |  | <code>&#34;Terraform-managed.&#34;</code> |
-| [generate_key](variables.tf#L29) | Generate a key for service account. | <code>bool</code> |  | <code>false</code> |
-| [iam](variables.tf#L35) | IAM bindings on the service account in {ROLE => [MEMBERS]} format. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [iam_billing_roles](variables.tf#L42) | Billing account roles granted to this service account, by billing account id. Non-authoritative. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [iam_bindings](variables.tf#L49) | Authoritative IAM bindings in {KEY => {role = ROLE, members = [], condition = {}}}. Keys are arbitrary. | <code title="map&#40;object&#40;&#123;&#10;  members &#61; list&#40;string&#41;&#10;  role    &#61; string&#10;  condition &#61; optional&#40;object&#40;&#123;&#10;    expression  &#61; string&#10;    title       &#61; string&#10;    description &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [iam_bindings_additive](variables.tf#L64) | Individual additive IAM bindings on the service account. Keys are arbitrary. | <code title="map&#40;object&#40;&#123;&#10;  member &#61; string&#10;  role   &#61; string&#10;  condition &#61; optional&#40;object&#40;&#123;&#10;    expression  &#61; string&#10;    title       &#61; string&#10;    description &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [iam_folder_roles](variables.tf#L79) | Folder roles granted to this service account, by folder id. Non-authoritative. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [iam_organization_roles](variables.tf#L86) | Organization roles granted to this service account, by organization id. Non-authoritative. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [iam_project_roles](variables.tf#L93) | Project roles granted to this service account, by project id. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [iam_sa_roles](variables.tf#L100) | Service account roles granted to this service account, by service account name. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [iam_storage_roles](variables.tf#L107) | Storage roles granted to this service account, by bucket name. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [prefix](variables.tf#L119) | Prefix applied to service account names. | <code>string</code> |  | <code>null</code> |
-| [public_keys_directory](variables.tf#L134) | Path to public keys data files to upload to the service account (should have `.pem` extension). | <code>string</code> |  | <code>&#34;&#34;</code> |
-| [service_account_create](variables.tf#L140) | Create service account. When set to false, uses a data source to reference an existing service account. | <code>bool</code> |  | <code>true</code> |
+| [iam](variables.tf#L29) | IAM bindings on the service account in {ROLE => [MEMBERS]} format. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [iam_billing_roles](variables.tf#L36) | Billing account roles granted to this service account, by billing account id. Non-authoritative. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [iam_bindings](variables.tf#L43) | Authoritative IAM bindings in {KEY => {role = ROLE, members = [], condition = {}}}. Keys are arbitrary. | <code title="map&#40;object&#40;&#123;&#10;  members &#61; list&#40;string&#41;&#10;  role    &#61; string&#10;  condition &#61; optional&#40;object&#40;&#123;&#10;    expression  &#61; string&#10;    title       &#61; string&#10;    description &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [iam_bindings_additive](variables.tf#L58) | Individual additive IAM bindings on the service account. Keys are arbitrary. | <code title="map&#40;object&#40;&#123;&#10;  member &#61; string&#10;  role   &#61; string&#10;  condition &#61; optional&#40;object&#40;&#123;&#10;    expression  &#61; string&#10;    title       &#61; string&#10;    description &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [iam_folder_roles](variables.tf#L73) | Folder roles granted to this service account, by folder id. Non-authoritative. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [iam_organization_roles](variables.tf#L80) | Organization roles granted to this service account, by organization id. Non-authoritative. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [iam_project_roles](variables.tf#L87) | Project roles granted to this service account, by project id. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [iam_sa_roles](variables.tf#L94) | Service account roles granted to this service account, by service account name. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [iam_storage_roles](variables.tf#L101) | Storage roles granted to this service account, by bucket name. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [prefix](variables.tf#L113) | Prefix applied to service account names. | <code>string</code> |  | <code>null</code> |
+| [public_keys_directory](variables.tf#L128) | Path to public keys data files to upload to the service account (should have `.pem` extension). | <code>string</code> |  | <code>&#34;&#34;</code> |
+| [service_account_create](variables.tf#L134) | Create service account. When set to false, uses a data source to reference an existing service account. | <code>bool</code> |  | <code>true</code> |
 
 ## Outputs
 
@@ -70,8 +67,7 @@ module "myproject-default-service-accounts" {
 | [email](outputs.tf#L17) | Service account email. |  |
 | [iam_email](outputs.tf#L25) | IAM-format service account email. |  |
 | [id](outputs.tf#L33) | Fully qualified service account id. |  |
-| [key](outputs.tf#L41) | Service account key. | ✓ |
-| [name](outputs.tf#L47) | Service account name. |  |
-| [service_account](outputs.tf#L55) | Service account resource. |  |
-| [service_account_credentials](outputs.tf#L60) | Service account json credential templates for uploaded public keys data. |  |
+| [name](outputs.tf#L41) | Service account name. |  |
+| [service_account](outputs.tf#L49) | Service account resource. |  |
+| [service_account_credentials](outputs.tf#L54) | Service account json credential templates for uploaded public keys data. |  |
 <!-- END TFDOC -->

--- a/modules/iam-service-account/main.tf
+++ b/modules/iam-service-account/main.tf
@@ -15,12 +15,6 @@
  */
 
 locals {
-  # https://github.com/hashicorp/terraform/issues/22405#issuecomment-591917758
-  key = try(
-    var.generate_key
-    ? google_service_account_key.key["1"]
-    : map("", null)
-  , {})
   name                  = split("@", var.name)[0]
   prefix                = var.prefix == null ? "" : "${var.prefix}-"
   resource_email_static = "${local.prefix}${local.name}@${var.project_id}.iam.gserviceaccount.com"
@@ -74,11 +68,6 @@ resource "google_service_account" "service_account" {
   account_id   = "${local.prefix}${local.name}"
   display_name = var.display_name
   description  = var.description
-}
-
-resource "google_service_account_key" "key" {
-  for_each           = var.generate_key ? { 1 = 1 } : {}
-  service_account_id = local.service_account.email
 }
 
 resource "google_service_account_key" "upload_key" {

--- a/modules/iam-service-account/outputs.tf
+++ b/modules/iam-service-account/outputs.tf
@@ -38,12 +38,6 @@ output "id" {
   ]
 }
 
-output "key" {
-  description = "Service account key."
-  sensitive   = true
-  value       = local.key
-}
-
 output "name" {
   description = "Service account name."
   value       = local.service_account_id_static

--- a/modules/iam-service-account/variables.tf
+++ b/modules/iam-service-account/variables.tf
@@ -26,12 +26,6 @@ variable "display_name" {
   default     = "Terraform-managed."
 }
 
-variable "generate_key" {
-  description = "Generate a key for service account."
-  type        = bool
-  default     = false
-}
-
 variable "iam" {
   description = "IAM bindings on the service account in {ROLE => [MEMBERS]} format."
   type        = map(list(string))


### PR DESCRIPTION
Remove Service Account key generation functionality as it stores the generated key in state. Users wanting to use this functionality, it is possible by adding `google_service_account_key` referring service account email.


---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [ ] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [ ] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass

<!--
Uncomment and complete the upgrade notes section below (if applicable), following the examples provided.
-->

** Upgrade Notes **

```upgrade-note
modules/iam-service-account: Removed service account key generation functionality
```
