### PR TITLE
fix Terraform version linter

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -114,7 +114,7 @@ jobs:
           egrep -v "(required_version|module_name)" default-versions.tofu > /tmp/versions.tofu
           diff -rub /tmp/versions.tf /tmp/versions.tofu
           DIFF_EC=$?
-          [[ "${DIFF_EC}" -eq "0" ||  -z "${OUTPUT_TF}" || -z "${OUTPUT_TOFU}" ]]
+          [[ "${DIFF_EC}" -eq "0" &&  -z "${OUTPUT_TF}" && -z "${OUTPUT_TOFU}" ]]
 
       - name: Check for diverging files
         id: duplicates


### PR DESCRIPTION
Terraform version linter did not fail ([evidence](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/actions/runs/18644457603/job/53148942829?pr=3429#step:16:29)), if one module had different version than all the others. It was sufficient, to pass any of the tests:
* no difference between Terraform and OpenTofu versions
* all modules matching default-versions.tf 
* all modules matching default.versions.tofu

Now, we require all tests to pass.


---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [ ] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [ ] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
