### PR TITLE
Provide node_pool_auto_config only when node auto provisioning is enabled for GKE standard cluster

### DIFF
--- a/modules/gke-cluster-standard/main.tf
+++ b/modules/gke-cluster-standard/main.tf
@@ -88,16 +88,19 @@ resource "google_container_cluster" "cluster" {
       }
     }
   }
-  node_pool_auto_config {
-    network_tags {
-      tags = var.node_pool_auto_config.network_tags
-    }
-    resource_manager_tags = var.node_pool_auto_config.resource_manager_tags
-    node_kubelet_config {
-      insecure_kubelet_readonly_port_enabled = upper(var.node_pool_auto_config.kubelet_readonly_port_enabled)
-    }
-    linux_node_config {
-      cgroup_mode = var.node_pool_auto_config.cgroup_mode
+  dynamic "node_pool_auto_config" {
+    for_each = (local.cas != null && local.cas.enabled) ? [""] : []
+    content {
+      network_tags {
+        tags = var.node_pool_auto_config.network_tags
+      }
+      resource_manager_tags = var.node_pool_auto_config.resource_manager_tags
+      node_kubelet_config {
+        insecure_kubelet_readonly_port_enabled = upper(var.node_pool_auto_config.kubelet_readonly_port_enabled)
+      }
+      linux_node_config {
+        cgroup_mode = var.node_pool_auto_config.cgroup_mode
+      }
     }
   }
   addons_config {

--- a/modules/gke-cluster-standard/main.tf
+++ b/modules/gke-cluster-standard/main.tf
@@ -89,7 +89,7 @@ resource "google_container_cluster" "cluster" {
     }
   }
   dynamic "node_pool_auto_config" {
-    for_each = (local.cas != null && local.cas.enabled) ? [""] : []
+    for_each = try(local.cas.enabled, null) == true ? [""] : []
     content {
       network_tags {
         tags = var.node_pool_auto_config.network_tags

--- a/modules/gke-hub/README.md
+++ b/modules/gke-hub/README.md
@@ -65,6 +65,9 @@ module "cluster_1" {
     dataplane_v2      = true
     workload_identity = true
   }
+  cluster_autoscaling = {
+    enabled = true
+  }
 }
 
 module "hub" {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here -->
For a GKE standard cluster with node auto provisioning disabled, the node_pool_auto_config settings are irrelevant and seeing the changes in terraform plan can be confusing.

With this PR, if the node auto provisioning is enabled then node_pool_auto_config settings will be applied otherwise not.

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [x] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
-->
