### PR TITLE
Support regional instance templates in compute-vm module outputs

### DIFF
--- a/modules/compute-vm/README.md
+++ b/modules/compute-vm/README.md
@@ -991,7 +991,7 @@ module "sole-tenancy" {
 | [service_account_email](outputs.tf#L73) | Service account email. |  |
 | [service_account_iam_email](outputs.tf#L78) | Service account email. |  |
 | [template](outputs.tf#L87) | Template resource. |  |
-| [template_name](outputs.tf#L92) | Template name. |  |
+| [template_name](outputs.tf#L96) | Template name. |  |
 
 ## Fixtures
 

--- a/modules/compute-vm/outputs.tf
+++ b/modules/compute-vm/outputs.tf
@@ -86,10 +86,18 @@ output "service_account_iam_email" {
 
 output "template" {
   description = "Template resource."
-  value       = try(google_compute_instance_template.default[0], null)
+  value = (
+    local.template_regional
+    ? try(google_compute_region_instance_template.default[0], null)
+    : try(google_compute_instance_template.default[0], null)
+  )
 }
 
 output "template_name" {
   description = "Template name."
-  value       = try(google_compute_instance_template.default[0].name, null)
+  value = (
+    local.template_regional
+    ? try(google_compute_region_instance_template.default[0].name, null)
+    : try(google_compute_instance_template.default[0].name, null)
+  )
 }

--- a/modules/compute-vm/template.tf
+++ b/modules/compute-vm/template.tf
@@ -332,13 +332,6 @@ resource "google_compute_region_instance_template" "default" {
     }
   }
 
-  dynamic "network_interface" {
-    for_each = var.network_attached_interfaces
-    content {
-      network_attachment = network_interface.value
-    }
-  }
-
   scheduling {
     automatic_restart           = !var.options.spot
     instance_termination_action = local.termination_action


### PR DESCRIPTION
This PR fixes the null outputs when creating regional instance templates.

Fixes #3225

---
**Checklist**

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
