### PR TITLE
fix(vpc-sc): correctly handle null `from.identities` in ingress/egress policies (regression since v39.0.0)

### DIFF
--- a/modules/vpc-sc/perimeters.tf
+++ b/modules/vpc-sc/perimeters.tf
@@ -74,8 +74,8 @@ resource "google_access_context_manager_service_perimeter" "regular" {
             for_each = policy.value.from == null ? [] : [""]
             content {
               identity_type = policy.value.from.identity_type
-              identities = flatten([
-                for i in policy.value.from.identities : (
+              identities = policy.value.from.identities == null ? null : flatten([
+                for i in coalesce(policy.value.from.identities, []) : (
                   startswith(i, "$identity_sets:")
                   ? lookup(local.ctx.identity_sets, i, [i])
                   : lookup(local.ctx.iam_principals_list, i, [i])
@@ -159,8 +159,8 @@ resource "google_access_context_manager_service_perimeter" "regular" {
             for_each = policy.value.from == null ? [] : [""]
             content {
               identity_type = policy.value.from.identity_type
-              identities = flatten([
-                for i in policy.value.from.identities : (
+              identities = policy.value.from.identities == null ? null : flatten([
+                for i in coalesce(policy.value.from.identities, []) : (
                   startswith(i, "$identity_sets:")
                   ? lookup(local.ctx.identity_sets, i, [i])
                   : lookup(local.ctx.iam_principals_list, i, [i])
@@ -271,8 +271,8 @@ resource "google_access_context_manager_service_perimeter" "regular" {
             for_each = policy.value.from == null ? [] : [""]
             content {
               identity_type = policy.value.from.identity_type
-              identities = flatten([
-                for i in policy.value.from.identities : (
+              identities = policy.value.from.identities == null ? null : flatten([
+                for i in coalesce(policy.value.from.identities, []) : (
                   startswith(i, "$identity_sets:")
                   ? lookup(local.ctx.identity_sets, i, [i])
                   : lookup(local.ctx.iam_principals_list, i, [i])
@@ -356,8 +356,8 @@ resource "google_access_context_manager_service_perimeter" "regular" {
             for_each = policy.value.from == null ? [] : [""]
             content {
               identity_type = policy.value.from.identity_type
-              identities = flatten([
-                for i in policy.value.from.identities : (
+              identities = policy.value.from.identities == null ? null : flatten([
+                for i in coalesce(policy.value.from.identities, []) : (
                   startswith(i, "$identity_sets:")
                   ? lookup(local.ctx.identity_sets, i, [i])
                   : lookup(local.ctx.iam_principals_list, i, [i])


### PR DESCRIPTION
Allow `null` as a valid value for the `from.identities` attribute in ingress/egress policies. A regression introduced in v39.0.0 caused the module to assume `from.identities` was always a list, which produced errors when `null` was provided.

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [x] Made sure all relevant tests pass