### PR TITLE
Bypass accounts.google.com in FAST DNS policy rules

### DIFF
--- a/fast/stages/2-networking-a-simple/data/dns-policy-rules.yaml
+++ b/fast/stages/2-networking-a-simple/data/dns-policy-rules.yaml
@@ -6,7 +6,7 @@
 
 accounts:
   dns_name: "accounts.google.com."
-  local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
+  behavior: bypassResponsePolicy
 aiplatform-notebook-cloud-all:
   dns_name: "*.aiplatform-notebook.cloud.google.com."
   local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
@@ -19,7 +19,6 @@ appengine:
 appspot-all:
   dns_name: "*.appspot.com."
   local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
-
 backupdr-cloud:
   dns_name: "backupdr.cloud.google.com."
   local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }

--- a/fast/stages/2-networking-b-nva/data/dns-policy-rules.yaml
+++ b/fast/stages/2-networking-b-nva/data/dns-policy-rules.yaml
@@ -6,7 +6,7 @@
 
 accounts:
   dns_name: "accounts.google.com."
-  local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
+  behavior: bypassResponsePolicy
 aiplatform-notebook-cloud-all:
   dns_name: "*.aiplatform-notebook.cloud.google.com."
   local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
@@ -19,7 +19,6 @@ appengine:
 appspot-all:
   dns_name: "*.appspot.com."
   local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
-
 backupdr-cloud:
   dns_name: "backupdr.cloud.google.com."
   local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }

--- a/fast/stages/2-networking-c-separate-envs/data/dns-policy-rules.yaml
+++ b/fast/stages/2-networking-c-separate-envs/data/dns-policy-rules.yaml
@@ -6,7 +6,7 @@
 
 accounts:
   dns_name: "accounts.google.com."
-  local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
+  behavior: bypassResponsePolicy
 aiplatform-notebook-cloud-all:
   dns_name: "*.aiplatform-notebook.cloud.google.com."
   local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
@@ -19,7 +19,6 @@ appengine:
 appspot-all:
   dns_name: "*.appspot.com."
   local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }
-
 backupdr-cloud:
   dns_name: "backupdr.cloud.google.com."
   local_data: { CNAME: { rrdatas: ["private.googleapis.com."] } }


### PR DESCRIPTION
This reinstates #3179 after internal discussions.