### PR TITLE
Fixed option to set descriptions for environment tag values

### DIFF
--- a/fast/stages/1-resman/organization.tf
+++ b/fast/stages/1-resman/organization.tf
@@ -60,7 +60,7 @@ locals {
         }
       )
       description = try(
-        local.tags.environment.values[v].description, null
+        local.tags.environment.values[v.tag_name].description, null
       )
     }
   }


### PR DESCRIPTION
fixed option to set descriptions for environment tag values. Currently it indexes on the key/short name from the bootstrap environment var/output, instead of the tag name that the rest of this references in resman. Similar to how it's defined for IAM customisations a few lines above

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
-->
