### PR TITLE
[cloud-run-v2] Add ability to deploy OpenTelemetry Collector sidecar

### DIFF
--- a/modules/cloud-run-v2/README.md
+++ b/modules/cloud-run-v2/README.md
@@ -10,6 +10,7 @@ Cloud Run Services and Jobs, with support for IAM roles and Eventarc trigger cre
 - [Direct VPC Egress](#direct-vpc-egress)
 - [VPC Access Connector](#vpc-access-connector)
 - [Using Customer-Managed Encryption Key](#using-customer-managed-encryption-key)
+- [Deploying OpenTelemetry Collector sidecar](#deploying-opentelemetry-collector-sidecar)
 - [Eventarc triggers](#eventarc-triggers)
   - [PubSub](#pubsub)
   - [Audit logs](#audit-logs)

--- a/modules/cloud-run-v2/README.md
+++ b/modules/cloud-run-v2/README.md
@@ -308,6 +308,252 @@ module "cloud_run" {
 # tftest modules=3 resources=11 e2e
 ```
 
+## Deploying OpenTelemetry Collector sidecar
+
+```yaml
+# Reference: https://cloud.google.com/stackdriver/docs/instrumentation/opentelemetry-collector-cloud-run#gotc-provided-config
+
+receivers:
+  # Open two OTLP servers:
+  # - On port 4317, open an OTLP GRPC server
+  # - On port 4318, open an OTLP HTTP server
+  #
+  # Docs:
+  # https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver/otlpreceiver
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+      http:
+        cors:
+          # This effectively allows any origin
+          # to make requests to the HTTP server.
+          allowed_origins:
+          - http://*
+          - https://*
+        endpoint: localhost:4318
+
+  # Using the prometheus scraper, scrape the Collector's self metrics.
+  #
+  # Docs:
+  # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver
+  # https://opentelemetry.io/docs/collector/internal-telemetry/
+  prometheus/self-metrics:
+    config:
+      scrape_configs:
+      - job_name: otel-self-metrics
+        scrape_interval: 1m
+        static_configs:
+        - targets:
+          - localhost:8888
+
+processors:
+  # The batch processor is in place to regulate both the number of requests
+  # being made and the size of those requests.
+  #
+  # Docs:
+  # https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/batchprocessor
+  batch:
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 5s
+
+  # The memorylimiter will check the memory usage of the collector process.
+  #
+  # Docs:
+  # https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/memorylimiterprocessor
+  memory_limiter:
+    check_interval: 1s
+    limit_percentage: 65
+    spike_limit_percentage: 20
+
+  # The resourcedetection processor is configured to detect GCP resources.
+  # Resource attributes that represent the GCP resource the collector is
+  # running on will be attached to all telemetry that goes through this
+  # processor.
+  #
+  # Docs:
+  # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor
+  # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor#gcp-metadata
+  resourcedetection:
+    detectors: [gcp]
+    timeout: 10s
+
+  # The transform/collision processor ensures that any attributes that may
+  # collide with the googlemanagedprometheus exporter's monitored resource
+  # construction are moved to a similar name that is not reserved.
+  transform/collision:
+    metric_statements:
+    - context: datapoint
+      statements:
+      - set(attributes["exported_location"], attributes["location"])
+      - delete_key(attributes, "location")
+      - set(attributes["exported_cluster"], attributes["cluster"])
+      - delete_key(attributes, "cluster")
+      - set(attributes["exported_namespace"], attributes["namespace"])
+      - delete_key(attributes, "namespace")
+      - set(attributes["exported_job"], attributes["job"])
+      - delete_key(attributes, "job")
+      - set(attributes["exported_instance"], attributes["instance"])
+      - delete_key(attributes, "instance")
+      - set(attributes["exported_project_id"], attributes["project_id"])
+      - delete_key(attributes, "project_id")
+
+exporters:
+  # The googlecloud exporter will export telemetry to different
+  # Google Cloud services:
+  # Logs -> Cloud Logging
+  # Metrics -> Cloud Monitoring
+  # Traces -> Cloud Trace
+  #
+  # Docs:
+  # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlecloudexporter
+  googlecloud:
+    log:
+      default_log_name: opentelemetry-collector
+
+  # The googlemanagedprometheus exporter will send metrics to
+  # Google Managed Service for Prometheus.
+  #
+  # Docs:
+  # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlemanagedprometheusexporter
+  googlemanagedprometheus:
+
+extensions:
+  # Opens an endpoint on 13133 that can be used to check the
+  # status of the collector. Since this does not configure the
+  # `path` config value, the endpoint will default to `/`.
+  #
+  # When running on Cloud Run, this extension is required and not optional.
+  # In other environments it is recommended but may not be required for operation
+  # (i.e. in Container-Optimized OS or other GCE environments).
+  #
+  # Docs:
+  # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/healthcheckextension
+  health_check:
+    endpoint: 0.0.0.0:13133
+
+service:
+  extensions:
+  - health_check
+  pipelines:
+    logs:
+      receivers:
+      - otlp
+      processors:
+      - resourcedetection
+      - memory_limiter
+      - batch
+      exporters:
+      - googlecloud
+    metrics/otlp:
+      receivers:
+      - otlp
+      processors:
+      - transform/collision
+      - resourcedetection
+      - memory_limiter
+      - batch
+      exporters:
+      - googlemanagedprometheus
+    metrics/self-metrics:
+      receivers:
+      - prometheus/self-metrics
+      processors:
+      - resourcedetection
+      - memory_limiter
+      - batch
+      exporters:
+      - googlemanagedprometheus
+    traces:
+      receivers:
+      - otlp
+      processors:
+      - resourcedetection
+      - memory_limiter
+      - batch
+      exporters:
+      - googlecloud
+  telemetry:
+    metrics:
+      address: localhost:8888
+
+# tftest-file id=otel-config path=config/otel-config.yaml
+```
+
+```hcl
+module "secrets" {
+  source     = "./fabric/modules/secret-manager"
+  project_id = var.project_id
+  secrets = {
+    otel-config = {}
+  }
+  iam = {
+    otel-config = {
+      "roles/secretmanager.secretAccessor" = [
+        "serviceAccount:${var.project_number}-compute@developer.gserviceaccount.com",
+      ]
+    }
+  }
+  versions = {
+    otel-config = {
+      v1 = { enabled = true, data = file("${path.module}/config/otel-config.yaml") }
+    }
+  }
+}
+
+module "cloud_run" {
+  source     = "./fabric/modules/cloud-run-v2"
+  project_id = var.project_id
+  region     = var.region
+  name       = "hello"
+  containers = {
+    hello = {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+      ports = {
+        default = {
+          container_port = 3000
+        }
+      }
+      depends_on = ["collector"]
+    }
+    collector = {
+      image = "us-docker.pkg.dev/cloud-ops-agents-artifacts/google-cloud-opentelemetry-collector/otelcol-google:0.122.1"
+      startup_probe = {
+        http_get = {
+          path = "/"
+          port = 13133
+        }
+        timeout_seconds = 30
+        period_seconds  = 30
+      }
+      liveness_probe = {
+        http_get = {
+          path = "/"
+          port = 13133
+        }
+        timeout_seconds = 30
+        period_seconds  = 30
+      }
+      volume_mounts = {
+        "otel-config" = "/etc/otelcol-google/"
+      }
+    }
+  }
+  volumes = {
+    otel-config = {
+      secret = {
+        name    = "otel-config"
+        version = "1"
+        path    = "config.yaml"
+      }
+    }
+  }
+  deletion_protection = false
+}
+# tftest modules=2 resources=4 files=otel-config inventory=service-otel-sidecar.yaml e2e
+```
+
 ## Eventarc triggers
 
 ### PubSub
@@ -566,27 +812,27 @@ module "cloud_run" {
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [name](variables.tf#L178) | Name used for Cloud Run service. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L193) | Project id used for all resources. | <code>string</code> | ✓ |  |
-| [region](variables.tf#L198) | Region used for all resources. | <code>string</code> | ✓ |  |
-| [containers](variables.tf#L17) | Containers in name => attributes format. | <code title="map&#40;object&#40;&#123;&#10;  image   &#61; string&#10;  command &#61; optional&#40;list&#40;string&#41;&#41;&#10;  args    &#61; optional&#40;list&#40;string&#41;&#41;&#10;  env     &#61; optional&#40;map&#40;string&#41;&#41;&#10;  env_from_key &#61; optional&#40;map&#40;object&#40;&#123;&#10;    secret  &#61; string&#10;    version &#61; string&#10;  &#125;&#41;&#41;&#41;&#10;  liveness_probe &#61; optional&#40;object&#40;&#123;&#10;    grpc &#61; optional&#40;object&#40;&#123;&#10;      port    &#61; optional&#40;number&#41;&#10;      service &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;    http_get &#61; optional&#40;object&#40;&#123;&#10;      http_headers &#61; optional&#40;map&#40;string&#41;&#41;&#10;      path         &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;    failure_threshold     &#61; optional&#40;number&#41;&#10;    initial_delay_seconds &#61; optional&#40;number&#41;&#10;    period_seconds        &#61; optional&#40;number&#41;&#10;    timeout_seconds       &#61; optional&#40;number&#41;&#10;  &#125;&#41;&#41;&#10;  ports &#61; optional&#40;map&#40;object&#40;&#123;&#10;    container_port &#61; optional&#40;number&#41;&#10;    name           &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#41;&#10;  resources &#61; optional&#40;object&#40;&#123;&#10;    limits &#61; optional&#40;object&#40;&#123;&#10;      cpu    &#61; string&#10;      memory &#61; string&#10;    &#125;&#41;&#41;&#10;    cpu_idle          &#61; optional&#40;bool&#41;&#10;    startup_cpu_boost &#61; optional&#40;bool&#41;&#10;  &#125;&#41;&#41;&#10;  startup_probe &#61; optional&#40;object&#40;&#123;&#10;    grpc &#61; optional&#40;object&#40;&#123;&#10;      port    &#61; optional&#40;number&#41;&#10;      service &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;    http_get &#61; optional&#40;object&#40;&#123;&#10;      http_headers &#61; optional&#40;map&#40;string&#41;&#41;&#10;      path         &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;    tcp_socket &#61; optional&#40;object&#40;&#123;&#10;      port &#61; optional&#40;number&#41;&#10;    &#125;&#41;&#41;&#10;    failure_threshold     &#61; optional&#40;number&#41;&#10;    initial_delay_seconds &#61; optional&#40;number&#41;&#10;    period_seconds        &#61; optional&#40;number&#41;&#10;    timeout_seconds       &#61; optional&#40;number&#41;&#10;  &#125;&#41;&#41;&#10;  volume_mounts &#61; optional&#40;map&#40;string&#41;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [create_job](variables.tf#L77) | Create Cloud Run Job instead of Service. | <code>bool</code> |  | <code>false</code> |
-| [custom_audiences](variables.tf#L83) | Custom audiences for service. | <code>list&#40;string&#41;</code> |  | <code>null</code> |
-| [deletion_protection](variables.tf#L89) | Deletion protection setting for this Cloud Run service. | <code>string</code> |  | <code>null</code> |
-| [encryption_key](variables.tf#L95) | The full resource name of the Cloud KMS CryptoKey. | <code>string</code> |  | <code>null</code> |
-| [eventarc_triggers](variables.tf#L101) | Event arc triggers for different sources. | <code title="object&#40;&#123;&#10;  audit_log &#61; optional&#40;map&#40;object&#40;&#123;&#10;    method  &#61; string&#10;    service &#61; string&#10;  &#125;&#41;&#41;&#41;&#10;  pubsub                 &#61; optional&#40;map&#40;string&#41;&#41;&#10;  service_account_email  &#61; optional&#40;string&#41;&#10;  service_account_create &#61; optional&#40;bool, false&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [iam](variables.tf#L119) | IAM bindings for Cloud Run service in {ROLE => [MEMBERS]} format. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [ingress](variables.tf#L125) | Ingress settings. | <code>string</code> |  | <code>null</code> |
-| [invoker_iam_disabled](variables.tf#L142) | Disables IAM permission check for run.routes.invoke for callers of this service. | <code>bool</code> |  | <code>false</code> |
-| [labels](variables.tf#L148) | Resource labels. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
-| [launch_stage](variables.tf#L154) | The launch stage as defined by Google Cloud Platform Launch Stages. | <code>string</code> |  | <code>null</code> |
-| [managed_revision](variables.tf#L171) | Whether the Terraform module should control the deployment of revisions. | <code>bool</code> |  | <code>true</code> |
-| [prefix](variables.tf#L183) | Optional prefix used for resource names. | <code>string</code> |  | <code>null</code> |
-| [revision](variables.tf#L203) | Revision template configurations. | <code title="object&#40;&#123;&#10;  name                       &#61; optional&#40;string&#41;&#10;  gen2_execution_environment &#61; optional&#40;bool&#41;&#10;  max_concurrency            &#61; optional&#40;number&#41;&#10;  max_instance_count         &#61; optional&#40;number&#41;&#10;  min_instance_count         &#61; optional&#40;number&#41;&#10;  job &#61; optional&#40;object&#40;&#123;&#10;    max_retries &#61; optional&#40;number&#41;&#10;    task_count  &#61; optional&#40;number&#41;&#10;  &#125;&#41;, &#123;&#125;&#41;&#10;  vpc_access &#61; optional&#40;object&#40;&#123;&#10;    connector &#61; optional&#40;string&#41;&#10;    egress    &#61; optional&#40;string&#41;&#10;    network   &#61; optional&#40;string&#41;&#10;    subnet    &#61; optional&#40;string&#41;&#10;    tags      &#61; optional&#40;list&#40;string&#41;&#41;&#10;  &#125;&#41;, &#123;&#125;&#41;&#10;  timeout &#61; optional&#40;string&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [service_account](variables.tf#L241) | Service account email. Unused if service account is auto-created. | <code>string</code> |  | <code>null</code> |
-| [service_account_create](variables.tf#L247) | Auto-create service account. | <code>bool</code> |  | <code>false</code> |
-| [tag_bindings](variables.tf#L253) | Tag bindings for this service, in key => tag value id format. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
-| [volumes](variables.tf#L260) | Named volumes in containers in name => attributes format. | <code title="map&#40;object&#40;&#123;&#10;  secret &#61; optional&#40;object&#40;&#123;&#10;    name         &#61; string&#10;    default_mode &#61; optional&#40;string&#41;&#10;    path         &#61; optional&#40;string&#41;&#10;    version      &#61; optional&#40;string&#41;&#10;    mode         &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;  cloud_sql_instances &#61; optional&#40;list&#40;string&#41;&#41;&#10;  empty_dir_size      &#61; optional&#40;string&#41;&#10;  gcs &#61; optional&#40;object&#40;&#123;&#10;    bucket       &#61; string&#10;    is_read_only &#61; optional&#40;bool&#41;&#10;  &#125;&#41;&#41;&#10;  nfs &#61; optional&#40;object&#40;&#123;&#10;    server       &#61; string&#10;    path         &#61; optional&#40;string&#41;&#10;    is_read_only &#61; optional&#40;bool&#41;&#10;  &#125;&#41;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [name](variables.tf#L181) | Name used for Cloud Run service. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L196) | Project id used for all resources. | <code>string</code> | ✓ |  |
+| [region](variables.tf#L201) | Region used for all resources. | <code>string</code> | ✓ |  |
+| [containers](variables.tf#L17) | Containers in name => attributes format. | <code title="map&#40;object&#40;&#123;&#10;  image      &#61; string&#10;  depends_on &#61; optional&#40;list&#40;string&#41;&#41;&#10;  command    &#61; optional&#40;list&#40;string&#41;&#41;&#10;  args       &#61; optional&#40;list&#40;string&#41;&#41;&#10;  env        &#61; optional&#40;map&#40;string&#41;&#41;&#10;  env_from_key &#61; optional&#40;map&#40;object&#40;&#123;&#10;    secret  &#61; string&#10;    version &#61; string&#10;  &#125;&#41;&#41;&#41;&#10;  liveness_probe &#61; optional&#40;object&#40;&#123;&#10;    grpc &#61; optional&#40;object&#40;&#123;&#10;      port    &#61; optional&#40;number&#41;&#10;      service &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;    http_get &#61; optional&#40;object&#40;&#123;&#10;      http_headers &#61; optional&#40;map&#40;string&#41;&#41;&#10;      path         &#61; optional&#40;string&#41;&#10;      port         &#61; optional&#40;number&#41;&#10;    &#125;&#41;&#41;&#10;    failure_threshold     &#61; optional&#40;number&#41;&#10;    initial_delay_seconds &#61; optional&#40;number&#41;&#10;    period_seconds        &#61; optional&#40;number&#41;&#10;    timeout_seconds       &#61; optional&#40;number&#41;&#10;  &#125;&#41;&#41;&#10;  ports &#61; optional&#40;map&#40;object&#40;&#123;&#10;    container_port &#61; optional&#40;number&#41;&#10;    name           &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#41;&#10;  resources &#61; optional&#40;object&#40;&#123;&#10;    limits &#61; optional&#40;object&#40;&#123;&#10;      cpu    &#61; string&#10;      memory &#61; string&#10;    &#125;&#41;&#41;&#10;    cpu_idle          &#61; optional&#40;bool&#41;&#10;    startup_cpu_boost &#61; optional&#40;bool&#41;&#10;  &#125;&#41;&#41;&#10;  startup_probe &#61; optional&#40;object&#40;&#123;&#10;    grpc &#61; optional&#40;object&#40;&#123;&#10;      port    &#61; optional&#40;number&#41;&#10;      service &#61; optional&#40;string&#41;&#10;    &#125;&#41;&#41;&#10;    http_get &#61; optional&#40;object&#40;&#123;&#10;      http_headers &#61; optional&#40;map&#40;string&#41;&#41;&#10;      path         &#61; optional&#40;string&#41;&#10;      port         &#61; optional&#40;number&#41;&#10;    &#125;&#41;&#41;&#10;    tcp_socket &#61; optional&#40;object&#40;&#123;&#10;      port &#61; optional&#40;number&#41;&#10;    &#125;&#41;&#41;&#10;    failure_threshold     &#61; optional&#40;number&#41;&#10;    initial_delay_seconds &#61; optional&#40;number&#41;&#10;    period_seconds        &#61; optional&#40;number&#41;&#10;    timeout_seconds       &#61; optional&#40;number&#41;&#10;  &#125;&#41;&#41;&#10;  volume_mounts &#61; optional&#40;map&#40;string&#41;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [create_job](variables.tf#L80) | Create Cloud Run Job instead of Service. | <code>bool</code> |  | <code>false</code> |
+| [custom_audiences](variables.tf#L86) | Custom audiences for service. | <code>list&#40;string&#41;</code> |  | <code>null</code> |
+| [deletion_protection](variables.tf#L92) | Deletion protection setting for this Cloud Run service. | <code>string</code> |  | <code>null</code> |
+| [encryption_key](variables.tf#L98) | The full resource name of the Cloud KMS CryptoKey. | <code>string</code> |  | <code>null</code> |
+| [eventarc_triggers](variables.tf#L104) | Event arc triggers for different sources. | <code title="object&#40;&#123;&#10;  audit_log &#61; optional&#40;map&#40;object&#40;&#123;&#10;    method  &#61; string&#10;    service &#61; string&#10;  &#125;&#41;&#41;&#41;&#10;  pubsub                 &#61; optional&#40;map&#40;string&#41;&#41;&#10;  service_account_email  &#61; optional&#40;string&#41;&#10;  service_account_create &#61; optional&#40;bool, false&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [iam](variables.tf#L122) | IAM bindings for Cloud Run service in {ROLE => [MEMBERS]} format. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [ingress](variables.tf#L128) | Ingress settings. | <code>string</code> |  | <code>null</code> |
+| [invoker_iam_disabled](variables.tf#L145) | Disables IAM permission check for run.routes.invoke for callers of this service. | <code>bool</code> |  | <code>false</code> |
+| [labels](variables.tf#L151) | Resource labels. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [launch_stage](variables.tf#L157) | The launch stage as defined by Google Cloud Platform Launch Stages. | <code>string</code> |  | <code>null</code> |
+| [managed_revision](variables.tf#L174) | Whether the Terraform module should control the deployment of revisions. | <code>bool</code> |  | <code>true</code> |
+| [prefix](variables.tf#L186) | Optional prefix used for resource names. | <code>string</code> |  | <code>null</code> |
+| [revision](variables.tf#L206) | Revision template configurations. | <code title="object&#40;&#123;&#10;  name                       &#61; optional&#40;string&#41;&#10;  gen2_execution_environment &#61; optional&#40;bool&#41;&#10;  max_concurrency            &#61; optional&#40;number&#41;&#10;  max_instance_count         &#61; optional&#40;number&#41;&#10;  min_instance_count         &#61; optional&#40;number&#41;&#10;  job &#61; optional&#40;object&#40;&#123;&#10;    max_retries &#61; optional&#40;number&#41;&#10;    task_count  &#61; optional&#40;number&#41;&#10;  &#125;&#41;, &#123;&#125;&#41;&#10;  vpc_access &#61; optional&#40;object&#40;&#123;&#10;    connector &#61; optional&#40;string&#41;&#10;    egress    &#61; optional&#40;string&#41;&#10;    network   &#61; optional&#40;string&#41;&#10;    subnet    &#61; optional&#40;string&#41;&#10;    tags      &#61; optional&#40;list&#40;string&#41;&#41;&#10;  &#125;&#41;, &#123;&#125;&#41;&#10;  timeout &#61; optional&#40;string&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [service_account](variables.tf#L244) | Service account email. Unused if service account is auto-created. | <code>string</code> |  | <code>null</code> |
+| [service_account_create](variables.tf#L250) | Auto-create service account. | <code>bool</code> |  | <code>false</code> |
+| [tag_bindings](variables.tf#L256) | Tag bindings for this service, in key => tag value id format. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [volumes](variables.tf#L263) | Named volumes in containers in name => attributes format. | <code title="map&#40;object&#40;&#123;&#10;  secret &#61; optional&#40;object&#40;&#123;&#10;    name         &#61; string&#10;    default_mode &#61; optional&#40;string&#41;&#10;    path         &#61; optional&#40;string&#41;&#10;    version      &#61; optional&#40;string&#41;&#10;    mode         &#61; optional&#40;string&#41;&#10;  &#125;&#41;&#41;&#10;  cloud_sql_instances &#61; optional&#40;list&#40;string&#41;&#41;&#10;  empty_dir_size      &#61; optional&#40;string&#41;&#10;  gcs &#61; optional&#40;object&#40;&#123;&#10;    bucket       &#61; string&#10;    is_read_only &#61; optional&#40;bool&#41;&#10;  &#125;&#41;&#41;&#10;  nfs &#61; optional&#40;object&#40;&#123;&#10;    server       &#61; string&#10;    path         &#61; optional&#40;string&#41;&#10;    is_read_only &#61; optional&#40;bool&#41;&#10;  &#125;&#41;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [vpc_connector_create](variables-vpcconnector.tf#L17) | Populate this to create a Serverless VPC Access connector. | <code title="object&#40;&#123;&#10;  ip_cidr_range &#61; optional&#40;string&#41;&#10;  machine_type  &#61; optional&#40;string&#41;&#10;  name          &#61; optional&#40;string&#41;&#10;  network       &#61; optional&#40;string&#41;&#10;  instances &#61; optional&#40;object&#40;&#123;&#10;    max &#61; optional&#40;number&#41;&#10;    min &#61; optional&#40;number&#41;&#10;    &#125;&#41;, &#123;&#125;&#10;  &#41;&#10;  throughput &#61; optional&#40;object&#40;&#123;&#10;    max &#61; optional&#40;number&#41;&#10;    min &#61; optional&#40;number&#41;&#10;    &#125;&#41;, &#123;&#125;&#10;  &#41;&#10;  subnet &#61; optional&#40;object&#40;&#123;&#10;    name       &#61; optional&#40;string&#41;&#10;    project_id &#61; optional&#40;string&#41;&#10;  &#125;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
 
 ## Outputs

--- a/modules/cloud-run-v2/service.tf
+++ b/modules/cloud-run-v2/service.tf
@@ -377,6 +377,7 @@ resource "google_cloud_run_v2_service" "service_unmanaged" {
               for_each = containers.value.liveness_probe.http_get == null ? [] : [""]
               content {
                 path = containers.value.liveness_probe.http_get.path
+                port = containers.value.liveness_probe.http_get.port
                 dynamic "http_headers" {
                   for_each = coalesce(containers.value.liveness_probe.http_get.http_headers, tomap({}))
                   content {
@@ -406,6 +407,7 @@ resource "google_cloud_run_v2_service" "service_unmanaged" {
               for_each = containers.value.startup_probe.http_get == null ? [] : [""]
               content {
                 path = containers.value.startup_probe.http_get.path
+                port = containers.value.startup_probe.http_get.port
                 dynamic "http_headers" {
                   for_each = coalesce(containers.value.startup_probe.http_get.http_headers, tomap({}))
                   content {

--- a/modules/cloud-run-v2/service.tf
+++ b/modules/cloud-run-v2/service.tf
@@ -69,10 +69,11 @@ resource "google_cloud_run_v2_service" "service" {
     dynamic "containers" {
       for_each = var.containers
       content {
-        name    = containers.key
-        image   = containers.value.image
-        command = containers.value.command
-        args    = containers.value.args
+        name       = containers.key
+        image      = containers.value.image
+        depends_on = containers.value.depends_on
+        command    = containers.value.command
+        args       = containers.value.args
         dynamic "env" {
           for_each = coalesce(containers.value.env, tomap({}))
           content {
@@ -133,6 +134,7 @@ resource "google_cloud_run_v2_service" "service" {
               for_each = containers.value.liveness_probe.http_get == null ? [] : [""]
               content {
                 path = containers.value.liveness_probe.http_get.path
+                port = containers.value.liveness_probe.http_get.port
                 dynamic "http_headers" {
                   for_each = coalesce(containers.value.liveness_probe.http_get.http_headers, tomap({}))
                   content {
@@ -162,6 +164,7 @@ resource "google_cloud_run_v2_service" "service" {
               for_each = containers.value.startup_probe.http_get == null ? [] : [""]
               content {
                 path = containers.value.startup_probe.http_get.path
+                port = containers.value.startup_probe.http_get.port
                 dynamic "http_headers" {
                   for_each = coalesce(containers.value.startup_probe.http_get.http_headers, tomap({}))
                   content {
@@ -309,10 +312,11 @@ resource "google_cloud_run_v2_service" "service_unmanaged" {
     dynamic "containers" {
       for_each = var.containers
       content {
-        name    = containers.key
-        image   = containers.value.image
-        command = containers.value.command
-        args    = containers.value.args
+        name       = containers.key
+        image      = containers.value.image
+        depends_on = containers.value.depends_on
+        command    = containers.value.command
+        args       = containers.value.args
         dynamic "env" {
           for_each = coalesce(containers.value.env, tomap({}))
           content {

--- a/modules/cloud-run-v2/variables.tf
+++ b/modules/cloud-run-v2/variables.tf
@@ -17,10 +17,11 @@
 variable "containers" {
   description = "Containers in name => attributes format."
   type = map(object({
-    image   = string
-    command = optional(list(string))
-    args    = optional(list(string))
-    env     = optional(map(string))
+    image      = string
+    depends_on = optional(list(string))
+    command    = optional(list(string))
+    args       = optional(list(string))
+    env        = optional(map(string))
     env_from_key = optional(map(object({
       secret  = string
       version = string
@@ -33,6 +34,7 @@ variable "containers" {
       http_get = optional(object({
         http_headers = optional(map(string))
         path         = optional(string)
+        port         = optional(number)
       }))
       failure_threshold     = optional(number)
       initial_delay_seconds = optional(number)
@@ -59,6 +61,7 @@ variable "containers" {
       http_get = optional(object({
         http_headers = optional(map(string))
         path         = optional(string)
+        port         = optional(number)
       }))
       tcp_socket = optional(object({
         port = optional(number)

--- a/tests/modules/cloud_run_v2/examples/service-otel-sidecar.yaml
+++ b/tests/modules/cloud_run_v2/examples/service-otel-sidecar.yaml
@@ -1,3 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 values:
   module.cloud_run.google_cloud_run_v2_service.service[0]:
     template:

--- a/tests/modules/cloud_run_v2/examples/service-otel-sidecar.yaml
+++ b/tests/modules/cloud_run_v2/examples/service-otel-sidecar.yaml
@@ -1,0 +1,44 @@
+values:
+  module.cloud_run.google_cloud_run_v2_service.service[0]:
+    template:
+    - containers:
+      - image: us-docker.pkg.dev/cloud-ops-agents-artifacts/google-cloud-opentelemetry-collector/otelcol-google:0.122.1
+        liveness_probe:
+        - failure_threshold: 3
+          grpc: []
+          http_get:
+          - http_headers: []
+            path: /
+            port: 13133
+          initial_delay_seconds: 0
+          period_seconds: 30
+          tcp_socket: []
+          timeout_seconds: 30
+        name: collector
+        startup_probe:
+        - failure_threshold: 3
+          grpc: []
+          http_get:
+          - http_headers: []
+            path: /
+            port: 13133
+          initial_delay_seconds: 0
+          period_seconds: 30
+          tcp_socket: []
+          timeout_seconds: 30
+      - depends_on:
+        - collector
+        image: us-docker.pkg.dev/cloudrun/container/hello
+        name: hello
+        ports:
+        - container_port: 3000
+
+counts:
+  google_cloud_run_v2_service: 1
+  google_secret_manager_secret: 1
+  google_secret_manager_secret_iam_binding: 1
+  google_secret_manager_secret_version: 1
+  modules: 2
+  resources: 4
+
+outputs: {}


### PR DESCRIPTION
- Adds `depends_on` flag to container definition
- Adds `port` to HTTP liveness & startup probes

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
-->
