### PR TITLE
Added option to set force_destroy on pf buckets

### DIFF
--- a/modules/project-factory/automation.tf
+++ b/modules/project-factory/automation.tf
@@ -53,6 +53,7 @@ module "automation-bucket" {
   prefix         = each.value.prefix
   name           = "tf-state"
   encryption_key = lookup(each.value, "encryption_key", null)
+  force_destroy  = lookup(each.value, "force_destroy", null)
   iam = {
     for k, v in lookup(each.value, "iam", {}) : k => [
       for vv in v : try(

--- a/modules/project-factory/factory-projects.tf
+++ b/modules/project-factory/factory-projects.tf
@@ -64,6 +64,7 @@ locals {
         name                  = name
         description           = lookup(opts, "description", "Terraform-managed.")
         encryption_key        = lookup(opts, "encryption_key", null)
+        force_destroy         = lookup(opts, "force_destroy", null)
         iam                   = lookup(opts, "iam", {})
         iam_bindings          = lookup(opts, "iam_bindings", {})
         iam_bindings_additive = lookup(opts, "iam_bindings_additive", {})

--- a/modules/project-factory/main.tf
+++ b/modules/project-factory/main.tf
@@ -283,6 +283,7 @@ module "buckets" {
   prefix         = each.value.prefix
   name           = "${each.value.project_name}-${each.value.name}"
   encryption_key = each.value.encryption_key
+  force_destroy  = each.value.force_destroy
   iam = {
     for k, v in each.value.iam : k => [
       for vv in v : try(

--- a/modules/project-factory/schemas/project.schema.json
+++ b/modules/project-factory/schemas/project.schema.json
@@ -456,6 +456,9 @@
         "iam_bindings_additive": {
           "$ref": "#/$defs/iam_bindings_additive"
         },
+        "force_destroy": {
+          "type": "boolean"
+        },
         "labels": {
           "type": "object",
           "additionalProperties": {

--- a/modules/project-factory/schemas/project.schema.md
+++ b/modules/project-factory/schemas/project.schema.md
@@ -135,6 +135,7 @@
   - **iam**: *reference([iam](#refs-iam))*
   - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
   - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
+  - **force_destroy**: *boolean*
   - **labels**: *object*
     *additional properties: String*
   - **location**: *string*


### PR DESCRIPTION
Added option to set force_destroy on the buckets in the project-factory module. For #3188 

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
-->
