### PR TITLE
Allow explicit definition of automation prefix in project factory

### DIFF
--- a/modules/project-factory/README.md
+++ b/modules/project-factory/README.md
@@ -428,6 +428,8 @@ service_accounts:
         - automation/rw
 automation:
   project: test-pf-teams-iac-0
+  # prefix used for automation resources can be explicitly set if needed
+  # prefix: test-pf-dev-tb-0-0
   service_accounts:
     rw:
       description: Team B app 0 read/write automation sa.

--- a/modules/project-factory/schemas/project.schema.json
+++ b/modules/project-factory/schemas/project.schema.json
@@ -11,6 +11,9 @@
         "project"
       ],
       "properties": {
+        "prefix": {
+          "type": "string"
+        },
         "project": {
           "type": "string"
         },

--- a/modules/project-factory/schemas/project.schema.md
+++ b/modules/project-factory/schemas/project.schema.md
@@ -8,6 +8,7 @@
 
 - **automation**: *object*
   <br>*additional properties: false*
+  - **prefix**: *string*
   - ⁺**project**: *string*
   - **bucket**: *reference([bucket](#refs-bucket))*
   - **service_accounts**: *object*
@@ -86,6 +87,7 @@
     - **iam_self_roles**: *array*
       - items: *string*
     - **iam_project_roles**: *reference([iam_project_roles](#refs-iam_project_roles))*
+    - **iam_sa_roles**: *reference([iam_sa_roles](#refs-iam_sa_roles))*
 - **service_encryption_key_ids**: *object*
   <br>*additional properties: false*
   - **`^[a-z-]+\.googleapis\.com$`**: *array*


### PR DESCRIPTION
This supersedes #3097 by optionally exposing the prefix used in automation resource names by the project factory.

Old behaviour and new behaviour if prefix is unset, is to use the project id as the prefix in automation resource names. This is of course to a) guarantee univocity of the bucket name, b) allow easy identification of resources in the IaC project, which pools automation resources for many application-level projects.

This yaml shows the above and will generate a `[project id]-tf-state` bucket and a `[project id]-rw` service account. 

```yaml
automation:
  project: foo-iac-0
  service_accounts:
    rw:
      description: Read/write automation service account for apt registries.
  bucket:
    description: Terraform state bucket for apt registries.
```

New behaviour when `automation.prefix` is set is to use that for automation resource names. This yaml will generate a `foo-tf-state` bucket and a `foo-rw` service account. Prefix is not optional, if it's null the default above will be used.

```yaml
automation:
  prefix: foo
  project: foo-iac-0
  service_accounts:
    rw:
      description: Read/write automation service account for apt registries.
  bucket:
    description: Terraform state bucket for apt registries.
```
