### PR TITLE
Fixes force_destroy for project factory buckets

### DIFF
--- a/modules/project-factory/factory-projects.tf
+++ b/modules/project-factory/factory-projects.tf
@@ -75,7 +75,7 @@ locals {
         encryption_key = lookup(opts, "encryption_key", null)
         force_destroy = try(coalesce(
           var.data_overrides.bucket.force_destroy,
-          opts.force_destroy,
+          try(opts.force_destroy, null),
           var.data_defaults.bucket.force_destroy,
         ), null)
         iam                   = lookup(opts, "iam", {})


### PR DESCRIPTION
Fixes force_destroy for project factory buckets

---
**Checklist**

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass