### PR TITLE
[FAST] Remove object creator permission from storage viewer custom role

### DIFF
--- a/fast/stages/0-bootstrap/data/custom-roles/storage_viewer.yaml
+++ b/fast/stages/0-bootstrap/data/custom-roles/storage_viewer.yaml
@@ -28,7 +28,6 @@ includedPermissions:
   - storage.managedFolders.list
   - storage.multipartUploads.list
   - storage.multipartUploads.listParts
-  - storage.objects.create
   - storage.objects.get
   - storage.objects.getIamPolicy
   - storage.objects.list


### PR DESCRIPTION
Removes object creator permission from storage viewer custom role.

---
**Checklist**

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass