### PR TITLE
Allow un-managed reverse lookup zones

### DIFF
--- a/modules/dns/README.md
+++ b/modules/dns/README.md
@@ -10,6 +10,7 @@ For DNSSEC configuration, refer to the [`dns_managed_zone` documentation](https:
 - [Peering Zone](#peering-zone)
 - [Routing Policies](#routing-policies)
 - [Reverse Lookup Zone](#reverse-lookup-zone)
+- [Reverse Lookup Managed Zone](#reverse-lookup-managed-zone)
 - [Public Zone](#public-zone)
 - [Variables](#variables)
 - [Outputs](#outputs)
@@ -138,8 +139,30 @@ module "private-dns" {
       client_networks = [var.vpc.self_link]
     }
   }
+  recordsets = {
+    "PTR 10.0.0.10.in-addr.arpa." = { ttl = 300, records = ["test.example.com."] }
+  }
 }
-# tftest modules=1 resources=1 inventory=reverse-zone.yaml e2e
+# tftest inventory=reverse-zone.yaml e2e
+```
+
+## Reverse Lookup Managed Zone
+A managed reverse lookup zone is a private zone with a special attribute that instructs Cloud DNS to perform a PTR lookup against Compute Engine DNS data
+
+```hcl
+module "private-dns" {
+  source     = "./fabric/modules/dns"
+  project_id = var.project_id
+  name       = "test-example"
+  zone_config = {
+    domain = "0.0.10.in-addr.arpa."
+    private = {
+      client_networks = [var.vpc.self_link]
+      reverse_managed = true
+    }
+  }
+}
+# tftest inventory=reverse-zone-managed.yaml e2e
 ```
 
 ## Public Zone
@@ -173,7 +196,7 @@ module "public-dns" {
 | [force_destroy](variables.tf#L23) | Set this to true to delete all records in the zone upon zone destruction. | <code>bool</code> |  | <code>null</code> |
 | [iam](variables.tf#L29) | IAM bindings in {ROLE => [MEMBERS]} format. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>null</code> |
 | [recordsets](variables.tf#L45) | Map of DNS recordsets in \"type name\" => {ttl, [records]} format. | <code title="map&#40;object&#40;&#123;&#10;  ttl     &#61; optional&#40;number, 300&#41;&#10;  records &#61; optional&#40;list&#40;string&#41;&#41;&#10;  geo_routing &#61; optional&#40;list&#40;object&#40;&#123;&#10;    location &#61; string&#10;    records  &#61; optional&#40;list&#40;string&#41;&#41;&#10;    health_checked_targets &#61; optional&#40;list&#40;object&#40;&#123;&#10;      load_balancer_type &#61; string&#10;      ip_address         &#61; string&#10;      port               &#61; string&#10;      ip_protocol        &#61; string&#10;      network_url        &#61; string&#10;      project            &#61; string&#10;      region             &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#41;&#10;  &#125;&#41;&#41;&#41;&#10;  wrr_routing &#61; optional&#40;list&#40;object&#40;&#123;&#10;    weight  &#61; number&#10;    records &#61; list&#40;string&#41;&#10;  &#125;&#41;&#41;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [zone_config](variables.tf#L102) | DNS zone configuration. | <code title="object&#40;&#123;&#10;  domain &#61; string&#10;  forwarding &#61; optional&#40;object&#40;&#123;&#10;    forwarders      &#61; optional&#40;map&#40;string&#41;&#41;&#10;    client_networks &#61; list&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;  peering &#61; optional&#40;object&#40;&#123;&#10;    client_networks &#61; list&#40;string&#41;&#10;    peer_network    &#61; string&#10;  &#125;&#41;&#41;&#10;  public &#61; optional&#40;object&#40;&#123;&#10;    dnssec_config &#61; optional&#40;object&#40;&#123;&#10;      non_existence &#61; optional&#40;string, &#34;nsec3&#34;&#41;&#10;      state         &#61; string&#10;      key_signing_key &#61; optional&#40;object&#40;&#10;        &#123; algorithm &#61; string, key_length &#61; number &#125;&#41;,&#10;        &#123; algorithm &#61; &#34;rsasha256&#34;, key_length &#61; 2048 &#125;&#10;      &#41;&#10;      zone_signing_key &#61; optional&#40;object&#40;&#10;        &#123; algorithm &#61; string, key_length &#61; number &#125;&#41;,&#10;        &#123; algorithm &#61; &#34;rsasha256&#34;, key_length &#61; 1024 &#125;&#10;      &#41;&#10;    &#125;&#41;&#41;&#10;    enable_logging &#61; optional&#40;bool, false&#41;&#10;  &#125;&#41;&#41;&#10;  private &#61; optional&#40;object&#40;&#123;&#10;    client_networks             &#61; list&#40;string&#41;&#10;    service_directory_namespace &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [zone_config](variables.tf#L102) | DNS zone configuration. | <code title="object&#40;&#123;&#10;  domain &#61; string&#10;  forwarding &#61; optional&#40;object&#40;&#123;&#10;    forwarders      &#61; optional&#40;map&#40;string&#41;&#41;&#10;    client_networks &#61; list&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;  peering &#61; optional&#40;object&#40;&#123;&#10;    client_networks &#61; list&#40;string&#41;&#10;    peer_network    &#61; string&#10;  &#125;&#41;&#41;&#10;  public &#61; optional&#40;object&#40;&#123;&#10;    dnssec_config &#61; optional&#40;object&#40;&#123;&#10;      non_existence &#61; optional&#40;string, &#34;nsec3&#34;&#41;&#10;      state         &#61; string&#10;      key_signing_key &#61; optional&#40;object&#40;&#10;        &#123; algorithm &#61; string, key_length &#61; number &#125;&#41;,&#10;        &#123; algorithm &#61; &#34;rsasha256&#34;, key_length &#61; 2048 &#125;&#10;      &#41;&#10;      zone_signing_key &#61; optional&#40;object&#40;&#10;        &#123; algorithm &#61; string, key_length &#61; number &#125;&#41;,&#10;        &#123; algorithm &#61; &#34;rsasha256&#34;, key_length &#61; 1024 &#125;&#10;      &#41;&#10;    &#125;&#41;&#41;&#10;    enable_logging &#61; optional&#40;bool, false&#41;&#10;  &#125;&#41;&#41;&#10;  private &#61; optional&#40;object&#40;&#123;&#10;    client_networks             &#61; list&#40;string&#41;&#10;    service_directory_namespace &#61; optional&#40;string&#41;&#10;    reverse_managed             &#61; optional&#40;bool, false&#41;&#10;  &#125;&#41;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
 
 ## Outputs
 

--- a/modules/dns/main.tf
+++ b/modules/dns/main.tf
@@ -63,7 +63,7 @@ resource "google_dns_managed_zone" "dns_managed_zone" {
   description    = var.description
   force_destroy  = var.force_destroy
   visibility     = local.visibility
-  reverse_lookup = try(var.zone_config.private, null) != null && endswith(var.zone_config.domain, ".in-addr.arpa.")
+  reverse_lookup = var.zone_config.private == null ? false : var.zone_config.private.reverse_managed
 
   dynamic "dnssec_config" {
     for_each = try(var.zone_config.public.dnssec_config, null) == null ? [] : [""]

--- a/modules/dns/variables.tf
+++ b/modules/dns/variables.tf
@@ -129,6 +129,7 @@ variable "zone_config" {
     private = optional(object({
       client_networks             = list(string)
       service_directory_namespace = optional(string)
+      reverse_managed             = optional(bool, false)
     }))
   })
   validation {
@@ -142,5 +143,3 @@ variable "zone_config" {
   }
   default = null
 }
-
-

--- a/tests/modules/dns/examples/reverse-zone-managed.yaml
+++ b/tests/modules/dns/examples/reverse-zone-managed.yaml
@@ -17,25 +17,9 @@ values:
     description: Terraform managed.
     dns_name: 0.0.10.in-addr.arpa.
     name: test-example
-    private_visibility_config:
-    - networks:
-      - network_url: projects/xxx/global/networks/aaa
     project: project-id
-    reverse_lookup: false
-    service_directory_config: []
+    reverse_lookup: true
     visibility: private
-  module.private-dns.google_dns_record_set.dns_record_set["PTR 10.0.0.10.in-addr.arpa."]:
-    managed_zone: test-example
-    name: 10.0.0.10.in-addr.arpa.
-    project: project-id
-    routing_policy: []
-    rrdatas:
-    - test.example.com.
-    ttl: 300
-    type: PTR
 
 counts:
   google_dns_managed_zone: 1
-  google_dns_record_set: 1
-  modules: 1
-  resources: 2


### PR DESCRIPTION
Allow creation of a lookup zones in Cloud DNS that have records (unmanaged). Add a flag to create managed zones, where records are added automatically.

I'm not sure what is the exact use case for managed reverse lookup zone, so I decided to make it a non-default option, and make an un-managed the default, happy to change that if managed approach is prevalent. 

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [ ] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [ ] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

**Breaking Changes**

```upgrade-note
`modules/dns`: Reverse zones are by default created as unmanaged now. To keep your zone as managed, please set `var.zone_config.private.reverse_managed` to `true`
```
