### PR TITLE
Fix GKE master authorized networks nullability

### DIFF
--- a/modules/gke-cluster-standard/variables.tf
+++ b/modules/gke-cluster-standard/variables.tf
@@ -19,9 +19,9 @@ variable "access_config" {
   type = object({
     dns_access = optional(bool, true)
     ip_access = optional(object({
-      authorized_ranges               = optional(map(string), {})
+      authorized_ranges               = optional(map(string), null)
       disable_public_endpoint         = optional(bool, true)
-      gcp_public_cidrs_access_enabled = optional(bool, false)
+      gcp_public_cidrs_access_enabled = optional(bool, null)
       private_endpoint_config = optional(object({
         endpoint_subnetwork = optional(string)
         global_access       = optional(bool, true)


### PR DESCRIPTION
## Summary
- Change default values for authorized_ranges from {} to null and gcp_public_cidrs_access_enabled from false to null
- Ensures the [dynamic master_authorized_networks_config block](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/e937a562c78cb060ebb63ed0fdae5e8b008d7454/modules/gke-cluster-standard/main.tf#L395) is properly conditional on user input
- Previously, these defaults would never evaluate to null, causing the block to always initialize

## Test plan
- Verify that users can set {} or true/false explicitly to configure the block
- Verify that leaving the values unset results in the dynamic block not being created

🤖 Generated with [Claude Code](https://claude.ai/code)