### PR TITLE
Allow automation resources with bucket or service accounts only in project factory

### DIFF
--- a/fast/stages/2-project-factory/output-files.tf
+++ b/fast/stages/2-project-factory/output-files.tf
@@ -124,7 +124,7 @@ resource "local_file" "providers" {
   for_each        = local.of_paths.local == null ? {} : local.of_providers
   file_permission = "0644"
   filename = (
-    "${local.of_paths.local}/providers/${each.value.filename}.tf"
+    "${local.of_paths.local}/providers/${each.value.filename}-providers.tf"
   )
   content = templatestring(local.of_template, {
     bucket = lookup(
@@ -151,7 +151,7 @@ resource "local_file" "tfvars" {
 resource "google_storage_bucket_object" "providers" {
   for_each = local.of_storage_bucket == null ? {} : local.of_providers
   bucket   = local.of_storage_bucket
-  name     = "providers/${each.value.filename}.tf"
+  name     = "providers/${each.value.filename}-providers.tf"
   content = templatestring(local.of_template, {
     bucket = lookup(
       local.of_storage_buckets,

--- a/modules/project-factory/automation.tf
+++ b/modules/project-factory/automation.tf
@@ -24,7 +24,7 @@ locals {
         prefix           = coalesce(try(v.automation.prefix, null), v.prefix)
         project          = try(v.automation.project, null)
         service_accounts = try(v.automation.service_accounts, {})
-      } if try(v.automation.bucket, null) != null
+      } if try(v.automation.bucket, null) != null || try(v.automation.service_accounts, null) != null
     },
     {
       for k, v in local.projects_input : k => {
@@ -34,7 +34,7 @@ locals {
         prefix           = coalesce(try(v.automation.prefix, null), v.prefix)
         project          = try(v.automation.project, null)
         service_accounts = try(v.automation.service_accounts, {})
-      } if try(v.automation.bucket, null) != null
+      } if try(v.automation.bucket, null) != null || try(v.automation.service_accounts, null) != null
     }
   )
   _automation_buckets = {
@@ -48,7 +48,7 @@ locals {
         v.prefix,
         local.data_defaults.defaults.prefix
       ), null)
-    })
+    }) if v.bucket != null
   }
   _automation_sas = flatten(concat([
     for k, v in local._automation : [
@@ -58,7 +58,7 @@ locals {
         parent             = k
         parent_name        = v.parent_name
       })
-    ]
+    ] if v.service_accounts != null
   ]))
   automation_buckets = {
     for k, v in local._automation_buckets :


### PR DESCRIPTION
This PR allows creation of automation resources, where project definitions only contain service accounts or a bucket. This was previously prevented as an internal check enforced the presence of both.

The approach in this PR allows defining automation blocks with service accounts only, and then leveraging the output files definitions in the FAST stage to automatically create managed folders in a single GCS bucket.

The PR also reintroduces the `-providers` suffix to output provider files, to allow excluding them with a single `.gitignore` line.