### PR TITLE
exposing the network_id from the net-vpc module for use with tags

### DIFF
--- a/modules/net-vpc/main.tf
+++ b/modules/net-vpc/main.tf
@@ -18,22 +18,16 @@ locals {
   network = (
     var.vpc_create
     ? {
-      id        = try(google_compute_network.network[0].id, null)
-      name      = try(google_compute_network.network[0].name, null)
-      self_link = try(google_compute_network.network[0].self_link, null)
+      id         = try(google_compute_network.network[0].id, null)
+      name       = try(google_compute_network.network[0].name, null)
+      network_id = try(google_compute_network.network[0].network_id, null)
+      self_link  = try(google_compute_network.network[0].self_link, null)
     }
     : {
-      id = format(
-        "projects/%s/global/networks/%s",
-        var.project_id,
-        var.name
-      )
-      name = var.name
-      self_link = format(
-        "https://www.googleapis.com/compute/v1/projects/%s/global/networks/%s",
-        var.project_id,
-        var.name
-      )
+      id         = try(data.google_compute_network.network[0].id, null)
+      name       = try(data.google_compute_network.network[0].name, null)
+      network_id = try(data.google_compute_network.network[0].network_id, null)
+      self_link  = try(data.google_compute_network.network[0].self_link, null)
     }
   )
   peer_network = (
@@ -41,6 +35,12 @@ locals {
     ? null
     : element(reverse(split("/", var.peering_config.peer_vpc_self_link)), 0)
   )
+}
+
+data "google_compute_network" "network" {
+  count   = var.vpc_create ? 0 : 1
+  name    = var.name
+  project = var.project_id
 }
 
 resource "google_compute_network" "network" {


### PR DESCRIPTION
For binding secure tags to network resources we require the resource number (https://cloud.google.com/vpc/docs/create-manage-tags-vpc-resources#attach_tags). This change exposes the network_id on the net-vpc outputs. Given I had to create a datasources, I also converted id/name/self_link to also use the datasource option instead of template.


<!-- Put a description of what this PR is for here -->

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
-->
