### PR TITLE
Fix broken upgrades of TF provider for routes

### DIFF
--- a/blueprints/gke/patterns/autopilot-cluster/versions.tf
+++ b/blueprints/gke/patterns/autopilot-cluster/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/blueprints/gke/patterns/autopilot-cluster/versions.tofu
+++ b/blueprints/gke/patterns/autopilot-cluster/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/blueprints/gke/patterns/batch/versions.tf
+++ b/blueprints/gke/patterns/batch/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/blueprints/gke/patterns/batch/versions.tofu
+++ b/blueprints/gke/patterns/batch/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/blueprints/gke/patterns/kafka/versions.tf
+++ b/blueprints/gke/patterns/kafka/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/blueprints/gke/patterns/kafka/versions.tofu
+++ b/blueprints/gke/patterns/kafka/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/blueprints/gke/patterns/kong-cloudrun/versions.tf
+++ b/blueprints/gke/patterns/kong-cloudrun/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/blueprints/gke/patterns/kong-cloudrun/versions.tofu
+++ b/blueprints/gke/patterns/kong-cloudrun/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/blueprints/gke/patterns/mysql/versions.tf
+++ b/blueprints/gke/patterns/mysql/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/blueprints/gke/patterns/mysql/versions.tofu
+++ b/blueprints/gke/patterns/mysql/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/blueprints/gke/patterns/redis-cluster/versions.tf
+++ b/blueprints/gke/patterns/redis-cluster/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/blueprints/gke/patterns/redis-cluster/versions.tofu
+++ b/blueprints/gke/patterns/redis-cluster/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/blueprints/secops/secops-gke-forwarder/versions.tf
+++ b/blueprints/secops/secops-gke-forwarder/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/blueprints/secops/secops-gke-forwarder/versions.tofu
+++ b/blueprints/secops/secops-gke-forwarder/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/default-versions.tf
+++ b/default-versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/default-versions.tofu
+++ b/default-versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0,  < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/__experimental_deprecated/alloydb-instance/versions.tf
+++ b/modules/__experimental_deprecated/alloydb-instance/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/__experimental_deprecated/alloydb-instance/versions.tofu
+++ b/modules/__experimental_deprecated/alloydb-instance/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/__experimental_deprecated/net-neg/versions.tf
+++ b/modules/__experimental_deprecated/net-neg/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/__experimental_deprecated/net-neg/versions.tofu
+++ b/modules/__experimental_deprecated/net-neg/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/__experimental_deprecated/project-iam-magic/versions.tf
+++ b/modules/__experimental_deprecated/project-iam-magic/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/__experimental_deprecated/project-iam-magic/versions.tofu
+++ b/modules/__experimental_deprecated/project-iam-magic/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/alloydb/versions.tf
+++ b/modules/alloydb/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/alloydb/versions.tofu
+++ b/modules/alloydb/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/analytics-hub/versions.tf
+++ b/modules/analytics-hub/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/analytics-hub/versions.tofu
+++ b/modules/analytics-hub/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/api-gateway/versions.tf
+++ b/modules/api-gateway/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/api-gateway/versions.tofu
+++ b/modules/api-gateway/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/apigee/versions.tf
+++ b/modules/apigee/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/apigee/versions.tofu
+++ b/modules/apigee/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/artifact-registry/versions.tf
+++ b/modules/artifact-registry/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/artifact-registry/versions.tofu
+++ b/modules/artifact-registry/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/bigquery-dataset/versions.tf
+++ b/modules/bigquery-dataset/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/bigquery-dataset/versions.tofu
+++ b/modules/bigquery-dataset/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/bigtable-instance/versions.tf
+++ b/modules/bigtable-instance/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/bigtable-instance/versions.tofu
+++ b/modules/bigtable-instance/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/billing-account/versions.tf
+++ b/modules/billing-account/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/billing-account/versions.tofu
+++ b/modules/billing-account/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/binauthz/versions.tf
+++ b/modules/binauthz/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/binauthz/versions.tofu
+++ b/modules/binauthz/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/certificate-authority-service/versions.tf
+++ b/modules/certificate-authority-service/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/certificate-authority-service/versions.tofu
+++ b/modules/certificate-authority-service/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/certificate-manager/versions.tf
+++ b/modules/certificate-manager/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/certificate-manager/versions.tofu
+++ b/modules/certificate-manager/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/__need_fixing/onprem/versions.tf
+++ b/modules/cloud-config-container/__need_fixing/onprem/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/__need_fixing/onprem/versions.tofu
+++ b/modules/cloud-config-container/__need_fixing/onprem/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/__need_fixing/squid/versions.tf
+++ b/modules/cloud-config-container/__need_fixing/squid/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/__need_fixing/squid/versions.tofu
+++ b/modules/cloud-config-container/__need_fixing/squid/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/bindplane/versions.tf
+++ b/modules/cloud-config-container/bindplane/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/bindplane/versions.tofu
+++ b/modules/cloud-config-container/bindplane/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/coredns/versions.tf
+++ b/modules/cloud-config-container/coredns/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/coredns/versions.tofu
+++ b/modules/cloud-config-container/coredns/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/cos-generic-metadata/versions.tf
+++ b/modules/cloud-config-container/cos-generic-metadata/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/cos-generic-metadata/versions.tofu
+++ b/modules/cloud-config-container/cos-generic-metadata/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/envoy-sni-dyn-fwd-proxy/versions.tf
+++ b/modules/cloud-config-container/envoy-sni-dyn-fwd-proxy/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/envoy-sni-dyn-fwd-proxy/versions.tofu
+++ b/modules/cloud-config-container/envoy-sni-dyn-fwd-proxy/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/envoy-traffic-director/versions.tf
+++ b/modules/cloud-config-container/envoy-traffic-director/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/envoy-traffic-director/versions.tofu
+++ b/modules/cloud-config-container/envoy-traffic-director/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/mysql/versions.tf
+++ b/modules/cloud-config-container/mysql/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/mysql/versions.tofu
+++ b/modules/cloud-config-container/mysql/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/nginx-tls/versions.tf
+++ b/modules/cloud-config-container/nginx-tls/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/nginx-tls/versions.tofu
+++ b/modules/cloud-config-container/nginx-tls/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/nginx/versions.tf
+++ b/modules/cloud-config-container/nginx/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/nginx/versions.tofu
+++ b/modules/cloud-config-container/nginx/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/simple-nva/versions.tf
+++ b/modules/cloud-config-container/simple-nva/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/simple-nva/versions.tofu
+++ b/modules/cloud-config-container/simple-nva/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-function-v1/versions.tf
+++ b/modules/cloud-function-v1/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-function-v1/versions.tofu
+++ b/modules/cloud-function-v1/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-function-v2/versions.tf
+++ b/modules/cloud-function-v2/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-function-v2/versions.tofu
+++ b/modules/cloud-function-v2/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-identity-group/versions.tf
+++ b/modules/cloud-identity-group/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-identity-group/versions.tofu
+++ b/modules/cloud-identity-group/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-run-v2/versions.tf
+++ b/modules/cloud-run-v2/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-run-v2/versions.tofu
+++ b/modules/cloud-run-v2/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-run/versions.tf
+++ b/modules/cloud-run/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-run/versions.tofu
+++ b/modules/cloud-run/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloudsql-instance/versions.tf
+++ b/modules/cloudsql-instance/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloudsql-instance/versions.tofu
+++ b/modules/cloudsql-instance/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/compute-mig/versions.tf
+++ b/modules/compute-mig/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/compute-mig/versions.tofu
+++ b/modules/compute-mig/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/compute-vm/versions.tf
+++ b/modules/compute-vm/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/compute-vm/versions.tofu
+++ b/modules/compute-vm/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/container-registry/versions.tf
+++ b/modules/container-registry/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/container-registry/versions.tofu
+++ b/modules/container-registry/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/data-catalog-policy-tag/versions.tf
+++ b/modules/data-catalog-policy-tag/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/data-catalog-policy-tag/versions.tofu
+++ b/modules/data-catalog-policy-tag/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/data-catalog-tag-template/versions.tf
+++ b/modules/data-catalog-tag-template/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/data-catalog-tag-template/versions.tofu
+++ b/modules/data-catalog-tag-template/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/data-catalog-tag/versions.tf
+++ b/modules/data-catalog-tag/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/data-catalog-tag/versions.tofu
+++ b/modules/data-catalog-tag/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/dataform-repository/versions.tf
+++ b/modules/dataform-repository/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/dataform-repository/versions.tofu
+++ b/modules/dataform-repository/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/datafusion/versions.tf
+++ b/modules/datafusion/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/datafusion/versions.tofu
+++ b/modules/datafusion/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/dataplex-datascan/versions.tf
+++ b/modules/dataplex-datascan/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/dataplex-datascan/versions.tofu
+++ b/modules/dataplex-datascan/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/dataplex/versions.tf
+++ b/modules/dataplex/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/dataplex/versions.tofu
+++ b/modules/dataplex/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/dataproc/versions.tf
+++ b/modules/dataproc/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/dataproc/versions.tofu
+++ b/modules/dataproc/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/dns-response-policy/versions.tf
+++ b/modules/dns-response-policy/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/dns-response-policy/versions.tofu
+++ b/modules/dns-response-policy/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/dns/versions.tf
+++ b/modules/dns/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/dns/versions.tofu
+++ b/modules/dns/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/endpoints/versions.tf
+++ b/modules/endpoints/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/endpoints/versions.tofu
+++ b/modules/endpoints/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/firestore/versions.tf
+++ b/modules/firestore/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/firestore/versions.tofu
+++ b/modules/firestore/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/folder/versions.tf
+++ b/modules/folder/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/folder/versions.tofu
+++ b/modules/folder/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/gcs/versions.tf
+++ b/modules/gcs/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/gcs/versions.tofu
+++ b/modules/gcs/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/gcve-private-cloud/versions.tf
+++ b/modules/gcve-private-cloud/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/gcve-private-cloud/versions.tofu
+++ b/modules/gcve-private-cloud/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/gke-cluster-autopilot/versions.tf
+++ b/modules/gke-cluster-autopilot/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/gke-cluster-autopilot/versions.tofu
+++ b/modules/gke-cluster-autopilot/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/gke-cluster-standard/versions.tf
+++ b/modules/gke-cluster-standard/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/gke-cluster-standard/versions.tofu
+++ b/modules/gke-cluster-standard/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/gke-hub/versions.tf
+++ b/modules/gke-hub/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/gke-hub/versions.tofu
+++ b/modules/gke-hub/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/gke-nodepool/versions.tf
+++ b/modules/gke-nodepool/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/gke-nodepool/versions.tofu
+++ b/modules/gke-nodepool/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/iam-service-account/versions.tf
+++ b/modules/iam-service-account/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/iam-service-account/versions.tofu
+++ b/modules/iam-service-account/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/kms/versions.tf
+++ b/modules/kms/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/kms/versions.tofu
+++ b/modules/kms/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/logging-bucket/versions.tf
+++ b/modules/logging-bucket/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/logging-bucket/versions.tofu
+++ b/modules/logging-bucket/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/looker-core/versions.tf
+++ b/modules/looker-core/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/looker-core/versions.tofu
+++ b/modules/looker-core/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/ncc-spoke-ra/versions.tf
+++ b/modules/ncc-spoke-ra/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/ncc-spoke-ra/versions.tofu
+++ b/modules/ncc-spoke-ra/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-address/versions.tf
+++ b/modules/net-address/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-address/versions.tofu
+++ b/modules/net-address/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-cloudnat/versions.tf
+++ b/modules/net-cloudnat/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-cloudnat/versions.tofu
+++ b/modules/net-cloudnat/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-firewall-policy/versions.tf
+++ b/modules/net-firewall-policy/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-firewall-policy/versions.tofu
+++ b/modules/net-firewall-policy/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-ipsec-over-interconnect/versions.tf
+++ b/modules/net-ipsec-over-interconnect/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-ipsec-over-interconnect/versions.tofu
+++ b/modules/net-ipsec-over-interconnect/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-lb-app-ext-regional/versions.tf
+++ b/modules/net-lb-app-ext-regional/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-lb-app-ext-regional/versions.tofu
+++ b/modules/net-lb-app-ext-regional/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-lb-app-ext/versions.tf
+++ b/modules/net-lb-app-ext/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-lb-app-ext/versions.tofu
+++ b/modules/net-lb-app-ext/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-lb-app-int-cross-region/versions.tf
+++ b/modules/net-lb-app-int-cross-region/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-lb-app-int-cross-region/versions.tofu
+++ b/modules/net-lb-app-int-cross-region/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-lb-app-int/versions.tf
+++ b/modules/net-lb-app-int/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-lb-app-int/versions.tofu
+++ b/modules/net-lb-app-int/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-lb-ext/versions.tf
+++ b/modules/net-lb-ext/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-lb-ext/versions.tofu
+++ b/modules/net-lb-ext/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-lb-int/versions.tf
+++ b/modules/net-lb-int/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-lb-int/versions.tofu
+++ b/modules/net-lb-int/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-lb-proxy-int/versions.tf
+++ b/modules/net-lb-proxy-int/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-lb-proxy-int/versions.tofu
+++ b/modules/net-lb-proxy-int/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-swp/versions.tf
+++ b/modules/net-swp/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-swp/versions.tofu
+++ b/modules/net-swp/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-vlan-attachment/versions.tf
+++ b/modules/net-vlan-attachment/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-vlan-attachment/versions.tofu
+++ b/modules/net-vlan-attachment/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-vpc-firewall/versions.tf
+++ b/modules/net-vpc-firewall/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-vpc-firewall/versions.tofu
+++ b/modules/net-vpc-firewall/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-vpc-peering/versions.tf
+++ b/modules/net-vpc-peering/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-vpc-peering/versions.tofu
+++ b/modules/net-vpc-peering/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-vpc/versions.tf
+++ b/modules/net-vpc/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-vpc/versions.tofu
+++ b/modules/net-vpc/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-vpn-dynamic/versions.tf
+++ b/modules/net-vpn-dynamic/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-vpn-dynamic/versions.tofu
+++ b/modules/net-vpn-dynamic/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-vpn-ha/versions.tf
+++ b/modules/net-vpn-ha/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-vpn-ha/versions.tofu
+++ b/modules/net-vpn-ha/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-vpn-static/versions.tf
+++ b/modules/net-vpn-static/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-vpn-static/versions.tofu
+++ b/modules/net-vpn-static/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/organization/versions.tf
+++ b/modules/organization/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/organization/versions.tofu
+++ b/modules/organization/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/project/versions.tf
+++ b/modules/project/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/project/versions.tofu
+++ b/modules/project/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/projects-data-source/versions.tf
+++ b/modules/projects-data-source/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/projects-data-source/versions.tofu
+++ b/modules/projects-data-source/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/pubsub/versions.tf
+++ b/modules/pubsub/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/pubsub/versions.tofu
+++ b/modules/pubsub/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/secret-manager/versions.tf
+++ b/modules/secret-manager/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/secret-manager/versions.tofu
+++ b/modules/secret-manager/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/secure-source-manager-instance/versions.tf
+++ b/modules/secure-source-manager-instance/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/secure-source-manager-instance/versions.tofu
+++ b/modules/secure-source-manager-instance/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/service-directory/versions.tf
+++ b/modules/service-directory/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/service-directory/versions.tofu
+++ b/modules/service-directory/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/source-repository/versions.tf
+++ b/modules/source-repository/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/source-repository/versions.tofu
+++ b/modules/source-repository/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/spanner-instance/versions.tf
+++ b/modules/spanner-instance/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/spanner-instance/versions.tofu
+++ b/modules/spanner-instance/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/vpc-sc/versions.tf
+++ b/modules/vpc-sc/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/vpc-sc/versions.tofu
+++ b/modules/vpc-sc/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/workstation-cluster/versions.tf
+++ b/modules/workstation-cluster/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/workstation-cluster/versions.tofu
+++ b/modules/workstation-cluster/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/tests/examples_e2e/setup_module/versions.tf
+++ b/tests/examples_e2e/setup_module/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/tests/examples_e2e/setup_module/versions.tofu
+++ b/tests/examples_e2e/setup_module/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/tools/lockfile/versions.tf
+++ b/tools/lockfile/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/tools/lockfile/versions.tofu
+++ b/tools/lockfile/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.21.0, < 7.0.0" # tftest
+      version = ">= 6.21.0, < 6.24.0, < 7.0.0" # tftest
     }
   }
   provider_meta "google" {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here -->

google_compute_route doesn't allow an update

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [ ] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [ ] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
-->
