### PR TITLE
Fix for service agent substitutions in project factory additive bindings

### DIFF
--- a/modules/project-factory/main.tf
+++ b/modules/project-factory/main.tf
@@ -178,7 +178,8 @@ module "projects-iam" {
           # other automation service account (project/automation/rw)
           local.context.iam_principals[vv],
           # project's service identities
-          local.service_agents_email[each.key][vv],
+          local.service_agents_email["${each.key}/${vv}"],
+          local.service_agents_email[vv],
           # passthrough + error handling using tonumber until Terraform gets fail/raise function
           (
             strcontains(vv, ":")
@@ -206,7 +207,8 @@ module "projects-iam" {
         # other automation service account (project/automation/rw)
         local.context.iam_principals[v.member],
         # project's service identities
-        local.service_agents_email[each.key][v.member],
+        local.service_agents_email["${each.key}/${vv}"],
+        local.service_agents_email[vv],
         # passthrough + error handling using tonumber until Terraform gets fail/raise function
         (
           strcontains(v.member, ":")
@@ -271,7 +273,8 @@ module "projects-iam" {
             # other automation service account (project/automation/rw)
             local.context.iam_principals[v.member],
             # project's service identities
-            local.service_agents_email[each.key][v.member],
+            local.service_agents_email["${each.key}/${vv}"],
+            local.service_agents_email[vv],
             # passthrough + error handling using tonumber until Terraform gets fail/raise function
             (
               strcontains(v.member, ":")

--- a/modules/project-factory/main.tf
+++ b/modules/project-factory/main.tf
@@ -207,8 +207,8 @@ module "projects-iam" {
         # other automation service account (project/automation/rw)
         local.context.iam_principals[v.member],
         # project's service identities
-        local.service_agents_email["${each.key}/${vv}"],
-        local.service_agents_email[vv],
+        local.service_agents_email["${each.key}/${v.member}"],
+        local.service_agents_email[v.member],
         # passthrough + error handling using tonumber until Terraform gets fail/raise function
         (
           strcontains(v.member, ":")
@@ -273,8 +273,8 @@ module "projects-iam" {
             # other automation service account (project/automation/rw)
             local.context.iam_principals[v.member],
             # project's service identities
-            local.service_agents_email["${each.key}/${vv}"],
-            local.service_agents_email[vv],
+            local.service_agents_email["${each.key}/${v.member}"],
+            local.service_agents_email[v.member],
             # passthrough + error handling using tonumber until Terraform gets fail/raise function
             (
               strcontains(v.member, ":")


### PR DESCRIPTION
Fixes broken substitution of Service Agents when calling module `project-iam`. Setting `iam_bindings` and `iam_bindings_additive` now substitutes like `iam`, where it already works.

Addresses the substitution issue described here: https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/issues/3208

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
-->
