### PR TITLE
Rationalize prefix handling for project factory automation resources

### DIFF
--- a/fast/stages/0-org-setup/schemas/project.schema.json
+++ b/fast/stages/0-org-setup/schemas/project.schema.json
@@ -530,6 +530,10 @@
         "name": {
           "type": "string"
         },
+        "create": {
+          "type": "boolean",
+          "default": true
+        },
         "description": {
           "type": "string"
         },

--- a/modules/project-factory/outputs.tf
+++ b/modules/project-factory/outputs.tf
@@ -16,10 +16,10 @@
 
 locals {
   _outputs_automation_buckets = {
-    for k, v in local.automation_buckets : v.source_project => k
+    for k, v in local.automation_buckets : v.parent_name => k
   }
   _outputs_automation_sas = {
-    for k, v in local.automation_sas : v.source_project => k...
+    for k, v in local.automation_sas : v.parent_name => k...
   }
   outputs_projects = {
     for k, v in local.projects_input : k => {

--- a/modules/project-factory/projects-buckets.tf
+++ b/modules/project-factory/projects-buckets.tf
@@ -21,6 +21,7 @@ locals {
         project_key    = k
         project_name   = v.name
         name           = name
+        create         = lookup(opts, "create", true)
         description    = lookup(opts, "description", "Terraform-managed.")
         encryption_key = lookup(opts, "encryption_key", null)
         force_destroy = try(coalesce(
@@ -62,6 +63,7 @@ module "buckets" {
   project_id     = module.projects[each.value.project_key].project_id
   prefix         = each.value.prefix
   name           = "${each.value.project_name}-${each.value.name}"
+  bucket_create  = each.value.create
   encryption_key = each.value.encryption_key
   force_destroy  = each.value.force_destroy
   context = merge(local.ctx, {

--- a/modules/project-factory/schemas/project.schema.json
+++ b/modules/project-factory/schemas/project.schema.json
@@ -530,6 +530,10 @@
         "name": {
           "type": "string"
         },
+        "create": {
+          "type": "boolean",
+          "default": true
+        },
         "description": {
           "type": "string"
         },

--- a/tests/modules/project_factory/examples/example.yaml
+++ b/tests/modules/project_factory/examples/example.yaml
@@ -44,7 +44,7 @@ values:
   : bucket: test-pf-dev-tb-app0-0-tf-state
     condition: []
     members:
-    - serviceAccount:test-pf-dev-tb-app0-0-rw@test-pf-teams-iac-0.iam.gserviceaccount.com
+    - serviceAccount:dev-tb-app0-0-rw@test-pf-teams-iac-0.iam.gserviceaccount.com
     role: roles/storage.objectCreator
   ? module.project-factory.module.automation-bucket["dev-tb-app0-0/automation/tf-state"].google_storage_bucket_iam_binding.authoritative["roles/storage.objectViewer"]
   : bucket: test-pf-dev-tb-app0-0-tf-state
@@ -52,27 +52,27 @@ values:
     members:
     - group:gcp-devops@example.org
     - group:team-b-admins@example.org
-    - serviceAccount:test-pf-dev-tb-app0-0-ro@test-pf-teams-iac-0.iam.gserviceaccount.com
-    - serviceAccount:test-pf-dev-tb-app0-0-rw@test-pf-teams-iac-0.iam.gserviceaccount.com
+    - serviceAccount:dev-tb-app0-0-ro@test-pf-teams-iac-0.iam.gserviceaccount.com
+    - serviceAccount:dev-tb-app0-0-rw@test-pf-teams-iac-0.iam.gserviceaccount.com
     role: roles/storage.objectViewer
   ? module.project-factory.module.automation-service-accounts["dev-tb-app0-0/automation/ro"].google_service_account.service_account[0]
-  : account_id: test-pf-dev-tb-app0-0-ro
+  : account_id: dev-tb-app0-0-ro
     create_ignore_already_exists: null
     description: Team B app 0 read-only automation sa.
     disabled: false
     display_name: Service account ro for dev-tb-app0-0.
-    email: test-pf-dev-tb-app0-0-ro@test-pf-teams-iac-0.iam.gserviceaccount.com
-    member: serviceAccount:test-pf-dev-tb-app0-0-ro@test-pf-teams-iac-0.iam.gserviceaccount.com
+    email: dev-tb-app0-0-ro@test-pf-teams-iac-0.iam.gserviceaccount.com
+    member: serviceAccount:dev-tb-app0-0-ro@test-pf-teams-iac-0.iam.gserviceaccount.com
     project: test-pf-teams-iac-0
     timeouts: null
   ? module.project-factory.module.automation-service-accounts["dev-tb-app0-0/automation/rw"].google_service_account.service_account[0]
-  : account_id: test-pf-dev-tb-app0-0-rw
+  : account_id: dev-tb-app0-0-rw
     create_ignore_already_exists: null
     description: Team B app 0 read/write automation sa.
     disabled: false
     display_name: Service account rw for dev-tb-app0-0.
-    email: test-pf-dev-tb-app0-0-rw@test-pf-teams-iac-0.iam.gserviceaccount.com
-    member: serviceAccount:test-pf-dev-tb-app0-0-rw@test-pf-teams-iac-0.iam.gserviceaccount.com
+    email: dev-tb-app0-0-rw@test-pf-teams-iac-0.iam.gserviceaccount.com
+    member: serviceAccount:dev-tb-app0-0-rw@test-pf-teams-iac-0.iam.gserviceaccount.com
     project: test-pf-teams-iac-0
     timeouts: null
   module.project-factory.module.billing-budgets[0].google_billing_budget.default["test-100"]:
@@ -195,13 +195,13 @@ values:
   module.project-factory.module.projects-iam["dev-tb-app0-0"].google_project_iam_binding.authoritative["roles/owner"]:
     condition: []
     members:
-    - serviceAccount:test-pf-dev-tb-app0-0-rw@test-pf-teams-iac-0.iam.gserviceaccount.com
+    - serviceAccount:dev-tb-app0-0-rw@test-pf-teams-iac-0.iam.gserviceaccount.com
     project: test-pf-dev-tb-app0-0
     role: roles/owner
   module.project-factory.module.projects-iam["dev-tb-app0-0"].google_project_iam_binding.authoritative["roles/viewer"]:
     condition: []
     members:
-    - serviceAccount:test-pf-dev-tb-app0-0-ro@test-pf-teams-iac-0.iam.gserviceaccount.com
+    - serviceAccount:dev-tb-app0-0-ro@test-pf-teams-iac-0.iam.gserviceaccount.com
     project: test-pf-dev-tb-app0-0
     role: roles/viewer
   module.project-factory.module.projects-iam["dev-tb-app0-1"].google_project_iam_binding.authoritative["roles/run.admin"]:
@@ -571,7 +571,7 @@ values:
   ? module.project-factory.module.service_accounts-iam["dev-tb-app0-0/vm-default"].google_service_account_iam_binding.authoritative["roles/iam.serviceAccountTokenCreator"]
   : condition: []
     members:
-    - serviceAccount:test-pf-dev-tb-app0-0-rw@test-pf-teams-iac-0.iam.gserviceaccount.com
+    - serviceAccount:dev-tb-app0-0-rw@test-pf-teams-iac-0.iam.gserviceaccount.com
     role: roles/iam.serviceAccountTokenCreator
   module.project-factory.terraform_data.defaults_preconditions:
     input: null


### PR DESCRIPTION
This PR rationalizes handling of prefix in project factory automation resources by

- skipping the global prefix in service account names, to simplify length constraints and adopt the convention used in the FAST org setup stage
- allowing to override prefix in storage buckets, so that an existing bucket can be referenced by "portable" key when defining managed folders and bucket creation is not wanted

A new subsection has been added to the project factory README to explain prefix behaviour for automation resources.

**Breaking Changes**

```upgrade-note
`modules/project-factory`: the format for automation service account names has changed.
```
