### PR TITLE
Fix factory budget check with threshold_rules[*].percent

### DIFF
--- a/modules/billing-account/factory.tf
+++ b/modules/billing-account/factory.tf
@@ -82,7 +82,7 @@ check "factory_budgets" {
   assert {
     condition = alltrue([
       for k, v in local.factory_budgets :
-      v.threshold_rules == null || try(v.threshold_rules.percent, null) != null
+      v.threshold_rules == null || try(v.threshold_rules[*].percent, null) != null
     ])
     error_message = "Threshold rules need percent set."
   }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here -->

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
