### PR TITLE
fixed schema patter for iam_bindings_additive roles

### DIFF
--- a/fast/stages/2-project-factory/schemas/project.schema.md
+++ b/fast/stages/2-project-factory/schemas/project.schema.md
@@ -173,7 +173,7 @@
     - **member**: *string*
       <br>*pattern: ^(?:domain:|group:|serviceAccount:|user:|principal:|principalSet:|[a-z])*
     - **role**: *string*
-      <br>*pattern: ^[a-zA-Z0-9_/]+$*
+      <br>*pattern: ^[a-zA-Z0-9_/.]+$*
     - **condition**: *object*
       <br>*additional properties: false*
       - ⁺**expression**: *string*

--- a/modules/project-factory/schemas/project.schema.json
+++ b/modules/project-factory/schemas/project.schema.json
@@ -249,7 +249,7 @@
           }
         }
       }
-     },
+    },
     "parent": {
       "type": "string"
     },
@@ -616,7 +616,7 @@
             },
             "role": {
               "type": "string",
-              "pattern": "^[a-zA-Z0-9_/]+$"
+              "pattern": "^[a-zA-Z0-9_/.]+$"
             },
             "condition": {
               "type": "object",


### PR DESCRIPTION
fixed schema to allow iam_bindings_additive roles with "." ( eg roles/compute.admin)

<!-- Put a description of what this PR is for here -->

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
-->
