### PR TITLE
Add support for IPv6 only subnets and IP collections

### DIFF
--- a/modules/net-vpc/schemas/subnet.schema.json
+++ b/modules/net-vpc/schemas/subnet.schema.json
@@ -56,8 +56,14 @@
       "properties": {
         "access_type": {
           "type": "string"
+        },
+        "ipv6_only": {
+          "type": "boolean"
         }
       }
+    },
+    "ip_collection": {
+      "type": "string"
     },
     "name": {
       "type": "string"

--- a/modules/net-vpc/schemas/subnet.schema.md
+++ b/modules/net-vpc/schemas/subnet.schema.md
@@ -23,6 +23,8 @@
 - **ipv6**: *object*
   <br>*additional properties: false*
   - **access_type**: *string*
+  - +**ipv6_only**: *boolean*
+- ⁺**ip_collection**: *string*
 - **name**: *string*
 - ⁺**region**: *string*
 - **psc**: *boolean*

--- a/modules/net-vpc/subnets.tf
+++ b/modules/net-vpc/subnets.tf
@@ -43,7 +43,9 @@ locals {
       ip_cidr_range = v.ip_cidr_range
       ipv6 = !can(v.ipv6) ? null : {
         access_type = try(v.ipv6.access_type, "INTERNAL")
+        ipv6_only   = try(v.ipv6.ipv6_only, false)
       }
+      ip_collection       = try(v.ip_collection, null)
       name                = try(v.name, k)
       region              = v.region_computed
       secondary_ip_ranges = try(v.secondary_ip_ranges, null)
@@ -139,13 +141,21 @@ locals {
 }
 
 resource "google_compute_subnetwork" "subnetwork" {
-  provider                         = google-beta
-  for_each                         = local.subnets
-  project                          = var.project_id
-  network                          = local.network.name
-  name                             = each.value.name
-  region                           = each.value.region
-  ip_cidr_range                    = each.value.ip_cidr_range
+  provider = google-beta
+  for_each = local.subnets
+  project  = var.project_id
+  network  = local.network.name
+  name     = each.value.name
+  region   = each.value.region
+  ip_cidr_range = (
+    try(each.value.ipv6, null) != null
+    ? (
+      try(each.value.ipv6.ipv6_only, false)
+      ? null
+      : each.value.ip_cidr_range
+    )
+    : each.value.ip_cidr_range
+  )
   allow_subnet_cidr_routes_overlap = each.value.allow_subnet_cidr_routes_overlap
   description = (
     each.value.description == null
@@ -154,12 +164,19 @@ resource "google_compute_subnetwork" "subnetwork" {
   )
   private_ip_google_access = each.value.enable_private_access
   stack_type = (
-    try(each.value.ipv6, null) != null ? "IPV4_IPV6" : null
+    try(each.value.ipv6, null) != null
+    ? (
+      try(each.value.ipv6.ipv6_only, false)
+      ? "IPV6_ONLY"
+      : "IPV4_IPV6"
+    )
+    : null
   )
   ipv6_access_type = (
     try(each.value.ipv6, null) != null ? each.value.ipv6.access_type : null
   )
   private_ipv6_google_access       = try(each.value.ipv6.enable_private_access, null)
+  ip_collection                    = each.value.ip_collection
   send_secondary_ip_range_if_empty = true
 
   dynamic "secondary_ip_range" {

--- a/modules/net-vpc/subnets.tf
+++ b/modules/net-vpc/subnets.tf
@@ -141,21 +141,13 @@ locals {
 }
 
 resource "google_compute_subnetwork" "subnetwork" {
-  provider = google-beta
-  for_each = local.subnets
-  project  = var.project_id
-  network  = local.network.name
-  name     = each.value.name
-  region   = each.value.region
-  ip_cidr_range = (
-    try(each.value.ipv6, null) != null
-    ? (
-      try(each.value.ipv6.ipv6_only, false)
-      ? null
-      : each.value.ip_cidr_range
-    )
-    : each.value.ip_cidr_range
-  )
+  provider                         = google-beta
+  for_each                         = local.subnets
+  project                          = var.project_id
+  network                          = local.network.name
+  name                             = each.value.name
+  region                           = each.value.region
+  ip_cidr_range                    = try(each.value.ipv6.ipv6_only, false) ? null : each.value.ip_cidr_range
   allow_subnet_cidr_routes_overlap = each.value.allow_subnet_cidr_routes_overlap
   description = (
     each.value.description == null

--- a/modules/net-vpc/variables.tf
+++ b/modules/net-vpc/variables.tf
@@ -274,7 +274,9 @@ variable "subnets" {
       access_type = optional(string, "INTERNAL")
       # this field is marked for internal use in the API documentation
       # enable_private_access = optional(string)
+      ipv6_only = optional(bool, false)
     }))
+    ip_collection       = optional(string, null)
     secondary_ip_ranges = optional(map(string))
     iam                 = optional(map(list(string)), {})
     iam_bindings = optional(map(object({

--- a/tests/modules/net_vpc/examples/ipv6_only.yaml
+++ b/tests/modules/net_vpc/examples/ipv6_only.yaml
@@ -1,0 +1,82 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values:
+  module.vpc.google_compute_network.network[0]:
+    auto_create_subnetworks: false
+    delete_default_routes_on_create: false
+    description: Terraform-managed.
+    enable_ula_internal_ipv6: true
+    # internal_ipv6_range: fd20:6b2:27e5:0:0:0:0:0/48
+    name: my-network
+    network_firewall_policy_enforcement_order: AFTER_CLASSIC_FIREWALL
+    project: project-id
+    routing_mode: GLOBAL
+    timeouts: null
+  module.vpc.google_compute_route.gateway["private-googleapis"]:
+    description: Terraform-managed.
+    dest_range: 199.36.153.8/30
+    name: my-network-private-googleapis
+    next_hop_gateway: default-internet-gateway
+    next_hop_ilb: null
+    next_hop_instance: null
+    next_hop_vpn_tunnel: null
+    priority: 1000
+    project: project-id
+    tags: null
+    timeouts: null
+  module.vpc.google_compute_route.gateway["restricted-googleapis"]:
+    description: Terraform-managed.
+    dest_range: 199.36.153.4/30
+    name: my-network-restricted-googleapis
+    next_hop_gateway: default-internet-gateway
+    next_hop_ilb: null
+    next_hop_instance: null
+    next_hop_vpn_tunnel: null
+    priority: 1000
+    project: project-id
+    tags: null
+    timeouts: null
+  module.vpc.google_compute_subnetwork.subnetwork["europe-west1/test-v6only"]:
+    description: Terraform-managed.
+    ipv6_access_type: INTERNAL
+    log_config: []
+    name: test-v6only
+    private_ip_google_access: true
+    project: project-id
+    region: europe-west1
+    role: null
+    stack_type: IPV6_ONLY
+    timeouts: null
+  module.vpc.google_compute_subnetwork.subnetwork["europe-west3/test-v6only"]:
+    description: Terraform-managed.
+    ipv6_access_type: EXTERNAL
+    log_config: []
+    name: test-v6only
+    private_ip_google_access: true
+    project: project-id
+    region: europe-west3
+    role: null
+    stack_type: IPV6_ONLY
+    timeouts: null
+    ip_collection: "https://www.googleapis.com/compute/v1/projects/project-id/regions/europe-west3/publicDelegatedPrefixes/test-sub-pdp"
+
+counts:
+  google_compute_network: 1
+  google_compute_route: 3
+  google_compute_subnetwork: 2
+  modules: 1
+  resources: 6
+
+outputs: {}


### PR DESCRIPTION
This PR adds support for IPv6-only subnets.  IP collections may also be specified to use Bring Your Own IPv6 prefixes when creating the subnet.

---

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
