### PR TITLE
Enable context replacements for IAM principals in project factory module

### DIFF
--- a/modules/project-factory/README.md
+++ b/modules/project-factory/README.md
@@ -350,6 +350,9 @@ service_encryption_key_ids:
 services:
   - container.googleapis.com
   - storage.googleapis.com
+iam_by_principals:
+  app-0-be:
+    - roles/storage.objectViewer
 service_accounts:
   app-0-be:
     display_name: "Backend instances."

--- a/modules/project-factory/folders.tf
+++ b/modules/project-factory/folders.tf
@@ -63,8 +63,13 @@ module "hierarchy-folder-lvl-1" {
       )
     })
   }
-  iam_by_principals = lookup(each.value, "iam_by_principals", {})
-  org_policies      = lookup(each.value, "org_policies", {})
+  iam_by_principals = {
+    for k, v in lookup(each.value, "iam_by_principals", {}) :
+    lookup(
+      var.factories_config.context.iam_principals, k, k
+    ) => v
+  }
+  org_policies = lookup(each.value, "org_policies", {})
   tag_bindings = {
     for k, v in lookup(each.value, "tag_bindings", {}) :
     k => lookup(var.factories_config.context.tag_values, v, v)

--- a/tests/modules/project_factory/examples/example.yaml
+++ b/tests/modules/project_factory/examples/example.yaml
@@ -525,7 +525,7 @@ counts:
   google_kms_crypto_key_iam_member: 1
   google_monitoring_notification_channel: 1
   google_project: 4
-  google_project_iam_binding: 4
+  google_project_iam_binding: 5
   google_project_iam_member: 18
   google_project_service: 12
   google_project_service_identity: 4
@@ -534,7 +534,10 @@ counts:
   google_storage_bucket_iam_binding: 2
   google_storage_project_service_account: 4
   google_tags_tag_binding: 1
+  google_tags_tag_key: 1
+  google_tags_tag_value: 2
+  google_tags_tag_value_iam_binding: 1
   modules: 20
-  resources: 74
+  resources: 75
 
 outputs: {}


### PR DESCRIPTION
Service account emails are static and can be used in context replacements.