### PR TITLE
Fix service account module datasource when universe is set

### DIFF
--- a/modules/iam-service-account/main.tf
+++ b/modules/iam-service-account/main.tf
@@ -50,8 +50,12 @@ locals {
 }
 
 data "google_service_account" "service_account" {
-  count      = var.service_account_create ? 0 : 1
-  project    = local.project_id
+  count = var.service_account_create ? 0 : 1
+  project = (
+    strcontains(local.project_id, ":")
+    ? join(".", reverse(split(":", local.project_id)))
+    : local.project_id
+  )
   account_id = "${local.prefix}${local.name}"
 }
 


### PR DESCRIPTION
When using the service account module with universe set, the provider datasource expects a different format for the project id (`foo-project.universe` instead of `universe:foo-project`).

This implements a workaround while the provider is being fixed to accept the regular format.