### PR TITLE
Support `display_name` for workstation configurations

### DIFF
--- a/modules/workstation-cluster/main.tf
+++ b/modules/workstation-cluster/main.tf
@@ -55,6 +55,7 @@ resource "google_workstations_workstation_config" "configs" {
   workstation_config_id   = each.key
   workstation_cluster_id  = google_workstations_workstation_cluster.cluster.workstation_cluster_id
   location                = google_workstations_workstation_cluster.cluster.location
+  display_name            = each.value.display_name
   max_usable_workstations = each.value.max_workstations
   idle_timeout = (
     each.value.timeouts.idle == null ? null : "${each.value.timeouts.idle}s"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here -->
The definition already had the property but it was not used anywhere: https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/modules/workstation-cluster/variables.tf#L86

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [x] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
-->
