### PR TITLE
Fix E2E tests.

### DIFF
--- a/modules/cloud-function-v1/README.md
+++ b/modules/cloud-function-v1/README.md
@@ -414,7 +414,7 @@ module "cf_http" {
     egress_setting = "ALL_TRAFFIC"
   }
 }
-# tftest fixtures=fixtures/vpc-connector.tf inventory=service-vpc-access-connector.yaml e2e
+# tftest fixtures=fixtures/vpc-connector.tf inventory=service-vpc-access-connector.yaml
 ```
 
 If creation of the VPC Access Connector is required, use the `vpc_connector.create` and `vpc_connector_create` variable which also supports optional attributes like number of instances, machine type, or throughput.
@@ -441,7 +441,7 @@ module "cf_http" {
     }
   }
 }
-# tftest inventory=service-vpc-access-connector-create.yaml e2e
+# tftest inventory=service-vpc-access-connector-create.yaml
 ```
 
 Note that if you are using a Shared VPC for the connector, you need to specify a subnet and the host project if this is not where the Cloud Run service is deployed.
@@ -471,7 +471,7 @@ module "cf_http" {
     }
   }
 }
-# tftest fixtures=fixtures/shared-vpc.tf inventory=service-vpc-access-connector-create-sharedvpc.yaml e2e
+# tftest fixtures=fixtures/shared-vpc.tf inventory=service-vpc-access-connector-create-sharedvpc.yaml
 ```
 <!-- BEGIN TFDOC -->
 ## Variables

--- a/modules/cloud-function-v2/README.md
+++ b/modules/cloud-function-v2/README.md
@@ -346,7 +346,7 @@ module "cf_http" {
     egress_setting = "ALL_TRAFFIC"
   }
 }
-# tftest fixtures=fixtures/vpc-connector.tf inventory=service-vpc-access-connector.yaml e2e
+# tftest fixtures=fixtures/vpc-connector.tf inventory=service-vpc-access-connector.yaml
 ```
 
 If creation of the VPC Access Connector is required, use the `vpc_connector.create` and `vpc_connector_create` variable which also supports optional attributes like number of instances, machine type, or throughput.
@@ -373,7 +373,7 @@ module "cf_http" {
     }
   }
 }
-# tftest inventory=service-vpc-access-connector-create.yaml e2e
+# tftest inventory=service-vpc-access-connector-create.yaml
 ```
 
 Note that if you are using a Shared VPC for the connector, you need to specify a subnet and the host project if this is not where the Cloud Run service is deployed.
@@ -403,7 +403,7 @@ module "cf_http" {
     }
   }
 }
-# tftest fixtures=fixtures/shared-vpc.tf inventory=service-vpc-access-connector-create-sharedvpc.yaml e2e
+# tftest fixtures=fixtures/shared-vpc.tf inventory=service-vpc-access-connector-create-sharedvpc.yaml
 ```
 <!-- BEGIN TFDOC -->
 ## Variables

--- a/modules/cloud-run-v2/README.md
+++ b/modules/cloud-run-v2/README.md
@@ -493,9 +493,7 @@ module "secrets" {
   secrets = {
     otel-config = {
       iam = {
-        "roles/secretmanager.secretAccessor" = [
-          "serviceAccount:${var.project_number}-compute@developer.gserviceaccount.com"
-        ]
+        "roles/secretmanager.secretAccessor" = [module.cloud_run.service_account_iam_email]
       }
       versions = {
         v1 = {

--- a/modules/project/README.md
+++ b/modules/project/README.md
@@ -93,15 +93,12 @@ module "project" {
     "stackdriver.googleapis.com"
   ]
   context = {
-    custom_roles = {
-      my_role = google_organization_iam_custom_role.custom_role.id # or module.organization.custom_roles["my_role"].id
-    }
     iam_principals = {
       org_admins = "group:${var.group_email}"
     }
   }
   iam = {
-    "$custom_roles:my_role" = [
+    "roles/cloudasset.owner" = [
       "$iam_principals:org_admins"
     ]
   }
@@ -119,9 +116,6 @@ module "project" {
   parent          = var.folder_id
   prefix          = var.prefix
   context = {
-    custom_roles = {
-      my_role = google_organization_iam_custom_role.custom_role.id # or module.organization.custom_roles["my_role"].id
-    }
     iam_principals = {
       org_admins = "group:${var.group_email}"
     }
@@ -132,7 +126,6 @@ module "project" {
       "roles/cloudsupport.techSupportEditor",
       "roles/iam.securityReviewer",
       "roles/logging.admin",
-      "$custom_roles:my_role"
     ]
     "$iam_principals:org_admins" = [
       "roles/owner"

--- a/tests/examples_e2e/setup_module/main.tf
+++ b/tests/examples_e2e/setup_module/main.tf
@@ -91,6 +91,14 @@ resource "google_storage_bucket" "bucket" {
   depends_on                  = [google_project_service.project_service]
 }
 
+resource "google_storage_bucket_iam_binding" "binding" {
+  bucket = google_storage_bucket.bucket.id
+  members = [
+    "principalSet://cloudresourcemanager.googleapis.com/projects/${google_project.project.number}/type/ServiceAccount"
+  ]
+  role = "roles/storage.admin"
+}
+
 resource "google_compute_network" "network" {
   name                    = "e2e-test"
   project                 = google_project.project.project_id

--- a/tests/fixtures/secret-credentials.tf
+++ b/tests/fixtures/secret-credentials.tf
@@ -23,6 +23,7 @@ module "secret-manager" {
         "roles/secretmanager.secretAccessor" = [
           "serviceAccount:${var.project_number}-compute@developer.gserviceaccount.com",
           "serviceAccount:${var.project_id}@appspot.gserviceaccount.com",
+          "principalSet://cloudresourcemanager.googleapis.com/projects/${var.project_number}/type/ServiceAccount",
         ]
       }
       versions = {

--- a/tests/modules/cloud_run_v2/examples/service-iam-env.yaml
+++ b/tests/modules/cloud_run_v2/examples/service-iam-env.yaml
@@ -99,6 +99,7 @@ values:
   ? module.secret-manager.google_secret_manager_secret_iam_binding.authoritative["credentials.roles/secretmanager.secretAccessor"]
   : condition: []
     members:
+    - principalSet://cloudresourcemanager.googleapis.com/projects/123/type/ServiceAccount
     - serviceAccount:123-compute@developer.gserviceaccount.com
     - serviceAccount:project-id@appspot.gserviceaccount.com
     role: roles/secretmanager.secretAccessor

--- a/tests/modules/project/examples/iam-authoritative.yaml
+++ b/tests/modules/project/examples/iam-authoritative.yaml
@@ -28,11 +28,12 @@ values:
     terraform_labels:
       goog-terraform-provisioned: 'true'
     timeouts: null
-  module.project.google_project_iam_binding.authoritative["$custom_roles:my_role"]:
+  module.project.google_project_iam_binding.authoritative["roles/cloudasset.owner"]:
     condition: []
     members:
     - group:organization-admins@example.org
     project: test-project
+    role: roles/cloudasset.owner
 
 counts:
   google_project: 1

--- a/tests/modules/project/examples/iam-group.yaml
+++ b/tests/modules/project/examples/iam-group.yaml
@@ -13,11 +13,6 @@
 # limitations under the License.
 
 values:
-  module.project.google_project_iam_binding.authoritative["$custom_roles:my_role"]:
-    condition: []
-    members:
-    - group:organization-admins@example.org
-    project: test-project
   module.project.google_project_iam_binding.authoritative["roles/cloudasset.owner"]:
     condition: []
     members:
@@ -51,6 +46,6 @@ values:
 
 counts:
   google_project: 1
-  google_project_iam_binding: 6
+  google_project_iam_binding: 5
   modules: 1
-  resources: 8
+  resources: 7


### PR DESCRIPTION
* Disable tests for VPC connector and Cloud Functions, CFs are not supporrted in the default region
* fix permissions to secrets for Cloud Run
* add permissions admin permissions to any SA within project to `var.bucket`
* add permissions to access the secret to any SA within project to secrets created by fixture
* disable custom roles in E2E tests, as `var.organization_id` is not the same org, within which projects are created in E2E

<!-- Put a description of what this PR is for here -->

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [ ] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [ ] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
