### PR TITLE
Remove warning for password argument in CloudSQL instance module

### DIFF
--- a/modules/cloudsql-instance/main.tf
+++ b/modules/cloudsql-instance/main.tf
@@ -315,13 +315,13 @@ resource "random_password" "root_password" {
 }
 
 resource "google_sql_user" "users" {
-  for_each = local.users
-  project  = var.project_id
-  instance = google_sql_database_instance.primary.name
-  name     = each.value.name
-  host     = each.value.host
-  password = each.value.password
-  type     = each.value.type
+  for_each    = local.users
+  project     = var.project_id
+  instance    = google_sql_database_instance.primary.name
+  name        = each.value.name
+  host        = each.value.host
+  password_wo = each.value.password
+  type        = each.value.type
 }
 
 moved {

--- a/tests/modules/cloudsql_instance/examples/custom.yaml
+++ b/tests/modules/cloudsql_instance/examples/custom.yaml
@@ -27,7 +27,7 @@ values:
   module.db.google_sql_user.users["fixture-service-account@project-id.iam.gserviceaccount.com"]:
     instance: db
     name: fixture-service-account@project-id.iam.gserviceaccount.com
-    password: null
+    password_wo: null
     password_policy: []
     project: project-id
     type: CLOUD_IAM_SERVICE_ACCOUNT


### PR DESCRIPTION
The CloudSQL instance module currently returns this warning:

```
Warning: Available Write-only Attribute Alternative
│
│   with module.cloudsql.google_sql_user.users,
│   on .terraform/modules/cloudsql/modules/cloudsql-instance/main.tf line 323, in resource "google_sql_user" "users":
│  323:   password = each.value.password
│
│ The attribute password has a write-only alternative password_wo available. Use the write-only alternative of the attribute when possible.
```

This PR removes the warning using the recommended argument `password_wo`.

**Checklist**

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
