### PR TITLE
Fix Cloud SQL deployment and use local remote docker hub for pulling gitlab docker image

### DIFF
--- a/blueprints/third-party-solutions/gitlab/README.md
+++ b/blueprints/third-party-solutions/gitlab/README.md
@@ -385,5 +385,5 @@ module "test" {
   project_id = "my-project"
   region     = "europe-west8"
 }
-# tftest modules=15 resources=58
+# tftest modules=15 resources=60
 ```

--- a/blueprints/third-party-solutions/gitlab/README.md
+++ b/blueprints/third-party-solutions/gitlab/README.md
@@ -317,7 +317,7 @@ gitlab-rake “gitlab:password:reset”
 | [gitlab.tf](./gitlab.tf) | None | <code>compute-vm</code> · <code>iam-service-account</code> · <code>net-lb-int</code> |  |
 | [main.tf](./main.tf) | Module-level locals and resources. | <code>project</code> |  |
 | [outputs.tf](./outputs.tf) | Module outputs. |  |  |
-| [services.tf](./services.tf) | None | <code>cloudsql-instance</code> · <code>gcs</code> | <code>google_redis_instance</code> |
+| [services.tf](./services.tf) | None | <code>artifact-registry</code> · <code>cloudsql-instance</code> · <code>gcs</code> | <code>google_redis_instance</code> |
 | [ssl.tf](./ssl.tf) | None |  | <code>tls_cert_request</code> · <code>tls_locally_signed_cert</code> · <code>tls_private_key</code> · <code>tls_self_signed_cert</code> |
 | [variables.tf](./variables.tf) | Module variables. |  |  |
 
@@ -325,7 +325,7 @@ gitlab-rake “gitlab:password:reset”
 
 | name | description | type | required | default | producer |
 |---|---|:---:|:---:|:---:|:---:|
-| [gitlab_instance_config](variables.tf#L69) | Gitlab Compute Engine instance config. | <code title="object&#40;&#123;&#10;  instance_type &#61; optional&#40;string, &#34;n1-highcpu-8&#34;&#41;&#10;  name          &#61; optional&#40;string, &#34;gitlab-0&#34;&#41;&#10;  network_tags  &#61; optional&#40;list&#40;string&#41;, &#91;&#93;&#41;&#10;  replica_zone  &#61; optional&#40;string&#41;&#10;  zone          &#61; optional&#40;string&#41;&#10;  boot_disk &#61; optional&#40;object&#40;&#123;&#10;    size &#61; optional&#40;number, 20&#41;&#10;    type &#61; optional&#40;string, &#34;pd-standard&#34;&#41;&#10;  &#125;&#41;, &#123;&#125;&#41;&#10;  data_disk &#61; optional&#40;object&#40;&#123;&#10;    size         &#61; optional&#40;number, 100&#41;&#10;    type         &#61; optional&#40;string, &#34;pd-ssd&#34;&#41;&#10;    replica_zone &#61; optional&#40;string&#41;&#10;  &#125;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |  |
+| [gitlab_instance_config](variables.tf#L69) | Gitlab Compute Engine instance config. | <code title="object&#40;&#123;&#10;  instance_type &#61; optional&#40;string, &#34;n2-highcpu-8&#34;&#41;&#10;  name          &#61; optional&#40;string, &#34;gitlab-0&#34;&#41;&#10;  network_tags  &#61; optional&#40;list&#40;string&#41;, &#91;&#93;&#41;&#10;  replica_zone  &#61; optional&#40;string&#41;&#10;  zone          &#61; optional&#40;string&#41;&#10;  boot_disk &#61; optional&#40;object&#40;&#123;&#10;    size &#61; optional&#40;number, 20&#41;&#10;    type &#61; optional&#40;string, &#34;pd-standard&#34;&#41;&#10;  &#125;&#41;, &#123;&#125;&#41;&#10;  data_disk &#61; optional&#40;object&#40;&#123;&#10;    size         &#61; optional&#40;number, 100&#41;&#10;    type         &#61; optional&#40;string, &#34;pd-ssd&#34;&#41;&#10;    replica_zone &#61; optional&#40;string&#41;&#10;  &#125;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |  |
 | [network_config](variables.tf#L89) | Shared VPC network configurations to use for Gitlab Runner VM. | <code title="object&#40;&#123;&#10;  host_project      &#61; optional&#40;string&#41;&#10;  network_self_link &#61; string&#10;  subnet_self_link  &#61; string&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |  |
 | [prefix](variables.tf#L98) | Prefix used for resource names. | <code>string</code> | ✓ |  |  |
 | [project_id](variables.tf#L117) | Project id, references existing project if `project_create` is null. | <code>string</code> | ✓ |  |  |

--- a/blueprints/third-party-solutions/gitlab/README.md
+++ b/blueprints/third-party-solutions/gitlab/README.md
@@ -291,7 +291,7 @@ terraform output ssh_to_bastion
 
 A gcloud command like the following should be available
 
-```bash 
+```bash
 gcloud compute ssh squid-vm --project ${project} --zone europe-west8-b -- -L 3128:127.0.0.1:3128 -N -q -f
 ```
 
@@ -325,7 +325,7 @@ gitlab-rake “gitlab:password:reset”
 
 | name | description | type | required | default | producer |
 |---|---|:---:|:---:|:---:|:---:|
-| [gitlab_instance_config](variables.tf#L69) | Gitlab Compute Engine instance config. | <code title="object&#40;&#123;&#10;  instance_type &#61; optional&#40;string, &#34;n1-highcpu-8&#34;&#41;&#10;  name          &#61; optional&#40;string, &#34;gitlab-0&#34;&#41;&#10;  network_tags  &#61; optional&#40;list&#40;string&#41;, &#91;&#93;&#41;&#10;  replica_zone  &#61; optional&#40;string&#41;&#10;  zone          &#61; optional&#40;string&#41;&#10;  boot_disk &#61; optional&#40;object&#40;&#123;&#10;    size &#61; optional&#40;number, 20&#41;&#10;    type &#61; optional&#40;string, &#34;pd-standard&#34;&#41;&#10;  &#125;&#41;, &#123;&#125;&#41;&#10;  data_disk &#61; optional&#40;object&#40;&#123;&#10;    size         &#61; optional&#40;number, 100&#41;&#10;    type         &#61; optional&#40;string, &#34;pd-ssd&#34;&#41;&#10;    replica_zone &#61; optional&#40;string&#41;&#10;  &#125;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |  |
+| [gitlab_instance_config](variables.tf#L69) | Gitlab Compute Engine instance config. | <code title="object&#40;&#123;&#10;  instance_type &#61; optional&#40;string, &#34;n2-highcpu-8&#34;&#41;&#10;  name          &#61; optional&#40;string, &#34;gitlab-0&#34;&#41;&#10;  network_tags  &#61; optional&#40;list&#40;string&#41;, &#91;&#93;&#41;&#10;  replica_zone  &#61; optional&#40;string&#41;&#10;  zone          &#61; optional&#40;string&#41;&#10;  boot_disk &#61; optional&#40;object&#40;&#123;&#10;    size &#61; optional&#40;number, 20&#41;&#10;    type &#61; optional&#40;string, &#34;pd-standard&#34;&#41;&#10;  &#125;&#41;, &#123;&#125;&#41;&#10;  data_disk &#61; optional&#40;object&#40;&#123;&#10;    size         &#61; optional&#40;number, 100&#41;&#10;    type         &#61; optional&#40;string, &#34;pd-ssd&#34;&#41;&#10;    replica_zone &#61; optional&#40;string&#41;&#10;  &#125;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |  |
 | [network_config](variables.tf#L89) | Shared VPC network configurations to use for Gitlab Runner VM. | <code title="object&#40;&#123;&#10;  host_project      &#61; optional&#40;string&#41;&#10;  network_self_link &#61; string&#10;  subnet_self_link  &#61; string&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |  |
 | [prefix](variables.tf#L98) | Prefix used for resource names. | <code>string</code> | ✓ |  |  |
 | [project_id](variables.tf#L117) | Project id, references existing project if `project_create` is null. | <code>string</code> | ✓ |  |  |

--- a/blueprints/third-party-solutions/gitlab/README.md
+++ b/blueprints/third-party-solutions/gitlab/README.md
@@ -291,7 +291,7 @@ terraform output ssh_to_bastion
 
 A gcloud command like the following should be available
 
-```bash
+```bash 
 gcloud compute ssh squid-vm --project ${project} --zone europe-west8-b -- -L 3128:127.0.0.1:3128 -N -q -f
 ```
 
@@ -325,7 +325,7 @@ gitlab-rake “gitlab:password:reset”
 
 | name | description | type | required | default | producer |
 |---|---|:---:|:---:|:---:|:---:|
-| [gitlab_instance_config](variables.tf#L69) | Gitlab Compute Engine instance config. | <code title="object&#40;&#123;&#10;  instance_type &#61; optional&#40;string, &#34;n2-highcpu-8&#34;&#41;&#10;  name          &#61; optional&#40;string, &#34;gitlab-0&#34;&#41;&#10;  network_tags  &#61; optional&#40;list&#40;string&#41;, &#91;&#93;&#41;&#10;  replica_zone  &#61; optional&#40;string&#41;&#10;  zone          &#61; optional&#40;string&#41;&#10;  boot_disk &#61; optional&#40;object&#40;&#123;&#10;    size &#61; optional&#40;number, 20&#41;&#10;    type &#61; optional&#40;string, &#34;pd-standard&#34;&#41;&#10;  &#125;&#41;, &#123;&#125;&#41;&#10;  data_disk &#61; optional&#40;object&#40;&#123;&#10;    size         &#61; optional&#40;number, 100&#41;&#10;    type         &#61; optional&#40;string, &#34;pd-ssd&#34;&#41;&#10;    replica_zone &#61; optional&#40;string&#41;&#10;  &#125;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |  |
+| [gitlab_instance_config](variables.tf#L69) | Gitlab Compute Engine instance config. | <code title="object&#40;&#123;&#10;  instance_type &#61; optional&#40;string, &#34;n1-highcpu-8&#34;&#41;&#10;  name          &#61; optional&#40;string, &#34;gitlab-0&#34;&#41;&#10;  network_tags  &#61; optional&#40;list&#40;string&#41;, &#91;&#93;&#41;&#10;  replica_zone  &#61; optional&#40;string&#41;&#10;  zone          &#61; optional&#40;string&#41;&#10;  boot_disk &#61; optional&#40;object&#40;&#123;&#10;    size &#61; optional&#40;number, 20&#41;&#10;    type &#61; optional&#40;string, &#34;pd-standard&#34;&#41;&#10;  &#125;&#41;, &#123;&#125;&#41;&#10;  data_disk &#61; optional&#40;object&#40;&#123;&#10;    size         &#61; optional&#40;number, 100&#41;&#10;    type         &#61; optional&#40;string, &#34;pd-ssd&#34;&#41;&#10;    replica_zone &#61; optional&#40;string&#41;&#10;  &#125;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |  |
 | [network_config](variables.tf#L89) | Shared VPC network configurations to use for Gitlab Runner VM. | <code title="object&#40;&#123;&#10;  host_project      &#61; optional&#40;string&#41;&#10;  network_self_link &#61; string&#10;  subnet_self_link  &#61; string&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |  |
 | [prefix](variables.tf#L98) | Prefix used for resource names. | <code>string</code> | ✓ |  |  |
 | [project_id](variables.tf#L117) | Project id, references existing project if `project_create` is null. | <code>string</code> | ✓ |  |  |

--- a/blueprints/third-party-solutions/gitlab/README.md
+++ b/blueprints/third-party-solutions/gitlab/README.md
@@ -291,7 +291,7 @@ terraform output ssh_to_bastion
 
 A gcloud command like the following should be available
 
-```bash 
+```bash
 gcloud compute ssh squid-vm --project ${project} --zone europe-west8-b -- -L 3128:127.0.0.1:3128 -N -q -f
 ```
 
@@ -385,5 +385,5 @@ module "test" {
   project_id = "my-project"
   region     = "europe-west8"
 }
-# tftest modules=14 resources=58
+# tftest modules=15 resources=58
 ```

--- a/blueprints/third-party-solutions/gitlab/assets/cloud-config.yaml
+++ b/blueprints/third-party-solutions/gitlab/assets/cloud-config.yaml
@@ -92,7 +92,7 @@ write_files:
       Wants=gitlab-data.service gcr-online.target docker.socket docker-events-collector.service
       [Service]
       Environment="HOME=/home/gitlab"
-      ExecStartPre=/usr/bin/docker-credential-gcr configure-docker
+      ExecStartPre=/usr/bin/docker-credential-gcr configure-docker --registries ${region}-docker.pkg.dev
       ExecStartPre=mkdir -p /run/gitlab
       ExecStart=/usr/bin/docker run --rm --name=gitlab  \
         --hostname ${gitlab_config.hostname} \
@@ -106,7 +106,7 @@ write_files:
         -v /run/gitlab/logs:/var/log/gitlab \
         -v /run/gitlab/data:/var/opt/gitlab \
         -v /run/gitlab/sshd_config:/assets/sshd_config \
-        gitlab/gitlab-ce
+        ${repo_url}/gitlab/gitlab-ce
       ExecStop=/usr/bin/docker stop gitlab
 
 runcmd:

--- a/blueprints/third-party-solutions/gitlab/gitlab.tf
+++ b/blueprints/third-party-solutions/gitlab/gitlab.tf
@@ -42,6 +42,8 @@ locals {
     gitlab_cert_name   = var.gitlab_config.hostname
     gitlab_ssl_key     = indent(6, base64encode(local.gitlab_ssl_key))
     gitlab_ssl_crt     = indent(6, base64encode(local.gitlab_ssl_crt))
+    region             = var.region
+    repo_url           = module.registry-remote.url
   })
 }
 

--- a/blueprints/third-party-solutions/gitlab/services.tf
+++ b/blueprints/third-party-solutions/gitlab/services.tf
@@ -35,11 +35,10 @@ module "db" {
   name              = var.cloudsql_config.name
   availability_type = var.gitlab_config.ha_required ? "REGIONAL" : "ZONAL"
   network_config = {
-    authorized_networks = {}
     connectivity = {
-      psa_configs = [{
+      psa_config = {
         private_network = var.network_config.network_self_link
-      }]
+      }
     }
   }
   database_version = var.cloudsql_config.database_version

--- a/blueprints/third-party-solutions/gitlab/services.tf
+++ b/blueprints/third-party-solutions/gitlab/services.tf
@@ -89,3 +89,20 @@ module "gitlab_object_storage" {
     ]
   }
 }
+
+module "registry-remote" {
+  source     = "../../../modules/artifact-registry"
+  project_id = var.project_id
+  location   = var.region
+  name       = "remote"
+  format = {
+    docker = {
+      remote = {
+        public_repository = "DOCKER_HUB"
+      }
+    }
+  }
+  iam = {
+    "roles/artifactregistry.reader" = [module.gitlab-sa.iam_email]
+  }
+}

--- a/blueprints/third-party-solutions/gitlab/variables.tf
+++ b/blueprints/third-party-solutions/gitlab/variables.tf
@@ -69,7 +69,7 @@ variable "gitlab_config" {
 variable "gitlab_instance_config" {
   description = "Gitlab Compute Engine instance config."
   type = object({
-    instance_type = optional(string, "n1-highcpu-8")
+    instance_type = optional(string, "n2-highcpu-8")
     name          = optional(string, "gitlab-0")
     network_tags  = optional(list(string), [])
     replica_zone  = optional(string)


### PR DESCRIPTION
As per the title this PR fixes Cloud SQL deployment adapting module arguments and update gitlab deployment to leverage local regional remote docker artifact registry for pulling gitlab ce image

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [] Made sure all relevant tests pass
