### PR TITLE
fix reference to boot disk in snapshots when using independent disks

### DIFF
--- a/modules/compute-vm/main.tf
+++ b/modules/compute-vm/main.tf
@@ -69,10 +69,12 @@ resource "google_compute_disk" "boot" {
   count   = !var.create_template && var.boot_disk.use_independent_disk ? 1 : 0
   project = var.project_id
   zone    = var.zone
-  name    = "${var.name}-boot"
-  type    = var.boot_disk.initialize_params.type
-  size    = var.boot_disk.initialize_params.size
-  image   = var.boot_disk.initialize_params.image
+  # by default, GCP creates boot disks with the same name as instance, the deviation here is kept for backwards
+  # compatibility
+  name  = "${var.name}-boot"
+  type  = var.boot_disk.initialize_params.type
+  size  = var.boot_disk.initialize_params.size
+  image = var.boot_disk.initialize_params.image
   labels = merge(var.labels, {
     disk_name = "boot"
     disk_type = var.boot_disk.initialize_params.type

--- a/modules/compute-vm/resource-policies.tf
+++ b/modules/compute-vm/resource-policies.tf
@@ -148,7 +148,8 @@ resource "google_compute_disk_resource_policy_attachment" "boot" {
     google_compute_resource_policy.snapshot[each.value].name,
     each.value
   )
-  disk       = var.name
+  # if independent disk is used for boot disk it will have a different name compared to when created implicitly
+  disk       = !var.create_template && var.boot_disk.use_independent_disk ? google_compute_disk.boot[0].name : var.name
   depends_on = [google_compute_instance.default]
 }
 


### PR DESCRIPTION
When using independent disks, the snapshot policy was not correctly referring the boot disks.

I decided not to align the boot-disk name when using independent disks, to avoid forcing everybody (using independent disks) to recreate instances when upgrading the module.

Closes: #3064

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [ ] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [ ] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
-->
