### PR TITLE
Prettify and standardize YAML controls from hardened datasets

### DIFF
--- a/fast/stages/0-org-setup/datasets/hardened/organization/custom-constraints/custom.firewallRestrictPublicAccessRule.yaml
+++ b/fast/stages/0-org-setup/datasets/hardened/organization/custom-constraints/custom.firewallRestrictPublicAccessRule.yaml
@@ -12,15 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# yamllint disable rule:line-length
-
-custom.firewallRestrictOpenWorldRule:
+custom.firewallRestrictPublicAccessRule:
   action_type: DENY
   condition: |-
-    (size(resource.allowed) > 0) && (resource.sourceRanges.exists(range, range == '0.0.0.0/0') || resource.destinationRanges.exists(range, range == '0.0.0.0/0'))
-  description: Prevent the creation of VPC firewall rule with source or destination
+    (size(resource.allowed) > 0) &&
+    (
+      resource.sourceRanges.exists(range, range == '0.0.0.0/0') ||
+      resource.destinationRanges.exists(range, range == '0.0.0.0/0')
+    )
+  description: Prevent the creation of VPC firewall rules with source or destination
     any IP address (0.0.0.0/0)
-  display_name: Restrict VPC Firewall rule creation that are open to the world
+  display_name: Restrict VPC Firewall rules allowing public Internet access
   method_types:
   - CREATE
   resource_types:

--- a/fast/stages/0-org-setup/datasets/hardened/organization/custom-constraints/custom.firewallRestrictRdpPolicyRule.yaml
+++ b/fast/stages/0-org-setup/datasets/hardened/organization/custom-constraints/custom.firewallRestrictRdpPolicyRule.yaml
@@ -29,9 +29,9 @@ custom.firewallRestrictRdpPolicyRule:
             l4config.ports.all(port, port == '3389')
         )
     )
-  description: Ensure that RDP access is restricted from the Internet when using Firewall
+  description: Ensure that RDP access is restricted from any source when using Firewall
     Policy Rule
-  display_name: Restrict Firewall Policy rules allowing RDP access from the Internet
+  display_name: Restrict Firewall Policy rules allowing RDP access from any source
   method_types:
   - CREATE
   - UPDATE

--- a/fast/stages/0-org-setup/datasets/hardened/organization/custom-constraints/custom.firewallRestrictRdpRule.yaml
+++ b/fast/stages/0-org-setup/datasets/hardened/organization/custom-constraints/custom.firewallRestrictRdpRule.yaml
@@ -16,12 +16,12 @@ custom.firewallRestrictRdpRule:
   action_type: DENY
   condition: |-
     resource.direction.matches('INGRESS') &&
-    !resource.name.startsWith("gke-") &&
-    !resource.name.startsWith("k8s-") &&
-    !resource.name.endsWith("-hc") &&
-    !resource.name.startsWith("k8s2-") &&
-    !resource.name.startsWith("gkegw1-l7-") &&
-    !resource.name.startsWith("gkemcg1-l7-") &&
+    !resource.name.startsWith('gke-') &&
+    !resource.name.startsWith('k8s-') &&
+    !resource.name.endsWith('-hc') &&
+    !resource.name.startsWith('k8s2-') &&
+    !resource.name.startsWith('gkegw1-l7-') &&
+    !resource.name.startsWith('gkemcg1-l7-') &&
     resource.allowed.containsFirewallPort('tcp', '3389') &&
     !resource.sourceRanges.all(range,
       range == '35.235.240.0/20' ||
@@ -29,8 +29,9 @@ custom.firewallRestrictRdpRule:
       range.matches('^172\\.(?:1[6-9]|2\\d|3[0-1]).*') ||
       range.startsWith('192.168.')
     )
-  description: Ensure that RDP access is restricted from the Internet when using VPC Firewall Rule
-  display_name: Restrict VPC Firewall rules allowing RDP access from the Internet
+  description: Ensure that RDP access is restricted from any source when using VPC
+    Firewall Rule
+  display_name: Restrict VPC Firewall rules allowing RDP access from any source
   method_types:
   - CREATE
   - UPDATE

--- a/fast/stages/0-org-setup/datasets/hardened/organization/custom-constraints/custom.firewallRestrictSshPolicyRule.yaml
+++ b/fast/stages/0-org-setup/datasets/hardened/organization/custom-constraints/custom.firewallRestrictSshPolicyRule.yaml
@@ -29,9 +29,9 @@ custom.firewallRestrictSshPolicyRule:
             l4config.ports.all(port, port == '22')
         )
     )
-  description: Ensure that SSH access is restricted from the Internet when using Firewall
+  description: Ensure that SSH access is restricted from any source when using Firewall
     Policy Rule
-  display_name: Restrict Firewall Policy rules allowing SSH access from the Internet
+  display_name: Restrict Firewall Policy rules allowing SSH access from any source
   method_types:
   - CREATE
   - UPDATE

--- a/fast/stages/0-org-setup/datasets/hardened/organization/custom-constraints/custom.firewallRestrictSshRule.yaml
+++ b/fast/stages/0-org-setup/datasets/hardened/organization/custom-constraints/custom.firewallRestrictSshRule.yaml
@@ -16,12 +16,12 @@ custom.firewallRestrictSshRule:
   action_type: DENY
   condition: |-
     resource.direction.matches('INGRESS') &&
-    !resource.name.startsWith("gke-") &&
-    !resource.name.startsWith("k8s-") &&
-    !resource.name.endsWith("-hc") &&
-    !resource.name.startsWith("k8s2-") &&
-    !resource.name.startsWith("gkegw1-l7-") &&
-    !resource.name.startsWith("gkemcg1-l7-") &&
+    !resource.name.startsWith('gke-') &&
+    !resource.name.startsWith('k8s-') &&
+    !resource.name.endsWith('-hc') &&
+    !resource.name.startsWith('k8s2-') &&
+    !resource.name.startsWith('gkegw1-l7-') &&
+    !resource.name.startsWith('gkemcg1-l7-') &&
     resource.allowed.containsFirewallPort('tcp', '22') &&
     !resource.sourceRanges.all(range,
       range == '35.235.240.0/20' ||
@@ -29,8 +29,9 @@ custom.firewallRestrictSshRule:
       range.matches('^172\\.(?:1[6-9]|2\\d|3[0-1]).*') ||
       range.startsWith('192.168.')
     )
-  description: Ensure that SSH access is restricted from the Internet when using VPC Firewall Rule
-  display_name: Restrict VPC Firewall rules allowing SSH access from the Internet
+  description: Ensure that SSH access is restricted from any source when using VPC
+    Firewall Rule
+  display_name: Restrict VPC Firewall rules allowing SSH access from any source
   method_types:
   - CREATE
   - UPDATE

--- a/fast/stages/0-org-setup/datasets/hardened/organization/custom-constraints/custom.gkeRequireNodePoolSandbox.yaml
+++ b/fast/stages/0-org-setup/datasets/hardened/organization/custom-constraints/custom.gkeRequireNodePoolSandbox.yaml
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# yamllint disable rule:line-length
-
 custom.gkeRequireNodePoolSandbox:
   action_type: DENY
   condition: |-
-    resource.name.matches("default-pool") == false && has(resource.config.sandboxConfig) == false && resource.config.sandboxConfig.type != 'GVISOR'
+    resource.name.matches("default-pool") == false &&
+      has(resource.config.sandboxConfig) == false &&
+      resource.config.sandboxConfig.type != 'GVISOR'
   description: Enforce that the GKE clusters nodes are isolated using GKE sandbox
     (excepting the default node pool)
   display_name: Require GKE Sandbox runtime

--- a/fast/stages/0-org-setup/datasets/hardened/organization/custom-constraints/custom.networkRequireSubnetPrivateGoogleAccess.yaml
+++ b/fast/stages/0-org-setup/datasets/hardened/organization/custom-constraints/custom.networkRequireSubnetPrivateGoogleAccess.yaml
@@ -15,8 +15,7 @@
 custom.networkRequireSubnetPrivateGoogleAccess:
   action_type: DENY
   condition: |-
-    resource.privateIpGoogleAccess == false &&
-      resource.purpose in ['REGIONAL_MANAGED_PROXY', 'GLOBAL_MANAGED_PROXY'] == false
+    !resource.privateIpGoogleAccess && resource.purpose in ['REGIONAL_MANAGED_PROXY', 'GLOBAL_MANAGED_PROXY'] == false
   description: Enforce that the VPC network subnets are configured with private Google
     access
   display_name: Require Private Google Access

--- a/fast/stages/0-org-setup/datasets/hardened/organization/observability/auditConfigChanges.yaml
+++ b/fast/stages/0-org-setup/datasets/hardened/organization/observability/auditConfigChanges.yaml
@@ -16,32 +16,35 @@ alerts:
   auditConfigChanges:
     combiner: OR
     conditions:
-    - condition_threshold:
-        aggregations:
-        - alignment_period: 60s
-          cross_series_reducer: REDUCE_SUM
-          group_by_fields:
-          - metric.label.principal
-          - metric.label.method_name
-          - metric.label.organization_id
-          - metric.label.folder_id
-          - metric.label.project_id
-          per_series_aligner: ALIGN_SUM
-        comparison: COMPARISON_GT
-        duration: 0s
-        filter: resource.type = "logging_bucket" AND metric.type = "logging.googleapis.com/user/auditConfigChanges"
-        threshold_value: 0
-        trigger:
-          count: 1
-      display_name: 'Log match condition: Audit Configuration Changes'
+      - condition_threshold:
+          aggregations:
+            - alignment_period: 60s
+              cross_series_reducer: REDUCE_SUM
+              group_by_fields:
+                - metric.label.principal
+                - metric.label.method_name
+                - metric.label.organization_id
+                - metric.label.folder_id
+                - metric.label.project_id
+              per_series_aligner: ALIGN_SUM
+          comparison: COMPARISON_GT
+          duration: 0s
+          filter: resource.type = "logging_bucket" AND metric.type = "logging.googleapis.com/user/auditConfigChanges"
+          threshold_value: 0
+          trigger:
+            count: 1
+        display_name: "Log match condition: Audit Configuration Changes"
     display_name: Audit Configuration Changes
     documentation:
-      content: 'Log-based alerting policy in project ${project} detected audit configuration
-        changes.
+      content: |-
+        Log-based alerting policy in project ${project} detected audit configuration changes.
 
-        This alert helps track GCP services audit log configuration changes to ensure
-        appropriate audit logs are being collected. ``` protoPayload.methodName="SetIamPolicy"
-        AND protoPayload.serviceData.policyDelta.auditConfigDeltas:* ```'
+        This alert helps track GCP services audit log configuration changes to ensure appropriate.
+        audit logs are being collected
+        ```
+        protoPayload.methodName="SetIamPolicy" AND
+        protoPayload.serviceData.policyDelta.auditConfigDeltas:*
+        ```
       mime_type: text/markdown
 logging_metrics:
   auditConfigChanges:
@@ -56,21 +59,21 @@ logging_metrics:
       project_id: EXTRACT(labels.project_id)
     metric_descriptor:
       labels:
-      - description: principal
-        key: principal
-        value_type: STRING
-      - description: method_name
-        key: method_name
-        value_type: STRING
-      - description: organization_id
-        key: organization_id
-        value_type: STRING
-      - description: folder_id
-        key: folder_id
-        value_type: STRING
-      - description: project_id
-        key: project_id
-        value_type: STRING
+        - description: principal
+          key: principal
+          value_type: STRING
+        - description: method_name
+          key: method_name
+          value_type: STRING
+        - description: organization_id
+          key: organization_id
+          value_type: STRING
+        - description: folder_id
+          key: folder_id
+          value_type: STRING
+        - description: project_id
+          key: project_id
+          value_type: STRING
       metric_kind: DELTA
-      unit: '1'
+      unit: "1"
       value_type: INT64

--- a/fast/stages/0-org-setup/datasets/hardened/organization/observability/cloudsqlInstanceChanges.yaml
+++ b/fast/stages/0-org-setup/datasets/hardened/organization/observability/cloudsqlInstanceChanges.yaml
@@ -16,30 +16,33 @@ alerts:
   cloudsqlInstanceChanges:
     combiner: OR
     conditions:
-    - condition_threshold:
-        aggregations:
-        - alignment_period: 60s
-          cross_series_reducer: REDUCE_SUM
-          group_by_fields:
-          - metric.label.principal
-          - metric.label.method_name
-          - metric.label.project_id
-          - metric.label.database_id
-          per_series_aligner: ALIGN_SUM
-        comparison: COMPARISON_GT
-        duration: 0s
-        filter: resource.type = "logging_bucket" AND metric.type = "logging.googleapis.com/user/cloudsqlInstanceChanges"
-        threshold_value: 0
-        trigger:
-          count: 1
-      display_name: 'Log match condition: Cloud SQL instance configuration changes'
+      - condition_threshold:
+          aggregations:
+            - alignment_period: 60s
+              cross_series_reducer: REDUCE_SUM
+              group_by_fields:
+                - metric.label.principal
+                - metric.label.method_name
+                - metric.label.project_id
+                - metric.label.database_id
+              per_series_aligner: ALIGN_SUM
+          comparison: COMPARISON_GT
+          duration: 0s
+          filter:
+            resource.type = "logging_bucket" AND metric.type = "logging.googleapis.com/user/cloudsqlInstanceChanges"
+          threshold_value: 0
+          trigger:
+            count: 1
+        display_name: "Log match condition: Cloud SQL instance configuration changes"
     display_name: Cloud SQL Instance Configuration Changes
     documentation:
-      content: 'Log-based alerting policy in project ${project} detected Cloud SQL
-        instance configuration changes.
+      content: |-
+        Log-based alerting policy in project ${project} detected Cloud SQL instance configuration changes.
 
-        This alert helps ensure security by monitoring configuration changes to SQL
-        instances. ``` protoPayload.methodName="cloudsql.instances.update" ```'
+        This alert helps ensure security by monitoring configuration changes to SQL instances.
+        ```
+        protoPayload.methodName="cloudsql.instances.update"
+        ```
       mime_type: text/markdown
 logging_metrics:
   cloudsqlInstanceChanges:
@@ -53,18 +56,18 @@ logging_metrics:
       project_id: EXTRACT(labels.project_id)
     metric_descriptor:
       labels:
-      - description: principal
-        key: principal
-        value_type: STRING
-      - description: method_name
-        key: method_name
-        value_type: STRING
-      - description: project_id
-        key: project_id
-        value_type: STRING
-      - description: database_id
-        key: database_id
-        value_type: STRING
+        - description: principal
+          key: principal
+          value_type: STRING
+        - description: method_name
+          key: method_name
+          value_type: STRING
+        - description: project_id
+          key: project_id
+          value_type: STRING
+        - description: database_id
+          key: database_id
+          value_type: STRING
       metric_kind: DELTA
-      unit: '1'
+      unit: "1"
       value_type: INT64

--- a/fast/stages/0-org-setup/datasets/hardened/organization/observability/customRoleChanges.yaml
+++ b/fast/stages/0-org-setup/datasets/hardened/organization/observability/customRoleChanges.yaml
@@ -16,40 +16,49 @@ alerts:
   customRoleChanges:
     combiner: OR
     conditions:
-    - condition_threshold:
-        aggregations:
-        - alignment_period: 60s
-          cross_series_reducer: REDUCE_SUM
-          group_by_fields:
-          - metric.label.principal
-          - metric.label.method_name
-          - metric.label.organization_id
-          - metric.label.project_id
-          - metric.label.role_name
-          per_series_aligner: ALIGN_SUM
-        comparison: COMPARISON_GT
-        duration: 0s
-        filter: resource.type = "logging_bucket" AND metric.type = "logging.googleapis.com/user/customRoleChanges"
-        threshold_value: 0
-        trigger:
-          count: 1
-      display_name: 'Log match condition: custom role changes'
+      - condition_threshold:
+          aggregations:
+            - alignment_period: 60s
+              cross_series_reducer: REDUCE_SUM
+              group_by_fields:
+                - metric.label.principal
+                - metric.label.method_name
+                - metric.label.organization_id
+                - metric.label.project_id
+                - metric.label.role_name
+              per_series_aligner: ALIGN_SUM
+          comparison: COMPARISON_GT
+          duration: 0s
+          filter: resource.type = "logging_bucket" AND metric.type = "logging.googleapis.com/user/customRoleChanges"
+          threshold_value: 0
+          trigger:
+            count: 1
+        display_name: "Log match condition: custom role changes"
     display_name: Custom Role Changes
     documentation:
-      content: "Log-based alerting policy in project ${project} detected custom IAM\
-        \ role creation, deletion or update activities.\nThis alert helps ensure security\
-        \ by monitoring changes to Identity and Access Management (IAM) roles. ```\n\
-        \  resource.type=\"iam_role\" AND \n  (\n    protoPayload.methodName=\"google.iam.admin.v1.CreateRole\"\
-        \ OR \n    protoPayload.methodName=\"google.iam.admin.v1.UpdateRole\" OR \n\
-        \    protoPayload.methodName=\"google.iam.admin.v1.DeleteRole\"\n  )\n```"
+      content: |-
+        Log-based alerting policy in project ${project} detected custom IAM role creation,
+        deletion or update activities.
+
+        This alert helps ensure security by monitoring changes to Identity and Access Management (IAM) roles.
+        ```
+        resource.type="iam_role" AND (
+          protoPayload.methodName="google.iam.admin.v1.CreateRole" OR
+          protoPayload.methodName="google.iam.admin.v1.UpdateRole" OR
+          protoPayload.methodName="google.iam.admin.v1.DeleteRole"
+        )
+        ```
       mime_type: text/markdown
 logging_metrics:
   customRoleChanges:
     bucket_name: log-0/audit-logs
     description: Custom Role Changes
-    filter: "resource.type=\"iam_role\" AND (\n  protoPayload.methodName=\"google.iam.admin.v1.CreateRole\"\
-      \ OR\n  protoPayload.methodName=\"google.iam.admin.v1.UpdateRole\" OR\n  protoPayload.methodName=\"\
-      google.iam.admin.v1.DeleteRole\"\n)"
+    filter: |-
+      resource.type="iam_role" AND (
+        protoPayload.methodName="google.iam.admin.v1.CreateRole" OR
+        protoPayload.methodName="google.iam.admin.v1.UpdateRole" OR
+        protoPayload.methodName="google.iam.admin.v1.DeleteRole"
+      )
     label_extractors:
       method_name: EXTRACT(protoPayload.methodName)
       organization_id: EXTRACT(labels.organization_id)
@@ -58,21 +67,21 @@ logging_metrics:
       role_name: EXTRACT(labels.role_name)
     metric_descriptor:
       labels:
-      - description: principal
-        key: principal
-        value_type: STRING
-      - description: method_name
-        key: method_name
-        value_type: STRING
-      - description: organization_id
-        key: organization_id
-        value_type: STRING
-      - description: project_id
-        key: project_id
-        value_type: STRING
-      - description: role_name
-        key: role_name
-        value_type: STRING
+        - description: principal
+          key: principal
+          value_type: STRING
+        - description: method_name
+          key: method_name
+          value_type: STRING
+        - description: organization_id
+          key: organization_id
+          value_type: STRING
+        - description: project_id
+          key: project_id
+          value_type: STRING
+        - description: role_name
+          key: role_name
+          value_type: STRING
       metric_kind: DELTA
-      unit: '1'
+      unit: "1"
       value_type: INT64

--- a/fast/stages/0-org-setup/datasets/hardened/organization/observability/firewallPolicyRuleChanges.yaml
+++ b/fast/stages/0-org-setup/datasets/hardened/organization/observability/firewallPolicyRuleChanges.yaml
@@ -16,50 +16,57 @@ alerts:
   firewallPolicyRuleChanges:
     combiner: OR
     conditions:
-    - condition_threshold:
-        aggregations:
-        - alignment_period: 60s
-          cross_series_reducer: REDUCE_SUM
-          group_by_fields:
-          - metric.label.principal
-          - metric.label.method_name
-          per_series_aligner: ALIGN_SUM
-        comparison: COMPARISON_GT
-        duration: 0s
-        filter: resource.type = "logging_bucket" AND metric.type = "logging.googleapis.com/user/firewallPolicyRuleChanges"
-        threshold_value: 0
-        trigger:
-          count: 1
-      display_name: 'Log match condition: Network Firewall Policy Rule Changes'
+      - condition_threshold:
+          aggregations:
+            - alignment_period: 60s
+              cross_series_reducer: REDUCE_SUM
+              group_by_fields:
+                - metric.label.principal
+                - metric.label.method_name
+              per_series_aligner: ALIGN_SUM
+          comparison: COMPARISON_GT
+          duration: 0s
+          filter:
+            resource.type = "logging_bucket" AND metric.type = "logging.googleapis.com/user/firewallPolicyRuleChanges"
+          threshold_value: 0
+          trigger:
+            count: 1
+        display_name: "Log match condition: Network Firewall Policy Rule Changes"
     display_name: Network Firewall Policy Rule Changes
     documentation:
-      content: "Log-based alerting policy in project ${project} detected Firewall\
-        \ Policy rule changes.\nThis alert helps ensure security by monitoring creation,\
-        \ modification, or deletion of firewall rules. ``` resource.labels.method:\"\
-        compute.networkFirewallPolicies\" AND  (\n  protoPayload.methodName:\"compute.networkFirewallPolicies.addRule\"\
-        \ OR \n  protoPayload.methodName:\"compute.networkFirewallPolicies.removeRule\"\
-        \ OR \n  protoPayload.methodName:\"compute.networkFirewallPolicies.patchRule\"\
-        )\n```"
+      content: |-
+        Log-based alerting policy in project ${project} detected Firewall Policy rule changes.
+
+        This alert helps ensure security by monitoring creation, modification, or deletion of firewall rules.
+        ```
+        resource.labels.method:"compute.networkFirewallPolicies" AND (
+          protoPayload.methodName:"compute.networkFirewallPolicies.addRule" OR
+          protoPayload.methodName:"compute.networkFirewallPolicies.removeRule" OR
+          protoPayload.methodName:"compute.networkFirewallPolicies.patchRule"
+        )
+        ```
       mime_type: text/markdown
 logging_metrics:
   firewallPolicyRuleChanges:
     bucket_name: log-0/audit-logs
     description: Network Firewall Policy Rule Changes
-    filter: "resource.labels.method:\"compute.networkFirewallPolicies\" AND (\n  protoPayload.methodName:\"\
-      compute.networkFirewallPolicies.addRule\" OR\n  protoPayload.methodName:\"compute.networkFirewallPolicies.removeRule\"\
-      \ OR\n  protoPayload.methodName:\"compute.networkFirewallPolicies.patchRule\"\
-      \n)"
+    filter: |-
+      resource.labels.method:"compute.networkFirewallPolicies" AND (
+        protoPayload.methodName:"compute.networkFirewallPolicies.addRule" OR
+        protoPayload.methodName:"compute.networkFirewallPolicies.removeRule" OR
+        protoPayload.methodName:"compute.networkFirewallPolicies.patchRule"
+      )
     label_extractors:
       method_name: EXTRACT(protoPayload.methodName)
       principal: EXTRACT(protoPayload.authenticationInfo.principalEmail)
     metric_descriptor:
       labels:
-      - description: principal
-        key: principal
-        value_type: STRING
-      - description: method_name
-        key: method_name
-        value_type: STRING
+        - description: principal
+          key: principal
+          value_type: STRING
+        - description: method_name
+          key: method_name
+          value_type: STRING
       metric_kind: DELTA
-      unit: '1'
+      unit: "1"
       value_type: INT64

--- a/fast/stages/0-org-setup/datasets/hardened/organization/observability/firewallRuleChanges.yaml
+++ b/fast/stages/0-org-setup/datasets/hardened/organization/observability/firewallRuleChanges.yaml
@@ -16,40 +16,44 @@ alerts:
   firewallRuleChanges:
     combiner: OR
     conditions:
-    - condition_threshold:
-        aggregations:
-        - alignment_period: 60s
-          cross_series_reducer: REDUCE_SUM
-          group_by_fields:
-          - metric.label.principal
-          - metric.label.method_name
-          - metric.label.project_id
-          - metric.label.firewall_rule_id
-          per_series_aligner: ALIGN_SUM
-        comparison: COMPARISON_GT
-        duration: 0s
-        filter: resource.type = "logging_bucket" AND metric.type = "logging.googleapis.com/user/firewallRuleChanges"
-        threshold_value: 0
-        trigger:
-          count: 1
-      display_name: 'Log match condition: VPC Network Firewall Rule Changes'
+      - condition_threshold:
+          aggregations:
+            - alignment_period: 60s
+              cross_series_reducer: REDUCE_SUM
+              group_by_fields:
+                - metric.label.principal
+                - metric.label.method_name
+                - metric.label.project_id
+                - metric.label.firewall_rule_id
+              per_series_aligner: ALIGN_SUM
+          comparison: COMPARISON_GT
+          duration: 0s
+          filter: resource.type = "logging_bucket" AND metric.type = "logging.googleapis.com/user/firewallRuleChanges"
+          threshold_value: 0
+          trigger:
+            count: 1
+        display_name: "Log match condition: VPC Network Firewall Rule Changes"
     display_name: VPC Network Firewall Rule Changes
     documentation:
-      content: 'Log-based alerting policy in project ${project} detected VPC Network
-        Firewall rule changes.
+      content: |-
+        Log-based alerting policy in project ${project} detected VPC Network Firewall rule changes.
 
-        This alert helps ensure security by monitoring creation, modification, or
-        deletion of firewall rules.
-        ``` resource.type="gce_firewall_rule" AND (protoPayload.methodName:"compute.firewalls.patch"
-        OR protoPayload.methodName:"compute.firewalls.insert" OR protoPayload.methodName:"compute.firewalls.delete")
-        ```'
+        This alert helps ensure security by monitoring creation, modification, or deletion of firewall rules.
+        ```
+        resource.type="gce_firewall_rule" AND (
+          protoPayload.methodName:"compute.firewalls.patch" OR
+          protoPayload.methodName:"compute.firewalls.insert" OR
+          protoPayload.methodName:"compute.firewalls.delete"
+        )
+        ```
       mime_type: text/markdown
 logging_metrics:
   firewallRuleChanges:
     bucket_name: log-0/audit-logs
     description: VPC Network Firewall Rule Changes
-    filter: resource.type="gce_firewall_rule" AND (protoPayload.methodName:"compute.firewalls.patch"
-      OR protoPayload.methodName:"compute.firewalls.insert" OR protoPayload.methodName:"compute.firewalls.delete")
+    filter:
+      resource.type="gce_firewall_rule" AND (protoPayload.methodName:"compute.firewalls.patch" OR
+      protoPayload.methodName:"compute.firewalls.insert" OR protoPayload.methodName:"compute.firewalls.delete")
     label_extractors:
       firewall_rule_id: EXTRACT(labels.firewall_rule_id)
       method_name: EXTRACT(protoPayload.methodName)
@@ -57,18 +61,18 @@ logging_metrics:
       project_id: EXTRACT(labels.project_id)
     metric_descriptor:
       labels:
-      - description: principal
-        key: principal
-        value_type: STRING
-      - description: method_name
-        key: method_name
-        value_type: STRING
-      - description: project_id
-        key: project_id
-        value_type: STRING
-      - description: firewall_rule_id
-        key: firewall_rule_id
-        value_type: STRING
+        - description: principal
+          key: principal
+          value_type: STRING
+        - description: method_name
+          key: method_name
+          value_type: STRING
+        - description: project_id
+          key: project_id
+          value_type: STRING
+        - description: firewall_rule_id
+          key: firewall_rule_id
+          value_type: STRING
       metric_kind: DELTA
-      unit: '1'
+      unit: "1"
       value_type: INT64

--- a/fast/stages/0-org-setup/datasets/hardened/organization/observability/networkChanges.yaml
+++ b/fast/stages/0-org-setup/datasets/hardened/organization/observability/networkChanges.yaml
@@ -16,43 +16,54 @@ alerts:
   networkChanges:
     combiner: OR
     conditions:
-    - condition_threshold:
-        aggregations:
-        - alignment_period: 60s
-          cross_series_reducer: REDUCE_SUM
-          group_by_fields:
-          - metric.label.principal
-          - metric.label.method_name
-          - metric.label.project_id
-          - metric.label.network_id
-          per_series_aligner: ALIGN_SUM
-        comparison: COMPARISON_GT
-        duration: 0s
-        filter: resource.type = "logging_bucket" AND metric.type = "logging.googleapis.com/user/networkChanges"
-        threshold_value: 0
-        trigger:
-          count: 1
-      display_name: 'Log match condition: VPC Network Changes'
+      - condition_threshold:
+          aggregations:
+            - alignment_period: 60s
+              cross_series_reducer: REDUCE_SUM
+              group_by_fields:
+                - metric.label.principal
+                - metric.label.method_name
+                - metric.label.project_id
+                - metric.label.network_id
+              per_series_aligner: ALIGN_SUM
+          comparison: COMPARISON_GT
+          duration: 0s
+          filter: resource.type = "logging_bucket" AND metric.type = "logging.googleapis.com/user/networkChanges"
+          threshold_value: 0
+          trigger:
+            count: 1
+        display_name: "Log match condition: VPC Network Changes"
     display_name: VPC Network Changes
     documentation:
-      content: "Log-based alerting policy in project ${project} detected VPC Network\
-        \ changes.\nThis alert helps ensure security by monitoring creation, modification,\
-        \ deletion, or peering changes to VPC networks. ``` resource.type=\"gce_network\"\
-        \ AND  (\n  protoPayload.methodName:\"compute.networks.insert\" OR \n  protoPayload.methodName:\"\
-        compute.networks.patch\" OR \n  protoPayload.methodName:\"compute.networks.delete\"\
-        \ OR \n  protoPayload.methodName:\"compute.networks.addPeering\" OR \n  protoPayload.methodName:\"\
-        compute.networks.updatePeering\" OR \n  protoPayload.methodName:\"compute.networks.removePeering\"\
-        \n) ```"
+      content: |-
+        Log-based alerting policy in project ${project} detected VPC Network changes.
+
+        This alert helps ensure security by monitoring creation, modification, deletion,
+        or peering changes to VPC networks.
+        ```
+        resource.type="gce_network" AND (
+          protoPayload.methodName:"compute.networks.insert" OR
+          protoPayload.methodName:"compute.networks.patch" OR
+          protoPayload.methodName:"compute.networks.delete" OR
+          protoPayload.methodName:"compute.networks.addPeering" OR
+          protoPayload.methodName:"compute.networks.updatePeering" OR
+          protoPayload.methodName:"compute.networks.removePeering"
+        )
+        ```
       mime_type: text/markdown
 logging_metrics:
   networkChanges:
     bucket_name: log-0/audit-logs
     description: VPC Network Changes
-    filter: "resource.type=\"gce_network\" AND (\n  protoPayload.methodName:\"compute.networks.insert\"\
-      \ OR\n  protoPayload.methodName:\"compute.networks.patch\" OR\n  protoPayload.methodName:\"\
-      compute.networks.delete\" OR\n  protoPayload.methodName:\"compute.networks.addPeering\"\
-      \ OR\n  protoPayload.methodName:\"compute.networks.updatePeering\" OR\n  protoPayload.methodName:\"\
-      compute.networks.removePeering\"\n)"
+    filter: |-
+      resource.type="gce_network" AND (
+        protoPayload.methodName:"compute.networks.insert" OR
+        protoPayload.methodName:"compute.networks.patch" OR
+        protoPayload.methodName:"compute.networks.delete" OR
+        protoPayload.methodName:"compute.networks.addPeering" OR
+        protoPayload.methodName:"compute.networks.updatePeering" OR
+        protoPayload.methodName:"compute.networks.removePeering"
+      )
     label_extractors:
       method_name: EXTRACT(protoPayload.methodName)
       network_id: EXTRACT(labels.network_id)
@@ -60,18 +71,18 @@ logging_metrics:
       project_id: EXTRACT(labels.project_id)
     metric_descriptor:
       labels:
-      - description: principal
-        key: principal
-        value_type: STRING
-      - description: method_name
-        key: method_name
-        value_type: STRING
-      - description: project_id
-        key: project_id
-        value_type: STRING
-      - description: network_id
-        key: network_id
-        value_type: STRING
+        - description: principal
+          key: principal
+          value_type: STRING
+        - description: method_name
+          key: method_name
+          value_type: STRING
+        - description: project_id
+          key: project_id
+          value_type: STRING
+        - description: network_id
+          key: network_id
+          value_type: STRING
       metric_kind: DELTA
-      unit: '1'
+      unit: "1"
       value_type: INT64

--- a/fast/stages/0-org-setup/datasets/hardened/organization/observability/networkRouteChanges.yaml
+++ b/fast/stages/0-org-setup/datasets/hardened/organization/observability/networkRouteChanges.yaml
@@ -16,37 +16,45 @@ alerts:
   networkRouteChanges:
     combiner: OR
     conditions:
-    - condition_threshold:
-        aggregations:
-        - alignment_period: 60s
-          cross_series_reducer: REDUCE_SUM
-          group_by_fields:
-          - metric.label.principal
-          - metric.label.method_name
-          - metric.label.project_id
-          - metric.label.route_id
-          per_series_aligner: ALIGN_SUM
-        comparison: COMPARISON_GT
-        duration: 0s
-        filter: resource.type = "logging_bucket" AND metric.type = "logging.googleapis.com/user/networkRouteChanges"
-        threshold_value: 0
-        trigger:
-          count: 1
-      display_name: 'Log match condition: VPC Network Route Changes'
+      - condition_threshold:
+          aggregations:
+            - alignment_period: 60s
+              cross_series_reducer: REDUCE_SUM
+              group_by_fields:
+                - metric.label.principal
+                - metric.label.method_name
+                - metric.label.project_id
+                - metric.label.route_id
+              per_series_aligner: ALIGN_SUM
+          comparison: COMPARISON_GT
+          duration: 0s
+          filter: resource.type = "logging_bucket" AND metric.type = "logging.googleapis.com/user/networkRouteChanges"
+          threshold_value: 0
+          trigger:
+            count: 1
+        display_name: "Log match condition: VPC Network Route Changes"
     display_name: VPC Network Route Changes
     documentation:
-      content: "Log-based alerting policy in project ${project} detected VPC Network\
-        \ Route changes.\nThis alert helps ensure security by monitoring creation\
-        \ or deletion of network routes. ``` resource.type=\"gce_route\" AND  (\n\
-        \  protoPayload.methodName:\"compute.routes.insert\" OR \n  protoPayload.methodName:\"\
-        compute.routes.delete\"\n) ```"
+      content: |-
+        Log-based alerting policy in project ${project} detected VPC Network Route changes.
+
+        This alert helps ensure security by monitoring creation or deletion of network routes.
+        ```
+        resource.type="gce_route" AND (
+          protoPayload.methodName:"compute.routes.insert" OR
+          protoPayload.methodName:"compute.routes.delete"
+        )
+        ```
       mime_type: text/markdown
 logging_metrics:
   networkRouteChanges:
     bucket_name: log-0/audit-logs
     description: VPC Network Route Changes
-    filter: "resource.type=\"gce_route\" AND (\n  protoPayload.methodName:\"compute.routes.insert\"\
-      \ OR\n  protoPayload.methodName:\"compute.routes.delete\"\n)"
+    filter: |-
+      resource.type="gce_route" AND (
+        protoPayload.methodName:"compute.routes.insert" OR
+        protoPayload.methodName:"compute.routes.delete"
+      )
     label_extractors:
       method_name: EXTRACT(protoPayload.methodName)
       principal: EXTRACT(protoPayload.authenticationInfo.principalEmail)
@@ -54,18 +62,18 @@ logging_metrics:
       route_id: EXTRACT(labels.route_id)
     metric_descriptor:
       labels:
-      - description: principal
-        key: principal
-        value_type: STRING
-      - description: method_name
-        key: method_name
-        value_type: STRING
-      - description: project_id
-        key: project_id
-        value_type: STRING
-      - description: route_id
-        key: route_id
-        value_type: STRING
+        - description: principal
+          key: principal
+          value_type: STRING
+        - description: method_name
+          key: method_name
+          value_type: STRING
+        - description: project_id
+          key: project_id
+          value_type: STRING
+        - description: route_id
+          key: route_id
+          value_type: STRING
       metric_kind: DELTA
-      unit: '1'
+      unit: "1"
       value_type: INT64

--- a/fast/stages/0-org-setup/datasets/hardened/organization/observability/projectOwnershipChange.yaml
+++ b/fast/stages/0-org-setup/datasets/hardened/organization/observability/projectOwnershipChange.yaml
@@ -12,52 +12,65 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# yamllint disable rule:line-length
-
 alerts:
   projectOwnershipChange:
     combiner: OR
     conditions:
-    - condition_threshold:
-        aggregations:
-        - alignment_period: 60s
-          cross_series_reducer: REDUCE_SUM
-          group_by_fields:
-          - metric.label.principal
-          - metric.label.method_name
-          - metric.label.organization_id
-          - metric.label.folder_id
-          - metric.label.project_id
-          per_series_aligner: ALIGN_SUM
-        comparison: COMPARISON_GT
-        duration: 0s
-        filter: |
-          resource.type = "logging_bucket" AND
-          metric.type = "logging.googleapis.com/user/projectOwnershipChange"
-        threshold_value: 0
-        trigger:
-          count: 1
-      display_name: Project Ownership Changes
+      - condition_threshold:
+          aggregations:
+            - alignment_period: 60s
+              cross_series_reducer: REDUCE_SUM
+              group_by_fields:
+                - metric.label.principal
+                - metric.label.method_name
+                - metric.label.organization_id
+                - metric.label.folder_id
+                - metric.label.project_id
+              per_series_aligner: ALIGN_SUM
+          comparison: COMPARISON_GT
+          duration: 0s
+          filter:
+            resource.type = "logging_bucket" AND metric.type = "logging.googleapis.com/user/projectOwnershipChange"
+          threshold_value: 0
+          trigger:
+            count: 1
+        display_name: Project Ownership Changes
     display_name: Project Ownership Changes
     documentation:
-      content: "Log-based alerting policy in project ${project} detected a project\
-        \ ownership assignments or changes. ``` (protoPayload.serviceName=\"cloudresourcemanager.googleapis.com\"\
-        ) AND  (ProjectOwnership OR projectOwnerInvitee)  OR  (\n  protoPayload.serviceData.policyDelta.bindingDeltas.action=\"\
-        REMOVE\" AND \n  protoPayload.serviceData.policyDelta.bindingDeltas.role=\"\
-        roles/owner\"\n)  OR  (\n  protoPayload.serviceData.policyDelta.bindingDeltas.action=\"\
-        ADD\" AND \n  protoPayload.serviceData.policyDelta.bindingDeltas.role=\"roles/owner\"\
-        \n) ```"
+      content: |-
+        Log-based alerting policy in project ${project} detected a project ownership assignments or changes.
+        ```
+        (protoPayload.serviceName="cloudresourcemanager.googleapis.com") AND
+        (ProjectOwnership OR projectOwnerInvitee)
+        OR
+        (
+          protoPayload.serviceData.policyDelta.bindingDeltas.action="REMOVE" AND
+          protoPayload.serviceData.policyDelta.bindingDeltas.role="roles/owner"
+        )
+        OR
+        (
+          protoPayload.serviceData.policyDelta.bindingDeltas.action="ADD" AND
+          protoPayload.serviceData.policyDelta.bindingDeltas.role="roles/owner"
+        )
+        ```
       mime_type: text/markdown
 logging_metrics:
   projectOwnershipChange:
     bucket_name: log-0/audit-logs
     description: Project Ownership Changes
-    filter: "(protoPayload.serviceName=\"cloudresourcemanager.googleapis.com\") AND\
-      \ (ProjectOwnership OR projectOwnerInvitee) OR (\n  protoPayload.serviceData.policyDelta.bindingDeltas.action=\"\
-      REMOVE\" AND\n  protoPayload.serviceData.policyDelta.bindingDeltas.role=\"roles/owner\"\
-      \n) OR (\n  protoPayload.serviceData.policyDelta.bindingDeltas.action=\"ADD\"\
-      \ AND\n  protoPayload.serviceData.policyDelta.bindingDeltas.role=\"roles/owner\"\
-      \n)"
+    filter: |-
+      (protoPayload.serviceName="cloudresourcemanager.googleapis.com") AND
+      (ProjectOwnership OR projectOwnerInvitee)
+      OR
+      (
+        protoPayload.serviceData.policyDelta.bindingDeltas.action="REMOVE" AND
+        protoPayload.serviceData.policyDelta.bindingDeltas.role="roles/owner"
+      )
+      OR
+      (
+        protoPayload.serviceData.policyDelta.bindingDeltas.action="ADD" AND
+        protoPayload.serviceData.policyDelta.bindingDeltas.role="roles/owner"
+      )
     label_extractors:
       folder_id: EXTRACT(labels.folder_id)
       method_name: EXTRACT(protoPayload.methodName)
@@ -66,21 +79,21 @@ logging_metrics:
       project_id: EXTRACT(labels.project_id)
     metric_descriptor:
       labels:
-      - description: principal
-        key: principal
-        value_type: STRING
-      - description: method_name
-        key: method_name
-        value_type: STRING
-      - description: organization_id
-        key: organization_id
-        value_type: STRING
-      - description: folder_id
-        key: folder_id
-        value_type: STRING
-      - description: project_id
-        key: project_id
-        value_type: STRING
+        - description: principal
+          key: principal
+          value_type: STRING
+        - description: method_name
+          key: method_name
+          value_type: STRING
+        - description: organization_id
+          key: organization_id
+          value_type: STRING
+        - description: folder_id
+          key: folder_id
+          value_type: STRING
+        - description: project_id
+          key: project_id
+          value_type: STRING
       metric_kind: DELTA
-      unit: '1'
+      unit: "1"
       value_type: INT64

--- a/fast/stages/0-org-setup/datasets/hardened/organization/observability/storageIamChanges.yaml
+++ b/fast/stages/0-org-setup/datasets/hardened/organization/observability/storageIamChanges.yaml
@@ -16,32 +16,33 @@ alerts:
   storageIamChanges:
     combiner: OR
     conditions:
-    - condition_threshold:
-        aggregations:
-        - alignment_period: 60s
-          cross_series_reducer: REDUCE_SUM
-          group_by_fields:
-          - metric.label.principal
-          - metric.label.method_name
-          - metric.label.project_id
-          - metric.label.location
-          - metric.label.bucket_name
-          per_series_aligner: ALIGN_SUM
-        comparison: COMPARISON_GT
-        duration: 0s
-        filter: resource.type = "logging_bucket" AND metric.type = "logging.googleapis.com/user/storageIamChanges"
-        threshold_value: 0
-        trigger:
-          count: 1
-      display_name: Cloud Storage IAM Permission Changes
+      - condition_threshold:
+          aggregations:
+            - alignment_period: 60s
+              cross_series_reducer: REDUCE_SUM
+              group_by_fields:
+                - metric.label.principal
+                - metric.label.method_name
+                - metric.label.project_id
+                - metric.label.location
+                - metric.label.bucket_name
+              per_series_aligner: ALIGN_SUM
+          comparison: COMPARISON_GT
+          duration: 0s
+          filter: resource.type = "logging_bucket" AND metric.type = "logging.googleapis.com/user/storageIamChanges"
+          threshold_value: 0
+          trigger:
+            count: 1
+        display_name: Cloud Storage IAM Permission Changes
     display_name: Cloud Storage IAM Permission Changes
     documentation:
-      content: 'Log-based alerting policy in project ${project} detected Cloud Storage
-        Bucket IAM changes.
+      content: |-
+        Log-based alerting policy in project ${project} detected Cloud Storage Bucket IAM changes.
 
-        This alert helps ensure security by monitoring IAM permission changes to Cloud
-        Storage buckets. ``` resource.type="gcs_bucket" AND protoPayload.methodName="storage.setIamPermissions"
-        ```'
+        This alert helps ensure security by monitoring IAM permission changes to Cloud Storage buckets.
+        ```
+        resource.type="gcs_bucket" AND protoPayload.methodName="storage.setIamPermissions"
+        ```
       mime_type: text/markdown
 logging_metrics:
   storageIamChanges:
@@ -56,21 +57,21 @@ logging_metrics:
       project_id: EXTRACT(labels.project_id)
     metric_descriptor:
       labels:
-      - description: principal
-        key: principal
-        value_type: STRING
-      - description: method_name
-        key: method_name
-        value_type: STRING
-      - description: project_id
-        key: project_id
-        value_type: STRING
-      - description: location
-        key: location
-        value_type: STRING
-      - description: bucket_name
-        key: bucket_name
-        value_type: STRING
+        - description: principal
+          key: principal
+          value_type: STRING
+        - description: method_name
+          key: method_name
+          value_type: STRING
+        - description: project_id
+          key: project_id
+          value_type: STRING
+        - description: location
+          key: location
+          value_type: STRING
+        - description: bucket_name
+          key: bucket_name
+          value_type: STRING
       metric_kind: DELTA
-      unit: '1'
+      unit: "1"
       value_type: INT64

--- a/fast/stages/0-org-setup/datasets/hardened/organization/org-policies/firewall.yaml
+++ b/fast/stages/0-org-setup/datasets/hardened/organization/org-policies/firewall.yaml
@@ -26,7 +26,7 @@ custom.firewallEnforceRuleLogging:
   rules:
     - enforce: true
 
-custom.firewallRestrictOpenWorldRule:
+custom.firewallRestrictPublicAccessRule:
   rules:
     - enforce: true
 

--- a/fast/stages/0-org-setup/datasets/hardened/organization/scc-sha-custom-modules/cloudfunctionsV1RequireIngressInternalAndLoadBalancer.yaml
+++ b/fast/stages/0-org-setup/datasets/hardened/organization/scc-sha-custom-modules/cloudfunctionsV1RequireIngressInternalAndLoadBalancer.yaml
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 cloudfunctionsV1RequireIngressInternalAndLoadBalancer:
-  description: Detect if Gen1 Cloud Functions are not configured to allow only internal
-    traffic and traffic from load balancer
+  description:
+    Detect if Gen1 Cloud Functions are not configured to allow only internal traffic and traffic from load balancer
   predicate:
     expression: (!resource.ingressSettings.matches("ALLOW_INTERNAL_AND_GCLB"))
-  recommendation: Ensure Gen1 Cloud Functions are configured to allow only internal
-    traffic and traffic from load balancer
+  recommendation:
+    Ensure Gen1 Cloud Functions are configured to allow only internal traffic and traffic from load balancer
   resource_selector:
     resource_types:
-    - cloudfunctions.googleapis.com/CloudFunction
+      - cloudfunctions.googleapis.com/CloudFunction
   severity: MEDIUM

--- a/fast/stages/0-org-setup/datasets/hardened/organization/scc-sha-custom-modules/cloudfunctionsV1RequireVPCConnector.yaml
+++ b/fast/stages/0-org-setup/datasets/hardened/organization/scc-sha-custom-modules/cloudfunctionsV1RequireVPCConnector.yaml
@@ -19,5 +19,5 @@ cloudfunctionsV1RequireVPCConnector:
   recommendation: Ensure Gen1 Cloud Functions are configured with VPC Connector
   resource_selector:
     resource_types:
-    - cloudfunctions.googleapis.com/CloudFunction
+      - cloudfunctions.googleapis.com/CloudFunction
   severity: MEDIUM

--- a/fast/stages/0-org-setup/datasets/hardened/organization/scc-sha-custom-modules/cloudrunRequireBinaryAuthorization.yaml
+++ b/fast/stages/0-org-setup/datasets/hardened/organization/scc-sha-custom-modules/cloudrunRequireBinaryAuthorization.yaml
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 cloudrunRequireBinaryAuthorization:
-  description: Detect if Cloud Run services are configured without Binary Authorization
-    enabled
+  description: Detect if Cloud Run services are configured without Binary Authorization enabled
   predicate:
     expression: (!resource.metadata.annotations.exists(data, data == 'run.googleapis.com/binary-authorization'))
-  recommendation: Ensure that Binary Authorization is enabled for all Cloud Run services
-    and that the project's default Binary Authorization policy requires attestation
+  recommendation:
+    Ensure that Binary Authorization is enabled for all Cloud Run services and that the project's default Binary
+    Authorization policy requires attestation
   resource_selector:
     resource_types:
-    - run.googleapis.com/Job
-    - run.googleapis.com/Service
+      - run.googleapis.com/Job
+      - run.googleapis.com/Service
   severity: HIGH

--- a/fast/stages/0-org-setup/datasets/hardened/organization/scc-sha-custom-modules/cloudrunRequireIngressInternalAndLoadBalancer.yaml
+++ b/fast/stages/0-org-setup/datasets/hardened/organization/scc-sha-custom-modules/cloudrunRequireIngressInternalAndLoadBalancer.yaml
@@ -13,16 +13,15 @@
 # limitations under the License.
 
 cloudrunRequireIngressInternalAndLoadBalancer:
-  description: Detect if Cloud Run services are not configured to allow only internal
-    traffic and traffic from load balancer
+  description:
+    Detect if Cloud Run services are not configured to allow only internal traffic and traffic from load balancer
   predicate:
     expression: |-
       (
         !resource.metadata.annotations['run.googleapis.com/ingress'].matches('internal-and-cloud-load-balancing')
       )
-  recommendation: Ensure Cloud Run services are configured to allow only internal
-    traffic and traffic from load balancer
+  recommendation: Ensure Cloud Run services are configured to allow only internal traffic and traffic from load balancer
   resource_selector:
     resource_types:
-    - run.googleapis.com/Service
+      - run.googleapis.com/Service
   severity: HIGH

--- a/fast/stages/0-org-setup/datasets/hardened/organization/scc-sha-custom-modules/cloudsqlRequirePointInTimeRecovery.yaml
+++ b/fast/stages/0-org-setup/datasets/hardened/organization/scc-sha-custom-modules/cloudsqlRequirePointInTimeRecovery.yaml
@@ -23,5 +23,5 @@ cloudsqlRequirePointInTimeRecovery:
   recommendation: Ensure the CloudSQL instances have point in time recovery enabled
   resource_selector:
     resource_types:
-    - sqladmin.googleapis.com/Instance
+      - sqladmin.googleapis.com/Instance
   severity: HIGH

--- a/fast/stages/0-org-setup/datasets/hardened/organization/scc-sha-custom-modules/computeDisableNestedVirtualization.yaml
+++ b/fast/stages/0-org-setup/datasets/hardened/organization/scc-sha-custom-modules/computeDisableNestedVirtualization.yaml
@@ -19,5 +19,5 @@ computeDisableNestedVirtualization:
   recommendation: Ensure Compute Instance does not have nested virtualization enabled
   resource_selector:
     resource_types:
-    - compute.googleapis.com/Instance
+      - compute.googleapis.com/Instance
   severity: MEDIUM

--- a/fast/stages/0-org-setup/datasets/hardened/organization/scc-sha-custom-modules/gkeDisableClientCertificateAuth.yaml
+++ b/fast/stages/0-org-setup/datasets/hardened/organization/scc-sha-custom-modules/gkeDisableClientCertificateAuth.yaml
@@ -15,10 +15,9 @@
 gkeDisableClientCertificateAuth:
   description: Detect if any GKE clusters uses client certificate authentication
   predicate:
-    expression: resource.masterAuth.clientCertificateConfig.issueClientCertificate
-      == true
+    expression: resource.masterAuth.clientCertificateConfig.issueClientCertificate == true
   recommendation: Ensure that control plane does not use client certificate authentication
   resource_selector:
     resource_types:
-    - container.googleapis.com/Cluster
+      - container.googleapis.com/Cluster
   severity: CRITICAL

--- a/fast/stages/0-org-setup/datasets/hardened/organization/scc-sha-custom-modules/gkeRequireDataplaneV2.yaml
+++ b/fast/stages/0-org-setup/datasets/hardened/organization/scc-sha-custom-modules/gkeRequireDataplaneV2.yaml
@@ -13,12 +13,11 @@
 # limitations under the License.
 
 gkeRequireDataplaneV2:
-  description: Detect if GKE clusters are configured with a version different than
-    Dataplane V2
+  description: Detect if GKE clusters are configured with a version different than Dataplane V2
   predicate:
     expression: resource.networkConfig.datapathProvider == 'ADVANCED_DATAPATH'
   recommendation: Ensure only GKE Dataplane V2 are configured
   resource_selector:
     resource_types:
-    - container.googleapis.com/Cluster
+      - container.googleapis.com/Cluster
   severity: MEDIUM

--- a/fast/stages/0-org-setup/datasets/hardened/organization/scc-sha-custom-modules/gkeRequireRegionalCluster.yaml
+++ b/fast/stages/0-org-setup/datasets/hardened/organization/scc-sha-custom-modules/gkeRequireRegionalCluster.yaml
@@ -19,5 +19,5 @@ gkeRequireRegionalCluster:
   recommendation: Ensure GKE clusters are configured to be regional
   resource_selector:
     resource_types:
-    - container.googleapis.com/Cluster
+      - container.googleapis.com/Cluster
   severity: MEDIUM

--- a/tests/fast/stages/s0_org_setup/hardened.yaml
+++ b/tests/fast/stages/s0_org_setup/hardened.yaml
@@ -1337,10 +1337,10 @@ values:
     bucket_options: []
     description: Project Ownership Changes
     disabled: null
-    filter: "(protoPayload.serviceName=\"cloudresourcemanager.googleapis.com\") AND\
-      \ (ProjectOwnership OR projectOwnerInvitee) OR (\n  protoPayload.serviceData.policyDelta.bindingDeltas.action=\"\
+    filter: "(protoPayload.serviceName=\"cloudresourcemanager.googleapis.com\") AND\n\
+      (ProjectOwnership OR projectOwnerInvitee)\nOR\n(\n  protoPayload.serviceData.policyDelta.bindingDeltas.action=\"\
       REMOVE\" AND\n  protoPayload.serviceData.policyDelta.bindingDeltas.role=\"roles/owner\"\
-      \n) OR (\n  protoPayload.serviceData.policyDelta.bindingDeltas.action=\"ADD\"\
+      \n)\nOR\n(\n  protoPayload.serviceData.policyDelta.bindingDeltas.action=\"ADD\"\
       \ AND\n  protoPayload.serviceData.policyDelta.bindingDeltas.role=\"roles/owner\"\
       \n)"
     label_extractors:
@@ -1447,9 +1447,19 @@ values:
     - content: 'Log-based alerting policy in project ${project} detected audit configuration
         changes.
 
+
         This alert helps track GCP services audit log configuration changes to ensure
-        appropriate audit logs are being collected. ``` protoPayload.methodName="SetIamPolicy"
-        AND protoPayload.serviceData.policyDelta.auditConfigDeltas:* ```'
+        appropriate.
+
+        audit logs are being collected
+
+        ```
+
+        protoPayload.methodName="SetIamPolicy" AND
+
+        protoPayload.serviceData.policyDelta.auditConfigDeltas:*
+
+        ```'
       links: []
       mime_type: text/markdown
       subject: null
@@ -1495,8 +1505,15 @@ values:
     - content: 'Log-based alerting policy in project ${project} detected Cloud SQL
         instance configuration changes.
 
+
         This alert helps ensure security by monitoring configuration changes to SQL
-        instances. ``` protoPayload.methodName="cloudsql.instances.update" ```'
+        instances.
+
+        ```
+
+        protoPayload.methodName="cloudsql.instances.update"
+
+        ```'
       links: []
       mime_type: text/markdown
       subject: null
@@ -1541,11 +1558,11 @@ values:
     display_name: Custom Role Changes
     documentation:
     - content: "Log-based alerting policy in project ${project} detected custom IAM\
-        \ role creation, deletion or update activities.\nThis alert helps ensure security\
-        \ by monitoring changes to Identity and Access Management (IAM) roles. ```\n\
-        \  resource.type=\"iam_role\" AND \n  (\n    protoPayload.methodName=\"google.iam.admin.v1.CreateRole\"\
-        \ OR \n    protoPayload.methodName=\"google.iam.admin.v1.UpdateRole\" OR \n\
-        \    protoPayload.methodName=\"google.iam.admin.v1.DeleteRole\"\n  )\n```"
+        \ role creation,\ndeletion or update activities.\n\nThis alert helps ensure\
+        \ security by monitoring changes to Identity and Access Management (IAM) roles.\n\
+        ```\nresource.type=\"iam_role\" AND (\n  protoPayload.methodName=\"google.iam.admin.v1.CreateRole\"\
+        \ OR\n  protoPayload.methodName=\"google.iam.admin.v1.UpdateRole\" OR\n  protoPayload.methodName=\"\
+        google.iam.admin.v1.DeleteRole\"\n)\n```"
       links: []
       mime_type: text/markdown
       subject: null
@@ -1587,12 +1604,12 @@ values:
     display_name: Network Firewall Policy Rule Changes
     documentation:
     - content: "Log-based alerting policy in project ${project} detected Firewall\
-        \ Policy rule changes.\nThis alert helps ensure security by monitoring creation,\
-        \ modification, or deletion of firewall rules. ``` resource.labels.method:\"\
-        compute.networkFirewallPolicies\" AND  (\n  protoPayload.methodName:\"compute.networkFirewallPolicies.addRule\"\
-        \ OR \n  protoPayload.methodName:\"compute.networkFirewallPolicies.removeRule\"\
-        \ OR \n  protoPayload.methodName:\"compute.networkFirewallPolicies.patchRule\"\
-        )\n```"
+        \ Policy rule changes.\n\nThis alert helps ensure security by monitoring creation,\
+        \ modification, or deletion of firewall rules.\n```\nresource.labels.method:\"\
+        compute.networkFirewallPolicies\" AND (\n  protoPayload.methodName:\"compute.networkFirewallPolicies.addRule\"\
+        \ OR\n  protoPayload.methodName:\"compute.networkFirewallPolicies.removeRule\"\
+        \ OR\n  protoPayload.methodName:\"compute.networkFirewallPolicies.patchRule\"\
+        \n)\n```"
       links: []
       mime_type: text/markdown
       subject: null
@@ -1635,13 +1652,12 @@ values:
       display_name: 'Log match condition: VPC Network Firewall Rule Changes'
     display_name: VPC Network Firewall Rule Changes
     documentation:
-    - content: 'Log-based alerting policy in project ${project} detected VPC Network
-        Firewall rule changes.
-
-        This alert helps ensure security by monitoring creation, modification, or
-        deletion of firewall rules. ``` resource.type="gce_firewall_rule" AND (protoPayload.methodName:"compute.firewalls.patch"
-        OR protoPayload.methodName:"compute.firewalls.insert" OR protoPayload.methodName:"compute.firewalls.delete")
-        ```'
+    - content: "Log-based alerting policy in project ${project} detected VPC Network\
+        \ Firewall rule changes.\n\nThis alert helps ensure security by monitoring\
+        \ creation, modification, or deletion of firewall rules.\n```\nresource.type=\"\
+        gce_firewall_rule\" AND (\n  protoPayload.methodName:\"compute.firewalls.patch\"\
+        \ OR\n  protoPayload.methodName:\"compute.firewalls.insert\" OR\n  protoPayload.methodName:\"\
+        compute.firewalls.delete\"\n)\n```"
       links: []
       mime_type: text/markdown
       subject: null
@@ -1685,13 +1701,13 @@ values:
     display_name: VPC Network Changes
     documentation:
     - content: "Log-based alerting policy in project ${project} detected VPC Network\
-        \ changes.\nThis alert helps ensure security by monitoring creation, modification,\
-        \ deletion, or peering changes to VPC networks. ``` resource.type=\"gce_network\"\
-        \ AND  (\n  protoPayload.methodName:\"compute.networks.insert\" OR \n  protoPayload.methodName:\"\
-        compute.networks.patch\" OR \n  protoPayload.methodName:\"compute.networks.delete\"\
-        \ OR \n  protoPayload.methodName:\"compute.networks.addPeering\" OR \n  protoPayload.methodName:\"\
-        compute.networks.updatePeering\" OR \n  protoPayload.methodName:\"compute.networks.removePeering\"\
-        \n) ```"
+        \ changes.\n\nThis alert helps ensure security by monitoring creation, modification,\
+        \ deletion,\nor peering changes to VPC networks.\n```\nresource.type=\"gce_network\"\
+        \ AND (\n  protoPayload.methodName:\"compute.networks.insert\" OR\n  protoPayload.methodName:\"\
+        compute.networks.patch\" OR\n  protoPayload.methodName:\"compute.networks.delete\"\
+        \ OR\n  protoPayload.methodName:\"compute.networks.addPeering\" OR\n  protoPayload.methodName:\"\
+        compute.networks.updatePeering\" OR\n  protoPayload.methodName:\"compute.networks.removePeering\"\
+        \n)\n```"
       links: []
       mime_type: text/markdown
       subject: null
@@ -1735,10 +1751,10 @@ values:
     display_name: VPC Network Route Changes
     documentation:
     - content: "Log-based alerting policy in project ${project} detected VPC Network\
-        \ Route changes.\nThis alert helps ensure security by monitoring creation\
-        \ or deletion of network routes. ``` resource.type=\"gce_route\" AND  (\n\
-        \  protoPayload.methodName:\"compute.routes.insert\" OR \n  protoPayload.methodName:\"\
-        compute.routes.delete\"\n) ```"
+        \ Route changes.\n\nThis alert helps ensure security by monitoring creation\
+        \ or deletion of network routes.\n```\nresource.type=\"gce_route\" AND (\n\
+        \  protoPayload.methodName:\"compute.routes.insert\" OR\n  protoPayload.methodName:\"\
+        compute.routes.delete\"\n)\n```"
       links: []
       mime_type: text/markdown
       subject: null
@@ -1773,11 +1789,7 @@ values:
         denominator_filter: null
         duration: 0s
         evaluation_missing_data: null
-        filter: 'resource.type = "logging_bucket" AND
-
-          metric.type = "logging.googleapis.com/user/projectOwnershipChange"
-
-          '
+        filter: resource.type = "logging_bucket" AND metric.type = "logging.googleapis.com/user/projectOwnershipChange"
         forecast_options: []
         threshold_value: 0
         trigger:
@@ -1787,12 +1799,12 @@ values:
     display_name: Project Ownership Changes
     documentation:
     - content: "Log-based alerting policy in project ${project} detected a project\
-        \ ownership assignments or changes. ``` (protoPayload.serviceName=\"cloudresourcemanager.googleapis.com\"\
-        ) AND  (ProjectOwnership OR projectOwnerInvitee)  OR  (\n  protoPayload.serviceData.policyDelta.bindingDeltas.action=\"\
-        REMOVE\" AND \n  protoPayload.serviceData.policyDelta.bindingDeltas.role=\"\
-        roles/owner\"\n)  OR  (\n  protoPayload.serviceData.policyDelta.bindingDeltas.action=\"\
-        ADD\" AND \n  protoPayload.serviceData.policyDelta.bindingDeltas.role=\"roles/owner\"\
-        \n) ```"
+        \ ownership assignments or changes.\n```\n(protoPayload.serviceName=\"cloudresourcemanager.googleapis.com\"\
+        ) AND\n(ProjectOwnership OR projectOwnerInvitee)\nOR\n(\n  protoPayload.serviceData.policyDelta.bindingDeltas.action=\"\
+        REMOVE\" AND\n  protoPayload.serviceData.policyDelta.bindingDeltas.role=\"\
+        roles/owner\"\n)\nOR\n(\n  protoPayload.serviceData.policyDelta.bindingDeltas.action=\"\
+        ADD\" AND\n  protoPayload.serviceData.policyDelta.bindingDeltas.role=\"roles/owner\"\
+        \n)\n```"
       links: []
       mime_type: text/markdown
       subject: null
@@ -1839,8 +1851,14 @@ values:
     - content: 'Log-based alerting policy in project ${project} detected Cloud Storage
         Bucket IAM changes.
 
+
         This alert helps ensure security by monitoring IAM permission changes to Cloud
-        Storage buckets. ``` resource.type="gcs_bucket" AND protoPayload.methodName="storage.setIamPermissions"
+        Storage buckets.
+
+        ```
+
+        resource.type="gcs_bucket" AND protoPayload.methodName="storage.setIamPermissions"
+
         ```'
       links: []
       mime_type: text/markdown
@@ -3394,9 +3412,9 @@ values:
         parameters: null
         values: []
     timeouts: null
-  module.organization-iam[0].google_org_policy_policy.default["custom.firewallRestrictOpenWorldRule"]:
+  module.organization-iam[0].google_org_policy_policy.default["custom.firewallRestrictPublicAccessRule"]:
     dry_run_spec: []
-    name: organizations/1234567890/policies/custom.firewallRestrictOpenWorldRule
+    name: organizations/1234567890/policies/custom.firewallRestrictPublicAccessRule
     parent: organizations/1234567890
     spec:
     - inherit_from_parent: null
@@ -4852,16 +4870,17 @@ values:
     resource_types:
     - compute.googleapis.com/Firewall
     timeouts: null
-  module.organization[0].google_org_policy_custom_constraint.constraint["custom.firewallRestrictOpenWorldRule"]:
+  module.organization[0].google_org_policy_custom_constraint.constraint["custom.firewallRestrictPublicAccessRule"]:
     action_type: DENY
-    condition: (size(resource.allowed) > 0) && (resource.sourceRanges.exists(range,
-      range == '0.0.0.0/0') || resource.destinationRanges.exists(range, range == '0.0.0.0/0'))
-    description: Prevent the creation of VPC firewall rule with source or destination
+    condition: "(size(resource.allowed) > 0) &&\n(\n  resource.sourceRanges.exists(range,\
+      \ range == '0.0.0.0/0') ||\n  resource.destinationRanges.exists(range, range\
+      \ == '0.0.0.0/0')\n)"
+    description: Prevent the creation of VPC firewall rules with source or destination
       any IP address (0.0.0.0/0)
-    display_name: Restrict VPC Firewall rule creation that are open to the world
+    display_name: Restrict VPC Firewall rules allowing public Internet access
     method_types:
     - CREATE
-    name: custom.firewallRestrictOpenWorldRule
+    name: custom.firewallRestrictPublicAccessRule
     parent: organizations/1234567890
     resource_types:
     - compute.googleapis.com/Firewall
@@ -4875,9 +4894,9 @@ values:
       \      ipRange.startsWith('10.')\n    ) &&\n    rule.match.layer4Configs.all(l4config,\n\
       \        l4config.ipProtocol == 'tcp' &&\n        l4config.ports.all(port, port\
       \ == '3389')\n    )\n)"
-    description: Ensure that RDP access is restricted from the Internet when using
-      Firewall Policy Rule
-    display_name: Restrict Firewall Policy rules allowing RDP access from the Internet
+    description: Ensure that RDP access is restricted from any source when using Firewall
+      Policy Rule
+    display_name: Restrict Firewall Policy rules allowing RDP access from any source
     method_types:
     - CREATE
     - UPDATE
@@ -4888,16 +4907,16 @@ values:
     timeouts: null
   module.organization[0].google_org_policy_custom_constraint.constraint["custom.firewallRestrictRdpRule"]:
     action_type: DENY
-    condition: "resource.direction.matches('INGRESS') &&\n!resource.name.startsWith(\"\
-      gke-\") &&\n!resource.name.startsWith(\"k8s-\") &&\n!resource.name.endsWith(\"\
-      -hc\") &&\n!resource.name.startsWith(\"k8s2-\") &&\n!resource.name.startsWith(\"\
-      gkegw1-l7-\") &&\n!resource.name.startsWith(\"gkemcg1-l7-\") &&\nresource.allowed.containsFirewallPort('tcp',\
+    condition: "resource.direction.matches('INGRESS') &&\n!resource.name.startsWith('gke-')\
+      \ &&\n!resource.name.startsWith('k8s-') &&\n!resource.name.endsWith('-hc') &&\n\
+      !resource.name.startsWith('k8s2-') &&\n!resource.name.startsWith('gkegw1-l7-')\
+      \ &&\n!resource.name.startsWith('gkemcg1-l7-') &&\nresource.allowed.containsFirewallPort('tcp',\
       \ '3389') &&\n!resource.sourceRanges.all(range,\n  range == '35.235.240.0/20'\
       \ ||\n  range.startsWith('10.') ||\n  range.matches('^172\\\\.(?:1[6-9]|2\\\\\
       d|3[0-1]).*') ||\n  range.startsWith('192.168.')\n)"
-    description: Ensure that RDP access is restricted from the Internet when using
-      VPC Firewall Rule
-    display_name: Restrict VPC Firewall rules allowing RDP access from the Internet
+    description: Ensure that RDP access is restricted from any source when using VPC
+      Firewall Rule
+    display_name: Restrict VPC Firewall rules allowing RDP access from any source
     method_types:
     - CREATE
     - UPDATE
@@ -4915,9 +4934,9 @@ values:
       \      ipRange.startsWith('10.')\n    ) &&\n    rule.match.layer4Configs.all(l4config,\n\
       \        l4config.ipProtocol == 'tcp' &&\n        l4config.ports.all(port, port\
       \ == '22')\n    )\n)"
-    description: Ensure that SSH access is restricted from the Internet when using
-      Firewall Policy Rule
-    display_name: Restrict Firewall Policy rules allowing SSH access from the Internet
+    description: Ensure that SSH access is restricted from any source when using Firewall
+      Policy Rule
+    display_name: Restrict Firewall Policy rules allowing SSH access from any source
     method_types:
     - CREATE
     - UPDATE
@@ -4928,16 +4947,16 @@ values:
     timeouts: null
   module.organization[0].google_org_policy_custom_constraint.constraint["custom.firewallRestrictSshRule"]:
     action_type: DENY
-    condition: "resource.direction.matches('INGRESS') &&\n!resource.name.startsWith(\"\
-      gke-\") &&\n!resource.name.startsWith(\"k8s-\") &&\n!resource.name.endsWith(\"\
-      -hc\") &&\n!resource.name.startsWith(\"k8s2-\") &&\n!resource.name.startsWith(\"\
-      gkegw1-l7-\") &&\n!resource.name.startsWith(\"gkemcg1-l7-\") &&\nresource.allowed.containsFirewallPort('tcp',\
+    condition: "resource.direction.matches('INGRESS') &&\n!resource.name.startsWith('gke-')\
+      \ &&\n!resource.name.startsWith('k8s-') &&\n!resource.name.endsWith('-hc') &&\n\
+      !resource.name.startsWith('k8s2-') &&\n!resource.name.startsWith('gkegw1-l7-')\
+      \ &&\n!resource.name.startsWith('gkemcg1-l7-') &&\nresource.allowed.containsFirewallPort('tcp',\
       \ '22') &&\n!resource.sourceRanges.all(range,\n  range == '35.235.240.0/20'\
       \ ||\n  range.startsWith('10.') ||\n  range.matches('^172\\\\.(?:1[6-9]|2\\\\\
       d|3[0-1]).*') ||\n  range.startsWith('192.168.')\n)"
-    description: Ensure that SSH access is restricted from the Internet when using
-      VPC Firewall Rule
-    display_name: Restrict VPC Firewall rules allowing SSH access from the Internet
+    description: Ensure that SSH access is restricted from any source when using VPC
+      Firewall Rule
+    display_name: Restrict VPC Firewall rules allowing SSH access from any source
     method_types:
     - CREATE
     - UPDATE
@@ -5164,8 +5183,8 @@ values:
     timeouts: null
   module.organization[0].google_org_policy_custom_constraint.constraint["custom.gkeRequireNodePoolSandbox"]:
     action_type: DENY
-    condition: resource.name.matches("default-pool") == false && has(resource.config.sandboxConfig)
-      == false && resource.config.sandboxConfig.type != 'GVISOR'
+    condition: "resource.name.matches(\"default-pool\") == false &&\n  has(resource.config.sandboxConfig)\
+      \ == false &&\n  resource.config.sandboxConfig.type != 'GVISOR'"
     description: Enforce that the GKE clusters nodes are isolated using GKE sandbox
       (excepting the default node pool)
     display_name: Require GKE Sandbox runtime
@@ -5340,8 +5359,8 @@ values:
     timeouts: null
   module.organization[0].google_org_policy_custom_constraint.constraint["custom.networkRequireSubnetPrivateGoogleAccess"]:
     action_type: DENY
-    condition: "resource.privateIpGoogleAccess == false &&\n  resource.purpose in\
-      \ ['REGIONAL_MANAGED_PROXY', 'GLOBAL_MANAGED_PROXY'] == false"
+    condition: '!resource.privateIpGoogleAccess && resource.purpose in [''REGIONAL_MANAGED_PROXY'',
+      ''GLOBAL_MANAGED_PROXY''] == false'
     description: Enforce that the VPC network subnets are configured with private
       Google access
     display_name: Require Private Google Access


### PR DESCRIPTION
Minor PR that consists:
- to clean YAML to follow YAML guidelines from yamllint
- Ensure multiline YAML are more readable and use identation when possible

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass

