### PR TITLE
Allow project id with universe prefix in project module

### DIFF
--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -68,7 +68,11 @@ locals {
       }
     )
   )
-  project_id         = "${local.universe_prefix}${local.prefix}${var.name}"
+  project_id = (
+    strcontains("${local.prefix}${var.name}", ":")
+    ? "${local.prefix}${var.name}"
+    : "${local.universe_prefix}${local.prefix}${var.name}"
+  )
   universe_prefix    = var.universe == null ? "" : "${var.universe.prefix}:"
   available_services = tolist(setsubtract(var.services, try(var.universe.unavailable_services, [])))
 }


### PR DESCRIPTION
This fixes an error when contatenating project modules for the same project (like in the project factory to split IAM), and universe is set in defaults/overrides: the project id output from the first module already contains the universe prefix (eg `foo:my_project`) so the second module does not need to internally prefix it one more time.