### PR TITLE
fix: expose missing audiences variable for gitlab workflow file

### DIFF
--- a/fast/stages/0-org-setup/cicd.tf
+++ b/fast/stages/0-org-setup/cicd.tf
@@ -42,6 +42,7 @@ locals {
           v.workload_identity_provider.id,
           v.workload_identity_provider.id
         )
+        audiences = try(v.workload_identity_provider.audiences, [])
         service_accounts = {
           apply = lookup(
             local.of_service_accounts,


### PR DESCRIPTION

In 0-org-setup, when using gitlab cicd, workflow-gitlab.yaml expects an `audiences` variable.

This is an attempt to solve the issue described here: #3363  


---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass

