### PR TITLE
Use pre-commit managed Python environment for pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,22 +31,55 @@ repos:
   - id: cff-readme
     name: Regenerate README.md with tfdoc.py
     entry: tools/pre-commit-tfdoc.sh
-    language: script
+    language: python
+    additional_dependencies:
+      - click
+      - deepdiff
+      - ghapi
+      - iso8601
+      - marko
+      - requests
+      - yamale
+      - yapf
+      - jsonschema
+      - BeautifulSoup4
     #types: [terraform]
     files: ^(modules|fast).*(tf|README.md)$
     pass_filenames: true
     require_serial: true
   - id: licenese
     name: Check license presence and other boilerplate checks
-    language: system
+    language: python
     entry: tools/check_boilerplate.py
+    additional_dependencies:
+      - click
+      - deepdiff
+      - ghapi
+      - iso8601
+      - marko
+      - requests
+      - yamale
+      - yapf
+      - jsonschema
+      - BeautifulSoup4
     pass_filenames: true
     args:
     -  --scan-files
   - id: tflint-fast
     name: Checking FAST code with tflint
     entry: tools/tflint-fast.py
-    language: system
+    language: python
+    additional_dependencies:
+      - click
+      - deepdiff
+      - ghapi
+      - iso8601
+      - marko
+      - requests
+      - yamale
+      - yapf
+      - jsonschema
+      - BeautifulSoup4
     pass_filenames: false
     require_serial: true
     files: ^fast/.*tf
@@ -64,13 +97,35 @@ repos:
     entry: /usr/bin/find . -type f -name 'versions.tofu' -exec cp default-versions.tofu {} \;
   - id: check-names
     name: Check name lengths for FAST
-    language: system
+    language: python
+    additional_dependencies:
+      - click
+      - deepdiff
+      - ghapi
+      - iso8601
+      - marko
+      - requests
+      - yamale
+      - yapf
+      - jsonschema
+      - BeautifulSoup4
     pass_filenames: false
     files: ^fast
     entry: tools/check_names.py --prefix-length=10 --failed-only fast/stages
   - id: check-links
     name: Check links in markdown files
-    language: system
+    language: python
+    additional_dependencies:
+      - click
+      - deepdiff
+      - ghapi
+      - iso8601
+      - marko
+      - requests
+      - yamale
+      - yapf
+      - jsonschema
+      - BeautifulSoup4
     entry: tools/check_links.py --no-show-summary --scan-files
   - id: duplicate-diff
     name: duplicate-diff


### PR DESCRIPTION
With this change, `pre-commit` will create a dedicated virtual-environment with specified dependencies to run checks. Currently, it depends on the default interpreter having all dependencies installed from `tools/requirements.txt` 

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [ ] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [ ] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
