### PR TITLE
Add PEP 723 dependencies to tfdoc.py, versions.py and build_service_agents.py

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -634,6 +634,8 @@ pip install -r tests/requirements.txt
 pip install -r tools/requirements.txt
 ```
 
+Some of our tools declare their dependencies in a [PEP 723-style](https://peps.python.org/pep-0723/) format, allowing you to execute them directly with `uv run`. For instance, `tools/tfdoc.py` includes its dependencies inline. As a result, when you run `uv run tools/tfdoc.py`, `uv` will automatically download the necessary dependencies for you.
+
 #### Automated checks on PRs
 
 We run two GitHub workflows on PRs:

--- a/tools/build_service_agents.py
+++ b/tools/build_service_agents.py
@@ -13,6 +13,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#    "BeautifulSoup4",
+#    "click",
+#    "requests",
+#    "pyyaml",
+# ]
+# ///
 
 from dataclasses import asdict, dataclass
 from itertools import chain
@@ -42,6 +52,11 @@ ALIASES = {
     'monitoring-notification': ['monitoring'],
     'serverless-robot-prod': ['cloudrun', 'run'],
 }
+
+IGNORED_AGENTS = [
+    # Alloydb has two agents. Ignore the non-primary one
+    'c-PROJECT_NUMBER-IDENTIFIER@gcp-sa-alloydb.iam.gserviceaccount.com'
+]
 
 E2E_SERVICES = [
     "alloydb.googleapis.com",
@@ -110,6 +125,9 @@ def main(e2e=False):
       continue
 
     identity = col1.p.get_text()
+    if identity in IGNORED_AGENTS:
+      continue
+
     # skip agents that are not contained in a project
     if 'PROJECT_NUMBER' not in identity:
       continue

--- a/tools/tfdoc.py
+++ b/tools/tfdoc.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#    "click",
+#    "marko",
+# ]
+# ///
 '''Generate tables for Terraform root module files, outputs and variables.
 
 This tool generates nicely formatted Markdown tables from Terraform source

--- a/tools/versions.py
+++ b/tools/versions.py
@@ -13,6 +13,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#    "click",
+# ]
+# ///
 
 import re
 from pathlib import Path


### PR DESCRIPTION
This change adds inline [PEP 723-style](https://peps.python.org/pep-0723/) dependencies to a few of our script tools.

This simplifies the workflow for contributors, especially those without a fully configured Python environment. Now, anyone can run these tools directly using uv, which will automatically manage the necessary dependencies.