### PR TITLE
[FAST] fix host project ids in sample yaml files in project factory

### DIFF
--- a/fast/stages/2-project-factory/data/projects/dev-app-a-0.yaml
+++ b/fast/stages/2-project-factory/data/projects/dev-app-a-0.yaml
@@ -16,6 +16,6 @@
 
 parent: $folder_ids:team-a/dev
 shared_vpc_service_config:
-  host_project: $project_ids:dev-spoke-0
+  host_project: $project_ids:net-dev-0
   # network_users:
   #   - group:team-a-admins@example.com

--- a/fast/stages/2-project-factory/data/projects/prod-app-a-0.yaml
+++ b/fast/stages/2-project-factory/data/projects/prod-app-a-0.yaml
@@ -16,6 +16,6 @@
 
 parent: $folder_ids:team-a/prod
 shared_vpc_service_config:
-  host_project: $project_ids:prod-spoke-0
+  host_project: $project_ids:net-prod-0
   # network_users:
   #   - group:team-a-admins@example.com


### PR DESCRIPTION
Fixes host project ids in sample yaml files in project factory.
This matches the host project ids populated by the network stage.

---
**Checklist**

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass