### PR TITLE
Assign service usage roles on iac project to automation service accounts

### DIFF
--- a/fast/stages/0-org-setup/datasets/classic/projects/core/iac-0.yaml
+++ b/fast/stages/0-org-setup/datasets/classic/projects/core/iac-0.yaml
@@ -33,6 +33,18 @@ iam_by_principals:
     - roles/iam.workloadIdentityPoolAdmin
     - roles/owner
     - roles/storage.admin
+  $iam_principals:service_accounts/iac-0/iac-networking-rw:
+    - roles/serviceusage.serviceUsageConsumer
+  $iam_principals:service_accounts/iac-0/iac-networking-ro:
+    - roles/serviceusage.serviceUsageConsumer
+  $iam_principals:service_accounts/iac-0/iac-pf-rw:
+    - roles/serviceusage.serviceUsageConsumer
+  $iam_principals:service_accounts/iac-0/iac-pf-ro:
+    - roles/serviceusage.serviceUsageConsumer
+  $iam_principals:service_accounts/iac-0/iac-security-rw:
+    - roles/serviceusage.serviceUsageConsumer
+  $iam_principals:service_accounts/iac-0/iac-security-ro:
+    - roles/serviceusage.serviceUsageConsumer
 services:
   - accesscontextmanager.googleapis.com
   - bigquery.googleapis.com

--- a/fast/stages/0-org-setup/datasets/hardened/projects/core/iac-0.yaml
+++ b/fast/stages/0-org-setup/datasets/hardened/projects/core/iac-0.yaml
@@ -33,6 +33,18 @@ iam_by_principals:
     - roles/iam.workloadIdentityPoolAdmin
     - roles/owner
     - roles/storage.admin
+  $iam_principals:service_accounts/iac-0/iac-networking-rw:
+    - roles/serviceusage.serviceUsageConsumer
+  $iam_principals:service_accounts/iac-0/iac-networking-ro:
+    - roles/serviceusage.serviceUsageConsumer
+  $iam_principals:service_accounts/iac-0/iac-pf-rw:
+    - roles/serviceusage.serviceUsageConsumer
+  $iam_principals:service_accounts/iac-0/iac-pf-ro:
+    - roles/serviceusage.serviceUsageConsumer
+  $iam_principals:service_accounts/iac-0/iac-security-rw:
+    - roles/serviceusage.serviceUsageConsumer
+  $iam_principals:service_accounts/iac-0/iac-security-ro:
+    - roles/serviceusage.serviceUsageConsumer
 services:
   - accesscontextmanager.googleapis.com
   - bigquery.googleapis.com

--- a/tests/fast/stages/s0_org_setup/hardened.yaml
+++ b/tests/fast/stages/s0_org_setup/hardened.yaml
@@ -5784,7 +5784,7 @@ counts:
   google_organization_iam_binding: 37
   google_organization_iam_custom_role: 9
   google_project: 3
-  google_project_iam_binding: 16
+  google_project_iam_binding: 17
   google_project_iam_member: 15
   google_project_service: 34
   google_project_service_identity: 9
@@ -5804,5 +5804,5 @@ counts:
   google_tags_tag_value_iam_binding: 4
   local_file: 9
   modules: 48
-  resources: 473
+  resources: 474
   terraform_data: 3

--- a/tests/fast/stages/s0_org_setup/simple.yaml
+++ b/tests/fast/stages/s0_org_setup/simple.yaml
@@ -2820,7 +2820,7 @@ counts:
   google_organization_iam_custom_role: 9
   google_project: 3
   google_project_iam_audit_config: 2
-  google_project_iam_binding: 16
+  google_project_iam_binding: 17
   google_project_iam_member: 15
   google_project_service: 33
   google_project_service_identity: 9
@@ -2839,5 +2839,5 @@ counts:
   google_tags_tag_value_iam_binding: 4
   local_file: 9
   modules: 48
-  resources: 315
+  resources: 316
   terraform_data: 3


### PR DESCRIPTION
The old Service Usage dragon reared up its head again today when applying the security stage in a new org. This brings back (and extends) the Service Usage Consumer roles on the IaC project for the automation service accounts.