### PR TITLE
Support iam_sa_roles to project factory service accounts

### DIFF
--- a/modules/project-factory/main.tf
+++ b/modules/project-factory/main.tf
@@ -31,6 +31,9 @@ locals {
       # module.service-accounts are excluded here, as adding them here results in dependency cycles
     )
   }
+  service_accounts_names = {
+    for k, v in module.service-accounts : k => v.name
+  }
 }
 
 module "projects" {
@@ -375,6 +378,22 @@ module "service-accounts" {
       (module.projects[each.value.project_key].project_id) = each.value.iam_self_roles
     }
   )
+}
+
+module "service_accounts-iam" {
+  source = "../iam-service-account"
+  for_each = {
+    for k in local.service_accounts : "${k.project_key}/${k.name}" => k
+    if k.iam_sa_roles != {}
+  }
+  project_id             = module.service-accounts[each.key].service_account.project
+  name                   = each.value.name
+  service_account_create = false
+  iam_sa_roles = {
+    for k, v in each.value.iam_sa_roles : lookup(
+      local.service_accounts_names, "${each.value.project_key}/${k}", k
+    ) => v
+  }
 }
 
 module "billing-account" {

--- a/modules/project-factory/schemas/project.schema.json
+++ b/modules/project-factory/schemas/project.schema.json
@@ -252,6 +252,9 @@
             },
             "iam_project_roles": {
               "$ref": "#/$defs/iam_project_roles"
+            },
+            "iam_sa_roles": {
+              "$ref": "#/$defs/iam_sa_roles"
             }
           }
         }


### PR DESCRIPTION
This change addresses #3109 by adding support to the project factory for the `iam_sa_roles` attribute in the underlying service accounts module.

This allows management of additive IAM between service accounts within the same project.