### PR TITLE
Add custom default routes and delete default route in FAST networking datasets

### DIFF
--- a/fast/stages/2-networking/datasets/hub-and-spokes-ncc/vpcs/dev/.config.yaml
+++ b/fast/stages/2-networking/datasets/hub-and-spokes-ncc/vpcs/dev/.config.yaml
@@ -6,7 +6,7 @@
 
 project_id: $project_ids:net-dev-0
 name: dev-0
-delete_default_routes_on_create: false
+delete_default_routes_on_create: true
 mtu: 1500
 nat_config:
   nat-primary:
@@ -14,3 +14,8 @@ nat_config:
 ncc_config:
   hub: $ncc_hubs:hub
   group: $ncc_groups:hub/default
+routes:
+  default:
+    dest_range: 0.0.0.0/0
+    next_hop_type: "gateway"
+    next_hop: "default-internet-gateway"

--- a/fast/stages/2-networking/datasets/hub-and-spokes-ncc/vpcs/hub/.config.yaml
+++ b/fast/stages/2-networking/datasets/hub-and-spokes-ncc/vpcs/hub/.config.yaml
@@ -6,15 +6,13 @@
 
 project_id: $project_ids:net-core-0
 name: hub-0
-delete_default_routes_on_create: false
+delete_default_routes_on_create: true
 routers:
   vpn-router:
     region: $locations:primary
     asn: 64514
 routes:
-  gateway:
-    # The configuration above is purely illustrative. Adjust as needed.
-    dest_range: "8.8.8.8/32"
-    priority: 100
+  default:
+    dest_range: 0.0.0.0/0
     next_hop_type: "gateway"
     next_hop: "default-internet-gateway"

--- a/fast/stages/2-networking/datasets/hub-and-spokes-ncc/vpcs/prod/.config.yaml
+++ b/fast/stages/2-networking/datasets/hub-and-spokes-ncc/vpcs/prod/.config.yaml
@@ -6,7 +6,7 @@
 
 project_id: $project_ids:net-prod-0
 name: prod-0
-delete_default_routes_on_create: false
+delete_default_routes_on_create: true
 mtu: 1500
 nat_config:
   nat-primary:
@@ -21,6 +21,11 @@ psa_configs:
     import_routes: true
     peered_domains:
       - "test."
+routes:
+  default:
+    dest_range: 0.0.0.0/0
+    next_hop_type: "gateway"
+    next_hop: "default-internet-gateway"
 subnets_proxy_only:
   - ip_cidr_range: 10.72.240.0/24
     region: $locations:primary

--- a/fast/stages/2-networking/datasets/hub-and-spokes-nva/vpcs/hub/.config.yaml
+++ b/fast/stages/2-networking/datasets/hub-and-spokes-nva/vpcs/hub/.config.yaml
@@ -6,10 +6,9 @@
 
 project_id: $project_ids:net-core-0
 name: hub-0
-delete_default_routes_on_create: false
+delete_default_routes_on_create: true
 routes:
-  gateway:
-    dest_range: "8.8.8.8/32"
-    priority: 100
+  default:
+    dest_range: 0.0.0.0/0
     next_hop_type: "gateway"
     next_hop: "default-internet-gateway"

--- a/fast/stages/2-networking/datasets/hub-and-spokes-peerings/vpcs/dev/.config.yaml
+++ b/fast/stages/2-networking/datasets/hub-and-spokes-peerings/vpcs/dev/.config.yaml
@@ -6,7 +6,7 @@
 
 project_id: $project_ids:net-dev-0
 name: dev-0
-delete_default_routes_on_create: false
+delete_default_routes_on_create: true
 mtu: 1500
 nat_config:
   nat-ew8:
@@ -14,3 +14,8 @@ nat_config:
 peering_config:
   to-hub:
     peer_network: $networks:hub
+routes:
+  default:
+    dest_range: 0.0.0.0/0
+    next_hop_type: "gateway"
+    next_hop: "default-internet-gateway"

--- a/fast/stages/2-networking/datasets/hub-and-spokes-peerings/vpcs/hub/.config.yaml
+++ b/fast/stages/2-networking/datasets/hub-and-spokes-peerings/vpcs/hub/.config.yaml
@@ -6,22 +6,21 @@
 
 project_id: $project_ids:net-core-0
 name: hub-0
-delete_default_routes_on_create: false
+delete_default_routes_on_create: true
 nat_config:
   nat-ew8:
     region: $locations:primary
-routers:
-  vpn-router:
-    region: $locations:primary
-    asn: 64514
-routes:
-  gateway:
-    dest_range: "8.8.8.8/32"
-    priority: 100
-    next_hop_type: "gateway"
-    next_hop: "default-internet-gateway"
 peering_config:
   to-prod:
     peer_network: $networks:prod
   to-dev:
     peer_network: $networks:dev
+routers:
+  vpn-router:
+    region: $locations:primary
+    asn: 64514
+routes:
+  default:
+    dest_range: 0.0.0.0/0
+    next_hop_type: "gateway"
+    next_hop: "default-internet-gateway"

--- a/fast/stages/2-networking/datasets/hub-and-spokes-peerings/vpcs/prod/.config.yaml
+++ b/fast/stages/2-networking/datasets/hub-and-spokes-peerings/vpcs/prod/.config.yaml
@@ -6,7 +6,7 @@
 
 project_id: $project_ids:net-prod-0
 name: prod-0
-delete_default_routes_on_create: false
+delete_default_routes_on_create: true
 mtu: 1500
 nat_config:
   nat-ew8:
@@ -21,6 +21,11 @@ psa_configs:
     import_routes: true
     peered_domains:
       - "test."
+routes:
+  default:
+    dest_range: 0.0.0.0/0
+    next_hop_type: "gateway"
+    next_hop: "default-internet-gateway"
 subnets_proxy_only:
   - ip_cidr_range: 10.72.240.0/24
     region: $locations:primary

--- a/fast/stages/2-networking/datasets/hub-and-spokes-vpns/vpcs/dev/.config.yaml
+++ b/fast/stages/2-networking/datasets/hub-and-spokes-vpns/vpcs/dev/.config.yaml
@@ -6,9 +6,14 @@
 
 project_id: $project_ids:net-dev-0
 name: dev-0
-delete_default_routes_on_create: false
+delete_default_routes_on_create: true
 mtu: 1500
 routers:
   vpn-router:
     region: $locations:primary
     asn: 64516
+routes:
+  default:
+    dest_range: 0.0.0.0/0
+    next_hop_type: "gateway"
+    next_hop: "default-internet-gateway"

--- a/fast/stages/2-networking/datasets/hub-and-spokes-vpns/vpcs/hub/.config.yaml
+++ b/fast/stages/2-networking/datasets/hub-and-spokes-vpns/vpcs/hub/.config.yaml
@@ -6,7 +6,7 @@
 
 project_id: $project_ids:net-core-0
 name: hub-0
-delete_default_routes_on_create: false
+delete_default_routes_on_create: true
 nat_config:
   nat-ew8:
     region: $locations:primary
@@ -20,8 +20,7 @@ routers:
         "172.16.0.0/12": "rfc1918-172"
         "192.168.0.0/16": "rfc1918-192"
 routes:
-  gateway:
-    dest_range: "8.8.8.8/32"
-    priority: 100
+  default:
+    dest_range: 0.0.0.0/0
     next_hop_type: "gateway"
     next_hop: "default-internet-gateway"

--- a/fast/stages/2-networking/datasets/hub-and-spokes-vpns/vpcs/prod/.config.yaml
+++ b/fast/stages/2-networking/datasets/hub-and-spokes-vpns/vpcs/prod/.config.yaml
@@ -6,9 +6,14 @@
 
 project_id: $project_ids:net-prod-0
 name: prod-0
-delete_default_routes_on_create: false
+delete_default_routes_on_create: true
 mtu: 1500
 routers:
   vpn-router:
     region: $locations:primary
     asn: 64515
+routes:
+  default:
+    dest_range: 0.0.0.0/0
+    next_hop_type: "gateway"
+    next_hop: "default-internet-gateway"

--- a/tests/fast/stages/s2_networking/ncc.yaml
+++ b/tests/fast/stages/s2_networking/ncc.yaml
@@ -1585,22 +1585,48 @@ values:
     input: null
     output: null
     triggers_replace: null
-  module.vpc_routes["hub"].google_compute_route.gateway["gateway"]:
+  module.vpc_routes["hub"].google_compute_route.gateway["default"]:
     description: Terraform-managed.
-    dest_range: 8.8.8.8/32
-    name: hub-0-gateway
+    dest_range: 0.0.0.0/0
+    name: hub-0-default
     network: hub-0
     next_hop_gateway: default-internet-gateway
     next_hop_ilb: null
     next_hop_instance: null
     next_hop_vpn_tunnel: null
-    priority: 100
+    priority: 1000
     project: fast-prod-net-core-0
+    tags: null
+    timeouts: null
+  module.vpc_routes["dev"].google_compute_route.gateway["default"]:
+    description: Terraform-managed.
+    dest_range: 0.0.0.0/0
+    name: dev-0-default
+    network: dev-0
+    next_hop_gateway: default-internet-gateway
+    next_hop_ilb: null
+    next_hop_instance: null
+    next_hop_vpn_tunnel: null
+    priority: 1000
+    project: fast-dev-net-spoke-0
+    tags: null
+    timeouts: null
+  module.vpc_routes["prod"].google_compute_route.gateway["default"]:
+    description: Terraform-managed.
+    dest_range: 0.0.0.0/0
+    name: prod-0-default
+    network: prod-0
+    next_hop_gateway: default-internet-gateway
+    next_hop_ilb: null
+    next_hop_instance: null
+    next_hop_vpn_tunnel: null
+    priority: 1000
+    project: fast-prod-net-spoke-0
     tags: null
     timeouts: null
   module.vpcs["dev"].google_compute_network.network[0]:
     auto_create_subnetworks: false
-    delete_default_routes_on_create: false
+    delete_default_routes_on_create: true
     description: Terraform managed
     enable_ula_internal_ipv6: null
     mtu: 1500
@@ -1666,7 +1692,7 @@ values:
     timeouts: null
   module.vpcs["hub"].google_compute_network.network[0]:
     auto_create_subnetworks: false
-    delete_default_routes_on_create: false
+    delete_default_routes_on_create: true
     description: Terraform managed
     enable_ula_internal_ipv6: null
     mtu: 1500
@@ -1747,7 +1773,7 @@ values:
     timeouts: null
   module.vpcs["prod"].google_compute_network.network[0]:
     auto_create_subnetworks: false
-    delete_default_routes_on_create: false
+    delete_default_routes_on_create: true
     description: Terraform managed
     enable_ula_internal_ipv6: null
     mtu: 1500
@@ -1995,7 +2021,7 @@ counts:
   google_compute_ha_vpn_gateway: 1
   google_compute_network: 3
   google_compute_network_peering_routes_config: 1
-  google_compute_route: 10
+  google_compute_route: 12
   google_compute_router: 3
   google_compute_router_interface: 2
   google_compute_router_nat: 2
@@ -2017,7 +2043,7 @@ counts:
   google_service_networking_connection: 1
   google_service_networking_peered_dns_domain: 1
   google_storage_bucket_object: 2
-  modules: 23
+  modules: 25
   random_id: 3
-  resources: 181
+  resources: 183
   terraform_data: 2

--- a/tests/fast/stages/s2_networking/simple.yaml
+++ b/tests/fast/stages/s2_networking/simple.yaml
@@ -1594,22 +1594,48 @@ values:
     input: null
     output: null
     triggers_replace: null
-  module.vpc_routes["hub"].google_compute_route.gateway["gateway"]:
+  module.vpc_routes["hub"].google_compute_route.gateway["default"]:
     description: Terraform-managed.
-    dest_range: 8.8.8.8/32
-    name: hub-0-gateway
+    dest_range: 0.0.0.0/0
+    name: hub-0-default
     network: hub-0
     next_hop_gateway: default-internet-gateway
     next_hop_ilb: null
     next_hop_instance: null
     next_hop_vpn_tunnel: null
-    priority: 100
+    priority: 1000
     project: fast-prod-net-core-0
+    tags: null
+    timeouts: null
+  module.vpc_routes["dev"].google_compute_route.gateway["default"]:
+    description: Terraform-managed.
+    dest_range: 0.0.0.0/0
+    name: dev-0-default
+    network: dev-0
+    next_hop_gateway: default-internet-gateway
+    next_hop_ilb: null
+    next_hop_instance: null
+    next_hop_vpn_tunnel: null
+    priority: 1000
+    project: fast-dev-net-spoke-0
+    tags: null
+    timeouts: null
+  module.vpc_routes["prod"].google_compute_route.gateway["default"]:
+    description: Terraform-managed.
+    dest_range: 0.0.0.0/0
+    name: prod-0-default
+    network: prod-0
+    next_hop_gateway: default-internet-gateway
+    next_hop_ilb: null
+    next_hop_instance: null
+    next_hop_vpn_tunnel: null
+    priority: 1000
+    project: fast-prod-net-spoke-0
     tags: null
     timeouts: null
   module.vpcs["dev"].google_compute_network.network[0]:
     auto_create_subnetworks: false
-    delete_default_routes_on_create: false
+    delete_default_routes_on_create: true
     description: Terraform managed
     enable_ula_internal_ipv6: null
     mtu: 1500
@@ -1675,7 +1701,7 @@ values:
     timeouts: null
   module.vpcs["hub"].google_compute_network.network[0]:
     auto_create_subnetworks: false
-    delete_default_routes_on_create: false
+    delete_default_routes_on_create: true
     description: Terraform managed
     enable_ula_internal_ipv6: null
     mtu: 1500
@@ -1756,7 +1782,7 @@ values:
     timeouts: null
   module.vpcs["prod"].google_compute_network.network[0]:
     auto_create_subnetworks: false
-    delete_default_routes_on_create: false
+    delete_default_routes_on_create: true
     description: Terraform managed
     enable_ula_internal_ipv6: null
     mtu: 1500
@@ -2005,7 +2031,7 @@ counts:
   google_compute_network: 3
   google_compute_network_peering: 4
   google_compute_network_peering_routes_config: 1
-  google_compute_route: 10
+  google_compute_route: 12
   google_compute_router: 4
   google_compute_router_interface: 2
   google_compute_router_nat: 3
@@ -2024,7 +2050,7 @@ counts:
   google_service_networking_connection: 1
   google_service_networking_peered_dns_domain: 1
   google_storage_bucket_object: 2
-  modules: 25
+  modules: 27
   random_id: 3
-  resources: 183
+  resources: 185
   terraform_data: 2

--- a/tests/fast/stages/s2_networking/vpns.yaml
+++ b/tests/fast/stages/s2_networking/vpns.yaml
@@ -1580,22 +1580,48 @@ values:
     input: null
     output: null
     triggers_replace: null
-  module.vpc_routes["hub"].google_compute_route.gateway["gateway"]:
+  module.vpc_routes["hub"].google_compute_route.gateway["default"]:
     description: Terraform-managed.
-    dest_range: 8.8.8.8/32
-    name: hub-0-gateway
+    dest_range: 0.0.0.0/0
+    name: hub-0-default
     network: hub-0
     next_hop_gateway: default-internet-gateway
     next_hop_ilb: null
     next_hop_instance: null
     next_hop_vpn_tunnel: null
-    priority: 100
+    priority: 1000
     project: fast-prod-net-core-0
+    tags: null
+    timeouts: null
+  module.vpc_routes["dev"].google_compute_route.gateway["default"]:
+    description: Terraform-managed.
+    dest_range: 0.0.0.0/0
+    name: dev-0-default
+    network: dev-0
+    next_hop_gateway: default-internet-gateway
+    next_hop_ilb: null
+    next_hop_instance: null
+    next_hop_vpn_tunnel: null
+    priority: 1000
+    project: fast-dev-net-spoke-0
+    tags: null
+    timeouts: null
+  module.vpc_routes["prod"].google_compute_route.gateway["default"]:
+    description: Terraform-managed.
+    dest_range: 0.0.0.0/0
+    name: prod-0-default
+    network: prod-0
+    next_hop_gateway: default-internet-gateway
+    next_hop_ilb: null
+    next_hop_instance: null
+    next_hop_vpn_tunnel: null
+    priority: 1000
+    project: fast-prod-net-spoke-0
     tags: null
     timeouts: null
   module.vpcs["dev"].google_compute_network.network[0]:
     auto_create_subnetworks: false
-    delete_default_routes_on_create: false
+    delete_default_routes_on_create: true
     description: Terraform managed
     enable_ula_internal_ipv6: null
     mtu: 1500
@@ -1661,7 +1687,7 @@ values:
     timeouts: null
   module.vpcs["hub"].google_compute_network.network[0]:
     auto_create_subnetworks: false
-    delete_default_routes_on_create: false
+    delete_default_routes_on_create: true
     description: Terraform managed
     enable_ula_internal_ipv6: null
     mtu: 1500
@@ -1727,7 +1753,7 @@ values:
     timeouts: null
   module.vpcs["prod"].google_compute_network.network[0]:
     auto_create_subnetworks: false
-    delete_default_routes_on_create: false
+    delete_default_routes_on_create: true
     description: Terraform managed
     enable_ula_internal_ipv6: null
     mtu: 1500
@@ -2425,7 +2451,7 @@ counts:
   google_compute_firewall_policy_rule: 5
   google_compute_ha_vpn_gateway: 5
   google_compute_network: 3
-  google_compute_route: 10
+  google_compute_route: 12
   google_compute_router: 4
   google_compute_router_interface: 10
   google_compute_router_nat: 1
@@ -2442,7 +2468,7 @@ counts:
   google_project_service: 27
   google_project_service_identity: 21
   google_storage_bucket_object: 2
-  modules: 27
+  modules: 29
   random_id: 15
-  resources: 212
+  resources: 214
   terraform_data: 2


### PR DESCRIPTION
This deletes the auto-generated default route in VPCs and adds a custom default route, so as to allow route manipulation of the default route after VPC creation.