### PR TITLE
Make local.rules convertible to map

### DIFF
--- a/modules/net-firewall-policy/factory.tf
+++ b/modules/net-firewall-policy/factory.tf
@@ -40,18 +40,18 @@ locals {
       disabled                = lookup(v, "disabled", false)
       enable_logging          = lookup(v, "enable_logging", null)
       security_profile_group  = lookup(v, "security_profile_group", null)
-      target_resources        = lookup(v, "target_resources", null)
-      target_service_accounts = lookup(v, "target_service_accounts", null)
-      target_tags             = lookup(v, "target_tags", null)
+      target_resources        = lookup(v, "target_resources", tolist(null))
+      target_service_accounts = lookup(v, "target_service_accounts", tolist(null))
+      target_tags             = lookup(v, "target_tags", tolist(null))
       tls_inspect             = lookup(v, "tls_inspect", null)
       match = {
-        address_groups       = lookup(v.match, "address_groups", null)
-        fqdns                = lookup(v.match, "fqdns", null)
-        region_codes         = lookup(v.match, "region_codes", null)
-        threat_intelligences = lookup(v.match, "threat_intelligences", null)
+        address_groups       = lookup(v.match, "address_groups", tolist(null))
+        fqdns                = lookup(v.match, "fqdns", tolist(null))
+        region_codes         = lookup(v.match, "region_codes", tolist(null))
+        threat_intelligences = lookup(v.match, "threat_intelligences", tolist(null))
         destination_ranges = (
           lookup(v.match, "destination_ranges", null) == null
-          ? null
+          ? tolist(null)
           : flatten([
             for r in v.match.destination_ranges :
             try(local.factory_cidrs[r], r)
@@ -59,13 +59,13 @@ locals {
         )
         source_ranges = (
           lookup(v.match, "source_ranges", null) == null
-          ? null
+          ? tolist(null)
           : flatten([
             for r in v.match.source_ranges :
             try(local.factory_cidrs[r], r)
           ])
         )
-        source_tags = lookup(v.match, "source_tags", null)
+        source_tags = lookup(v.match, "source_tags", tolist(null))
         layer4_configs = (
           lookup(v.match, "layer4_configs", null) == null
           ? [{ protocol = "all", ports = null }]
@@ -87,18 +87,18 @@ locals {
       disabled                = lookup(v, "disabled", false)
       enable_logging          = lookup(v, "enable_logging", null)
       security_profile_group  = lookup(v, "security_profile_group", null)
-      target_resources        = lookup(v, "target_resources", null)
-      target_service_accounts = lookup(v, "target_service_accounts", null)
-      target_tags             = lookup(v, "target_tags", null)
+      target_resources        = lookup(v, "target_resources", tolist(null))
+      target_service_accounts = lookup(v, "target_service_accounts", tolist(null))
+      target_tags             = lookup(v, "target_tags", tolist(null))
       tls_inspect             = lookup(v, "tls_inspect", null)
       match = {
-        address_groups       = lookup(v.match, "address_groups", null)
-        fqdns                = lookup(v.match, "fqdns", null)
-        region_codes         = lookup(v.match, "region_codes", null)
-        threat_intelligences = lookup(v.match, "threat_intelligences", null)
+        address_groups       = lookup(v.match, "address_groups", tolist(null))
+        fqdns                = lookup(v.match, "fqdns", tolist(null))
+        region_codes         = lookup(v.match, "region_codes", tolist(null))
+        threat_intelligences = lookup(v.match, "threat_intelligences", tolist(null))
         destination_ranges = (
           lookup(v.match, "destination_ranges", null) == null
-          ? null
+          ? tolist(null)
           : flatten([
             for r in v.match.destination_ranges :
             try(local.factory_cidrs[r], r)
@@ -106,13 +106,13 @@ locals {
         )
         source_ranges = (
           lookup(v.match, "source_ranges", null) == null
-          ? null
+          ? tolist(null)
           : flatten([
             for r in v.match.source_ranges :
             try(local.factory_cidrs[r], r)
           ])
         )
-        source_tags = lookup(v.match, "source_tags", null)
+        source_tags = lookup(v.match, "source_tags", tolist(null))
         layer4_configs = (
           lookup(v.match, "layer4_configs", null) == null
           ? [{ protocol = "all", ports = null }]

--- a/modules/net-firewall-policy/hierarchical.tf
+++ b/modules/net-firewall-policy/hierarchical.tf
@@ -30,88 +30,86 @@ resource "google_compute_firewall_policy_association" "hierarchical" {
 
 resource "google_compute_firewall_policy_rule" "hierarchical" {
   # Terraform's type system barfs in the condition if we use the locals map
-  for_each = toset(
-    local.use_hierarchical ? keys(local.rules) : []
-  )
+  for_each        = local.use_hierarchical ? local.rules : {}
   firewall_policy = google_compute_firewall_policy.hierarchical[0].name
-  action          = local.rules[each.key].action
-  description     = local.rules[each.key].description
-  direction       = local.rules[each.key].direction
-  disabled        = local.rules[each.key].disabled
-  enable_logging  = local.rules[each.key].enable_logging
-  priority        = local.rules[each.key].priority
+  action          = each.value.action
+  description     = each.value.description
+  direction       = each.value.direction
+  disabled        = each.value.disabled
+  enable_logging  = each.value.enable_logging
+  priority        = each.value.priority
   target_resources = (
-    local.rules[each.key].target_resources == null ? null : [
-      for n in local.rules[each.key].target_resources :
+    each.value.target_resources == null ? null : [
+      for n in each.value.target_resources :
       lookup(local.ctx.networks, n, n)
     ]
   )
   target_service_accounts = (
-    local.rules[each.key].target_service_accounts == null ? null : [
-      for n in local.rules[each.key].target_service_accounts :
+    each.value.target_service_accounts == null ? null : [
+      for n in each.value.target_service_accounts :
       lookup(local.ctx.iam_principals, n, n)
     ]
   )
-  tls_inspect = local.rules[each.key].tls_inspect
+  tls_inspect = each.value.tls_inspect
   security_profile_group = try(
-    var.security_profile_group_ids[local.rules[each.key].security_profile_group],
-    local.rules[each.key].security_profile_group
+    var.security_profile_group_ids[each.value.security_profile_group],
+    each.value.security_profile_group
   )
   match {
     dest_ip_ranges = (
-      local.rules[each.key].match.destination_ranges == null ? null : [
-        for r in local.rules[each.key].match.destination_ranges :
+      each.value.match.destination_ranges == null ? null : [
+        for r in each.value.match.destination_ranges :
         lookup(local.ctx.cidr_ranges, r, r)
       ]
     )
     src_ip_ranges = (
-      local.rules[each.key].match.source_ranges == null ? null : [
-        for r in local.rules[each.key].match.source_ranges :
+      each.value.match.source_ranges == null ? null : [
+        for r in each.value.match.source_ranges :
         lookup(local.ctx.cidr_ranges, r, r)
       ]
     )
     dest_address_groups = (
-      local.rules[each.key].direction == "EGRESS"
-      ? local.rules[each.key].match.address_groups
+      each.value.direction == "EGRESS"
+      ? each.value.match.address_groups
       : null
     )
     dest_fqdns = (
-      local.rules[each.key].direction == "EGRESS"
-      ? local.rules[each.key].match.fqdns
+      each.value.direction == "EGRESS"
+      ? each.value.match.fqdns
       : null
     )
     dest_region_codes = (
-      local.rules[each.key].direction == "EGRESS"
-      ? local.rules[each.key].match.region_codes
+      each.value.direction == "EGRESS"
+      ? each.value.match.region_codes
       : null
     )
     dest_threat_intelligences = (
-      local.rules[each.key].direction == "EGRESS"
-      ? local.rules[each.key].match.threat_intelligences
+      each.value.direction == "EGRESS"
+      ? each.value.match.threat_intelligences
       : null
     )
     src_address_groups = (
-      local.rules[each.key].direction == "INGRESS"
-      ? local.rules[each.key].match.address_groups
+      each.value.direction == "INGRESS"
+      ? each.value.match.address_groups
       : null
     )
     src_fqdns = (
-      local.rules[each.key].direction == "INGRESS"
-      ? local.rules[each.key].match.fqdns
+      each.value.direction == "INGRESS"
+      ? each.value.match.fqdns
       : null
     )
     src_region_codes = (
-      local.rules[each.key].direction == "INGRESS"
-      ? local.rules[each.key].match.region_codes
+      each.value.direction == "INGRESS"
+      ? each.value.match.region_codes
       : null
     )
     src_threat_intelligences = (
-      local.rules[each.key].direction == "INGRESS"
-      ? local.rules[each.key].match.threat_intelligences
+      each.value.direction == "INGRESS"
+      ? each.value.match.threat_intelligences
       : null
     )
     dynamic "layer4_configs" {
-      for_each = local.rules[each.key].match.layer4_configs
+      for_each = each.value.match.layer4_configs
       content {
         ip_protocol = layer4_configs.value.protocol
         ports       = layer4_configs.value.ports

--- a/modules/net-firewall-policy/net-global.tf
+++ b/modules/net-firewall-policy/net-global.tf
@@ -33,93 +33,93 @@ resource "google_compute_network_firewall_policy_association" "net-global" {
 
 resource "google_compute_network_firewall_policy_rule" "net-global" {
   # Terraform's type system barfs in the condition if we use the locals map
-  for_each = toset(
+  for_each = (
     !local.use_hierarchical && !local.use_regional
-    ? keys(local.rules)
-    : []
+    ? local.rules
+    : {}
   )
   project         = lookup(local.ctx.project_ids, var.parent_id, var.parent_id)
   firewall_policy = google_compute_network_firewall_policy.net-global[0].name
-  rule_name       = local.rules[each.key].name
-  action          = local.rules[each.key].action
-  description     = local.rules[each.key].description
-  direction       = local.rules[each.key].direction
-  disabled        = local.rules[each.key].disabled
-  enable_logging  = local.rules[each.key].enable_logging
-  priority        = local.rules[each.key].priority
+  rule_name       = each.value.name
+  action          = each.value.action
+  description     = each.value.description
+  direction       = each.value.direction
+  disabled        = each.value.disabled
+  enable_logging  = each.value.enable_logging
+  priority        = each.value.priority
   target_service_accounts = (
-    local.rules[each.key].target_service_accounts == null ? null : [
-      for n in local.rules[each.key].target_service_accounts :
+    each.value.target_service_accounts == null ? null : [
+      for n in each.value.target_service_accounts :
       lookup(local.ctx.iam_principals, n, n)
     ]
   )
-  tls_inspect = local.rules[each.key].tls_inspect
+  tls_inspect = each.value.tls_inspect
   security_profile_group = try(
-    var.security_profile_group_ids[local.rules[each.key].security_profile_group],
-    local.rules[each.key].security_profile_group
+    var.security_profile_group_ids[each.value.security_profile_group],
+    each.value.security_profile_group
   )
   match {
     dest_ip_ranges = (
-      local.rules[each.key].match.destination_ranges == null ? null : [
-        for r in local.rules[each.key].match.destination_ranges :
+      each.value.match.destination_ranges == null ? null : [
+        for r in each.value.match.destination_ranges :
         lookup(local.ctx.cidr_ranges, r, r)
       ]
     )
     src_ip_ranges = (
-      local.rules[each.key].match.source_ranges == null ? null : [
-        for r in local.rules[each.key].match.source_ranges :
+      each.value.match.source_ranges == null ? null : [
+        for r in each.value.match.source_ranges :
         lookup(local.ctx.cidr_ranges, r, r)
       ]
     )
     dest_address_groups = (
-      local.rules[each.key].direction == "EGRESS"
-      ? local.rules[each.key].match.address_groups
+      each.value.direction == "EGRESS"
+      ? each.value.match.address_groups
       : null
     )
     dest_fqdns = (
-      local.rules[each.key].direction == "EGRESS"
-      ? local.rules[each.key].match.fqdns
+      each.value.direction == "EGRESS"
+      ? each.value.match.fqdns
       : null
     )
     dest_region_codes = (
-      local.rules[each.key].direction == "EGRESS"
-      ? local.rules[each.key].match.region_codes
+      each.value.direction == "EGRESS"
+      ? each.value.match.region_codes
       : null
     )
     dest_threat_intelligences = (
-      local.rules[each.key].direction == "EGRESS"
-      ? local.rules[each.key].match.threat_intelligences
+      each.value.direction == "EGRESS"
+      ? each.value.match.threat_intelligences
       : null
     )
     src_address_groups = (
-      local.rules[each.key].direction == "INGRESS"
-      ? local.rules[each.key].match.address_groups
+      each.value.direction == "INGRESS"
+      ? each.value.match.address_groups
       : null
     )
     src_fqdns = (
-      local.rules[each.key].direction == "INGRESS"
-      ? local.rules[each.key].match.fqdns
+      each.value.direction == "INGRESS"
+      ? each.value.match.fqdns
       : null
     )
     src_region_codes = (
-      local.rules[each.key].direction == "INGRESS"
-      ? local.rules[each.key].match.region_codes
+      each.value.direction == "INGRESS"
+      ? each.value.match.region_codes
       : null
     )
     src_threat_intelligences = (
-      local.rules[each.key].direction == "INGRESS"
-      ? local.rules[each.key].match.threat_intelligences
+      each.value.direction == "INGRESS"
+      ? each.value.match.threat_intelligences
       : null
     )
     dynamic "layer4_configs" {
-      for_each = local.rules[each.key].match.layer4_configs
+      for_each = each.value.match.layer4_configs
       content {
         ip_protocol = layer4_configs.value.protocol
         ports       = layer4_configs.value.ports
       }
     }
     dynamic "src_secure_tags" {
-      for_each = toset(coalesce(local.rules[each.key].match.source_tags, []))
+      for_each = toset(coalesce(each.value.match.source_tags, []))
       content {
         name = lookup(
           local.ctx.tag_values, src_secure_tags.key, src_secure_tags.key
@@ -129,9 +129,9 @@ resource "google_compute_network_firewall_policy_rule" "net-global" {
   }
   dynamic "target_secure_tags" {
     for_each = toset(
-      local.rules[each.key].target_tags == null
+      each.value.target_tags == null
       ? []
-      : local.rules[each.key].target_tags
+      : each.value.target_tags
     )
     content {
       name = lookup(

--- a/modules/net-firewall-policy/net-regional.tf
+++ b/modules/net-firewall-policy/net-regional.tf
@@ -35,89 +35,89 @@ resource "google_compute_region_network_firewall_policy_association" "net-region
 
 resource "google_compute_region_network_firewall_policy_rule" "net-regional" {
   # Terraform's type system barfs in the condition if we use the locals map
-  for_each = toset(
+  for_each = (
     !local.use_hierarchical && local.use_regional
-    ? keys(local.rules)
-    : []
+    ? local.rules
+    : {}
   )
   project         = lookup(local.ctx.project_ids, var.parent_id, var.parent_id)
   region          = lookup(local.ctx.locations, var.region, var.region)
   firewall_policy = google_compute_region_network_firewall_policy.net-regional[0].name
-  rule_name       = local.rules[each.key].name
-  action          = local.rules[each.key].action
-  description     = local.rules[each.key].description
-  direction       = local.rules[each.key].direction
-  disabled        = local.rules[each.key].disabled
-  enable_logging  = local.rules[each.key].enable_logging
-  priority        = local.rules[each.key].priority
+  rule_name       = each.value.name
+  action          = each.value.action
+  description     = each.value.description
+  direction       = each.value.direction
+  disabled        = each.value.disabled
+  enable_logging  = each.value.enable_logging
+  priority        = each.value.priority
   target_service_accounts = (
-    local.rules[each.key].target_service_accounts == null ? null : [
-      for n in local.rules[each.key].target_service_accounts :
+    each.value.target_service_accounts == null ? null : [
+      for n in each.value.target_service_accounts :
       lookup(local.ctx.iam_principals, n, n)
     ]
   )
   match {
     dest_ip_ranges = (
-      local.rules[each.key].match.destination_ranges == null ? null : [
-        for r in local.rules[each.key].match.destination_ranges :
+      each.value.match.destination_ranges == null ? null : [
+        for r in each.value.match.destination_ranges :
         lookup(local.ctx.cidr_ranges, r, r)
       ]
     )
     src_ip_ranges = (
-      local.rules[each.key].match.source_ranges == null ? null : [
-        for r in local.rules[each.key].match.source_ranges :
+      each.value.match.source_ranges == null ? null : [
+        for r in each.value.match.source_ranges :
         lookup(local.ctx.cidr_ranges, r, r)
       ]
     )
     dest_address_groups = (
-      local.rules[each.key].direction == "EGRESS"
-      ? local.rules[each.key].match.address_groups
+      each.value.direction == "EGRESS"
+      ? each.value.match.address_groups
       : null
     )
     dest_fqdns = (
-      local.rules[each.key].direction == "EGRESS"
-      ? local.rules[each.key].match.fqdns
+      each.value.direction == "EGRESS"
+      ? each.value.match.fqdns
       : null
     )
     dest_region_codes = (
-      local.rules[each.key].direction == "EGRESS"
-      ? local.rules[each.key].match.region_codes
+      each.value.direction == "EGRESS"
+      ? each.value.match.region_codes
       : null
     )
     dest_threat_intelligences = (
-      local.rules[each.key].direction == "EGRESS"
-      ? local.rules[each.key].match.threat_intelligences
+      each.value.direction == "EGRESS"
+      ? each.value.match.threat_intelligences
       : null
     )
     src_address_groups = (
-      local.rules[each.key].direction == "INGRESS"
-      ? local.rules[each.key].match.address_groups
+      each.value.direction == "INGRESS"
+      ? each.value.match.address_groups
       : null
     )
     src_fqdns = (
-      local.rules[each.key].direction == "INGRESS"
-      ? local.rules[each.key].match.fqdns
+      each.value.direction == "INGRESS"
+      ? each.value.match.fqdns
       : null
     )
     src_region_codes = (
-      local.rules[each.key].direction == "INGRESS"
-      ? local.rules[each.key].match.region_codes
+      each.value.direction == "INGRESS"
+      ? each.value.match.region_codes
       : null
     )
     src_threat_intelligences = (
-      local.rules[each.key].direction == "INGRESS"
-      ? local.rules[each.key].match.threat_intelligences
+      each.value.direction == "INGRESS"
+      ? each.value.match.threat_intelligences
       : null
     )
     dynamic "layer4_configs" {
-      for_each = local.rules[each.key].match.layer4_configs
+      for_each = each.value.match.layer4_configs
       content {
         ip_protocol = layer4_configs.value.protocol
         ports       = layer4_configs.value.ports
       }
     }
     dynamic "src_secure_tags" {
-      for_each = toset(coalesce(local.rules[each.key].match.source_tags, []))
+      for_each = toset(coalesce(each.value.match.source_tags, []))
       content {
         name = lookup(
           local.ctx.tag_values, src_secure_tags.key, src_secure_tags.key
@@ -127,9 +127,9 @@ resource "google_compute_region_network_firewall_policy_rule" "net-regional" {
   }
   dynamic "target_secure_tags" {
     for_each = toset(
-      local.rules[each.key].target_tags == null
+      each.value.target_tags == null
       ? []
-      : local.rules[each.key].target_tags
+      : each.value.target_tags
     )
     content {
       name = lookup(


### PR DESCRIPTION
Using `tolist(null)` instead of `null` allows type convergence, and in result - conversion to map in `for_each`

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [ ] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [ ] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
