### PR TITLE
Improve and document org policy tags use in FAST resman stage

### DIFF
--- a/fast/stages/0-bootstrap/data/custom-constraints/gke.yaml
+++ b/fast/stages/0-bootstrap/data/custom-constraints/gke.yaml
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# yaml-language-server: $schema=../../schemas/org-policy-custom-constraint.schema.json
-
 ---
+# sample subset of useful organization policies, edit to suit requirements
+# start of document (---) avoids errors if the file only contains comments
+
+# yaml-language-server: $schema=../../schemas/org-policy-custom-constraint.schema.json
 
 # custom.disableKubeletReadOnlyPort:
 #   resource_types:

--- a/fast/stages/0-bootstrap/data/custom-constraints/gke.yaml
+++ b/fast/stages/0-bootstrap/data/custom-constraints/gke.yaml
@@ -14,13 +14,15 @@
 
 # yaml-language-server: $schema=../../schemas/org-policy-custom-constraint.schema.json
 
-custom.disableKubeletReadOnlyPort:
-  resource_types:
-    - container.googleapis.com/Cluster
-  method_types:
-    - CREATE
-    - UPDATE
-  condition: resource.nodeConfig.kubeletConfig.insecureKubeletReadonlyPortEnabled == true
-  action_type: DENY
-  display_name: Disable Kubelet Read-Only Port 10255
-  description: Disallows the use of Kubelet read-only port 10255 to enhance security
+---
+
+# custom.disableKubeletReadOnlyPort:
+#   resource_types:
+#     - container.googleapis.com/Cluster
+#   method_types:
+#     - CREATE
+#     - UPDATE
+#   condition: resource.nodeConfig.kubeletConfig.insecureKubeletReadonlyPortEnabled == true
+#   action_type: DENY
+#   display_name: Disable Kubelet Read-Only Port 10255
+#   description: Disallows the use of Kubelet read-only port 10255 to enhance security

--- a/fast/stages/0-bootstrap/data/org-policies-managed/gke.yaml
+++ b/fast/stages/0-bootstrap/data/org-policies-managed/gke.yaml
@@ -18,6 +18,6 @@
 
 # yaml-language-server: $schema=../../schemas/org-policies.schema.json
 
-custom.disableKubeletReadOnlyPort:
-  rules:
-    - enforce: true
+# custom.disableKubeletReadOnlyPort:
+#   rules:
+#     - enforce: true

--- a/fast/stages/0-bootstrap/data/org-policies/gke.yaml
+++ b/fast/stages/0-bootstrap/data/org-policies/gke.yaml
@@ -18,6 +18,6 @@
 
 # yaml-language-server: $schema=../../schemas/org-policies.schema.json
 
-custom.disableKubeletReadOnlyPort:
-  rules:
-    - enforce: true
+# custom.disableKubeletReadOnlyPort:
+#   rules:
+#     - enforce: true

--- a/fast/stages/1-resman/README.md
+++ b/fast/stages/1-resman/README.md
@@ -21,6 +21,7 @@ The following diagram is a high level reference of the resources created and man
   - [Project and hierarchy factory](#project-and-hierarchy-factory)
 - [Other design considerations](#other-design-considerations)
   - [Secure tags](#secure-tags)
+    - [Organization policy tag values from the bootstrap stage](#organization-policy-tag-values-from-the-bootstrap-stage)
   - [Multitenancy](#multitenancy)
   - [Workload Identity Federation and CI/CD](#workload-identity-federation-and-cicd)
 - [How to run this stage](#how-to-run-this-stage)
@@ -295,7 +296,8 @@ terraform apply
 |---|---|---|---|
 | [billing.tf](./billing.tf) | Billing resources for external billing use cases. |  | <code>google_billing_account_iam_member</code> |
 | [main.tf](./main.tf) | Module-level locals and resources. |  |  |
-| [organization.tf](./organization.tf) | Organization policies. | <code>organization</code> |  |
+| [organization-tags.tf](./organization-tags.tf) | Organization-level tag locals. |  |  |
+| [organization.tf](./organization.tf) | Organization-level IAM and org policies. | <code>organization</code> |  |
 | [outputs-cicd.tf](./outputs-cicd.tf) | Locals for CI/CD workflow files. |  |  |
 | [outputs-files.tf](./outputs-files.tf) | Output files persistence to local filesystem. |  | <code>google_storage_bucket_object</code> · <code>local_file</code> |
 | [outputs-providers.tf](./outputs-providers.tf) | Locals for provider output files. |  |  |

--- a/fast/stages/1-resman/main.tf
+++ b/fast/stages/1-resman/main.tf
@@ -51,6 +51,9 @@ locals {
     { for k, v in local.stage3 : "${k}-rw" => module.stage3-sa-rw[k].email },
     { for k, v in local.stage3 : "${k}-ro" => module.stage3-sa-ro[k].email },
   )
+  stage_service_accounts_iam = {
+    for k, v in local.stage_service_accounts : k => "serviceAccount:${v}"
+  }
   tag_keys = (
     var.root_node == null
     ? module.organization[0].tag_keys

--- a/fast/stages/1-resman/organization-tags.tf
+++ b/fast/stages/1-resman/organization-tags.tf
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# tfdoc:file:description Organization-level tag locals.
+
+locals {
+  # context tag values for enabled stage 2s (merged in the final map below)
+  _context_tag_values_stage2 = {
+    for k, v in local.stage2 : k => replace(k, "_", "-")
+  }
+  # merge all context tag values into a single map
+  context_tag_values = merge(
+    # user-defined
+    try(local.tags["context"]["values"], {}),
+    # top-level folders
+    {
+      for k, v in local.top_level_folders : k => {
+        iam         = try(local.tags.context.values.iam[k], {})
+        description = try(local.tags.context.values.description[k], null)
+      } if v.is_fast_context == true
+    },
+    # stage 2s
+    {
+      for k, v in local._context_tag_values_stage2 : v => {
+        iam         = try(local.tags.context.values.iam[v], {})
+        description = try(local.tags.context.values.description[v], null)
+      }
+    },
+    # stage 3 define no context as they attach to a top-level folder
+  )
+  # environment tag values and their IAM bindings for stage 2 service accounts
+  environment_tag_values = {
+    for k, v in var.environments : v.tag_name => {
+      iam = merge(
+        # user-defined configuration
+        try(local.tags.environment.values[v.tag_name].iam, {}),
+        # stage 2 service accounts
+        {
+          "roles/resourcemanager.tagUser" = distinct(concat(
+            try(local.tags.environment.values[v.tag_name].iam["roles/resourcemanager.tagUser"], []),
+            [for k, v in module.stage2-sa-rw : v.iam_email]
+          ))
+          "roles/resourcemanager.tagViewer" = distinct(concat(
+            try(local.tags.environment.values[v.tag_name].iam["roles/resourcemanager.tagViewer"], []),
+            [for k, v in module.stage2-sa-ro : v.iam_email]
+          ))
+        }
+      )
+      description = try(
+        local.tags.environment.values[v].description, null
+      )
+    }
+  }
+  # organization policy tags managed in stage 0
+  org_policy_tags = {
+    for k, v in var.org_policy_tags.values :
+    "${var.org_policy_tags.key_name}/${k}" => v
+  }
+  # IAM principal expansion for user-specified tag values
+  tags = {
+    for k, v in var.tags : k => merge(v, {
+      iam = {
+        for rk, rv in v.iam : rk => [
+          for rm in rv : lookup(local.principals_iam, rm, rm)
+        ]
+      }
+      id = (
+        v.id == null || v.id != var.org_policy_tags.key_name
+        ? v.id
+        : var.org_policy_tags.key_id
+      )
+      values = {
+        for vk, vv in v.values : vk => merge(vv, {
+          iam = {
+            for rk, rv in vv.iam : rk => [
+              for rm in rv : try(
+                local.principals_iam[rm],
+                local.stage_service_accounts_iam[rm],
+                rm
+              )
+            ]
+          }
+          id = (
+            vv.id == null || v.id != var.org_policy_tags.key_name
+            ? null
+            : try(
+              local.org_policy_tags["${var.org_policy_tags.key_name}/${vv.id}"],
+              vv.id
+            )
+          )
+        })
+      }
+    })
+  }
+}

--- a/fast/stages/1-resman/organization.tf
+++ b/fast/stages/1-resman/organization.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,56 +14,9 @@
  * limitations under the License.
  */
 
-# tfdoc:file:description Organization policies.
+# tfdoc:file:description Organization-level IAM and org policies.
 
 locals {
-  # context tag values for enabled stage 2s (merged in the final map below)
-  _context_tag_values_stage2 = {
-    for k, v in local.stage2 : k => replace(k, "_", "-")
-  }
-  # merge all context tag values into a single map
-  context_tag_values = merge(
-    # user-defined
-    try(local.tags["context"]["values"], {}),
-    # top-level folders
-    {
-      for k, v in local.top_level_folders : k => {
-        iam         = try(local.tags.context.values.iam[k], {})
-        description = try(local.tags.context.values.description[k], null)
-      } if v.is_fast_context == true
-    },
-    # stage 2s
-    {
-      for k, v in local._context_tag_values_stage2 : v => {
-        iam         = try(local.tags.context.values.iam[v], {})
-        description = try(local.tags.context.values.description[v], null)
-      }
-    },
-    # stage 3 define no context as they attach to a top-level folder
-  )
-  # environment tag values and their IAM bindings for stage 2 service accounts
-  environment_tag_values = {
-    for k, v in var.environments : v.tag_name => {
-      iam = merge(
-        # user-defined configuration
-        try(local.tags.environment.values[v.tag_name].iam, {}),
-        # stage 2 service accounts
-        {
-          "roles/resourcemanager.tagUser" = distinct(concat(
-            try(local.tags.environment.values[v.tag_name].iam["roles/resourcemanager.tagUser"], []),
-            [for k, v in module.stage2-sa-rw : v.iam_email]
-          ))
-          "roles/resourcemanager.tagViewer" = distinct(concat(
-            try(local.tags.environment.values[v.tag_name].iam["roles/resourcemanager.tagViewer"], []),
-            [for k, v in module.stage2-sa-ro : v.iam_email]
-          ))
-        }
-      )
-      description = try(
-        local.tags.environment.values[v].description, null
-      )
-    }
-  }
   # combine org-level IAM additive from billing and stage 2s
   iam_bindings_additive = merge(
     merge([
@@ -72,37 +25,6 @@ locals {
     ]...),
     local.billing_mode != "org" ? {} : local.billing_iam
   )
-  org_policy_tags = {
-    for k, v in var.org_policy_tags.values :
-    "${var.org_policy_tags.key_name}/${k}" => v
-  }
-  # IAM principal expansion for user-specified tag values
-  tags = {
-    for k, v in var.tags : k => merge(v, {
-      iam = {
-        for rk, rv in v.iam : rk => [
-          for rm in rv : lookup(local.principals_iam, rm, rm)
-        ]
-      }
-      id = (
-        v.id == null || v.id != var.org_policy_tags.key_name
-        ? v.id
-        : var.org_policy_tags.key_id
-      )
-      values = {
-        for vk, vv in v.values : vk => merge(vv, {
-          iam = {
-            for rk, rv in vv.iam : rk => [
-              for rm in rv : lookup(local.principals_iam, rm, rm)
-            ]
-          }
-          id = (
-            vv.id == null ? null : lookup(local.org_policy_tags, vv.id, vv.id)
-          )
-        })
-      }
-    })
-  }
 }
 
 module "organization" {

--- a/tests/fast/stages/s0_bootstrap/cicd.yaml
+++ b/tests/fast/stages/s0_bootstrap/cicd.yaml
@@ -1150,20 +1150,6 @@ values:
     resource_types:
     - accesscontextmanager.googleapis.com/ServicePerimeter
     timeouts: null
-  module.organization.google_org_policy_custom_constraint.constraint["custom.disableKubeletReadOnlyPort"]:
-    action_type: DENY
-    condition: resource.nodeConfig.kubeletConfig.insecureKubeletReadonlyPortEnabled
-      == true
-    description: Disallows the use of Kubelet read-only port 10255 to enhance security
-    display_name: Disable Kubelet Read-Only Port 10255
-    method_types:
-    - CREATE
-    - UPDATE
-    name: custom.disableKubeletReadOnlyPort
-    parent: organizations/123456789012
-    resource_types:
-    - container.googleapis.com/Cluster
-    timeouts: null
   module.organization.google_org_policy_policy.default["cloudbuild.disableCreateDefaultServiceAccount"]:
     dry_run_spec: []
     name: organizations/123456789012/policies/cloudbuild.disableCreateDefaultServiceAccount
@@ -1423,21 +1409,6 @@ values:
   module.organization.google_org_policy_policy.default["custom.denyBridgePerimeters"]:
     dry_run_spec: []
     name: organizations/123456789012/policies/custom.denyBridgePerimeters
-    parent: organizations/123456789012
-    spec:
-    - inherit_from_parent: null
-      reset: null
-      rules:
-      - allow_all: null
-        condition: []
-        deny_all: null
-        enforce: 'TRUE'
-        parameters: null
-        values: []
-    timeouts: null
-  module.organization.google_org_policy_policy.default["custom.disableKubeletReadOnlyPort"]:
-    dry_run_spec: []
-    name: organizations/123456789012/policies/custom.disableKubeletReadOnlyPort
     parent: organizations/123456789012
     spec:
     - inherit_from_parent: null
@@ -2350,8 +2321,8 @@ counts:
   google_logging_organization_settings: 1
   google_logging_organization_sink: 4
   google_logging_project_bucket_config: 4
-  google_org_policy_custom_constraint: 2
-  google_org_policy_policy: 39
+  google_org_policy_custom_constraint: 1
+  google_org_policy_policy: 38
   google_organization_iam_binding: 26
   google_organization_iam_custom_role: 15
   google_organization_iam_member: 31
@@ -2372,7 +2343,7 @@ counts:
   google_tags_tag_value: 2
   local_file: 13
   modules: 26
-  resources: 296
+  resources: 294
 
 outputs:
   custom_roles:

--- a/tests/fast/stages/s0_bootstrap/managed_org_policies.yaml
+++ b/tests/fast/stages/s0_bootstrap/managed_org_policies.yaml
@@ -277,21 +277,6 @@ values:
         parameters: null
         values: []
     timeouts: null
-  module.organization.google_org_policy_policy.default["custom.disableKubeletReadOnlyPort"]:
-    dry_run_spec: []
-    name: organizations/123456789012/policies/custom.disableKubeletReadOnlyPort
-    parent: organizations/123456789012
-    spec:
-    - inherit_from_parent: null
-      reset: null
-      rules:
-      - allow_all: null
-        condition: []
-        deny_all: null
-        enforce: 'TRUE'
-        parameters: null
-        values: []
-    timeouts: null
   module.organization.google_org_policy_policy.default["essentialcontacts.allowedContactDomains"]:
     dry_run_spec: []
     name: organizations/123456789012/policies/essentialcontacts.allowedContactDomains

--- a/tests/fast/stages/s0_bootstrap/simple.yaml
+++ b/tests/fast/stages/s0_bootstrap/simple.yaml
@@ -956,20 +956,6 @@ values:
     resource_types:
     - accesscontextmanager.googleapis.com/ServicePerimeter
     timeouts: null
-  module.organization.google_org_policy_custom_constraint.constraint["custom.disableKubeletReadOnlyPort"]:
-    action_type: DENY
-    condition: resource.nodeConfig.kubeletConfig.insecureKubeletReadonlyPortEnabled
-      == true
-    description: Disallows the use of Kubelet read-only port 10255 to enhance security
-    display_name: Disable Kubelet Read-Only Port 10255
-    method_types:
-    - CREATE
-    - UPDATE
-    name: custom.disableKubeletReadOnlyPort
-    parent: organizations/123456789012
-    resource_types:
-    - container.googleapis.com/Cluster
-    timeouts: null
   module.organization.google_org_policy_policy.default["cloudbuild.disableCreateDefaultServiceAccount"]:
     dry_run_spec: []
     name: organizations/123456789012/policies/cloudbuild.disableCreateDefaultServiceAccount
@@ -1562,8 +1548,8 @@ counts:
   google_logging_organization_settings: 1
   google_logging_organization_sink: 4
   google_logging_project_bucket_config: 4
-  google_org_policy_custom_constraint: 2
-  google_org_policy_policy: 39
+  google_org_policy_custom_constraint: 1
+  google_org_policy_policy: 38
   google_organization_iam_binding: 26
   google_organization_iam_custom_role: 15
   google_organization_iam_member: 31
@@ -1584,7 +1570,7 @@ counts:
   google_tags_tag_value: 2
   local_file: 8
   modules: 20
-  resources: 259
+  resources: 257
 
 outputs:
   cicd_repositories: {}

--- a/tests/fast/stages/s0_bootstrap/simple_org_policies.yaml
+++ b/tests/fast/stages/s0_bootstrap/simple_org_policies.yaml
@@ -269,21 +269,6 @@ values:
         parameters: null
         values: []
     timeouts: null
-  module.organization.google_org_policy_policy.default["custom.disableKubeletReadOnlyPort"]:
-    dry_run_spec: []
-    name: organizations/123456789012/policies/custom.disableKubeletReadOnlyPort
-    parent: organizations/123456789012
-    spec:
-    - inherit_from_parent: null
-      reset: null
-      rules:
-      - allow_all: null
-        condition: []
-        deny_all: null
-        enforce: 'TRUE'
-        parameters: null
-        values: []
-    timeouts: null
   module.organization.google_org_policy_policy.default["essentialcontacts.allowedContactDomains"]:
     dry_run_spec: []
     name: organizations/123456789012/policies/essentialcontacts.allowedContactDomains


### PR DESCRIPTION
This also disables a custom constraint for GKE which needs to be imported and raises errors on apply.