### PR TITLE
[WIP] Workload Identity Federation module

### DIFF
--- a/modules/workload-identity-federation/main.tf
+++ b/modules/workload-identity-federation/main.tf
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_iam_workload_identity_pool" "default" {
+  workload_identity_pool_id = var.pool_name
+  project                   = var.project_id
+  display_name              = var.pool_display_name
+  description               = var.pool_description
+  disabled                  = var.pool_disabled
+}
+
+resource "google_iam_workload_identity_pool_provider" "default" {
+  workload_identity_pool_id = google_iam_workload_identity_pool.default.workload_identity_pool_id
+  project                   = var.project_id
+
+  workload_identity_pool_provider_id = var.provider_name
+  display_name                       = var.provider_display_name
+  description                        = var.provider_description
+  disabled                           = var.provider_disabled
+
+  attribute_mapping = var.attribute_mapping
+
+  attribute_condition = var.attribute_condition
+
+  dynamic "aws" {
+    for_each = var.aws_idp_account_id == null ? [] : [""]
+    content {
+      account_id = var.aws_idp_account_id
+    }
+  }
+
+  dynamic "oidc" {
+    for_each = var.oidc == null ? [] : [""]
+    content {
+      issuer_uri        = var.oidc.issuer_uri
+      allowed_audiences = var.oidc.allowed_audiences
+      jwks_json         = var.oidc.jwks_json
+    }
+  }
+
+  dynamic "saml" {
+    for_each = var.saml_idp_metadata_xml == null ? [] : [""]
+    content {
+      idp_metadata_xml = var.saml_idp_metadata_xml
+    }
+  }
+
+  dynamic "x509" {
+    for_each = var.x509_pem_certificate_path == null ? [] : [""]
+    content {
+      trust_store {
+        trust_anchors {
+          pem_certificate = file(var.x509_pem_certificate_path)
+        }
+      }
+    }
+
+  }
+
+}
+
+# // Example of principal set: member = "principalSet://iam.googleapis.com/projects/733032471643/locations/global/workloadIdentityPools/bitbucket-pool-iata/*"
+resource "google_service_account_iam_member" "sa_workload_identity_user_bindings" {
+  for_each = var.sa_iam_bindings_additive
+
+  service_account_id = each.key
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.default.name}/${each.value.principal_set_suffix}"
+}
+
+// Necessary to allow impersonification
+resource "google_service_account_iam_member" "sa_workload_identity_user_bindings_impersonification" {
+  for_each = {
+    for k, v in var.sa_iam_bindings_additive :
+    k => v
+    if v.allow_impersonification
+  }
+
+  service_account_id = each.key
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.default.name}/${each.value.principal_set_suffix}"
+}

--- a/modules/workload-identity-federation/outputs.tf
+++ b/modules/workload-identity-federation/outputs.tf
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+

--- a/modules/workload-identity-federation/variables.tf
+++ b/modules/workload-identity-federation/variables.tf
@@ -1,0 +1,123 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "Project used for resources."
+  type        = string
+}
+
+variable "pool_name" {
+  description = "Workload Identity Pool name."
+  type        = string
+}
+
+variable "pool_display_name" {
+  description = "Workload Identity Pool display name."
+  type        = string
+  default     = null
+}
+
+variable "pool_description" {
+  description = "Workload Identity Pool description."
+  type        = string
+  default     = null
+}
+
+variable "pool_disabled" {
+  description = "Workload Identity Pool status."
+  type        = bool
+  default     = false
+}
+
+variable "provider_name" {
+  description = "Workload Identity Provider name."
+  type        = string
+}
+
+variable "provider_display_name" {
+  description = "Workload Identity Provider display name."
+  type        = string
+  default     = null
+}
+
+variable "provider_description" {
+  description = "Workload Identity Provider description."
+  type        = string
+  default     = null
+}
+
+variable "provider_disabled" {
+  description = "Workload Identity Provider status."
+  type        = bool
+  default     = false
+}
+
+variable "aws_idp_account_id" {
+  description = "Workload Identity Provider AWS Account id."
+  type        = string
+  default     = null
+}
+
+variable "saml_idp_metadata_xml" {
+  description = "Workload Identity Provider SAML Metadata XML."
+  type        = string
+  default     = null
+}
+
+variable "x509_pem_certificate_path" {
+  description = "Workload Identity Provider X509 PEM Certificate path."
+  type        = string
+  default     = null
+}
+
+variable "oidc" {
+  description = "Workload Identity Provider OIDC IdP."
+  type = object({
+    issuer_uri        = string
+    allowed_audiences = optional(list(string))
+    jwks_json         = optional(string)
+  })
+  default = null
+}
+
+variable "attribute_mapping" {
+  description = "List of attributes"
+  type        = map(string)
+  validation {
+    condition     = contains(keys(var.attribute_mapping), "google.subject")
+    error_message = "If attribute_mapping is set, it must contain a key named 'google.subject'."
+  }
+  nullable = false
+  default = {
+    "google.subject" = "assertion.sub"
+  }
+}
+
+variable "attribute_condition" {
+  description = "Workload Identity Provider Attribute condition."
+  type        = string
+  default     = null
+}
+
+variable "sa_iam_bindings_additive" {
+  description = "List of GCP SA Identities to grant iam.workloadIdentityUser and optionally iam.serviceAccountTokenCreator."
+  type = map(object({
+    allow_impersonification = bool
+    principal_set_suffix    = string
+  }))
+  nullable = false
+  default  = {}
+}

--- a/modules/workload-identity-federation/versions.tf
+++ b/modules/workload-identity-federation/versions.tf
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = ">= 1.12.2"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 7.6.0, < 8.0.0" # tftest
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 7.6.0, < 8.0.0" # tftest
+    }
+  }
+}


### PR DESCRIPTION
Hello,

I noticed there is not the Workload Identity Provider module and I open this draft pull request to submit a V0.
I found important to have this module to avoid the usage of service account json credentials improving the security posture of the Google Cloud tenant.



---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
