### PR TITLE
Fix issue/3355: 'Output refers to sensitive values' in project-factory

### DIFF
--- a/modules/project-factory/README.md
+++ b/modules/project-factory/README.md
@@ -710,12 +710,12 @@ service_accounts:
 | [log_buckets](outputs.tf#L88) | Log bucket ids. |  |
 | [project_ids](outputs.tf#L95) | Project ids. |  |
 | [project_numbers](outputs.tf#L100) | Project numbers. |  |
-| [projects](outputs.tf#L107) | Project attributes. |  |
-| [service_account_emails](outputs.tf#L112) | Service account emails. |  |
-| [service_account_iam_emails](outputs.tf#L119) | Service account IAM-format emails. |  |
-| [service_account_ids](outputs.tf#L126) | Service account IDs. |  |
-| [service_accounts](outputs.tf#L133) | Service account emails. |  |
-| [storage_buckets](outputs.tf#L138) | Bucket names. |  |
+| [projects](outputs.tf#L107) | Project attributes. | ✓ |
+| [service_account_emails](outputs.tf#L113) | Service account emails. |  |
+| [service_account_iam_emails](outputs.tf#L120) | Service account IAM-format emails. |  |
+| [service_account_ids](outputs.tf#L127) | Service account IDs. |  |
+| [service_accounts](outputs.tf#L134) | Service account emails. |  |
+| [storage_buckets](outputs.tf#L139) | Bucket names. |  |
 <!-- END TFDOC -->
 ## Tests
 

--- a/modules/project-factory/outputs.tf
+++ b/modules/project-factory/outputs.tf
@@ -107,6 +107,7 @@ output "project_numbers" {
 output "projects" {
   description = "Project attributes."
   value       = local.outputs_projects
+  sensitive   = true
 }
 
 output "service_account_emails" {


### PR DESCRIPTION
Fix issue when outputs contains sensitive values in the project-factory module, `tf plan` fails.

https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/issues/3355

---
**Checklist**

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [x] Made sure all relevant tests pass
