### PR TITLE
fix: add workload identity pool as a principalset on role workload identity user

### DIFF
--- a/fast/stages/0-org-setup/cicd.tf
+++ b/fast/stages/0-org-setup/cicd.tf
@@ -93,6 +93,15 @@ resource "google_iam_workload_identity_pool" "default" {
   )
 }
 
+resource "google_project_iam_member" "workload_identity_user_principalset" {
+  count = local.wif_project == null ? 0 : 1
+  project = lookup(
+    local.cicd_project_ids, local.wif_project, local.wif_project
+  )
+  role    = "roles/iam.workloadIdentityUser"
+  member  = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.default[0].name}/*"
+}
+
 resource "google_iam_workload_identity_pool_provider" "default" {
   for_each = local.wif_providers
   project = (

--- a/tests/fast/stages/s0_org_setup/not-simple.yaml
+++ b/tests/fast/stages/s0_org_setup/not-simple.yaml
@@ -2776,7 +2776,7 @@ counts:
   google_organization_iam_custom_role: 7
   google_project: 3
   google_project_iam_binding: 16
-  google_project_iam_member: 15
+  google_project_iam_member: 16
   google_project_service: 33
   google_project_service_identity: 9
   google_service_account: 16
@@ -2793,5 +2793,5 @@ counts:
   google_tags_tag_value_iam_binding: 4
   local_file: 9
   modules: 46
-  resources: 308
+  resources: 309
   terraform_data: 2


### PR DESCRIPTION
When deploying 0-org-setup with cicd, Gitlab Saas and the extra stage 0-cicd-gitlab, Workload Identity Federation does not work entirely out of the box.

In the pipeline, the step gcp-setup fails with error:
```
ERROR: (gcloud.storage.cp) There was a problem refreshing your current auth tokens: ('Unable to acquire impersonated credentials',
'{
  "error": {
    "code": 403,
    "message": "Permission \'iam.serviceAccounts.getAccessToken\' denied on resource (or it may not exist).",
    "status": "PERMISSION_DENIED",
    "details": [
      {
        "@type": "type.googleapis.com/google.rpc.ErrorInfo",
        "reason": "IAM_PERMISSION_DENIED",
        "domain": "iam.googleapis.com",
        "metadata": {
          "permission": "iam.serviceAccounts.getAccessToken"
        }
      }
    ]
  }
}
')
```

Granting the Workload Identity User role`roles/iam.workloadIdentityUser` to `principalSet://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/*` solves the issue.

Based on:
* [Authenticate a deployment pipeline - Service account impersonation](https://cloud.google.com/iam/docs/workload-identity-federation-with-deployment-pipelines#by-pool)
* [Workload Identity Federation - Principal types](https://cloud.google.com/iam/docs/workload-identity-federation#principal-types)

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
