### PR TITLE
Pass context folder ids from defaults.yaml to project factory

### DIFF
--- a/fast/stages/0-org-setup/factory.tf
+++ b/fast/stages/0-org-setup/factory.tf
@@ -41,6 +41,7 @@ module "factory" {
     )
     folder_ids = merge(
       local.ctx.folder_ids,
+      try(local._defaults.context.folder_ids, {}), # the above contains only var.ctx.folder_ids
       lookup(local.ctx.folder_ids, "default", null) != null ? {} : {
         default = try(module.organization[0].id, null)
       }


### PR DESCRIPTION
This is not yet working as expected.

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [ ] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [ ] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
