### PR TITLE
Backup enablement for CloudSQL instance should be only based on user provided settings

### DIFF
--- a/modules/cloudsql-instance/main.tf
+++ b/modules/cloudsql-instance/main.tf
@@ -20,13 +20,6 @@ locals {
   is_postgres  = can(regex("^POSTGRES", var.database_version))
   has_replicas = length(var.replicas) > 0
   is_regional  = var.availability_type == "REGIONAL" ? true : false
-  # enable backup if the user asks for it or if the user is deploying
-  # MySQL in HA configuration (regional or with specified replicas)
-  enable_backup = (
-    var.backup_configuration.enabled ||
-    (local.is_mysql && local.has_replicas) ||
-    (local.is_mysql && local.is_regional)
-  )
   users = {
     for k, v in coalesce(var.users, {}) : k =>
     local.is_mysql
@@ -109,7 +102,7 @@ resource "google_sql_database_instance" "primary" {
     }
 
     dynamic "backup_configuration" {
-      for_each = local.enable_backup ? { 1 = 1 } : {}
+      for_each = var.backup_configuration.enabled ? { 1 = 1 } : {}
       content {
         enabled = true
         // enable binary log if the user asks for it or we have replicas (default in regional),


### PR DESCRIPTION
Trying to infer that whether backups should be enabled or not if it causing isues with DMS. DMS when you configure a migration job, demotes the destination instance to a replica and replicas do no allow backups, so if you created the instance originally with this module you will have a drift in the backup enablement always, because you are forcing the value programatically

<!-- Put a description of what this PR is for here -->

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [x] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
-->
