### PR TITLE
chore: cleanup remove fleet output

### DIFF
--- a/modules/gke-cluster-autopilot/README.md
+++ b/modules/gke-cluster-autopilot/README.md
@@ -297,12 +297,11 @@ module "cluster-1" {
 | [cluster](outputs.tf#L23) | Cluster resource. | ✓ |
 | [dns_endpoint](outputs.tf#L29) | Control plane DNS endpoint. |  |
 | [endpoint](outputs.tf#L37) | Cluster endpoint. |  |
-| [fleet](outputs.tf#L42) | GKE Fleet Membership. |  |
-| [id](outputs.tf#L47) | Fully qualified cluster ID. |  |
-| [location](outputs.tf#L52) | Cluster location. |  |
-| [master_version](outputs.tf#L57) | Master version. |  |
-| [name](outputs.tf#L62) | Cluster name. |  |
-| [notifications](outputs.tf#L67) | GKE Pub/Sub notifications topic. |  |
-| [self_link](outputs.tf#L72) | Cluster self link. | ✓ |
-| [workload_identity_pool](outputs.tf#L78) | Workload identity pool. |  |
+| [id](outputs.tf#L42) | Fully qualified cluster ID. |  |
+| [location](outputs.tf#L47) | Cluster location. |  |
+| [master_version](outputs.tf#L52) | Master version. |  |
+| [name](outputs.tf#L57) | Cluster name. |  |
+| [notifications](outputs.tf#L62) | GKE Pub/Sub notifications topic. |  |
+| [self_link](outputs.tf#L67) | Cluster self link. | ✓ |
+| [workload_identity_pool](outputs.tf#L73) | Workload identity pool. |  |
 <!-- END TFDOC -->

--- a/modules/gke-cluster-autopilot/outputs.tf
+++ b/modules/gke-cluster-autopilot/outputs.tf
@@ -39,11 +39,6 @@ output "endpoint" {
   value       = google_container_cluster.cluster.endpoint
 }
 
-output "fleet" {
-  description = "GKE Fleet Membership."
-  value       = google_container_cluster.cluster.endpoint
-}
-
 output "id" {
   description = "Fully qualified cluster ID."
   value       = google_container_cluster.cluster.id

--- a/modules/gke-cluster-standard/README.md
+++ b/modules/gke-cluster-standard/README.md
@@ -543,12 +543,11 @@ module "cluster-1" {
 | [cluster](outputs.tf#L25) | Cluster resource. | ✓ |
 | [dns_endpoint](outputs.tf#L31) | Control plane DNS endpoint. |  |
 | [endpoint](outputs.tf#L39) | Cluster endpoint. |  |
-| [fleet](outputs.tf#L44) | GKE Fleet Membership. |  |
-| [id](outputs.tf#L49) | FUlly qualified cluster id. |  |
-| [location](outputs.tf#L54) | Cluster location. |  |
-| [master_version](outputs.tf#L59) | Master version. |  |
-| [name](outputs.tf#L64) | Cluster name. |  |
-| [notifications](outputs.tf#L69) | GKE PubSub notifications topic. |  |
-| [self_link](outputs.tf#L74) | Cluster self link. | ✓ |
-| [workload_identity_pool](outputs.tf#L80) | Workload identity pool. |  |
+| [id](outputs.tf#L44) | FUlly qualified cluster id. |  |
+| [location](outputs.tf#L49) | Cluster location. |  |
+| [master_version](outputs.tf#L54) | Master version. |  |
+| [name](outputs.tf#L59) | Cluster name. |  |
+| [notifications](outputs.tf#L64) | GKE PubSub notifications topic. |  |
+| [self_link](outputs.tf#L69) | Cluster self link. | ✓ |
+| [workload_identity_pool](outputs.tf#L75) | Workload identity pool. |  |
 <!-- END TFDOC -->

--- a/modules/gke-cluster-standard/outputs.tf
+++ b/modules/gke-cluster-standard/outputs.tf
@@ -41,11 +41,6 @@ output "endpoint" {
   value       = google_container_cluster.cluster.endpoint
 }
 
-output "fleet" {
-  description = "GKE Fleet Membership."
-  value       = google_container_cluster.cluster.endpoint
-}
-
 output "id" {
   description = "FUlly qualified cluster id."
   value       = google_container_cluster.cluster.id


### PR DESCRIPTION
Removed the fleet from the output as it's available through `cluster.fleet` and not necessarily that important to have on the top level.

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [x] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
