### PR TITLE
Create (or import) subnets with empty description

### DIFF
--- a/modules/net-vpc/subnets.tf
+++ b/modules/net-vpc/subnets.tf
@@ -150,6 +150,7 @@ resource "google_compute_subnetwork" "subnetwork" {
   ip_cidr_range                    = try(each.value.ipv6.ipv6_only, false) ? null : each.value.ip_cidr_range
   allow_subnet_cidr_routes_overlap = each.value.allow_subnet_cidr_routes_overlap
   description = (
+    # Set description to an empty string (eg "") to create subnet without a description.
     each.value.description == null
     ? "Terraform-managed."
     : each.value.description
@@ -218,6 +219,7 @@ resource "google_compute_subnetwork" "private_nat" {
   region        = each.value.region
   ip_cidr_range = each.value.ip_cidr_range
   description = (
+    # Set description to an empty string (eg "") to create subnet without a description.
     each.value.description == null
     ? "Terraform-managed private NAT subnet."
     : each.value.description
@@ -233,6 +235,7 @@ resource "google_compute_subnetwork" "psc" {
   region        = each.value.region
   ip_cidr_range = each.value.ip_cidr_range
   description = (
+    # Set description to an empty string (eg "") to create subnet without a description.
     each.value.description == null
     ? "Terraform-managed subnet for Private Service Connect (PSC NAT)."
     : each.value.description

--- a/modules/net-vpc/subnets.tf
+++ b/modules/net-vpc/subnets.tf
@@ -203,6 +203,7 @@ resource "google_compute_subnetwork" "proxy_only" {
   region        = each.value.region
   ip_cidr_range = each.value.ip_cidr_range
   description = (
+    # Set description to an empty string (eg "") to create subnet without a description.
     each.value.description == null
     ? "Terraform-managed proxy-only subnet for Regional HTTPS, Internal HTTPS or Cross-Regional HTTPS Internal LB."
     : each.value.description

--- a/modules/net-vpc/subnets.tf
+++ b/modules/net-vpc/subnets.tf
@@ -201,9 +201,10 @@ resource "google_compute_subnetwork" "proxy_only" {
   name          = each.value.name
   region        = each.value.region
   ip_cidr_range = each.value.ip_cidr_range
-  description = coalesce(
-    each.value.description,
-    "Terraform-managed proxy-only subnet for Regional HTTPS, Internal HTTPS or Cross-Regional HTTPS Internal LB."
+  description = (
+    each.value.description == null
+    ? "Terraform-managed proxy-only subnet for Regional HTTPS, Internal HTTPS or Cross-Regional HTTPS Internal LB."
+    : each.value.description
   )
   purpose = each.value.global ? "GLOBAL_MANAGED_PROXY" : "REGIONAL_MANAGED_PROXY"
   role    = each.value.active ? "ACTIVE" : "BACKUP"
@@ -216,9 +217,10 @@ resource "google_compute_subnetwork" "private_nat" {
   name          = each.value.name
   region        = each.value.region
   ip_cidr_range = each.value.ip_cidr_range
-  description = coalesce(
-    each.value.description,
-    "Terraform-managed private NAT subnet."
+  description = (
+    each.value.description == null
+    ? "Terraform-managed private NAT subnet."
+    : each.value.description
   )
   purpose = "PRIVATE_NAT"
 }
@@ -230,9 +232,10 @@ resource "google_compute_subnetwork" "psc" {
   name          = each.value.name
   region        = each.value.region
   ip_cidr_range = each.value.ip_cidr_range
-  description = coalesce(
-    each.value.description,
-    "Terraform-managed subnet for Private Service Connect (PSC NAT)."
+  description = (
+    each.value.description == null
+    ? "Terraform-managed subnet for Private Service Connect (PSC NAT)."
+    : each.value.description
   )
   purpose = "PRIVATE_SERVICE_CONNECT"
 }


### PR DESCRIPTION
Create (or import) subnets with empty description. Google forces recreate on subnet description change (for some reason). This change lines up how the alternative types of subnets (proxy only/PSC) handles descriptions with how the regular subnet blocks handles descriptions. This is required when importing existing subnets into the subnet factory that don't have a description without needed to recreate the whole subnet.

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
-->
