### PR TITLE
Added option for tag factory on resman

### DIFF
--- a/fast/stages/1-resman/organization.tf
+++ b/fast/stages/1-resman/organization.tf
@@ -117,6 +117,9 @@ module "organization" {
       condition = lookup(v, "condition", null)
     }
   }
+  factories_config = {
+    tags = var.factories_config.tags
+  }
   # do not assign tagViewer or tagUser roles here on tag keys and values as
   # they are managed authoritatively and will break multitenant stages
   tags = merge(local.tags, {

--- a/fast/stages/1-resman/variables.tf
+++ b/fast/stages/1-resman/variables.tf
@@ -22,6 +22,7 @@ variable "factories_config" {
   type = object({
     stage_2           = optional(string, "data/stage-2")
     stage_3           = optional(string, "data/stage-3")
+    tags              = optional(string, "data/tags")
     top_level_folders = optional(string, "data/top-level-folders")
   })
   nullable = false


### PR DESCRIPTION
PENDING:
#3178 
#3180 

Adds option to use the org tag factory in the resman stage.

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [ ] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [ ] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
-->
