### PR TITLE
Add error messages for failing interpolations

### DIFF
--- a/modules/project-factory/main.tf
+++ b/modules/project-factory/main.tf
@@ -113,8 +113,8 @@ module "projects-iam" {
         module.service-accounts[vv].iam_email,
         # other automation service account
         local.context.iam_principals[vv],
-        # passthrough
-        vv
+        # passthrough + error handling using tonumber until Terraform gets fail/raise function
+        strcontains(vv, ":") ? vv : tonumber("[Error] Invalid member: '${vv}' in project '${each.key}'")
       )
     ]
   }
@@ -130,8 +130,8 @@ module "projects-iam" {
           module.service-accounts[vv].iam_email,
           # other automation service account
           local.context.iam_principals[vv],
-          # passthrough
-          vv
+          # passthrough + error handling using tonumber until Terraform gets fail/raise function
+          strcontains(vv, ":") ? vv : tonumber("[Error] Invalid member: '${vv}' in project '${each.key}'")
         )
       ]
     })
@@ -147,8 +147,8 @@ module "projects-iam" {
         module.service-accounts[v.member].iam_email,
         # other automation service account
         local.context.iam_principals[v.member],
-        # passthrough
-        v.member
+        # passthrough + error handling using tonumber until Terraform gets fail/raise function
+        strcontains(v.member, ":") ? v.member : tonumber("[Error] Invalid member: '${v.member}' in project '${each.key}'")
       )
     })
   }
@@ -179,8 +179,8 @@ module "projects-iam" {
           module.service-accounts[v].iam_email,
           # other automation service account
           local.context.iam_principals[v],
-          # passthrough
-          v
+          # passthrough + error handling using tonumber until Terraform gets fail/raise function
+          strcontains(v, ":") ? v : tonumber("[Error] Invalid member: '${v}' in project '${each.key}'")
         )
       ]
       # TODO: network subnet users
@@ -212,8 +212,8 @@ module "buckets" {
         module.service-accounts[vv].iam_email,
         # other automation service account
         local.context.iam_principals[vv],
-        # passthrough
-        vv
+        # passthrough + error handling using tonumber until Terraform gets fail/raise function
+        strcontains(vv, ":") ? vv : tonumber("[Error] Invalid member: '${vv}' for bucket '${each.key}' in project '${each.value.project}'")
       )
     ]
   }
@@ -229,8 +229,8 @@ module "buckets" {
           module.service-accounts[vv].iam_email,
           # other automation service account
           local.context.iam_principals[vv],
-          # passthrough
-          vv
+          # passthrough + error handling using tonumber until Terraform gets fail/raise function
+          strcontains(vv, ":") ? vv : tonumber("[Error] Invalid member: '${vv}' for bucket '${each.key}' in project '${each.value.project}'")
         )
       ]
     })
@@ -246,8 +246,8 @@ module "buckets" {
         module.service-accounts[v.member].iam_email,
         # other automation service account
         local.context.iam_principals[v.member],
-        # passthrough
-        v.member
+        # passthrough + error handling using tonumber until Terraform gets fail/raise function
+        strcontains(v.member, ":") ? v.member : tonumber("[Error] Invalid member: '${v.member}' for bucket '${each.key}' in project '${each.value.project}'")
       )
     })
   }


### PR DESCRIPTION
Currently, failed interpolations fail with the error message like this:
```
Error: invalid value for member (IAM members must have one of the values outlined here: https://cloud.google.com/billing/docs/reference/rest/v1/Policy#Binding)

  with module.projects-iam["service1"].google_project_iam_member.shared_vpc_host_iam["rw"],
  on ../project/shared-vpc.tf line 131, in resource "google_project_iam_member" "shared_vpc_host_iam":
 131:   member     = each.value
```

This is not helpful, when looking for a source of the issue. With this PR, error messages look like this:
```
Error: Error in function call

  on main.tf line 173, in module "projects-iam":
 173:         try(
 174:           # project service accounts
 175:           module.service-accounts["${each.key}/${v}"].iam_email,
 176:           # automation service account
 177:           local.context.iam_principals["${each.key}/${v}"],
 178:           # other projects service accounts
 179:           module.service-accounts[v].iam_email,
 180:           # other automation service account
 181:           local.context.iam_principals[v],
 182:           # passthrough + error handling using tonumber until Terraform gets fail/raise function
 183:           strcontains(v, ":") ? v : tonumber("[Error] Invalid member: '${v}' in project '${each.key}'")
 184:         )
    ├────────────────
    │ each.key is "service1"
    │ local.context.iam_principals is object with 3 attributes
    │ module.service-accounts is object with 4 attributes

Call to function "try" failed: no expression succeeded:
- Invalid index (at main.tf:175,34-54)
  The given key does not identify an element in this collection value.
- Invalid index (at main.tf:177,39-59)
  The given key does not identify an element in this collection value.
- Invalid index (at main.tf:179,34-37)
  The given key does not identify an element in this collection value.
- Invalid index (at main.tf:181,39-42)
  The given key does not identify an element in this collection value.
- Invalid function argument (at main.tf:183,47-72)
  Invalid value for "v" parameter: cannot convert "[Error] Invalid member: 'rw' in project 'service1'" to number; given string must be a decimal representation of a number.

At least one expression must produce a successful result.
```

Which provides the user with the information that allows them to narrow down the search area.

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [ ] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [ ] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
-->
