### PR TITLE
Exclude folder config files from project factory paths

### DIFF
--- a/modules/project-factory/projects.tf
+++ b/modules/project-factory/projects.tf
@@ -37,6 +37,7 @@ locals {
   _projects_raw = {
     for f in try(fileset(local._projects_path, "**/*.yaml"), []) :
     trimsuffix(f, ".yaml") => yamldecode(file("${local._projects_path}/${f}"))
+    if !endswith(f, ".config.yaml")
   }
   _templates_path = try(
     pathexpand(var.factories_config.project_templates), null


### PR DESCRIPTION
This allows use of the project factory module "as a library", when folder configs ar eparsed from the outside but project configs are fed to the project factory.