### PR TITLE
Use path as keys in project factory

### DIFF
--- a/modules/net-vpc-factory/factory-projects-object.tf
+++ b/modules/net-vpc-factory/factory-projects-object.tf
@@ -180,9 +180,9 @@ locals {
         try(v.metric_scopes, null),
         local.__projects_config.data_defaults.metric_scopes
       )
-      name         = lookup(v, "name", k)    # type: string
-      org_policies = try(v.org_policies, {}) # type: map(object({...}))
-      parent = try(                          # type: string, nullable
+      name         = lookup(v, "name", basename(k)) # type: string
+      org_policies = try(v.org_policies, {})        # type: map(object({...}))
+      parent = try(                                 # type: string, nullable
         coalesce(
           local.__projects_config.data_overrides.parent,
           try(v.parent, null),
@@ -253,5 +253,12 @@ locals {
         local.__projects_config.data_defaults.logging_data_access
       )
     })
+  }
+  # tflint-ignore: terraform_unused_declarations
+  _projects_uniqunees_validation = {
+    # will raise error, if the same project (derived from file name, or provided in the YAML file)
+    # is sued more than once
+    for k, v in local._projects_output :
+    v.name => k
   }
 }

--- a/modules/project-factory/factory-projects-object.tf
+++ b/modules/project-factory/factory-projects-object.tf
@@ -180,9 +180,9 @@ locals {
         try(v.metric_scopes, null),
         local.__projects_config.data_defaults.metric_scopes
       )
-      name         = lookup(v, "name", k)    # type: string
-      org_policies = try(v.org_policies, {}) # type: map(object({...}))
-      parent = try(                          # type: string, nullable
+      name         = lookup(v, "name", basename(k)) # type: string
+      org_policies = try(v.org_policies, {})        # type: map(object({...}))
+      parent = try(                                 # type: string, nullable
         coalesce(
           local.__projects_config.data_overrides.parent,
           try(v.parent, null),
@@ -253,5 +253,12 @@ locals {
         local.__projects_config.data_defaults.logging_data_access
       )
     })
+  }
+  # tflint-ignore: terraform_unused_declarations
+  _projects_uniqunees_validation = {
+    # will raise error, if the same project (derived from file name, or provided in the YAML file)
+    # is sued more than once
+    for k, v in local._projects_output :
+    v.name => k
   }
 }

--- a/modules/project-factory/factory-projects.tf
+++ b/modules/project-factory/factory-projects.tf
@@ -32,12 +32,8 @@ locals {
     for f in try(fileset(local._project_path, "**/*.yaml"), []) :
     trimsuffix(f, ".yaml") => yamldecode(file("${local._project_path}/${f}"))
   }
-  _projects_input = {
-    # will raise error, if the same filename is used multiple times
-    # and project name is not set via name in YAML
-    for k, v in merge(local._hierarchy_projects_full_path, local._projects_full_path) :
-    lookup(v, "name", basename(k)) => v
-  }
+
+  _projects_input = merge(local._hierarchy_projects_full_path, local._projects_full_path)
   _project_budgets = flatten([
     for k, v in local._projects_input : [
       for b in try(v.billing_budgets, []) : {

--- a/modules/project-factory/main.tf
+++ b/modules/project-factory/main.tf
@@ -37,7 +37,7 @@ module "projects" {
   source          = "../project"
   for_each        = local.projects
   billing_account = each.value.billing_account
-  name            = each.key
+  name            = each.value.name
   parent = lookup(
     local.context.folder_ids, each.value.parent, each.value.parent
   )

--- a/tests/modules/project_factory/bucket_iam.yaml
+++ b/tests/modules/project_factory/bucket_iam.yaml
@@ -13,38 +13,6 @@
 # limitations under the License.
 
 values:
-  module.buckets["project1/state"].google_storage_bucket.bucket[0]:
-    autoclass: []
-    cors: []
-    custom_placement_config: []
-    default_event_based_hold: null
-    effective_labels:
-      goog-terraform-provisioned: 'true'
-    enable_object_retention: null
-    encryption: []
-    force_destroy: false
-    hierarchical_namespace: []
-    labels: null
-    lifecycle_rule: []
-    location: EUROPE-WEST8
-    logging: []
-    name: test-pf-project1-state
-    project: test-pf-project1
-    requester_pays: null
-    retention_policy: []
-    storage_class: STANDARD
-    terraform_labels:
-      goog-terraform-provisioned: 'true'
-    timeouts: null
-    uniform_bucket_level_access: true
-    versioning:
-    - enabled: false
-  module.buckets["project1/state"].google_storage_bucket_iam_binding.authoritative["roles/storage.admin"]:
-    bucket: test-pf-project1-state
-    condition: []
-    members:
-    - serviceAccount:terraform-rw@test-pf-project1.iam.gserviceaccount.com
-    role: roles/storage.admin
   module.buckets["project2/state"].google_storage_bucket.bucket[0]:
     autoclass: []
     cors: []
@@ -71,6 +39,38 @@ values:
     uniform_bucket_level_access: true
     versioning:
     - enabled: false
+  module.buckets["team-a/project1/state"].google_storage_bucket.bucket[0]:
+    autoclass: []
+    cors: []
+    custom_placement_config: []
+    default_event_based_hold: null
+    effective_labels:
+      goog-terraform-provisioned: 'true'
+    enable_object_retention: null
+    encryption: []
+    force_destroy: false
+    hierarchical_namespace: []
+    labels: null
+    lifecycle_rule: []
+    location: EUROPE-WEST8
+    logging: []
+    name: test-pf-project1-state
+    project: test-pf-project1
+    requester_pays: null
+    retention_policy: []
+    storage_class: STANDARD
+    terraform_labels:
+      goog-terraform-provisioned: 'true'
+    timeouts: null
+    uniform_bucket_level_access: true
+    versioning:
+    - enabled: false
+  module.buckets["team-a/project1/state"].google_storage_bucket_iam_binding.authoritative["roles/storage.admin"]:
+    bucket: test-pf-project1-state
+    condition: []
+    members:
+    - serviceAccount:terraform-rw@test-pf-project1.iam.gserviceaccount.com
+    role: roles/storage.admin
   module.hierarchy-folder-lvl-1["team-a"].google_folder.folder[0]:
     deletion_protection: false
     display_name: Team A
@@ -88,174 +88,6 @@ values:
     display_name: Team B
     parent: folders/5678901234
     tags: null
-    timeouts: null
-  module.projects["auto-team-a"].data.google_storage_project_service_account.gcs_sa[0]:
-    project: test-pf-auto-team-a
-    user_project: null
-  module.projects["auto-team-a"].google_essential_contacts_contact.contact["admin@example.org"]:
-    email: admin@example.org
-    language_tag: en
-    notification_category_subscriptions:
-    - ALL
-    parent: projects/test-pf-auto-team-a
-    timeouts: null
-  module.projects["auto-team-a"].google_project.project[0]:
-    auto_create_network: false
-    billing_account: 012345-67890A-BCDEF0
-    deletion_policy: DELETE
-    effective_labels:
-      environment: test
-      goog-terraform-provisioned: 'true'
-    labels:
-      environment: test
-    name: test-pf-auto-team-a
-    project_id: test-pf-auto-team-a
-    tags: null
-    terraform_labels:
-      environment: test
-      goog-terraform-provisioned: 'true'
-    timeouts: null
-  module.projects["auto-team-a"].google_project_iam_member.service_agents["container-engine-robot"]:
-    condition: []
-    project: test-pf-auto-team-a
-    role: roles/container.serviceAgent
-  module.projects["auto-team-a"].google_project_iam_member.service_agents["gkenode"]:
-    condition: []
-    project: test-pf-auto-team-a
-    role: roles/container.defaultNodeServiceAgent
-  module.projects["auto-team-a"].google_project_service.project_services["container.googleapis.com"]:
-    disable_dependent_services: false
-    disable_on_destroy: false
-    project: test-pf-auto-team-a
-    service: container.googleapis.com
-    timeouts: null
-  module.projects["auto-team-a"].google_project_service.project_services["stackdriver.googleapis.com"]:
-    disable_dependent_services: false
-    disable_on_destroy: false
-    project: test-pf-auto-team-a
-    service: stackdriver.googleapis.com
-    timeouts: null
-  module.projects["auto-team-a"].google_project_service.project_services["storage.googleapis.com"]:
-    disable_dependent_services: false
-    disable_on_destroy: false
-    project: test-pf-auto-team-a
-    service: storage.googleapis.com
-    timeouts: null
-  module.projects["auto-team-a"].google_project_service_identity.default["container.googleapis.com"]:
-    project: test-pf-auto-team-a
-    service: container.googleapis.com
-    timeouts: null
-  module.projects["auto-team-b"].data.google_storage_project_service_account.gcs_sa[0]:
-    project: test-pf-auto-team-b
-    user_project: null
-  module.projects["auto-team-b"].google_essential_contacts_contact.contact["admin@example.org"]:
-    email: admin@example.org
-    language_tag: en
-    notification_category_subscriptions:
-    - ALL
-    parent: projects/test-pf-auto-team-b
-    timeouts: null
-  module.projects["auto-team-b"].google_project.project[0]:
-    auto_create_network: false
-    billing_account: 012345-67890A-BCDEF0
-    deletion_policy: DELETE
-    effective_labels:
-      environment: test
-      goog-terraform-provisioned: 'true'
-    labels:
-      environment: test
-    name: test-pf-auto-team-b
-    project_id: test-pf-auto-team-b
-    tags: null
-    terraform_labels:
-      environment: test
-      goog-terraform-provisioned: 'true'
-    timeouts: null
-  module.projects["auto-team-b"].google_project_iam_member.service_agents["container-engine-robot"]:
-    condition: []
-    project: test-pf-auto-team-b
-    role: roles/container.serviceAgent
-  module.projects["auto-team-b"].google_project_iam_member.service_agents["gkenode"]:
-    condition: []
-    project: test-pf-auto-team-b
-    role: roles/container.defaultNodeServiceAgent
-  module.projects["auto-team-b"].google_project_service.project_services["container.googleapis.com"]:
-    disable_dependent_services: false
-    disable_on_destroy: false
-    project: test-pf-auto-team-b
-    service: container.googleapis.com
-    timeouts: null
-  module.projects["auto-team-b"].google_project_service.project_services["stackdriver.googleapis.com"]:
-    disable_dependent_services: false
-    disable_on_destroy: false
-    project: test-pf-auto-team-b
-    service: stackdriver.googleapis.com
-    timeouts: null
-  module.projects["auto-team-b"].google_project_service.project_services["storage.googleapis.com"]:
-    disable_dependent_services: false
-    disable_on_destroy: false
-    project: test-pf-auto-team-b
-    service: storage.googleapis.com
-    timeouts: null
-  module.projects["auto-team-b"].google_project_service_identity.default["container.googleapis.com"]:
-    project: test-pf-auto-team-b
-    service: container.googleapis.com
-    timeouts: null
-  module.projects["project1"].data.google_storage_project_service_account.gcs_sa[0]:
-    project: test-pf-project1
-    user_project: null
-  module.projects["project1"].google_essential_contacts_contact.contact["admin@example.org"]:
-    email: admin@example.org
-    language_tag: en
-    notification_category_subscriptions:
-    - ALL
-    parent: projects/test-pf-project1
-    timeouts: null
-  module.projects["project1"].google_project.project[0]:
-    auto_create_network: false
-    billing_account: 012345-67890A-BCDEF0
-    deletion_policy: DELETE
-    effective_labels:
-      environment: test
-      goog-terraform-provisioned: 'true'
-    labels:
-      environment: test
-    name: test-pf-project1
-    project_id: test-pf-project1
-    tags: null
-    terraform_labels:
-      environment: test
-      goog-terraform-provisioned: 'true'
-    timeouts: null
-  module.projects["project1"].google_project_iam_member.service_agents["container-engine-robot"]:
-    condition: []
-    project: test-pf-project1
-    role: roles/container.serviceAgent
-  module.projects["project1"].google_project_iam_member.service_agents["gkenode"]:
-    condition: []
-    project: test-pf-project1
-    role: roles/container.defaultNodeServiceAgent
-  module.projects["project1"].google_project_service.project_services["container.googleapis.com"]:
-    disable_dependent_services: false
-    disable_on_destroy: false
-    project: test-pf-project1
-    service: container.googleapis.com
-    timeouts: null
-  module.projects["project1"].google_project_service.project_services["stackdriver.googleapis.com"]:
-    disable_dependent_services: false
-    disable_on_destroy: false
-    project: test-pf-project1
-    service: stackdriver.googleapis.com
-    timeouts: null
-  module.projects["project1"].google_project_service.project_services["storage.googleapis.com"]:
-    disable_dependent_services: false
-    disable_on_destroy: false
-    project: test-pf-project1
-    service: storage.googleapis.com
-    timeouts: null
-  module.projects["project1"].google_project_service_identity.default["container.googleapis.com"]:
-    project: test-pf-project1
-    service: container.googleapis.com
     timeouts: null
   module.projects["project2"].google_essential_contacts_contact.contact["admin@example.org"]:
     email: admin@example.org
@@ -293,72 +125,16 @@ values:
     service: stackdriver.googleapis.com
     timeouts: null
   module.projects["project3"].data.google_storage_project_service_account.gcs_sa[0]:
-    project: test-pf-project3
+    project: test-pf-top-project3
     user_project: null
   module.projects["project3"].google_essential_contacts_contact.contact["admin@example.org"]:
     email: admin@example.org
     language_tag: en
     notification_category_subscriptions:
     - ALL
-    parent: projects/test-pf-project3
-    timeouts: null
-  module.projects["project3"].google_project.project[0]:
-    auto_create_network: false
-    billing_account: 012345-67890A-BCDEF0
-    deletion_policy: DELETE
-    effective_labels:
-      environment: test
-      goog-terraform-provisioned: 'true'
-    labels:
-      environment: test
-    name: test-pf-project3
-    project_id: test-pf-project3
-    tags: null
-    terraform_labels:
-      environment: test
-      goog-terraform-provisioned: 'true'
-    timeouts: null
-  module.projects["project3"].google_project_iam_member.service_agents["container-engine-robot"]:
-    condition: []
-    project: test-pf-project3
-    role: roles/container.serviceAgent
-  module.projects["project3"].google_project_iam_member.service_agents["gkenode"]:
-    condition: []
-    project: test-pf-project3
-    role: roles/container.defaultNodeServiceAgent
-  module.projects["project3"].google_project_service.project_services["container.googleapis.com"]:
-    disable_dependent_services: false
-    disable_on_destroy: false
-    project: test-pf-project3
-    service: container.googleapis.com
-    timeouts: null
-  module.projects["project3"].google_project_service.project_services["stackdriver.googleapis.com"]:
-    disable_dependent_services: false
-    disable_on_destroy: false
-    project: test-pf-project3
-    service: stackdriver.googleapis.com
-    timeouts: null
-  module.projects["project3"].google_project_service.project_services["storage.googleapis.com"]:
-    disable_dependent_services: false
-    disable_on_destroy: false
-    project: test-pf-project3
-    service: storage.googleapis.com
-    timeouts: null
-  module.projects["project3"].google_project_service_identity.default["container.googleapis.com"]:
-    project: test-pf-project3
-    service: container.googleapis.com
-    timeouts: null
-  module.projects["top-project3"].data.google_storage_project_service_account.gcs_sa[0]:
-    project: test-pf-top-project3
-    user_project: null
-  module.projects["top-project3"].google_essential_contacts_contact.contact["admin@example.org"]:
-    email: admin@example.org
-    language_tag: en
-    notification_category_subscriptions:
-    - ALL
     parent: projects/test-pf-top-project3
     timeouts: null
-  module.projects["top-project3"].google_project.project[0]:
+  module.projects["project3"].google_project.project[0]:
     auto_create_network: false
     billing_account: 012345-67890A-BCDEF0
     deletion_policy: DELETE
@@ -374,73 +150,259 @@ values:
       environment: test
       goog-terraform-provisioned: 'true'
     timeouts: null
-  module.projects["top-project3"].google_project_iam_member.service_agents["container-engine-robot"]:
+  module.projects["project3"].google_project_iam_member.service_agents["container-engine-robot"]:
     condition: []
     project: test-pf-top-project3
     role: roles/container.serviceAgent
-  module.projects["top-project3"].google_project_iam_member.service_agents["gkenode"]:
+  module.projects["project3"].google_project_iam_member.service_agents["gkenode"]:
     condition: []
     project: test-pf-top-project3
     role: roles/container.defaultNodeServiceAgent
-  module.projects["top-project3"].google_project_service.project_services["container.googleapis.com"]:
+  module.projects["project3"].google_project_service.project_services["container.googleapis.com"]:
     disable_dependent_services: false
     disable_on_destroy: false
     project: test-pf-top-project3
     service: container.googleapis.com
     timeouts: null
-  module.projects["top-project3"].google_project_service.project_services["stackdriver.googleapis.com"]:
+  module.projects["project3"].google_project_service.project_services["stackdriver.googleapis.com"]:
     disable_dependent_services: false
     disable_on_destroy: false
     project: test-pf-top-project3
     service: stackdriver.googleapis.com
     timeouts: null
-  module.projects["top-project3"].google_project_service.project_services["storage.googleapis.com"]:
+  module.projects["project3"].google_project_service.project_services["storage.googleapis.com"]:
     disable_dependent_services: false
     disable_on_destroy: false
     project: test-pf-top-project3
     service: storage.googleapis.com
     timeouts: null
-  module.projects["top-project3"].google_project_service_identity.default["container.googleapis.com"]:
+  module.projects["project3"].google_project_service_identity.default["container.googleapis.com"]:
     project: test-pf-top-project3
     service: container.googleapis.com
     timeouts: null
-  module.service-accounts["project1/app-be-0"].google_service_account.service_account[0]:
-    account_id: app-be-0
-    create_ignore_already_exists: null
-    description: null
-    disabled: false
-    display_name: Terraform-managed.
-    email: app-be-0@test-pf-project1.iam.gserviceaccount.com
-    member: serviceAccount:app-be-0@test-pf-project1.iam.gserviceaccount.com
-    project: test-pf-project1
+  module.projects["team-a/automation"].data.google_storage_project_service_account.gcs_sa[0]:
+    project: test-pf-auto-team-a
+    user_project: null
+  module.projects["team-a/automation"].google_essential_contacts_contact.contact["admin@example.org"]:
+    email: admin@example.org
+    language_tag: en
+    notification_category_subscriptions:
+    - ALL
+    parent: projects/test-pf-auto-team-a
     timeouts: null
-  ? module.service-accounts["project1/app-fe-1"].google_project_iam_member.project-roles["my-host-project-roles/compute.networkUser"]
-  : condition: []
-    project: my-host-project
-    role: roles/compute.networkUser
-  ? module.service-accounts["project1/app-fe-1"].google_project_iam_member.project-roles["test-pf-project1-roles/storage.objectViewer"]
-  : condition: []
-    project: test-pf-project1
-    role: roles/storage.objectViewer
-  module.service-accounts["project1/app-fe-1"].google_service_account.service_account[0]:
-    account_id: app-fe-1
-    create_ignore_already_exists: null
-    description: null
-    disabled: false
-    display_name: GCE frontend service account.
-    email: app-fe-1@test-pf-project1.iam.gserviceaccount.com
-    member: serviceAccount:app-fe-1@test-pf-project1.iam.gserviceaccount.com
-    project: test-pf-project1
+  module.projects["team-a/automation"].google_project.project[0]:
+    auto_create_network: false
+    billing_account: 012345-67890A-BCDEF0
+    deletion_policy: DELETE
+    effective_labels:
+      environment: test
+      goog-terraform-provisioned: 'true'
+    labels:
+      environment: test
+    name: test-pf-auto-team-a
+    project_id: test-pf-auto-team-a
+    tags: null
+    terraform_labels:
+      environment: test
+      goog-terraform-provisioned: 'true'
     timeouts: null
-  module.service-accounts["project1/terraform-rw"].google_service_account.service_account[0]:
-    account_id: terraform-rw
-    create_ignore_already_exists: null
-    description: null
-    disabled: false
-    display_name: Terraform-managed.
-    email: terraform-rw@test-pf-project1.iam.gserviceaccount.com
-    member: serviceAccount:terraform-rw@test-pf-project1.iam.gserviceaccount.com
+  module.projects["team-a/automation"].google_project_iam_member.service_agents["container-engine-robot"]:
+    condition: []
+    project: test-pf-auto-team-a
+    role: roles/container.serviceAgent
+  module.projects["team-a/automation"].google_project_iam_member.service_agents["gkenode"]:
+    condition: []
+    project: test-pf-auto-team-a
+    role: roles/container.defaultNodeServiceAgent
+  module.projects["team-a/automation"].google_project_service.project_services["container.googleapis.com"]:
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: test-pf-auto-team-a
+    service: container.googleapis.com
+    timeouts: null
+  module.projects["team-a/automation"].google_project_service.project_services["stackdriver.googleapis.com"]:
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: test-pf-auto-team-a
+    service: stackdriver.googleapis.com
+    timeouts: null
+  module.projects["team-a/automation"].google_project_service.project_services["storage.googleapis.com"]:
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: test-pf-auto-team-a
+    service: storage.googleapis.com
+    timeouts: null
+  module.projects["team-a/automation"].google_project_service_identity.default["container.googleapis.com"]:
+    project: test-pf-auto-team-a
+    service: container.googleapis.com
+    timeouts: null
+  module.projects["team-a/project1"].data.google_storage_project_service_account.gcs_sa[0]:
     project: test-pf-project1
+    user_project: null
+  module.projects["team-a/project1"].google_essential_contacts_contact.contact["admin@example.org"]:
+    email: admin@example.org
+    language_tag: en
+    notification_category_subscriptions:
+    - ALL
+    parent: projects/test-pf-project1
+    timeouts: null
+  module.projects["team-a/project1"].google_project.project[0]:
+    auto_create_network: false
+    billing_account: 012345-67890A-BCDEF0
+    deletion_policy: DELETE
+    effective_labels:
+      environment: test
+      goog-terraform-provisioned: 'true'
+    labels:
+      environment: test
+    name: test-pf-project1
+    project_id: test-pf-project1
+    tags: null
+    terraform_labels:
+      environment: test
+      goog-terraform-provisioned: 'true'
+    timeouts: null
+  module.projects["team-a/project1"].google_project_iam_member.service_agents["container-engine-robot"]:
+    condition: []
+    project: test-pf-project1
+    role: roles/container.serviceAgent
+  module.projects["team-a/project1"].google_project_iam_member.service_agents["gkenode"]:
+    condition: []
+    project: test-pf-project1
+    role: roles/container.defaultNodeServiceAgent
+  module.projects["team-a/project1"].google_project_service.project_services["container.googleapis.com"]:
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: test-pf-project1
+    service: container.googleapis.com
+    timeouts: null
+  module.projects["team-a/project1"].google_project_service.project_services["stackdriver.googleapis.com"]:
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: test-pf-project1
+    service: stackdriver.googleapis.com
+    timeouts: null
+  module.projects["team-a/project1"].google_project_service.project_services["storage.googleapis.com"]:
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: test-pf-project1
+    service: storage.googleapis.com
+    timeouts: null
+  module.projects["team-a/project1"].google_project_service_identity.default["container.googleapis.com"]:
+    project: test-pf-project1
+    service: container.googleapis.com
+    timeouts: null
+  module.projects["team-b/automation"].data.google_storage_project_service_account.gcs_sa[0]:
+    project: test-pf-auto-team-b
+    user_project: null
+  module.projects["team-b/automation"].google_essential_contacts_contact.contact["admin@example.org"]:
+    email: admin@example.org
+    language_tag: en
+    notification_category_subscriptions:
+    - ALL
+    parent: projects/test-pf-auto-team-b
+    timeouts: null
+  module.projects["team-b/automation"].google_project.project[0]:
+    auto_create_network: false
+    billing_account: 012345-67890A-BCDEF0
+    deletion_policy: DELETE
+    effective_labels:
+      environment: test
+      goog-terraform-provisioned: 'true'
+    labels:
+      environment: test
+    name: test-pf-auto-team-b
+    project_id: test-pf-auto-team-b
+    tags: null
+    terraform_labels:
+      environment: test
+      goog-terraform-provisioned: 'true'
+    timeouts: null
+  module.projects["team-b/automation"].google_project_iam_member.service_agents["container-engine-robot"]:
+    condition: []
+    project: test-pf-auto-team-b
+    role: roles/container.serviceAgent
+  module.projects["team-b/automation"].google_project_iam_member.service_agents["gkenode"]:
+    condition: []
+    project: test-pf-auto-team-b
+    role: roles/container.defaultNodeServiceAgent
+  module.projects["team-b/automation"].google_project_service.project_services["container.googleapis.com"]:
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: test-pf-auto-team-b
+    service: container.googleapis.com
+    timeouts: null
+  module.projects["team-b/automation"].google_project_service.project_services["stackdriver.googleapis.com"]:
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: test-pf-auto-team-b
+    service: stackdriver.googleapis.com
+    timeouts: null
+  module.projects["team-b/automation"].google_project_service.project_services["storage.googleapis.com"]:
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: test-pf-auto-team-b
+    service: storage.googleapis.com
+    timeouts: null
+  module.projects["team-b/automation"].google_project_service_identity.default["container.googleapis.com"]:
+    project: test-pf-auto-team-b
+    service: container.googleapis.com
+    timeouts: null
+  module.projects["team-b/project3"].data.google_storage_project_service_account.gcs_sa[0]:
+    project: test-pf-project3
+    user_project: null
+  module.projects["team-b/project3"].google_essential_contacts_contact.contact["admin@example.org"]:
+    email: admin@example.org
+    language_tag: en
+    notification_category_subscriptions:
+    - ALL
+    parent: projects/test-pf-project3
+    timeouts: null
+  module.projects["team-b/project3"].google_project.project[0]:
+    auto_create_network: false
+    billing_account: 012345-67890A-BCDEF0
+    deletion_policy: DELETE
+    effective_labels:
+      environment: test
+      goog-terraform-provisioned: 'true'
+    labels:
+      environment: test
+    name: test-pf-project3
+    project_id: test-pf-project3
+    tags: null
+    terraform_labels:
+      environment: test
+      goog-terraform-provisioned: 'true'
+    timeouts: null
+  module.projects["team-b/project3"].google_project_iam_member.service_agents["container-engine-robot"]:
+    condition: []
+    project: test-pf-project3
+    role: roles/container.serviceAgent
+  module.projects["team-b/project3"].google_project_iam_member.service_agents["gkenode"]:
+    condition: []
+    project: test-pf-project3
+    role: roles/container.defaultNodeServiceAgent
+  module.projects["team-b/project3"].google_project_service.project_services["container.googleapis.com"]:
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: test-pf-project3
+    service: container.googleapis.com
+    timeouts: null
+  module.projects["team-b/project3"].google_project_service.project_services["stackdriver.googleapis.com"]:
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: test-pf-project3
+    service: stackdriver.googleapis.com
+    timeouts: null
+  module.projects["team-b/project3"].google_project_service.project_services["storage.googleapis.com"]:
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: test-pf-project3
+    service: storage.googleapis.com
+    timeouts: null
+  module.projects["team-b/project3"].google_project_service_identity.default["container.googleapis.com"]:
+    project: test-pf-project3
+    service: container.googleapis.com
     timeouts: null
   module.service-accounts["project2/app-be-0"].google_service_account.service_account[0]:
     account_id: app-be-0
@@ -480,6 +442,44 @@ values:
     member: serviceAccount:terraform-rw@test-pf-project2.iam.gserviceaccount.com
     project: test-pf-project2
     timeouts: null
+  module.service-accounts["team-a/project1/app-be-0"].google_service_account.service_account[0]:
+    account_id: app-be-0
+    create_ignore_already_exists: null
+    description: null
+    disabled: false
+    display_name: Terraform-managed.
+    email: app-be-0@test-pf-project1.iam.gserviceaccount.com
+    member: serviceAccount:app-be-0@test-pf-project1.iam.gserviceaccount.com
+    project: test-pf-project1
+    timeouts: null
+  ? module.service-accounts["team-a/project1/app-fe-1"].google_project_iam_member.project-roles["my-host-project-roles/compute.networkUser"]
+  : condition: []
+    project: my-host-project
+    role: roles/compute.networkUser
+  ? module.service-accounts["team-a/project1/app-fe-1"].google_project_iam_member.project-roles["test-pf-project1-roles/storage.objectViewer"]
+  : condition: []
+    project: test-pf-project1
+    role: roles/storage.objectViewer
+  module.service-accounts["team-a/project1/app-fe-1"].google_service_account.service_account[0]:
+    account_id: app-fe-1
+    create_ignore_already_exists: null
+    description: null
+    disabled: false
+    display_name: GCE frontend service account.
+    email: app-fe-1@test-pf-project1.iam.gserviceaccount.com
+    member: serviceAccount:app-fe-1@test-pf-project1.iam.gserviceaccount.com
+    project: test-pf-project1
+    timeouts: null
+  module.service-accounts["team-a/project1/terraform-rw"].google_service_account.service_account[0]:
+    account_id: terraform-rw
+    create_ignore_already_exists: null
+    description: null
+    disabled: false
+    display_name: Terraform-managed.
+    email: terraform-rw@test-pf-project1.iam.gserviceaccount.com
+    member: serviceAccount:terraform-rw@test-pf-project1.iam.gserviceaccount.com
+    project: test-pf-project1
+    timeouts: null
 
 counts:
   google_essential_contacts_contact: 6
@@ -498,8 +498,8 @@ counts:
 
 outputs:
   buckets:
-    project1/state: test-pf-project1-state
     project2/state: test-pf-project2-state
+    team-a/project1/state: test-pf-project1-state
   folders: __missing__
   projects: __missing__
   service_accounts: __missing__


### PR DESCRIPTION
* use `name` output as project name in project factory instead of key
* assume in `factory_projects_objects` that the keys may come with paths, and set `name` using `basename(...)`
* add a validation in `factory_projects_objects` that project names are unique

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [ ] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [ ] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
-->
