### PR TITLE
Add notebooks, appengine and appspot to dns policy routing in FAST networking stage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,7 +83,7 @@ repos:
     entry: python3 tools/duplicate-diff.py
     language: python
     language_version: python3
-    files: '.*(\.sh|\.tf|\.tftpl|\.tpl)$'
+    files: '.*(\.sh|\.tf|\.tftpl|\.tpl|\.yaml)$'
     pass_filenames: true
     require_serial: true
 

--- a/fast/stages/2-networking-a-simple/data/dns-policy-rules.yaml
+++ b/fast/stages/2-networking-a-simple/data/dns-policy-rules.yaml
@@ -13,6 +13,13 @@ aiplatform-notebook-cloud-all:
 aiplatform-notebook-gu-all:
   dns_name: "*.aiplatform-notebook.googleusercontent.com."
   local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
+appengine:
+  dns_name: "appengine.google.com."
+  local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
+appspot-all:
+  dns_name: "*.appspot.com."
+  local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
+
 backupdr-cloud:
   dns_name: "backupdr.cloud.google.com."
   local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
@@ -105,6 +112,9 @@ kernels-gu-all:
   local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
 ltsapis-all:
   dns_name: "*.ltsapis.goog."
+  local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
+notebooks:
+  dns_name: "notebooks.cloud.google.com."
   local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
 notebooks-all:
   dns_name: "*.notebooks.cloud.google.com."

--- a/fast/stages/2-networking-b-nva/data/dns-policy-rules.yaml
+++ b/fast/stages/2-networking-b-nva/data/dns-policy-rules.yaml
@@ -13,6 +13,13 @@ aiplatform-notebook-cloud-all:
 aiplatform-notebook-gu-all:
   dns_name: "*.aiplatform-notebook.googleusercontent.com."
   local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
+appengine:
+  dns_name: "appengine.google.com."
+  local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
+appspot-all:
+  dns_name: "*.appspot.com."
+  local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
+
 backupdr-cloud:
   dns_name: "backupdr.cloud.google.com."
   local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
@@ -105,6 +112,9 @@ kernels-gu-all:
   local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
 ltsapis-all:
   dns_name: "*.ltsapis.goog."
+  local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
+notebooks:
+  dns_name: "notebooks.cloud.google.com."
   local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
 notebooks-all:
   dns_name: "*.notebooks.cloud.google.com."

--- a/fast/stages/2-networking-c-separate-envs/data/dns-policy-rules.yaml
+++ b/fast/stages/2-networking-c-separate-envs/data/dns-policy-rules.yaml
@@ -13,6 +13,13 @@ aiplatform-notebook-cloud-all:
 aiplatform-notebook-gu-all:
   dns_name: "*.aiplatform-notebook.googleusercontent.com."
   local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
+appengine:
+  dns_name: "appengine.google.com."
+  local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
+appspot-all:
+  dns_name: "*.appspot.com."
+  local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
+
 backupdr-cloud:
   dns_name: "backupdr.cloud.google.com."
   local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
@@ -105,6 +112,9 @@ kernels-gu-all:
   local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
 ltsapis-all:
   dns_name: "*.ltsapis.goog."
+  local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
+notebooks:
+  dns_name: "notebooks.cloud.google.com."
   local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
 notebooks-all:
   dns_name: "*.notebooks.cloud.google.com."

--- a/tests/fast/stages/s2_networking_a_simple/ncc.yaml
+++ b/tests/fast/stages/s2_networking_a_simple/ncc.yaml
@@ -27,7 +27,7 @@ counts:
   google_dns_policy: 3
   google_dns_record_set: 3
   google_dns_response_policy: 1
-  google_dns_response_policy_rule: 39
+  google_dns_response_policy_rule: 42
   google_essential_contacts_contact: 1
   google_monitoring_alert_policy: 2
   google_monitoring_dashboard: 3
@@ -42,4 +42,4 @@ counts:
   google_storage_bucket_object: 2
   google_tags_tag_binding: 3
   modules: 23
-  resources: 186
+  resources: 189

--- a/tests/fast/stages/s2_networking_a_simple/simple.yaml
+++ b/tests/fast/stages/s2_networking_a_simple/simple.yaml
@@ -33,7 +33,7 @@ counts:
   google_dns_policy: 3
   google_dns_record_set: 3
   google_dns_response_policy: 1
-  google_dns_response_policy_rule: 39
+  google_dns_response_policy_rule: 42
   google_essential_contacts_contact: 1
   google_monitoring_alert_policy: 2
   google_monitoring_dashboard: 3
@@ -47,4 +47,4 @@ counts:
   google_tags_tag_binding: 3
   modules: 28
   random_id: 3
-  resources: 203
+  resources: 206

--- a/tests/fast/stages/s2_networking_a_simple/vpn.yaml
+++ b/tests/fast/stages/s2_networking_a_simple/vpn.yaml
@@ -31,7 +31,7 @@ counts:
   google_dns_policy: 3
   google_dns_record_set: 3
   google_dns_response_policy: 1
-  google_dns_response_policy_rule: 39
+  google_dns_response_policy_rule: 42
   google_essential_contacts_contact: 1
   google_monitoring_alert_policy: 2
   google_monitoring_dashboard: 3
@@ -45,4 +45,4 @@ counts:
   google_tags_tag_binding: 3
   modules: 30
   random_id: 17
-  resources: 250
+  resources: 253

--- a/tests/fast/stages/s2_networking_b_nva/ncc-ra.yaml
+++ b/tests/fast/stages/s2_networking_b_nva/ncc-ra.yaml
@@ -34,7 +34,7 @@ counts:
   google_dns_policy: 4
   google_dns_record_set: 3
   google_dns_response_policy: 1
-  google_dns_response_policy_rule: 39
+  google_dns_response_policy_rule: 42
   google_essential_contacts_contact: 1
   google_monitoring_alert_policy: 2
   google_monitoring_dashboard: 3
@@ -50,4 +50,4 @@ counts:
   google_tags_tag_binding: 3
   modules: 38
   random_id: 6
-  resources: 270
+  resources: 273

--- a/tests/fast/stages/s2_networking_b_nva/regional.yaml
+++ b/tests/fast/stages/s2_networking_b_nva/regional.yaml
@@ -38,7 +38,7 @@ counts:
   google_dns_policy: 6
   google_dns_record_set: 3
   google_dns_response_policy: 1
-  google_dns_response_policy_rule: 39
+  google_dns_response_policy_rule: 42
   google_essential_contacts_contact: 1
   google_monitoring_alert_policy: 2
   google_monitoring_dashboard: 3
@@ -52,4 +52,4 @@ counts:
   google_tags_tag_binding: 3
   modules: 46
   random_id: 6
-  resources: 280
+  resources: 283

--- a/tests/fast/stages/s2_networking_b_nva/simple.yaml
+++ b/tests/fast/stages/s2_networking_b_nva/simple.yaml
@@ -38,7 +38,7 @@ counts:
   google_dns_policy: 4
   google_dns_record_set: 3
   google_dns_response_policy: 1
-  google_dns_response_policy_rule: 39
+  google_dns_response_policy_rule: 42
   google_essential_contacts_contact: 1
   google_monitoring_alert_policy: 2
   google_monitoring_dashboard: 3
@@ -52,4 +52,4 @@ counts:
   google_tags_tag_binding: 3
   modules: 42
   random_id: 6
-  resources: 256
+  resources: 259

--- a/tests/fast/stages/s2_networking_c_separate_envs/simple.yaml
+++ b/tests/fast/stages/s2_networking_c_separate_envs/simple.yaml
@@ -32,7 +32,7 @@ counts:
   google_dns_policy: 2
   google_dns_record_set: 2
   google_dns_response_policy: 2
-  google_dns_response_policy_rule: 78
+  google_dns_response_policy_rule: 84
   google_essential_contacts_contact: 1
   google_monitoring_alert_policy: 4
   google_monitoring_dashboard: 6
@@ -45,4 +45,4 @@ counts:
   google_tags_tag_binding: 2
   modules: 22
   random_id: 6
-  resources: 223
+  resources: 229

--- a/tools/duplicate-diff.py
+++ b/tools/duplicate-diff.py
@@ -27,6 +27,16 @@ duplicates = [
     [
         "fast/stages/0-bootstrap/identity-providers-wfif-defs.tf",
         "fast/stages/2-secops/identity-providers-defs.tf",
+    ],
+    [
+        "fast/stages/2-networking-a-simple/data/dns-policy-rules.yaml",
+        "fast/stages/2-networking-b-nva/data/dns-policy-rules.yaml",
+        "fast/stages/2-networking-c-separate-envs/data/dns-policy-rules.yaml",
+    ],
+    [
+        "fast/stages/2-networking-a-simple/data/cidrs.yaml",
+        "fast/stages/2-networking-b-nva/data/cidrs.yaml",
+        "fast/stages/2-networking-c-separate-envs/data/cidrs.yaml",
     ]
 ]
 


### PR DESCRIPTION
Add missing policy routing for Private Google Access

Added checks to keep files in sync between stages

Closes #3159

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [ ] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [ ] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
-->
