### PR TITLE
Fix CICD SA access

### DIFF
--- a/fast/stages/1-resman/stage-2.tf
+++ b/fast/stages/1-resman/stage-2.tf
@@ -230,7 +230,7 @@ module "stage2-sa-rw" {
   prefix = "${var.prefix}-${local.environment_default.short_name}"
   iam = {
     "roles/iam.serviceAccountTokenCreator" = compact([
-      try(module.cicd-sa-rw["${each.key}-prod"].iam_email, null)
+      try(module.cicd-sa-rw[each.key].iam_email, null)
     ])
   }
   iam_project_roles = {
@@ -254,7 +254,7 @@ module "stage2-sa-ro" {
   prefix = "${var.prefix}-${local.environment_default.short_name}"
   iam = {
     "roles/iam.serviceAccountTokenCreator" = compact([
-      try(module.cicd-sa-ro["${each.key}-prod"].iam_email, null)
+      try(module.cicd-sa-ro[each.key].iam_email, null)
     ])
   }
   iam_project_roles = {


### PR DESCRIPTION
The stage2 CICD SAs were not being granted roles/iam.serviceAccountTokenCreator on the corresponding stage2 SAs. For whatever reason the code was appending "-prod" to the cicd-sa-ro/rw keys when adding them resulting in nulls. 

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
-->
