### PR TITLE
Side-step create-before-destroy disease by forcing new subnet creation on CIDR range change

### DIFF
--- a/modules/net-vpc/README.md
+++ b/modules/net-vpc/README.md
@@ -942,13 +942,13 @@ secondary_ip_ranges:
 | [project_id](outputs.tf#L95) | Project ID containing the network. Use this when you need to create resources *after* the VPC is fully set up (e.g. subnets created, shared VPC service projects attached, Private Service Networking configured). |  |
 | [self_link](outputs.tf#L108) | Network self link. |  |
 | [subnet_ids](outputs.tf#L120) | Map of subnet IDs keyed by name. |  |
-| [subnet_ips](outputs.tf#L129) | Map of subnet address ranges keyed by name. |  |
-| [subnet_ipv6_external_prefixes](outputs.tf#L136) | Map of subnet external IPv6 prefixes keyed by name. |  |
-| [subnet_regions](outputs.tf#L144) | Map of subnet regions keyed by name. |  |
-| [subnet_secondary_ranges](outputs.tf#L151) | Map of subnet secondary ranges keyed by name. |  |
+| [subnet_ips](outputs.tf#L131) | Map of subnet address ranges keyed by name. |  |
+| [subnet_ipv6_external_prefixes](outputs.tf#L138) | Map of subnet external IPv6 prefixes keyed by name. |  |
+| [subnet_regions](outputs.tf#L145) | Map of subnet regions keyed by name. |  |
+| [subnet_secondary_ranges](outputs.tf#L152) | Map of subnet secondary ranges keyed by name. |  |
 | [subnet_self_links](outputs.tf#L162) | Map of subnet self links keyed by name. |  |
-| [subnets](outputs.tf#L171) | Subnet resources. |  |
-| [subnets_private_nat](outputs.tf#L180) | Private NAT subnet resources. |  |
-| [subnets_proxy_only](outputs.tf#L185) | L7 ILB or L7 Regional LB subnet resources. |  |
-| [subnets_psc](outputs.tf#L190) | Private Service Connect subnet resources. |  |
+| [subnets](outputs.tf#L174) | Subnet resources. |  |
+| [subnets_private_nat](outputs.tf#L185) | Private NAT subnet resources. |  |
+| [subnets_proxy_only](outputs.tf#L190) | L7 ILB or L7 Regional LB subnet resources. |  |
+| [subnets_psc](outputs.tf#L195) | Private Service Connect subnet resources. |  |
 <!-- END TFDOC -->

--- a/modules/net-vpc/outputs.tf
+++ b/modules/net-vpc/outputs.tf
@@ -119,7 +119,9 @@ output "self_link" {
 
 output "subnet_ids" {
   description = "Map of subnet IDs keyed by name."
-  value       = { for k, v in google_compute_subnetwork.subnetwork : k => v.id }
+  value = {
+    for k, v in local.subnets : k => google_compute_subnetwork.subnetwork[v.resource_key].id
+  }
   depends_on = [
     # allows correct destruction of internal application load balancers
     google_compute_subnetwork.proxy_only
@@ -129,31 +131,29 @@ output "subnet_ids" {
 output "subnet_ips" {
   description = "Map of subnet address ranges keyed by name."
   value = {
-    for k, v in google_compute_subnetwork.subnetwork : k => v.ip_cidr_range
+    for k, v in local.subnets : k => google_compute_subnetwork.subnetwork[v.resource_key].ip_cidr_range
   }
 }
 
 output "subnet_ipv6_external_prefixes" {
   description = "Map of subnet external IPv6 prefixes keyed by name."
   value = {
-    for k, v in google_compute_subnetwork.subnetwork :
-    k => try(v.external_ipv6_prefix, null)
+    for k, v in local.subnets : k => try(google_compute_subnetwork.subnetwork[v.resource_key].external_ipv6_prefix)
   }
 }
 
 output "subnet_regions" {
   description = "Map of subnet regions keyed by name."
   value = {
-    for k, v in google_compute_subnetwork.subnetwork : k => v.region
+    for k, v in local.subnets : k => google_compute_subnetwork.subnetwork[v.resource_key].region
   }
 }
 
 output "subnet_secondary_ranges" {
   description = "Map of subnet secondary ranges keyed by name."
   value = {
-    for k, v in google_compute_subnetwork.subnetwork :
-    k => {
-      for range in v.secondary_ip_range :
+    for k, v in local.subnets : k => {
+      for range in google_compute_subnetwork.subnetwork[v.resource_key].secondary_ip_range :
       range.range_name => range.ip_cidr_range
     }
   }
@@ -161,7 +161,10 @@ output "subnet_secondary_ranges" {
 
 output "subnet_self_links" {
   description = "Map of subnet self links keyed by name."
-  value       = { for k, v in google_compute_subnetwork.subnetwork : k => v.self_link }
+  # value       = { for k, v in google_compute_subnetwork.subnetwork : k => v.self_link }
+  value = {
+    for k, v in local.subnets : k => google_compute_subnetwork.subnetwork[v.resource_key].self_link
+  }
   depends_on = [
     # allows correct destruction of internal application load balancers
     google_compute_subnetwork.proxy_only
@@ -170,7 +173,9 @@ output "subnet_self_links" {
 
 output "subnets" {
   description = "Subnet resources."
-  value       = { for k, v in google_compute_subnetwork.subnetwork : k => v }
+  value = {
+    for k, v in local.subnets : k => google_compute_subnetwork.subnetwork[v.resource_key]
+  }
   depends_on = [
     # allows correct destruction of internal application load balancers
     google_compute_subnetwork.proxy_only

--- a/tests/modules/net_vpc/context.yaml
+++ b/tests/modules/net_vpc/context.yaml
@@ -96,7 +96,7 @@ values:
     project: foo-test-0
     tags: null
     timeouts: null
-  google_compute_subnetwork.subnetwork["europe-west8/production"]:
+  google_compute_subnetwork.subnetwork["europe-west8/production/null"]:
     description: Terraform-managed.
     ip_collection: null
     ipv6_access_type: null

--- a/tests/modules/net_vpc/examples/dns-policies.yaml
+++ b/tests/modules/net_vpc/examples/dns-policies.yaml
@@ -16,7 +16,7 @@ values:
   module.vpc.google_compute_network.network[0]:
     name: my-network
     project: project-id
-  module.vpc.google_compute_subnetwork.subnetwork["europe-west1/production"]: {}
+  module.vpc.google_compute_subnetwork.subnetwork["europe-west1/production/10.0.0.0/24"]: {}
   module.vpc.google_dns_policy.default[0]:
     alternative_name_server_config:
     - target_name_servers:

--- a/tests/modules/net_vpc/examples/factory.yaml
+++ b/tests/modules/net_vpc/examples/factory.yaml
@@ -81,7 +81,7 @@ values:
     region: europe-west4
     role: null
     timeouts: null
-  ? module.vpc.google_compute_subnetwork.subnetwork["europe-west1/subnet-detailed"]
+  ? module.vpc.google_compute_subnetwork.subnetwork["europe-west1/subnet-detailed/10.0.0.0/24"]
   : description: Sample description
     ip_cidr_range: 10.0.0.0/24
     ipv6_access_type: null
@@ -94,7 +94,7 @@ values:
       - ip_cidr_range: 192.168.0.0/24
         range_name: secondary-range-a
     timeouts: null
-  module.vpc.google_compute_subnetwork.subnetwork["europe-west4/simple"]:
+  module.vpc.google_compute_subnetwork.subnetwork["europe-west4/simple/10.0.1.0/24"]:
     description: Terraform-managed.
     ip_cidr_range: 10.0.1.0/24
     ipv6_access_type: null
@@ -105,7 +105,7 @@ values:
     region: europe-west4
     role: null
     timeouts: null
-  module.vpc.google_compute_subnetwork.subnetwork["europe-west8/simple"]:
+  module.vpc.google_compute_subnetwork.subnetwork["europe-west8/simple/10.0.2.0/24"]:
     description: Terraform-managed.
     ip_cidr_range: 10.0.2.0/24
     ipv6_access_type: null

--- a/tests/modules/net_vpc/examples/firewall_policy_enforcement_order.yaml
+++ b/tests/modules/net_vpc/examples/firewall_policy_enforcement_order.yaml
@@ -21,7 +21,7 @@ values:
     project: project-id
     routing_mode: GLOBAL
     network_firewall_policy_enforcement_order: BEFORE_CLASSIC_FIREWALL
-  module.vpc.google_compute_subnetwork.subnetwork["europe-west1/production"]:
+  module.vpc.google_compute_subnetwork.subnetwork["europe-west1/production/10.0.0.0/24"]:
     description: Terraform-managed.
     ip_cidr_range: 10.0.0.0/24
     log_config: []
@@ -35,7 +35,7 @@ values:
         range_name: pods
       - ip_cidr_range: 192.168.0.0/24
         range_name: services
-  module.vpc.google_compute_subnetwork.subnetwork["europe-west2/production"]:
+  module.vpc.google_compute_subnetwork.subnetwork["europe-west2/production/10.0.16.0/24"]:
     description: Terraform-managed.
     ip_cidr_range: 10.0.16.0/24
     log_config: []

--- a/tests/modules/net_vpc/examples/ipv6.yaml
+++ b/tests/modules/net_vpc/examples/ipv6.yaml
@@ -48,7 +48,7 @@ values:
     project: project-id
     tags: null
     timeouts: null
-  module.vpc.google_compute_subnetwork.subnetwork["europe-west1/test"]:
+  module.vpc.google_compute_subnetwork.subnetwork["europe-west1/test/10.0.0.0/24"]:
     description: Terraform-managed.
     ip_cidr_range: 10.0.0.0/24
     ipv6_access_type: INTERNAL
@@ -60,7 +60,7 @@ values:
     role: null
     stack_type: IPV4_IPV6
     timeouts: null
-  module.vpc.google_compute_subnetwork.subnetwork["europe-west3/test"]:
+  module.vpc.google_compute_subnetwork.subnetwork["europe-west3/test/10.0.1.0/24"]:
     description: Terraform-managed.
     ip_cidr_range: 10.0.1.0/24
     ipv6_access_type: EXTERNAL

--- a/tests/modules/net_vpc/examples/ipv6_only.yaml
+++ b/tests/modules/net_vpc/examples/ipv6_only.yaml
@@ -49,7 +49,7 @@ values:
     project: project-id
     tags: null
     timeouts: null
-  module.vpc.google_compute_subnetwork.subnetwork["europe-west1/test-v6only"]:
+  module.vpc.google_compute_subnetwork.subnetwork["europe-west1/test-v6only/null"]:
     description: Terraform-managed.
     ipv6_access_type: INTERNAL
     log_config: []
@@ -60,7 +60,7 @@ values:
     role: null
     stack_type: IPV6_ONLY
     timeouts: null
-  module.vpc.google_compute_subnetwork.subnetwork["europe-west3/test-v6only"]:
+  module.vpc.google_compute_subnetwork.subnetwork["europe-west3/test-v6only/null"]:
     description: Terraform-managed.
     ipv6_access_type: EXTERNAL
     log_config: []

--- a/tests/modules/net_vpc/examples/peering.yaml
+++ b/tests/modules/net_vpc/examples/peering.yaml
@@ -63,7 +63,7 @@ values:
     project: project-id
     tags: null
     timeouts: null
-  module.vpc-hub.google_compute_subnetwork.subnetwork["europe-west1/subnet-1"]:
+  module.vpc-hub.google_compute_subnetwork.subnetwork["europe-west1/subnet-1/10.0.0.0/24"]:
     description: Terraform-managed.
     ip_cidr_range: 10.0.0.0/24
     ipv6_access_type: null
@@ -141,7 +141,7 @@ values:
     project: project-id
     tags: null
     timeouts: null
-  module.vpc-spoke-1.google_compute_subnetwork.subnetwork["europe-west1/subnet-2"]:
+  module.vpc-spoke-1.google_compute_subnetwork.subnetwork["europe-west1/subnet-2/10.0.1.0/24"]:
     description: Terraform-managed.
     ip_cidr_range: 10.0.1.0/24
     ipv6_access_type: null

--- a/tests/modules/net_vpc/examples/psa-multiple-providers.yaml
+++ b/tests/modules/net_vpc/examples/psa-multiple-providers.yaml
@@ -34,7 +34,7 @@ values:
     export_custom_routes: false
     import_custom_routes: false
     project: project-id
-  module.vpc.google_compute_subnetwork.subnetwork["europe-west1/production"]:
+  module.vpc.google_compute_subnetwork.subnetwork["europe-west1/production/10.0.0.0/24"]:
     ip_cidr_range: 10.0.0.0/24
     name: production
     project: project-id

--- a/tests/modules/net_vpc/examples/psa-prefix-services.yaml
+++ b/tests/modules/net_vpc/examples/psa-prefix-services.yaml
@@ -83,7 +83,7 @@ values:
     project: project-id
     tags: null
     timeouts: null
-  module.vpc.google_compute_subnetwork.subnetwork["europe-west1/production"]:
+  module.vpc.google_compute_subnetwork.subnetwork["europe-west1/production/10.0.0.0/24"]:
     description: Terraform-managed.
     ip_cidr_range: 10.0.0.0/24
     ipv6_access_type: null

--- a/tests/modules/net_vpc/examples/psa-prefix.yaml
+++ b/tests/modules/net_vpc/examples/psa-prefix.yaml
@@ -65,7 +65,7 @@ values:
     project: project-id
     tags: null
     timeouts: null
-  module.vpc.google_compute_subnetwork.subnetwork["europe-west1/production"]:
+  module.vpc.google_compute_subnetwork.subnetwork["europe-west1/production/10.0.0.0/24"]:
     description: Terraform-managed.
     ip_cidr_range: 10.0.0.0/24
     ipv6_access_type: null

--- a/tests/modules/net_vpc/examples/psa-routes.yaml
+++ b/tests/modules/net_vpc/examples/psa-routes.yaml
@@ -65,7 +65,7 @@ values:
     project: project-id
     tags: null
     timeouts: null
-  module.vpc.google_compute_subnetwork.subnetwork["europe-west1/production"]:
+  module.vpc.google_compute_subnetwork.subnetwork["europe-west1/production/10.0.0.0/24"]:
     description: Terraform-managed.
     ip_cidr_range: 10.0.0.0/24
     ipv6_access_type: null

--- a/tests/modules/net_vpc/examples/psa.yaml
+++ b/tests/modules/net_vpc/examples/psa.yaml
@@ -65,7 +65,7 @@ values:
     project: project-id
     tags: null
     timeouts: null
-  module.vpc.google_compute_subnetwork.subnetwork["europe-west1/production"]:
+  module.vpc.google_compute_subnetwork.subnetwork["europe-west1/production/10.0.0.0/24"]:
     description: Terraform-managed.
     ip_cidr_range: 10.0.0.0/24
     ipv6_access_type: null

--- a/tests/modules/net_vpc/examples/shared-vpc.yaml
+++ b/tests/modules/net_vpc/examples/shared-vpc.yaml
@@ -23,7 +23,7 @@ values:
   module.vpc-host.google_compute_shared_vpc_service_project.service_projects["test-prj1"]:
     host_project: project-id
     service_project: test-prj1
-  module.vpc-host.google_compute_subnetwork.subnetwork["europe-west1/subnet-1"]:
+  module.vpc-host.google_compute_subnetwork.subnetwork["europe-west1/subnet-1/10.0.0.0/24"]:
     secondary_ip_range:
     - ip_cidr_range: 172.16.0.0/20
       range_name: pods

--- a/tests/modules/net_vpc/examples/simple.yaml
+++ b/tests/modules/net_vpc/examples/simple.yaml
@@ -20,7 +20,7 @@ values:
     name: my-network
     project: project-id
     routing_mode: GLOBAL
-  module.vpc.google_compute_subnetwork.subnetwork["europe-west1/production"]:
+  module.vpc.google_compute_subnetwork.subnetwork["europe-west1/production/10.0.0.0/24"]:
     description: Terraform-managed.
     ip_cidr_range: 10.0.0.0/24
     log_config: []
@@ -34,7 +34,7 @@ values:
         range_name: pods
       - ip_cidr_range: 192.168.0.0/24
         range_name: services
-  module.vpc.google_compute_subnetwork.subnetwork["europe-west2/production"]:
+  module.vpc.google_compute_subnetwork.subnetwork["europe-west2/production/10.0.16.0/24"]:
     description: Terraform-managed.
     ip_cidr_range: 10.0.16.0/24
     log_config: []

--- a/tests/modules/net_vpc/examples/subnet-iam.yaml
+++ b/tests/modules/net_vpc/examples/subnet-iam.yaml
@@ -47,7 +47,7 @@ values:
     project: project-id
     tags: null
     timeouts: null
-  module.vpc.google_compute_subnetwork.subnetwork["europe-west1/subnet-1"]:
+  module.vpc.google_compute_subnetwork.subnetwork["europe-west1/subnet-1/10.0.1.0/24"]:
     description: Terraform-managed.
     ip_cidr_range: 10.0.1.0/24
     ipv6_access_type: null
@@ -58,7 +58,7 @@ values:
     region: europe-west1
     role: null
     timeouts: null
-  module.vpc.google_compute_subnetwork.subnetwork["europe-west1/subnet-2"]:
+  module.vpc.google_compute_subnetwork.subnetwork["europe-west1/subnet-2/10.0.2.0/24"]:
     description: Terraform-managed.
     ip_cidr_range: 10.0.2.0/24
     ipv6_access_type: null

--- a/tests/modules/net_vpc/examples/subnet-options.yaml
+++ b/tests/modules/net_vpc/examples/subnet-options.yaml
@@ -16,7 +16,7 @@ values:
   module.vpc.google_compute_network.network[0]:
     name: my-network
     project: project-id
-  module.vpc.google_compute_subnetwork.subnetwork["europe-west1/no-pga"]:
+  module.vpc.google_compute_subnetwork.subnetwork["europe-west1/no-pga/10.0.1.0/24"]:
     description: Subnet b
     ip_cidr_range: 10.0.1.0/24
     log_config: []
@@ -24,14 +24,14 @@ values:
     private_ip_google_access: false
     project: project-id
     region: europe-west1
-  module.vpc.google_compute_subnetwork.subnetwork["europe-west1/simple"]:
+  module.vpc.google_compute_subnetwork.subnetwork["europe-west1/simple/10.0.0.0/24"]:
     description: Terraform-managed.
     ip_cidr_range: 10.0.0.0/24
     name: simple
     private_ip_google_access: true
     project: project-id
     region: europe-west1
-  ? module.vpc.google_compute_subnetwork.subnetwork["europe-west1/hybrid"]
+  ? module.vpc.google_compute_subnetwork.subnetwork["europe-west1/hybrid/10.0.4.0/24"]
   : description: Terraform-managed.
     ip_cidr_range: 10.0.4.0/24
     log_config: []
@@ -40,7 +40,7 @@ values:
     project: project-id
     region: europe-west1
     allow_subnet_cidr_routes_overlap: true
-  ? module.vpc.google_compute_subnetwork.subnetwork["europe-west1/with-flow-logs"]
+  ? module.vpc.google_compute_subnetwork.subnetwork["europe-west1/with-flow-logs/10.0.3.0/24"]
   : description: Terraform-managed.
     ip_cidr_range: 10.0.3.0/24
     ipv6_access_type: null
@@ -49,7 +49,7 @@ values:
     project: project-id
     region: europe-west1
     role: null
-  ? module.vpc.google_compute_subnetwork.subnetwork["europe-west1/with-secondary-ranges"]
+  ? module.vpc.google_compute_subnetwork.subnetwork["europe-west1/with-secondary-ranges/10.0.2.0/24"]
   : description: Terraform-managed.
     ip_cidr_range: 10.0.2.0/24
     name: with-secondary-ranges

--- a/tests/modules/net_vpc/examples/subnets-internal-ranges.yaml
+++ b/tests/modules/net_vpc/examples/subnets-internal-ranges.yaml
@@ -25,7 +25,7 @@ values:
     project: project-id
     routing_mode: GLOBAL
     timeouts: null
-  module.vpc.google_compute_subnetwork.subnetwork["europe-west1/production"]:
+  module.vpc.google_compute_subnetwork.subnetwork["europe-west1/production/null"]:
     description: Terraform-managed.
     ip_collection: null
     ipv6_access_type: null


### PR DESCRIPTION
For evaluation, if such a change makes sense or not.

It introduces extra complexity in subnets.tf and outputs.tf, also - clean upgrade path requires a lot of work by preparing `move` statements for all subnets.

The gain is, that if you have any templates (or other resources with `create_before_destroy = true` that use subnet, you can change CIDRs on the other subnets by running `terraform apply` twice. First will usually fail, as terraform issues destroy and create in parallel, but subsequent should succeed and finish the job.


<!-- Put a description of what this PR is for here -->

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [ ] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [ ] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
