### PR TITLE
Cleanup 0-org-setup cloud build org-policies

### DIFF
--- a/fast/stages/0-org-setup/data/organization/org-policies/cloudbuild.yaml
+++ b/fast/stages/0-org-setup/data/organization/org-policies/cloudbuild.yaml
@@ -18,10 +18,6 @@
 
 # yaml-language-server: $schema=../../../schemas/org-policies.schema.json
 
-compute.disableGuestAttributesAccess:
-  rules:
-    - enforce: true
-
 cloudbuild.disableCreateDefaultServiceAccount:
   rules:
     - enforce: true
@@ -33,4 +29,3 @@ cloudbuild.useBuildServiceAccount:
 cloudbuild.useComputeServiceAccount:
   rules:
     - enforce: true
-


### PR DESCRIPTION
Remove compute policy from cloudbuild file.

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [ ] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [ ] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
