### PR TITLE
Fix stage-3 CICD SA access

### DIFF
--- a/fast/stages/1-resman/stage-3.tf
+++ b/fast/stages/1-resman/stage-3.tf
@@ -177,7 +177,7 @@ module "stage3-sa-rw" {
   prefix = "${var.prefix}-${var.environments[each.value.environment].short_name}"
   iam = {
     "roles/iam.serviceAccountTokenCreator" = compact([
-      try(module.cicd-sa-rw["${each.key}-prod"].iam_email, null)
+      try(module.cicd-sa-rw[each.key].iam_email, null)
     ])
   }
   iam_project_roles = {
@@ -201,7 +201,7 @@ module "stage3-sa-ro" {
   prefix = "${var.prefix}-${each.value.environment}"
   iam = {
     "roles/iam.serviceAccountTokenCreator" = compact([
-      try(module.cicd-sa-ro["${each.key}-prod"].iam_email, null)
+      try(module.cicd-sa-ro[each.key].iam_email, null)
     ])
   }
   iam_project_roles = {

--- a/modules/compute-vm/README.md
+++ b/modules/compute-vm/README.md
@@ -36,8 +36,7 @@ In both modes, an optional service account can be created and assigned to either
   - [Instance group](#instance-group)
   - [Instance Schedule](#instance-schedule)
   - [Snapshot Schedules](#snapshot-schedules)
-  - [Resource Manager Tags (non-firewall)](#resource-manager-tags-non-firewall)
-  - [Resource Manager Tags (firewall)](#resource-manager-tags-firewall)
+  - [Resource Manager Tags](#resource-manager-tags)
   - [Sole Tenancy](#sole-tenancy)
 - [Variables](#variables)
 - [Outputs](#outputs)
@@ -824,43 +823,39 @@ module "instance" {
 # tftest inventory=snapshot-schedule-create.yaml e2e
 ```
 
-### Resource Manager Tags (non-firewall)
+### Resource Manager Tags
 
-Resource manager tags bindings for use in IAM or org policy conditions are supported via the `tag_bindings` variable with the following limitations:
+Resource manager tags bindings for use in IAM or org policy conditions are supported via three different variables:
 
-- tag bindings are not created for attached disks
-- tag bindings will not be created for the boot disk if the `use_independent_disk` flag is true
-- tag bindings are ignored for instance templates
+- `network_tag_bindings` associates tags to instances after creation, and is meant for use with network firewall policies
+- `tag_bindings` associates tags to instances and zonal disks after creation, and is meant for use with IAM or organization policy conditions
+- `tag_bindings_immutable` associates tags to instances and disks created as part of the instance, or instance templates; the binding is applied at creation time and triggers resource recreation on change
 
-The current provider implementation is sub-optimal and forces
+The non-immutable variables follow our usual interface for tag bindings, and support specifying a map with arbitrary keys mapping to tag key or value ids. To prevent a provider permadiff also pass in the project number in the `project_number` variable.
 
-- recreation of the instance on tag changes
-- specifying both the key and value where only the value is actually needed
+The immutable variable uses a different format enforced by the Compute API, where keys need to be tag key ids, and values tag value ids.
 
-This is an example of setting tag bindings:
+This is an example of setting non-immutable tag bindings:
 
 ```hcl
 module "simple-vm-example" {
-  source     = "./fabric/modules/compute-vm"
-  project_id = var.project_id
-  zone       = "${var.region}-b"
-  name       = "test"
+  source         = "./fabric/modules/compute-vm"
+  project_id     = var.project_id
+  project_number = 12345678
+  zone           = "${var.region}-b"
+  name           = "test"
   network_interfaces = [{
     network    = var.vpc.self_link
     subnetwork = var.subnet.self_link
   }]
   tag_bindings = {
-    "tagKeys/1234567890" = "tagValues/7890123456"
+    dev = "tagValues/1234567890"
   }
 }
-# tftest inventory=tag-bindings.yaml
+# tftest modules=1 resources=2
 ```
 
-### Resource Manager Tags (firewall)
-
-Network-scoped resource manager tags (or "secure tags") bindings for use in firewall rules are supported with similar limitations as in the section above, via a separate `tag_bindings_firewall` variable that only applies bindings to the instance and not the boot disk.
-
-This is an example of setting both types of tag bindings:
+This example uses immutable tag bindings, and will trigger recreation if those are changed.
 
 ```hcl
 module "simple-vm-example" {
@@ -872,12 +867,8 @@ module "simple-vm-example" {
     network    = var.vpc.self_link
     subnetwork = var.subnet.self_link
   }]
-  tag_bindings = {
+  tag_bindings_immutable = {
     "tagKeys/1234567890" = "tagValues/7890123456"
-  }
-  # tags here need to be scoped to a VPC
-  tag_bindings_firewall = {
-    "tagKeys/5678901234" = "tagValues/3456789012"
   }
 }
 # tftest inventory=tag-bindings.yaml
@@ -917,37 +908,39 @@ module "sole-tenancy" {
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [name](variables.tf#L270) | Instance name. | <code>string</code> | ✓ |  |
-| [network_interfaces](variables.tf#L282) | Network interfaces configuration. Use self links for Shared VPC, set addresses to null if not needed. | <code title="list&#40;object&#40;&#123;&#10;  network    &#61; string&#10;  subnetwork &#61; string&#10;  alias_ips  &#61; optional&#40;map&#40;string&#41;, &#123;&#125;&#41;&#10;  nat        &#61; optional&#40;bool, false&#41;&#10;  nic_type   &#61; optional&#40;string&#41;&#10;  stack_type &#61; optional&#40;string&#41;&#10;  addresses &#61; optional&#40;object&#40;&#123;&#10;    internal &#61; optional&#40;string&#41;&#10;    external &#61; optional&#40;string&#41;&#10;  &#125;&#41;, null&#41;&#10;&#125;&#41;&#41;">list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> | ✓ |  |
-| [project_id](variables.tf#L355) | Project id. | <code>string</code> | ✓ |  |
-| [zone](variables.tf#L453) | Compute zone. | <code>string</code> | ✓ |  |
+| [name](variables.tf#L271) | Instance name. | <code>string</code> | ✓ |  |
+| [network_interfaces](variables.tf#L283) | Network interfaces configuration. Use self links for Shared VPC, set addresses to null if not needed. | <code title="list&#40;object&#40;&#123;&#10;  network    &#61; string&#10;  subnetwork &#61; string&#10;  alias_ips  &#61; optional&#40;map&#40;string&#41;, &#123;&#125;&#41;&#10;  nat        &#61; optional&#40;bool, false&#41;&#10;  nic_type   &#61; optional&#40;string&#41;&#10;  stack_type &#61; optional&#40;string&#41;&#10;  addresses &#61; optional&#40;object&#40;&#123;&#10;    internal &#61; optional&#40;string&#41;&#10;    external &#61; optional&#40;string&#41;&#10;  &#125;&#41;, null&#41;&#10;&#125;&#41;&#41;">list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> | ✓ |  |
+| [project_id](variables.tf#L363) | Project id. | <code>string</code> | ✓ |  |
+| [zone](variables.tf#L476) | Compute zone. | <code>string</code> | ✓ |  |
 | [attached_disk_defaults](variables.tf#L17) | Defaults for attached disks options. | <code title="object&#40;&#123;&#10;  auto_delete  &#61; optional&#40;bool, false&#41;&#10;  mode         &#61; string&#10;  replica_zone &#61; string&#10;  type         &#61; string&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code title="&#123;&#10;  auto_delete  &#61; true&#10;  mode         &#61; &#34;READ_WRITE&#34;&#10;  replica_zone &#61; null&#10;  type         &#61; &#34;pd-balanced&#34;&#10;&#125;">&#123;&#8230;&#125;</code> |
 | [attached_disks](variables.tf#L37) | Additional disks, if options is null defaults will be used in its place. Source type is one of 'image' (zonal disks in vms and template), 'snapshot' (vm), 'existing', and null. | <code title="list&#40;object&#40;&#123;&#10;  name        &#61; string&#10;  device_name &#61; optional&#40;string&#41;&#10;  size              &#61; string&#10;  snapshot_schedule &#61; optional&#40;list&#40;string&#41;&#41;&#10;  source            &#61; optional&#40;string&#41;&#10;  source_type       &#61; optional&#40;string&#41;&#10;  options &#61; optional&#40;&#10;    object&#40;&#123;&#10;      auto_delete  &#61; optional&#40;bool, false&#41;&#10;      mode         &#61; optional&#40;string, &#34;READ_WRITE&#34;&#41;&#10;      replica_zone &#61; optional&#40;string&#41;&#10;      type         &#61; optional&#40;string, &#34;pd-balanced&#34;&#41;&#10;    &#125;&#41;,&#10;    &#123;&#10;      auto_delete  &#61; true&#10;      mode         &#61; &#34;READ_WRITE&#34;&#10;      replica_zone &#61; null&#10;      type         &#61; &#34;pd-balanced&#34;&#10;    &#125;&#10;  &#41;&#10;&#125;&#41;&#41;">list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
-| [boot_disk](variables.tf#L83) | Boot disk properties. | <code title="object&#40;&#123;&#10;  auto_delete       &#61; optional&#40;bool, true&#41;&#10;  snapshot_schedule &#61; optional&#40;list&#40;string&#41;&#41;&#10;  source            &#61; optional&#40;string&#41;&#10;  initialize_params &#61; optional&#40;object&#40;&#123;&#10;    image &#61; optional&#40;string, &#34;projects&#47;debian-cloud&#47;global&#47;images&#47;family&#47;debian-11&#34;&#41;&#10;    size  &#61; optional&#40;number, 10&#41;&#10;    type  &#61; optional&#40;string, &#34;pd-balanced&#34;&#41;&#10;  &#125;&#41;&#41;&#10;  use_independent_disk &#61; optional&#40;bool, false&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code title="&#123;&#10;  initialize_params &#61; &#123;&#125;&#10;&#125;">&#123;&#8230;&#125;</code> |
+| [boot_disk](variables.tf#L83) | Boot disk properties. | <code title="object&#40;&#123;&#10;  auto_delete       &#61; optional&#40;bool, true&#41;&#10;  snapshot_schedule &#61; optional&#40;list&#40;string&#41;&#41;&#10;  source            &#61; optional&#40;string&#41;&#10;  initialize_params &#61; optional&#40;object&#40;&#123;&#10;    image &#61; optional&#40;string, &#34;projects&#47;debian-cloud&#47;global&#47;images&#47;family&#47;debian-11&#34;&#41;&#10;    size  &#61; optional&#40;number, 10&#41;&#10;    type  &#61; optional&#40;string, &#34;pd-balanced&#34;&#41;&#10;  &#125;&#41;, &#123;&#125;&#41;&#10;  use_independent_disk &#61; optional&#40;bool, false&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code title="&#123;&#10;  initialize_params &#61; &#123;&#125;&#10;&#125;">&#123;&#8230;&#125;</code> |
 | [can_ip_forward](variables.tf#L117) | Enable IP forwarding. | <code>bool</code> |  | <code>false</code> |
 | [confidential_compute](variables.tf#L123) | Enable Confidential Compute for these instances. | <code>bool</code> |  | <code>false</code> |
 | [create_template](variables.tf#L129) | Create instance template instead of instances. | <code>bool</code> |  | <code>false</code> |
-| [description](variables.tf#L134) | Description of a Compute Instance. | <code>string</code> |  | <code>&#34;Managed by the compute-vm Terraform module.&#34;</code> |
-| [enable_display](variables.tf#L140) | Enable virtual display on the instances. | <code>bool</code> |  | <code>false</code> |
-| [encryption](variables.tf#L146) | Encryption options. Only one of kms_key_self_link and disk_encryption_key_raw may be set. If needed, you can specify to encrypt or not the boot disk. | <code title="object&#40;&#123;&#10;  encrypt_boot            &#61; optional&#40;bool, false&#41;&#10;  disk_encryption_key_raw &#61; optional&#40;string&#41;&#10;  kms_key_self_link       &#61; optional&#40;string&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [gpu](variables.tf#L156) | GPU information. Based on https://cloud.google.com/compute/docs/gpus. | <code title="object&#40;&#123;&#10;  count &#61; number&#10;  type  &#61; string&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [group](variables.tf#L191) | Define this variable to create an instance group for instances. Disabled for template use. | <code title="object&#40;&#123;&#10;  named_ports &#61; map&#40;number&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [hostname](variables.tf#L199) | Instance FQDN name. | <code>string</code> |  | <code>null</code> |
-| [iam](variables.tf#L205) | IAM bindings in {ROLE => [MEMBERS]} format. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [instance_schedule](variables.tf#L211) | Assign or create and assign an instance schedule policy. Either resource policy id or create_config must be specified if not null. Set active to null to dtach a policy from vm before destroying. | <code title="object&#40;&#123;&#10;  resource_policy_id &#61; optional&#40;string&#41;&#10;  create_config &#61; optional&#40;object&#40;&#123;&#10;    active          &#61; optional&#40;bool, true&#41;&#10;    description     &#61; optional&#40;string&#41;&#10;    expiration_time &#61; optional&#40;string&#41;&#10;    start_time      &#61; optional&#40;string&#41;&#10;    timezone        &#61; optional&#40;string, &#34;UTC&#34;&#41;&#10;    vm_start        &#61; optional&#40;string&#41;&#10;    vm_stop         &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [instance_type](variables.tf#L246) | Instance type. | <code>string</code> |  | <code>&#34;f1-micro&#34;</code> |
-| [labels](variables.tf#L252) | Instance labels. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
-| [metadata](variables.tf#L258) | Instance metadata. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
-| [min_cpu_platform](variables.tf#L264) | Minimum CPU platform. | <code>string</code> |  | <code>null</code> |
-| [network_attached_interfaces](variables.tf#L275) | Network interfaces using network attachments. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
-| [options](variables.tf#L298) | Instance options. | <code title="object&#40;&#123;&#10;  advanced_machine_features &#61; optional&#40;object&#40;&#123;&#10;    enable_nested_virtualization &#61; optional&#40;bool&#41;&#10;    enable_turbo_mode            &#61; optional&#40;bool&#41;&#10;    enable_uefi_networking       &#61; optional&#40;bool&#41;&#10;    performance_monitoring_unit  &#61; optional&#40;string&#41;&#10;    threads_per_core             &#61; optional&#40;number&#41;&#10;    visible_core_count           &#61; optional&#40;number&#41;&#10;  &#125;&#41;&#41;&#10;  allow_stopping_for_update &#61; optional&#40;bool, true&#41;&#10;  deletion_protection       &#61; optional&#40;bool, false&#41;&#10;  graceful_shutdown &#61; optional&#40;object&#40;&#123;&#10;    enabled           &#61; optional&#40;bool, false&#41;&#10;    max_duration_secs &#61; optional&#40;number&#41;&#10;  &#125;&#41;&#41;&#10;  max_run_duration &#61; optional&#40;object&#40;&#123;&#10;    nanos   &#61; optional&#40;number&#41;&#10;    seconds &#61; number&#10;  &#125;&#41;&#41;&#10;  node_affinities &#61; optional&#40;map&#40;object&#40;&#123;&#10;    values &#61; list&#40;string&#41;&#10;    in     &#61; optional&#40;bool, true&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;  spot               &#61; optional&#40;bool, false&#41;&#10;  termination_action &#61; optional&#40;string&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code title="&#123;&#10;  allow_stopping_for_update &#61; true&#10;  deletion_protection       &#61; false&#10;  spot                      &#61; false&#10;  termination_action        &#61; null&#10;&#125;">&#123;&#8230;&#125;</code> |
-| [scratch_disks](variables.tf#L360) | Scratch disks configuration. | <code title="object&#40;&#123;&#10;  count     &#61; number&#10;  interface &#61; string&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code title="&#123;&#10;  count     &#61; 0&#10;  interface &#61; &#34;NVME&#34;&#10;&#125;">&#123;&#8230;&#125;</code> |
-| [service_account](variables.tf#L372) | Service account email and scopes. If email is null, the default Compute service account will be used unless auto_create is true, in which case a service account will be created. Set the variable to null to avoid attaching a service account. | <code title="object&#40;&#123;&#10;  auto_create &#61; optional&#40;bool, false&#41;&#10;  email       &#61; optional&#40;string&#41;&#10;  scopes      &#61; optional&#40;list&#40;string&#41;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [shielded_config](variables.tf#L382) | Shielded VM configuration of the instances. | <code title="object&#40;&#123;&#10;  enable_secure_boot          &#61; bool&#10;  enable_vtpm                 &#61; bool&#10;  enable_integrity_monitoring &#61; bool&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [snapshot_schedules](variables.tf#L392) | Snapshot schedule resource policies that can be attached to disks. | <code title="map&#40;object&#40;&#123;&#10;  schedule &#61; object&#40;&#123;&#10;    daily &#61; optional&#40;object&#40;&#123;&#10;      days_in_cycle &#61; number&#10;      start_time    &#61; string&#10;    &#125;&#41;&#41;&#10;    hourly &#61; optional&#40;object&#40;&#123;&#10;      hours_in_cycle &#61; number&#10;      start_time     &#61; string&#10;    &#125;&#41;&#41;&#10;    weekly &#61; optional&#40;list&#40;object&#40;&#123;&#10;      day        &#61; string&#10;      start_time &#61; string&#10;    &#125;&#41;&#41;&#41;&#10;  &#125;&#41;&#10;  description &#61; optional&#40;string&#41;&#10;  retention_policy &#61; optional&#40;object&#40;&#123;&#10;    max_retention_days         &#61; number&#10;    on_source_disk_delete_keep &#61; optional&#40;bool&#41;&#10;  &#125;&#41;&#41;&#10;  snapshot_properties &#61; optional&#40;object&#40;&#123;&#10;    chain_name        &#61; optional&#40;string&#41;&#10;    guest_flush       &#61; optional&#40;bool&#41;&#10;    labels            &#61; optional&#40;map&#40;string&#41;&#41;&#10;    storage_locations &#61; optional&#40;list&#40;string&#41;&#41;&#10;  &#125;&#41;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [tag_bindings](variables.tf#L435) | Resource manager tag bindings for this instance, in tag key => tag value format. | <code>map&#40;string&#41;</code> |  | <code>null</code> |
-| [tag_bindings_firewall](variables.tf#L441) | Firewall (network scoped) tag bindings for this instance, in tag key => tag value format. | <code>map&#40;string&#41;</code> |  | <code>null</code> |
-| [tags](variables.tf#L447) | Instance network tags for firewall rule targets. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
+| [description](variables.tf#L135) | Description of a Compute Instance. | <code>string</code> |  | <code>&#34;Managed by the compute-vm Terraform module.&#34;</code> |
+| [enable_display](variables.tf#L141) | Enable virtual display on the instances. | <code>bool</code> |  | <code>false</code> |
+| [encryption](variables.tf#L147) | Encryption options. Only one of kms_key_self_link and disk_encryption_key_raw may be set. If needed, you can specify to encrypt or not the boot disk. | <code title="object&#40;&#123;&#10;  encrypt_boot            &#61; optional&#40;bool, false&#41;&#10;  disk_encryption_key_raw &#61; optional&#40;string&#41;&#10;  kms_key_self_link       &#61; optional&#40;string&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [gpu](variables.tf#L157) | GPU information. Based on https://cloud.google.com/compute/docs/gpus. | <code title="object&#40;&#123;&#10;  count &#61; number&#10;  type  &#61; string&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [group](variables.tf#L192) | Define this variable to create an instance group for instances. Disabled for template use. | <code title="object&#40;&#123;&#10;  named_ports &#61; map&#40;number&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [hostname](variables.tf#L200) | Instance FQDN name. | <code>string</code> |  | <code>null</code> |
+| [iam](variables.tf#L206) | IAM bindings in {ROLE => [MEMBERS]} format. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [instance_schedule](variables.tf#L212) | Assign or create and assign an instance schedule policy. Either resource policy id or create_config must be specified if not null. Set active to null to dtach a policy from vm before destroying. | <code title="object&#40;&#123;&#10;  resource_policy_id &#61; optional&#40;string&#41;&#10;  create_config &#61; optional&#40;object&#40;&#123;&#10;    active          &#61; optional&#40;bool, true&#41;&#10;    description     &#61; optional&#40;string&#41;&#10;    expiration_time &#61; optional&#40;string&#41;&#10;    start_time      &#61; optional&#40;string&#41;&#10;    timezone        &#61; optional&#40;string, &#34;UTC&#34;&#41;&#10;    vm_start        &#61; optional&#40;string&#41;&#10;    vm_stop         &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [instance_type](variables.tf#L247) | Instance type. | <code>string</code> |  | <code>&#34;f1-micro&#34;</code> |
+| [labels](variables.tf#L253) | Instance labels. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [metadata](variables.tf#L259) | Instance metadata. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [min_cpu_platform](variables.tf#L265) | Minimum CPU platform. | <code>string</code> |  | <code>null</code> |
+| [network_attached_interfaces](variables.tf#L276) | Network interfaces using network attachments. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
+| [network_tag_bindings](variables.tf#L299) | Resource manager tag bindings in arbitrary key => tag key or value id format. Set on both the instance only for networking purposes, and modifiable without impacting the main resource lifecycle. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [options](variables.tf#L306) | Instance options. | <code title="object&#40;&#123;&#10;  advanced_machine_features &#61; optional&#40;object&#40;&#123;&#10;    enable_nested_virtualization &#61; optional&#40;bool&#41;&#10;    enable_turbo_mode            &#61; optional&#40;bool&#41;&#10;    enable_uefi_networking       &#61; optional&#40;bool&#41;&#10;    performance_monitoring_unit  &#61; optional&#40;string&#41;&#10;    threads_per_core             &#61; optional&#40;number&#41;&#10;    visible_core_count           &#61; optional&#40;number&#41;&#10;  &#125;&#41;&#41;&#10;  allow_stopping_for_update &#61; optional&#40;bool, true&#41;&#10;  deletion_protection       &#61; optional&#40;bool, false&#41;&#10;  graceful_shutdown &#61; optional&#40;object&#40;&#123;&#10;    enabled           &#61; optional&#40;bool, false&#41;&#10;    max_duration_secs &#61; optional&#40;number&#41;&#10;  &#125;&#41;&#41;&#10;  max_run_duration &#61; optional&#40;object&#40;&#123;&#10;    nanos   &#61; optional&#40;number&#41;&#10;    seconds &#61; number&#10;  &#125;&#41;&#41;&#10;  node_affinities &#61; optional&#40;map&#40;object&#40;&#123;&#10;    values &#61; list&#40;string&#41;&#10;    in     &#61; optional&#40;bool, true&#41;&#10;  &#125;&#41;&#41;, &#123;&#125;&#41;&#10;  spot               &#61; optional&#40;bool, false&#41;&#10;  termination_action &#61; optional&#40;string&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code title="&#123;&#10;  allow_stopping_for_update &#61; true&#10;  deletion_protection       &#61; false&#10;  spot                      &#61; false&#10;  termination_action        &#61; null&#10;&#125;">&#123;&#8230;&#125;</code> |
+| [project_number](variables.tf#L368) | Project number. Used in tag bindings to avoid a permadiff. | <code>string</code> |  | <code>null</code> |
+| [scratch_disks](variables.tf#L374) | Scratch disks configuration. | <code title="object&#40;&#123;&#10;  count     &#61; number&#10;  interface &#61; string&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code title="&#123;&#10;  count     &#61; 0&#10;  interface &#61; &#34;NVME&#34;&#10;&#125;">&#123;&#8230;&#125;</code> |
+| [service_account](variables.tf#L386) | Service account email and scopes. If email is null, the default Compute service account will be used unless auto_create is true, in which case a service account will be created. Set the variable to null to avoid attaching a service account. | <code title="object&#40;&#123;&#10;  auto_create &#61; optional&#40;bool, false&#41;&#10;  email       &#61; optional&#40;string&#41;&#10;  scopes      &#61; optional&#40;list&#40;string&#41;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [shielded_config](variables.tf#L396) | Shielded VM configuration of the instances. | <code title="object&#40;&#123;&#10;  enable_secure_boot          &#61; bool&#10;  enable_vtpm                 &#61; bool&#10;  enable_integrity_monitoring &#61; bool&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [snapshot_schedules](variables.tf#L406) | Snapshot schedule resource policies that can be attached to disks. | <code title="map&#40;object&#40;&#123;&#10;  schedule &#61; object&#40;&#123;&#10;    daily &#61; optional&#40;object&#40;&#123;&#10;      days_in_cycle &#61; number&#10;      start_time    &#61; string&#10;    &#125;&#41;&#41;&#10;    hourly &#61; optional&#40;object&#40;&#123;&#10;      hours_in_cycle &#61; number&#10;      start_time     &#61; string&#10;    &#125;&#41;&#41;&#10;    weekly &#61; optional&#40;list&#40;object&#40;&#123;&#10;      day        &#61; string&#10;      start_time &#61; string&#10;    &#125;&#41;&#41;&#41;&#10;  &#125;&#41;&#10;  description &#61; optional&#40;string&#41;&#10;  retention_policy &#61; optional&#40;object&#40;&#123;&#10;    max_retention_days         &#61; number&#10;    on_source_disk_delete_keep &#61; optional&#40;bool&#41;&#10;  &#125;&#41;&#41;&#10;  snapshot_properties &#61; optional&#40;object&#40;&#123;&#10;    chain_name        &#61; optional&#40;string&#41;&#10;    guest_flush       &#61; optional&#40;bool&#41;&#10;    labels            &#61; optional&#40;map&#40;string&#41;&#41;&#10;    storage_locations &#61; optional&#40;list&#40;string&#41;&#41;&#10;  &#125;&#41;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [tag_bindings](variables.tf#L449) | Resource manager tag bindings in arbitrary key => tag key or value id format. Set on both the instance and zonal disks, and modifiable without impacting the main resource lifecycle. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [tag_bindings_immutable](variables.tf#L456) | Immutable resource manager tag bindings, in tagKeys/id => tagValues/id format. These are set on the instance or instance template at creation time, and trigger recreation if changed. | <code>map&#40;string&#41;</code> |  | <code>null</code> |
+| [tags](variables.tf#L470) | Instance network tags for firewall rule targets. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
 
 ## Outputs
 

--- a/modules/compute-vm/main.tf
+++ b/modules/compute-vm/main.tf
@@ -60,14 +60,6 @@ locals {
       )
     )
   }
-  tags_combined = (
-    var.tag_bindings == null && var.tag_bindings_firewall == null
-    ? null
-    : merge(
-      coalesce(var.tag_bindings, {}),
-      coalesce(var.tag_bindings_firewall, {})
-    )
-  )
   termination_action = (
     var.options.spot || var.options.max_run_duration != null ? coalesce(var.options.termination_action, "STOP") : null
   )
@@ -245,7 +237,7 @@ resource "google_compute_instance" "default" {
         image                 = var.boot_disk.initialize_params.image
         size                  = var.boot_disk.initialize_params.size
         type                  = var.boot_disk.initialize_params.type
-        resource_manager_tags = var.tag_bindings
+        resource_manager_tags = var.tag_bindings_immutable
       }
     }
   }
@@ -359,9 +351,9 @@ resource "google_compute_instance" "default" {
   }
 
   dynamic "params" {
-    for_each = local.tags_combined == null ? [] : [""]
+    for_each = var.tag_bindings_immutable == null ? [] : [""]
     content {
-      resource_manager_tags = local.tags_combined
+      resource_manager_tags = var.tag_bindings_immutable
     }
   }
 
@@ -397,7 +389,7 @@ resource "google_compute_instance_template" "default" {
   can_ip_forward        = var.can_ip_forward
   metadata              = var.metadata
   labels                = var.labels
-  resource_manager_tags = local.tags_combined
+  resource_manager_tags = var.tag_bindings_immutable
 
   dynamic "advanced_machine_features" {
     for_each = local.advanced_mf != null ? [""] : []
@@ -418,7 +410,7 @@ resource "google_compute_instance_template" "default" {
     boot                  = true
     disk_size_gb          = var.boot_disk.initialize_params.size
     disk_type             = var.boot_disk.initialize_params.type
-    resource_manager_tags = var.tag_bindings
+    resource_manager_tags = var.tag_bindings_immutable
     source_image          = var.boot_disk.initialize_params.image
 
     dynamic "disk_encryption_key" {
@@ -467,7 +459,7 @@ resource "google_compute_instance_template" "default" {
       disk_name = (
         config.value.source_type != "attach" ? config.value.name : null
       )
-      resource_manager_tags = var.tag_bindings
+      resource_manager_tags = var.tag_bindings_immutable
       type                  = "PERSISTENT"
       dynamic "disk_encryption_key" {
         for_each = var.encryption != null ? [""] : []

--- a/modules/compute-vm/tags.tf
+++ b/modules/compute-vm/tags.tf
@@ -16,21 +16,102 @@
 
 # tfdoc:file:description Tag bindings.
 
-# TODO: re-implement once the following have been addressed in the provider
-# - permadiff in google_tags_location_tag_binding which returns a project
-#   number in the tag id even when a project id is set
-# - no numeric id exposed from the google_compute_disk resource making it
-#   impossible to derive the tag binding parent
-# - google_compute_instance.params.resource_manager_tags and
-#   google_compute_instance.boot_disk.initialize_params.resource_manager_tags
-#   attributes need a map of tag key => tag value, while only the tag value
-#   is really needed by the API
+locals {
+  boot_disk_tags = flatten([
+    for k, v in var.tag_bindings : [
+      for dk, dv in google_compute_disk.boot : {
+        disk_id   = dv.disk_id
+        key       = "${dk}/${k}"
+        tag_value = v
+      }
+    ]
+  ])
+  disk_tags = flatten([
+    for k, v in var.tag_bindings : [
+      for dk, dv in google_compute_disk.disks : {
+        disk_id   = dv.disk_id
+        key       = "${dk}/${k}"
+        tag_value = v
+      }
+    ]
+  ])
+  # region_disk_tags = flatten([
+  #   for k, v in var.tag_bindings : [
+  #     for dk, dv in google_compute_region_disk.disks : {
+  #       disk_id   = dv.disk_id
+  #       key       = "${dk}/${k}"
+  #       tag_value = v
+  #     }
+  #   ]
+  # ])
+  tag_parent_base = format(
+    "//compute.googleapis.com/projects/%s",
+    coalesce(var.project_number, var.project_id)
+  )
+}
 
-# resource "google_tags_location_tag_binding" "instance" {
-#   for_each = var.create_template ? {} : coalesce(var.tag_bindings, {})
+# use a different resource to avoid overlapping key issues
+
+resource "google_tags_location_tag_binding" "network" {
+  for_each = var.create_template ? {} : var.network_tag_bindings
+  parent = (
+    "${local.tag_parent_base}/zones/${var.zone}/instances/${google_compute_instance.default[0].instance_id}"
+  )
+  tag_value = each.value
+  location  = var.zone
+}
+
+resource "google_tags_location_tag_binding" "instance" {
+  for_each = var.create_template ? {} : var.tag_bindings
+  parent = (
+    "${local.tag_parent_base}/zones/${var.zone}/instances/${google_compute_instance.default[0].instance_id}"
+  )
+  tag_value = each.value
+  location  = var.zone
+}
+
+resource "google_tags_location_tag_binding" "boot_disks" {
+  for_each = (
+    var.create_template ? {} : { for v in local.boot_disk_tags : v.key => v }
+  )
+  parent = (
+    "${local.tag_parent_base}/zones/${var.zone}/disks/${each.value.disk_id}"
+  )
+  tag_value = each.value.tag_value
+  location  = var.zone
+}
+
+resource "google_tags_location_tag_binding" "disks" {
+  for_each = (
+    var.create_template ? {} : { for v in local.disk_tags : v.key => v }
+  )
+  parent = (
+    "${local.tag_parent_base}/zones/${var.zone}/disks/${each.value.disk_id}"
+  )
+  tag_value = each.value.tag_value
+  location  = var.zone
+}
+
+# TODO: enable once regional disks support disk_id
+
+# resource "google_tags_location_tag_binding" "disks_regional" {
+#   for_each = (
+#     var.create_template ? {} : { for v in local.region_disk_tags : v.key => v }
+#   )
 #   parent = (
-#     "${local.tag_parent_base}/instances/${google_compute_instance.default[0].instance_id}"
+#     "${local.tag_parent_base}/regions/${local.region}/disks/${each.value.disk_id}"
+#   )
+#   tag_value = each.value.tag_value
+#   location  = local.region
+# }
+
+# TODO: enable once the template id is available
+
+# resource "google_tags_location_tag_binding" "template" {
+#   for_each = var.create_template ? var.tag_bindings : {}
+#   parent = (
+#     "${local.tag_parent_base}/regions/${local.region}/instanceTemplates/${google_compute_instance.default[0].instance_id}"
 #   )
 #   tag_value = each.value
-#   location  = var.zone
+#   location  = local.region
 # }

--- a/modules/compute-vm/variables.tf
+++ b/modules/compute-vm/variables.tf
@@ -90,7 +90,7 @@ variable "boot_disk" {
       image = optional(string, "projects/debian-cloud/global/images/family/debian-11")
       size  = optional(number, 10)
       type  = optional(string, "pd-balanced")
-    }))
+    }), {})
     use_independent_disk = optional(bool, false)
   })
   default = {
@@ -131,6 +131,7 @@ variable "create_template" {
   type        = bool
   default     = false
 }
+
 variable "description" {
   description = "Description of a Compute Instance."
   type        = string
@@ -295,6 +296,13 @@ variable "network_interfaces" {
   }))
 }
 
+variable "network_tag_bindings" {
+  description = "Resource manager tag bindings in arbitrary key => tag key or value id format. Set on both the instance only for networking purposes, and modifiable without impacting the main resource lifecycle."
+  type        = map(string)
+  nullable    = false
+  default     = {}
+}
+
 variable "options" {
   description = "Instance options."
   type = object({
@@ -355,6 +363,12 @@ variable "options" {
 variable "project_id" {
   description = "Project id."
   type        = string
+}
+
+variable "project_number" {
+  description = "Project number. Used in tag bindings to avoid a permadiff."
+  type        = string
+  default     = null
 }
 
 variable "scratch_disks" {
@@ -433,15 +447,24 @@ variable "snapshot_schedules" {
 }
 
 variable "tag_bindings" {
-  description = "Resource manager tag bindings for this instance, in tag key => tag value format."
+  description = "Resource manager tag bindings in arbitrary key => tag key or value id format. Set on both the instance and zonal disks, and modifiable without impacting the main resource lifecycle."
   type        = map(string)
-  default     = null
+  nullable    = false
+  default     = {}
 }
 
-variable "tag_bindings_firewall" {
-  description = "Firewall (network scoped) tag bindings for this instance, in tag key => tag value format."
+variable "tag_bindings_immutable" {
+  description = "Immutable resource manager tag bindings, in tagKeys/id => tagValues/id format. These are set on the instance or instance template at creation time, and trigger recreation if changed."
   type        = map(string)
+  nullable    = true
   default     = null
+  validation {
+    condition = alltrue([
+      for k, v in coalesce(var.tag_bindings_immutable, {}) :
+      startswith(k, "tagKeys/") && startswith(v, "tagValues/")
+    ])
+    error_message = "Incorrect format for immutable tag bindings."
+  }
 }
 
 variable "tags" {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here -->
Similar to #2923, this fixes the CICD SAs not being granted roles/iam.serviceAccountTokenCreator on the stage 3 SAs by removing "-prod".

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
-->
