### PR TITLE
Fix subnet schema in net-vpc module & hybrid subnets example implementation

### DIFF
--- a/modules/net-vpc/README.md
+++ b/modules/net-vpc/README.md
@@ -95,10 +95,17 @@ module "vpc" {
         flow_sampling        = 0.5
         aggregation_interval = "INTERVAL_10_MIN"
       }
+    },
+    # hybrid subnet
+    {
+      name                             = "hybrid"
+      region                           = "europe-west1"
+      ip_cidr_range                    = "10.0.4.0/24"
+      allow_subnet_cidr_routes_overlap = true
     }
   ]
 }
-# tftest modules=1 resources=7 inventory=subnet-options.yaml e2e
+# tftest modules=1 resources=8 inventory=subnet-options.yaml e2e
 ```
 
 ### Subnet IAM

--- a/modules/net-vpc/schemas/subnet.schema.json
+++ b/modules/net-vpc/schemas/subnet.schema.json
@@ -17,6 +17,9 @@
     "enable_private_access": {
       "type": "boolean"
     },
+    "allow_subnet_cidr_routes_overlap": {
+      "type": "boolean"
+    },
     "flow_logs_config": {
       "type": "object",
       "additionalProperties": false,

--- a/tests/modules/net_vpc/examples/subnet-options.yaml
+++ b/tests/modules/net_vpc/examples/subnet-options.yaml
@@ -32,6 +32,15 @@ values:
     private_ip_google_access: true
     project: project-id
     region: europe-west1
+  ? module.vpc.google_compute_subnetwork.subnetwork["europe-west1/hybrid"]
+  : description: Terraform-managed.
+    ip_cidr_range: 10.0.4.0/24
+    log_config: []
+    name: hybrid
+    private_ip_google_access: true
+    project: project-id
+    region: europe-west1
+    allow_subnet_cidr_routes_overlap: true
   ? module.vpc.google_compute_subnetwork.subnetwork["europe-west1/with-flow-logs"]
   : description: Terraform-managed.
     ip_cidr_range: 10.0.3.0/24
@@ -64,4 +73,4 @@ values:
 
 counts:
   google_compute_network: 1
-  google_compute_subnetwork: 4
+  google_compute_subnetwork: 5


### PR DESCRIPTION
**Description**
- Fixed the subnet JSON schema in the `net-vpc` module to include the `allow_subnet_cidr_routes_overlap` attribute
- Added example code for hybrid subnets implementation

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
-->
