### PR TITLE
output dns_keys instead of a list

### DIFF
--- a/modules/dns/outputs.tf
+++ b/modules/dns/outputs.tf
@@ -16,7 +16,7 @@
 
 output "dns_keys" {
   description = "DNSKEY and DS records of DNSSEC-signed managed zones."
-  value       = try(data.google_dns_keys.dns_keys.0, null)
+  value       = try(data.google_dns_keys.dns_keys[0], null)
 }
 
 output "domain" {

--- a/modules/dns/outputs.tf
+++ b/modules/dns/outputs.tf
@@ -16,7 +16,7 @@
 
 output "dns_keys" {
   description = "DNSKEY and DS records of DNSSEC-signed managed zones."
-  value       = try(data.google_dns_keys.dns_keys, null)
+  value       = try(data.google_dns_keys.dns_keys.0, null)
 }
 
 output "domain" {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here -->
 #1728 introduced a `count` for the `google_dns_keys.dns_keys` data source, but the corresponding output was not updated accordingly.

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [x] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
-->
