### PR TITLE
Allow direct assignment of project id without prefix

### DIFF
--- a/modules/project-factory/factory-projects-object.tf
+++ b/modules/project-factory/factory-projects-object.tf
@@ -43,6 +43,7 @@ locals {
       metric_scopes              = []
       parent                     = null
       prefix                     = null
+      project_id                 = null
       service_encryption_key_ids = {}
       services                   = []
       shared_vpc_service_config = merge({
@@ -96,6 +97,7 @@ locals {
       )
       parent                     = null
       prefix                     = null
+      project_id                 = null
       service_encryption_key_ids = null
       storage_location           = null
       tag_bindings               = null
@@ -181,6 +183,7 @@ locals {
         local.__projects_config.data_defaults.metric_scopes
       )
       name         = lookup(v, "name", basename(k)) # type: string
+      project_id   = lookup(v, "project_id", null)  # type: string, nullable
       org_policies = try(v.org_policies, {})        # type: map(object({...}))
       parent = try(                                 # type: string, nullable
         coalesce(

--- a/modules/project-factory/main.tf
+++ b/modules/project-factory/main.tf
@@ -37,11 +37,11 @@ module "projects" {
   source          = "../project"
   for_each        = local.projects
   billing_account = each.value.billing_account
-  name            = each.value.name
+  name            = each.value.project_id == null ? each.value.name : each.value.project_id # if project_id is present it takes precedence
   parent = lookup(
     local.context.folder_ids, each.value.parent, each.value.parent
   )
-  prefix              = each.value.prefix
+  prefix              = each.value.project_id == null ? each.value.prefix : null # if project_id is present no prefix should be used
   alerts              = try(each.value.alerts, null)
   auto_create_network = try(each.value.auto_create_network, false)
   compute_metadata    = try(each.value.compute_metadata, {})

--- a/modules/project-factory/schemas/project.schema.json
+++ b/modules/project-factory/schemas/project.schema.json
@@ -109,6 +109,9 @@
     "name": {
       "type": "string"
     },
+    "project_id": {
+      "type": "string"
+    },
     "org_policies": {
       "type": "object",
       "additionalProperties": false,


### PR DESCRIPTION
This PR implements a feature that assists on deploying Cloud Foundation Fabric to a brownfield installation. 

An existing GCP organization adopting the Foundation Fabric will have, usually, projects that do not follow naming conventions in their project ids. With this feature addition a field called "project_id" will reflect the id of the project and thus allow adopting it to the fabric via Terraform imports.

---
**Checklist**

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [x] Made sure all relevant tests pass
