### PR TITLE
Allow referencing template-derived resources in project configuration files

### DIFF
--- a/modules/project-factory/README.md
+++ b/modules/project-factory/README.md
@@ -30,6 +30,7 @@ The code is meant to be executed by a high level service account with powerful p
 - [Projects](#projects)
   - [Factory-wide project defaults, merges, optionals](#factory-wide-project-defaults-merges-optionals)
   - [Project templates](#project-templates)
+    - [Context expansion for template-derived resources](#context-expansion-for-template-derived-resources)
   - [Service accounts and buckets](#service-accounts-and-buckets)
   - [Automation resources](#automation-resources)
     - [Prefix handling](#prefix-handling)
@@ -87,6 +88,10 @@ When referenced in a project configuration file, a template attributes are used 
 For example, declaring `iam` or `org_policies` in the template and then doing the same in the project file will result in those two attributes in the template being ignored.
 
 The set of available templates is defined via a dedicated path in the `factories_config` file, and then a template can be referenced from a project definition via the `project_template` YAML attribute.
+
+#### Context expansion for template-derived resources
+
+Using a template makes it hard or impossible to reference project-level resources that contain the project key in the context id, as for example `$iam_principals:service_accounts/my-project/rw`. In those cases, alternate context ids are provided of the form `$iam_principals:service_accounts/_self_/rw`. Those are only available within the scope of the project itself and are currently only supported for service accounts in the `$iam_principals` and `$service_account_ids` context namespaces.
 
 ### Service accounts and buckets
 
@@ -577,6 +582,9 @@ parent: $folder_ids:team-a/app-0
 iam_by_principals:
   $iam_principals:service_accounts/dev-ta-app0-be/app-0-be:
     - roles/storage.objectViewer
+  # alternate context lookup, mainly for project template use
+  $iam_principals:service_accounts/_self_/app-0-fe:
+    - roles/storage.objectViewer
 iam:
   roles/cloudkms.cryptoKeyEncrypterDecrypter:
     - $service_agents:storage
@@ -589,6 +597,13 @@ service_accounts:
     iam_self_roles:
       - roles/logging.logWriter
       - roles/monitoring.metricWriter
+    # this is just for illustrative/test purposes
+    iam:
+      roles/iam.serviceAccountUser:
+        - $iam_principals:service_accounts/_self_/app-0-fe
+    iam_sa_roles:
+      $service_account_ids:_self_/app-0-fe:
+        - roles/iam.serviceAccountUser
   app-0-fe:
     display_name: "Frontend instances."
     iam_project_roles:

--- a/modules/project-factory/automation.tf
+++ b/modules/project-factory/automation.tf
@@ -161,7 +161,7 @@ module "automation-service-accounts-iam" {
     use_data_source = false
   }
   context = merge(local.ctx, {
-    service_account_ids = local.project_sas_ids
+    service_account_ids = local.projects_sas_ids
   })
   iam_sa_roles = lookup(each.value, "iam_sa_roles", {})
 }

--- a/modules/project-factory/projects-bigquery.tf
+++ b/modules/project-factory/projects-bigquery.tf
@@ -39,7 +39,8 @@ module "bigquery-datasets" {
     iam_principals = merge(
       local.ctx.iam_principals,
       local.projects_sas_iam_emails,
-      local.automation_sas_iam_emails
+      local.automation_sas_iam_emails,
+      lookup(local.self_sas_iam_emails, each.value.project_key, {})
     )
     locations   = local.ctx.locations
     project_ids = local.ctx_project_ids

--- a/modules/project-factory/projects-buckets.tf
+++ b/modules/project-factory/projects-buckets.tf
@@ -72,7 +72,8 @@ module "buckets" {
     iam_principals = merge(
       local.ctx.iam_principals,
       local.projects_sas_iam_emails,
-      local.automation_sas_iam_emails
+      local.automation_sas_iam_emails,
+      lookup(local.self_sas_iam_emails, each.value.project_key, {})
     )
     locations   = local.ctx.locations
     project_ids = local.ctx_project_ids

--- a/modules/project-factory/projects-log-buckets.tf
+++ b/modules/project-factory/projects-log-buckets.tf
@@ -50,7 +50,8 @@ module "log-buckets" {
     iam_principals = merge(
       local.ctx.iam_principals,
       local.projects_sas_iam_emails,
-      local.automation_sas_iam_emails
+      local.automation_sas_iam_emails,
+      lookup(local.self_sas_iam_emails, each.value.project_key, {})
     )
     locations   = local.ctx.locations
     project_ids = local.ctx_project_ids

--- a/modules/project-factory/projects.tf
+++ b/modules/project-factory/projects.tf
@@ -124,10 +124,13 @@ module "projects-iam" {
     }
   }
   context = merge(local.ctx, {
-    folder_ids     = local.ctx.folder_ids
-    kms_keys       = local.ctx.kms_keys
-    iam_principals = local.ctx_iam_principals
-    log_buckets    = local.ctx_log_buckets
+    folder_ids = local.ctx.folder_ids
+    kms_keys   = local.ctx.kms_keys
+    iam_principals = merge(
+      local.ctx_iam_principals,
+      lookup(local.self_sas_iam_emails, each.key, {})
+    )
+    log_buckets = local.ctx_log_buckets
   })
   factories_config = {
     # we do anything that can refer to IAM and custom roles in this call

--- a/tests/modules/project_factory/examples/example.yaml
+++ b/tests/modules/project_factory/examples/example.yaml
@@ -265,6 +265,7 @@ values:
   : condition: []
     members:
     - serviceAccount:app-0-be@test-pf-dev-ta-app0-be.iam.gserviceaccount.com
+    - serviceAccount:app-0-fe@test-pf-dev-ta-app0-be.iam.gserviceaccount.com
     project: test-pf-dev-ta-app0-be
     role: roles/storage.objectViewer
   ? module.project-factory.module.projects-iam["dev-ta-app0-be"].google_project_iam_member.shared_vpc_host_iam["$iam_principals:gcp-devops"]
@@ -672,6 +673,15 @@ values:
     member: serviceAccount:app-0-be@test-pf-dev-tb-app0-1.iam.gserviceaccount.com
     project: test-pf-dev-tb-app0-1
     timeouts: null
+  ? module.project-factory.module.service_accounts-iam["dev-ta-app0-be/app-0-be"].google_service_account_iam_binding.authoritative["roles/iam.serviceAccountUser"]
+  : condition: []
+    members:
+    - serviceAccount:app-0-fe@test-pf-dev-ta-app0-be.iam.gserviceaccount.com
+    role: roles/iam.serviceAccountUser
+  ? module.project-factory.module.service_accounts-iam["dev-ta-app0-be/app-0-be"].google_service_account_iam_member.additive["$service_account_ids:_self_/app-0-fe-roles/iam.serviceAccountUser"]
+  : condition: []
+    role: roles/iam.serviceAccountUser
+    service_account_id: projects/test-pf-dev-ta-app0-be/serviceAccounts/app-0-fe@test-pf-dev-ta-app0-be.iam.gserviceaccount.com
   ? module.project-factory.module.service_accounts-iam["dev-tb-app0-0/vm-default"].google_service_account_iam_binding.authoritative["roles/iam.serviceAccountTokenCreator"]
   : condition: []
     members:
@@ -699,7 +709,8 @@ counts:
   google_project_service: 13
   google_project_service_identity: 4
   google_service_account: 6
-  google_service_account_iam_binding: 1
+  google_service_account_iam_binding: 2
+  google_service_account_iam_member: 1
   google_storage_bucket: 1
   google_storage_bucket_iam_binding: 2
   google_storage_project_service_account: 4
@@ -707,6 +718,6 @@ counts:
   google_tags_tag_key: 1
   google_tags_tag_value: 2
   google_tags_tag_value_iam_binding: 1
-  modules: 26
-  resources: 92
+  modules: 27
+  resources: 94
   terraform_data: 1


### PR DESCRIPTION
When using project templates in the project factory module or any FAST stage that leverages it, referring to template-defined resources via context expansion becomes very hard or impossible.

Consider for example a template that defines a `mysa` service account, and assigns a role to it at the project level: the context key for the service account is `$iam_principals:service_accounts/[project key]/mysa`, but the project key is not known in the template, and changes of course with how many project configuration files adopt the template.

This PR adds an extra set of keys for service accounts to the `$iam_principals` and `$service_account_ids` namespaces in each project, so that service accounts defined in the referenced template can use `_self_` in the context keys. So the above service account can be referenced in the template itself by abstracting from the project key where the template is used, and becomes `$iam_principals:service_accounts/_self_/mysa`. The use of underscores prevents clashes with project keys.

These extra per-project sets of keys are also available without a template from the project itself, since template and project definitions are internally merged, and the module does not care where a reference is coming from.