### PR TITLE
Fix stage-3 CICD SA access

### DIFF
--- a/fast/stages/1-resman/stage-3.tf
+++ b/fast/stages/1-resman/stage-3.tf
@@ -177,7 +177,7 @@ module "stage3-sa-rw" {
   prefix = "${var.prefix}-${var.environments[each.value.environment].short_name}"
   iam = {
     "roles/iam.serviceAccountTokenCreator" = compact([
-      try(module.cicd-sa-rw["${each.key}-prod"].iam_email, null)
+      try(module.cicd-sa-rw[each.key].iam_email, null)
     ])
   }
   iam_project_roles = {
@@ -201,7 +201,7 @@ module "stage3-sa-ro" {
   prefix = "${var.prefix}-${each.value.environment}"
   iam = {
     "roles/iam.serviceAccountTokenCreator" = compact([
-      try(module.cicd-sa-ro["${each.key}-prod"].iam_email, null)
+      try(module.cicd-sa-ro[each.key].iam_email, null)
     ])
   }
   iam_project_roles = {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here -->
Similar to #2923, this fixes the CICD SAs not being granted roles/iam.serviceAccountTokenCreator on the stage 3 SAs by removing "-prod".

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
-->
