### PR TITLE
Apply alerts and log based metrics after log buckets creation

### DIFF
--- a/modules/project-factory/projects.tf
+++ b/modules/project-factory/projects.tf
@@ -73,7 +73,7 @@ module "projects" {
   })
   default_service_account = try(each.value.default_service_account, "keep")
   descriptive_name        = try(each.value.descriptive_name, null)
-  factories_config        = each.value.factories_config
+  factories_config        = { for k, v in each.value.factories_config : k => v if k != "observability" }
   labels = merge(
     each.value.labels, var.data_merges.labels
   )
@@ -118,6 +118,7 @@ module "projects-iam" {
     kms_keys       = local.ctx.kms_keys
     iam_principals = local.ctx_iam_principals
   })
+  factories_config      = { for k, v in each.value.factories_config : k => v if k == "observability" }
   iam                   = lookup(each.value, "iam", {})
   iam_bindings          = lookup(each.value, "iam_bindings", {})
   iam_bindings_additive = lookup(each.value, "iam_bindings_additive", {})


### PR DESCRIPTION
Ensure alerts and log based metrics are created only after log buckets have been created (done in module `projects`)

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass