### PR TITLE
bug: mark policy_controller as optional

### DIFF
--- a/modules/gke-hub/variables.tf
+++ b/modules/gke-hub/variables.tf
@@ -51,13 +51,13 @@ variable "configmanagement_templates" {
       enable_hierarchical_resource_quota = optional(bool)
       enable_pod_tree_labels             = optional(bool)
     }))
-    policy_controller = object({
+    policy_controller = optional(object({
       audit_interval_seconds     = optional(number)
       exemptable_namespaces      = optional(list(string))
       log_denies_enabled         = optional(bool)
       referential_rules_enabled  = optional(bool)
       template_library_installed = optional(bool)
-    })
+    }))
   }))
   default  = {}
   nullable = false


### PR DESCRIPTION
Small change to mark `configmanagement_templates.*.policy_controller` as optional. This is optional in the underlying resource `google_gke_hub_membership` (https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/gke_hub_feature_membership#policy_controller-1). Right now it's not possible to enable config-sync without also enabling policy_controller

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [ ] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [ ] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
-->
