### PR TITLE
fix failing E2E test for net-vpc

### DIFF
--- a/modules/net-vpc/README.md
+++ b/modules/net-vpc/README.md
@@ -752,7 +752,7 @@ module "vpc" {
     }
   ]
 }
-# tftest modules=1 resources=6 inventory=ipv6_only.yaml e2e
+# tftest modules=1 resources=6 inventory=ipv6_only.yaml
 ```
 <!-- BEGIN TFDOC -->
 ## Variables

--- a/tests/examples_e2e/setup_module/main.tf
+++ b/tests/examples_e2e/setup_module/main.tf
@@ -83,11 +83,12 @@ resource "google_project_service" "project_service" {
 }
 
 resource "google_storage_bucket" "bucket" {
-  location      = var.region
-  name          = "${local.prefix}-bucket"
-  project       = google_project.project.project_id
-  force_destroy = true
-  depends_on    = [google_project_service.project_service]
+  location                    = var.region
+  name                        = "${local.prefix}-bucket"
+  project                     = google_project.project.project_id
+  force_destroy               = true
+  uniform_bucket_level_access = true
+  depends_on                  = [google_project_service.project_service]
 }
 
 resource "google_compute_network" "network" {


### PR DESCRIPTION
Remove BYOIPv6 from test cases run by E2E, as there is no good way to create test delegation prefixes.

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [ ] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [ ] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
-->
