### PR TITLE
Fix E2E: Disable E2E for dataproc on GKE

### DIFF
--- a/modules/dataproc/README.md
+++ b/modules/dataproc/README.md
@@ -242,7 +242,7 @@ module "processing-dp-cluster" {
     }
   }
 }
-# tftest modules=5 resources=9 fixtures=fixtures/gke-cluster-standard.tf e2e
+# tftest modules=5 resources=9 fixtures=fixtures/gke-cluster-standard.tf
 ```
 
 ## IAM

--- a/tests/fixtures/gke-cluster-standard.tf
+++ b/tests/fixtures/gke-cluster-standard.tf
@@ -41,7 +41,8 @@ module "gke-cluster-standard" {
     kubelet_readonly_port_enabled = false
   }
   node_pool_auto_config = {
-    network_tags = ["foo"] # to avoid perma-diff
+    network_tags                  = ["foo"] # to avoid perma-diff
+    kubelet_readonly_port_enabled = false
   }
 }
 


### PR DESCRIPTION
Dataproc on GKE looks like has some issues to point to existing GKE:

When node pool is provided as is:
```
Error waiting for creating Dataproc cluster: Error code 3, message: GKE Node Pool name '', must conform to pattern 'projects/([^/]+)/(?:locations|zones)/([^/]+)/clusters/([^/]+)/nodePools/([^/]+)' 
```

When node is provided following the pattern, cluster id is prepended, and then the name is still wrong, as it has `projects/([^/]+)/(?:locations|zones)/([^/]+)/clusters/([^/]+)/nodePools/` part twice.

🤷 

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [ ] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [ ] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
-->
