### PR TITLE
FAST org-setup: Add Network and Security admins editor access to respective folders

### DIFF
--- a/fast/stages/0-org-setup/data/folders/networking/.config.yaml
+++ b/fast/stages/0-org-setup/data/folders/networking/.config.yaml
@@ -32,6 +32,8 @@ iam_by_principals:
   $iam_principals:service_accounts/iac-0/iac-pf-ro:
     - roles/compute.viewer
     - $custom_roles:project_iam_viewer
+  $iam_principals:gcp-network-admins:
+    - roles/editor
 iam_bindings:
   dp_dev_rw:
     members:

--- a/fast/stages/0-org-setup/data/folders/security/.config.yaml
+++ b/fast/stages/0-org-setup/data/folders/security/.config.yaml
@@ -31,6 +31,8 @@ iam_by_principals:
   $iam_principals:service_accounts/iac-0/iac-pf-ro:
     - roles/cloudkms.viewer
     - $custom_roles:project_iam_viewer
+  $iam_principals:gcp-security-admins:
+    - roles/editor
 iam_bindings:
   project_factory:
     role: roles/resourcemanager.projectIamAdmin

--- a/tests/fast/stages/s0_org_setup/not-simple.yaml
+++ b/tests/fast/stages/s0_org_setup/not-simple.yaml
@@ -2764,7 +2764,7 @@ counts:
   google_bigquery_default_service_account: 2
   google_billing_account_iam_member: 6
   google_folder: 8
-  google_folder_iam_binding: 44
+  google_folder_iam_binding: 46
   google_iam_workload_identity_pool: 1
   google_iam_workload_identity_pool_provider: 1
   google_logging_organization_settings: 1
@@ -2793,5 +2793,5 @@ counts:
   google_tags_tag_value_iam_binding: 4
   local_file: 9
   modules: 46
-  resources: 308
+  resources: 310
   terraform_data: 2


### PR DESCRIPTION
FAST org-setup: Add Network and Security admins editor access to respective folders

<!-- Put a description of what this PR is for here -->

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
