### PR TITLE
Align locations in networking stage with other stages

### DIFF
--- a/fast/stages/2-networking/datasets/hub-and-spokes-ncc/defaults.yaml
+++ b/fast/stages/2-networking/datasets/hub-and-spokes-ncc/defaults.yaml
@@ -26,8 +26,8 @@ context:
       - 172.16.0.0/12
       - 192.168.0.0/16
   locations:
-    primary: europe-west8
-    secondary: europe-west12
+    primary: europe-west1
+    secondary: europe-west3
   iam_principals: {}
 projects:
   defaults:

--- a/fast/stages/2-networking/datasets/hub-and-spokes-nva/defaults.yaml
+++ b/fast/stages/2-networking/datasets/hub-and-spokes-nva/defaults.yaml
@@ -26,8 +26,8 @@ context:
       - 172.16.0.0/12
       - 192.168.0.0/16
   locations:
-    primary: europe-west8
-    secondary: europe-west12
+    primary: europe-west1
+    secondary: europe-west3
   iam_principals: {}
 projects:
   defaults:

--- a/fast/stages/2-networking/datasets/hub-and-spokes-nva/nvas/main.yaml
+++ b/fast/stages/2-networking/datasets/hub-and-spokes-nva/nvas/main.yaml
@@ -6,7 +6,7 @@
 
 project_id: $project_ids:net-core-0
 name: main
-region: europe-west8
+region: europe-west1
 
 auto_instance_config:
   image: projects/cos-cloud/global/images/family/cos-stable
@@ -16,7 +16,7 @@ auto_instance_config:
     - test
   nics:
     - network: $networks:dmz
-      subnet: $subnets:dmz/europe-west8/dmz-default
+      subnet: $subnets:dmz/europe-west1/dmz-default
       routes:
         - 10.74.0.0/16
       masquerade:
@@ -24,15 +24,15 @@ auto_instance_config:
         # default route via this NIC.
         true
     - network: $networks:hub
-      subnet: $subnets:hub/europe-west8/hub-default
+      subnet: $subnets:hub/europe-west1/hub-default
       routes:
         - 10.71.0.0/16
     - network: $networks:prod
-      subnet: $subnets:prod/europe-west8/prod-default
+      subnet: $subnets:prod/europe-west1/prod-default
       routes:
         - 10.72.0.0/16
     - network: $networks:dev
-      subnet: $subnets:dev/europe-west8/dev-default
+      subnet: $subnets:dev/europe-west1/dev-default
       routes:
         - 10.73.0.0/16
 
@@ -51,10 +51,10 @@ ilb_config:
       auto_create_instances: 2
   forwarding_rules:
     - network: $networks:dmz
-      subnet: $subnets:dmz/europe-west8/dmz-default
+      subnet: $subnets:dmz/europe-west1/dmz-default
     - network: $networks:hub
-      subnet: $subnets:hub/europe-west8/hub-default
+      subnet: $subnets:hub/europe-west1/hub-default
     - network: $networks:prod
-      subnet: $subnets:prod/europe-west8/prod-default
+      subnet: $subnets:prod/europe-west1/prod-default
     - network: $networks:dev
-      subnet: $subnets:dev/europe-west8/dev-default
+      subnet: $subnets:dev/europe-west1/dev-default

--- a/fast/stages/2-networking/datasets/hub-and-spokes-nva/vpcs/dmz/.config.yaml
+++ b/fast/stages/2-networking/datasets/hub-and-spokes-nva/vpcs/dmz/.config.yaml
@@ -19,7 +19,7 @@ routers:
         "192.168.0.0/16": "rfc1918-192"
 nat_config:
   nat-ew8:
-    region: europe-west8
+    region: europe-west1
 routes:
   rfc1918-10:
     dest_range: "10.0.0.0/8"

--- a/fast/stages/2-networking/datasets/hub-and-spokes-peerings/defaults.yaml
+++ b/fast/stages/2-networking/datasets/hub-and-spokes-peerings/defaults.yaml
@@ -26,8 +26,8 @@ context:
       - 172.16.0.0/12
       - 192.168.0.0/16
   locations:
-    primary: europe-west8
-    secondary: europe-west12
+    primary: europe-west1
+    secondary: europe-west3
   iam_principals: {}
 projects:
   defaults:

--- a/fast/stages/2-networking/datasets/hub-and-spokes-vpns/defaults.yaml
+++ b/fast/stages/2-networking/datasets/hub-and-spokes-vpns/defaults.yaml
@@ -26,8 +26,8 @@ context:
       - 172.16.0.0/12
       - 192.168.0.0/16
   locations:
-    primary: europe-west8
-    secondary: europe-west12
+    primary: europe-west1
+    secondary: europe-west3
   iam_principals: {}
 projects:
   defaults:

--- a/tests/fast/stages/s2_networking/ncc.yaml
+++ b/tests/fast/stages/s2_networking/ncc.yaml
@@ -22,7 +22,7 @@ values:
     name: hub-to-onprem
     network: hub-0
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     stack_type: IPV4_ONLY
     terraform_labels:
       goog-terraform-provisioned: "true"
@@ -39,7 +39,7 @@ values:
     md5_authentication_keys: []
     name: hub-vpn-router
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     timeouts: null
   google_network_connectivity_group.default["hub/default"]:
     auto_accept:
@@ -81,7 +81,7 @@ values:
     - include_import_ranges:
       - ALL_IPV4_RANGES
       site_to_site_data_transfer: true
-    location: europe-west8
+    location: europe-west1
     name: hub-to-onprem-hub
     project: fast-prod-net-core-0
     terraform_labels:
@@ -1132,7 +1132,7 @@ values:
     md5_authentication_keys: []
     name: dev-nat-primary-nat
     project: fast-dev-net-spoke-0
-    region: europe-west8
+    region: europe-west1
     timeouts: null
   module.nat["dev/nat-primary"].google_compute_router_nat.nat:
     enable_dynamic_port_allocation: false
@@ -1147,7 +1147,7 @@ values:
     nat64_subnetwork: []
     nat_ip_allocate_option: AUTO_ONLY
     project: fast-dev-net-spoke-0
-    region: europe-west8
+    region: europe-west1
     router: dev-nat-primary-nat
     rules: []
     source_subnetwork_ip_ranges_to_nat: ALL_SUBNETWORKS_ALL_IP_RANGES
@@ -1166,7 +1166,7 @@ values:
     md5_authentication_keys: []
     name: prod-nat-primary-nat
     project: fast-prod-net-spoke-0
-    region: europe-west8
+    region: europe-west1
     timeouts: null
   module.nat["prod/nat-primary"].google_compute_router_nat.nat:
     enable_dynamic_port_allocation: false
@@ -1181,7 +1181,7 @@ values:
     nat64_subnetwork: []
     nat_ip_allocate_option: AUTO_ONLY
     project: fast-prod-net-spoke-0
-    region: europe-west8
+    region: europe-west1
     router: prod-nat-primary-nat
     rules: []
     source_subnetwork_ip_ranges_to_nat: ALL_SUBNETWORKS_ALL_IP_RANGES
@@ -1675,7 +1675,7 @@ values:
     project: fast-dev-net-spoke-0
     tags: null
     timeouts: null
-  module.vpcs["dev"].google_compute_subnetwork.subnetwork["europe-west8/dev-default"]:
+  module.vpcs["dev"].google_compute_subnetwork.subnetwork["europe-west1/dev-default"]:
     description: Default primary-region subnet for dev
     ip_cidr_range: 10.73.0.0/24
     ip_collection: null
@@ -1685,7 +1685,7 @@ values:
     network: dev-0
     private_ip_google_access: true
     project: fast-dev-net-spoke-0
-    region: europe-west8
+    region: europe-west1
     reserved_internal_range: null
     role: null
     send_secondary_ip_range_if_empty: true
@@ -1741,7 +1741,7 @@ values:
     project: fast-prod-net-core-0
     tags: null
     timeouts: null
-  module.vpcs["hub"].google_compute_subnetwork.subnetwork["europe-west8/hub-default"]:
+  module.vpcs["hub"].google_compute_subnetwork.subnetwork["europe-west1/hub-default"]:
     description: Default primary-region subnet for hub
     ip_cidr_range: 10.71.0.0/24
     ip_collection: null
@@ -1751,7 +1751,7 @@ values:
     network: hub-0
     private_ip_google_access: true
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     reserved_internal_range: null
     role: null
     send_secondary_ip_range_if_empty: true
@@ -1828,7 +1828,7 @@ values:
     project: fast-prod-net-spoke-0
     tags: null
     timeouts: null
-  module.vpcs["prod"].google_compute_subnetwork.proxy_only["europe-west8/primary-region-proxy-only"]:
+  module.vpcs["prod"].google_compute_subnetwork.proxy_only["europe-west1/primary-region-proxy-only"]:
     description: Terraform-managed proxy-only subnet for Regional HTTPS, Internal
       HTTPS or Cross-Regional HTTPS Internal LB.
     ip_cidr_range: 10.72.240.0/24
@@ -1839,12 +1839,12 @@ values:
     network: prod-0
     project: fast-prod-net-spoke-0
     purpose: REGIONAL_MANAGED_PROXY
-    region: europe-west8
+    region: europe-west1
     reserved_internal_range: null
     role: ACTIVE
     send_secondary_ip_range_if_empty: null
     timeouts: null
-  module.vpcs["prod"].google_compute_subnetwork.subnetwork["europe-west8/prod-default"]:
+  module.vpcs["prod"].google_compute_subnetwork.subnetwork["europe-west1/prod-default"]:
     description: Default primary-region subnet for prod
     ip_cidr_range: 10.72.0.0/24
     ip_collection: null
@@ -1854,7 +1854,7 @@ values:
     network: prod-0
     private_ip_google_access: true
     project: fast-prod-net-spoke-0
-    region: europe-west8
+    region: europe-west1
     reserved_internal_range: null
     role: null
     send_secondary_ip_range_if_empty: true
@@ -1894,7 +1894,7 @@ values:
     name: hub-to-onprem-remote-0
     private_ip_address: null
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     router: hub-vpn-router
     subnetwork: null
     timeouts: null
@@ -1905,7 +1905,7 @@ values:
     name: hub-to-onprem-remote-1
     private_ip_address: null
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     router: hub-vpn-router
     subnetwork: null
     timeouts: null
@@ -1927,7 +1927,7 @@ values:
     peer_asn: 64513
     peer_ip_address: 169.254.128.1
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     router: hub-vpn-router
     router_appliance_instance: null
     timeouts: null
@@ -1950,7 +1950,7 @@ values:
     peer_asn: 64513
     peer_ip_address: 169.254.128.5
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     router: hub-vpn-router
     router_appliance_instance: null
     timeouts: null
@@ -1967,7 +1967,7 @@ values:
     peer_external_gateway_interface: 0
     peer_gcp_gateway: null
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     router: hub-vpn-router
     shared_secret: mySecret
     shared_secret_wo: null
@@ -1988,7 +1988,7 @@ values:
     peer_external_gateway_interface: 0
     peer_gcp_gateway: null
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     router: hub-vpn-router
     shared_secret: mySecret
     shared_secret_wo: null

--- a/tests/fast/stages/s2_networking/simple.yaml
+++ b/tests/fast/stages/s2_networking/simple.yaml
@@ -22,7 +22,7 @@ values:
     name: hub-to-onprem
     network: hub-0
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     stack_type: IPV4_ONLY
     terraform_labels:
       goog-terraform-provisioned: 'true'
@@ -75,7 +75,7 @@ values:
     md5_authentication_keys: []
     name: hub-vpn-router
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     timeouts: null
   google_storage_bucket_object.tfvars[0]:
     bucket: test
@@ -1107,7 +1107,7 @@ values:
     md5_authentication_keys: []
     name: dev-nat-ew8-nat
     project: fast-dev-net-spoke-0
-    region: europe-west8
+    region: europe-west1
     timeouts: null
   module.nat["dev/nat-ew8"].google_compute_router_nat.nat:
     enable_dynamic_port_allocation: false
@@ -1122,7 +1122,7 @@ values:
     nat64_subnetwork: []
     nat_ip_allocate_option: AUTO_ONLY
     project: fast-dev-net-spoke-0
-    region: europe-west8
+    region: europe-west1
     router: dev-nat-ew8-nat
     rules: []
     source_subnetwork_ip_ranges_to_nat: ALL_SUBNETWORKS_ALL_IP_RANGES
@@ -1141,7 +1141,7 @@ values:
     md5_authentication_keys: []
     name: hub-nat-ew8-nat
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     timeouts: null
   module.nat["hub/nat-ew8"].google_compute_router_nat.nat:
     enable_dynamic_port_allocation: false
@@ -1156,7 +1156,7 @@ values:
     nat64_subnetwork: []
     nat_ip_allocate_option: AUTO_ONLY
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     router: hub-nat-ew8-nat
     rules: []
     source_subnetwork_ip_ranges_to_nat: ALL_SUBNETWORKS_ALL_IP_RANGES
@@ -1175,7 +1175,7 @@ values:
     md5_authentication_keys: []
     name: prod-nat-ew8-nat
     project: fast-prod-net-spoke-0
-    region: europe-west8
+    region: europe-west1
     timeouts: null
   module.nat["prod/nat-ew8"].google_compute_router_nat.nat:
     enable_dynamic_port_allocation: false
@@ -1190,7 +1190,7 @@ values:
     nat64_subnetwork: []
     nat_ip_allocate_option: AUTO_ONLY
     project: fast-prod-net-spoke-0
-    region: europe-west8
+    region: europe-west1
     router: prod-nat-ew8-nat
     rules: []
     source_subnetwork_ip_ranges_to_nat: ALL_SUBNETWORKS_ALL_IP_RANGES
@@ -1684,7 +1684,7 @@ values:
     project: fast-dev-net-spoke-0
     tags: null
     timeouts: null
-  module.vpcs["dev"].google_compute_subnetwork.subnetwork["europe-west8/dev-default"]:
+  module.vpcs["dev"].google_compute_subnetwork.subnetwork["europe-west1/dev-default"]:
     description: Default primary-region subnet for dev
     ip_cidr_range: 10.73.0.0/24
     ip_collection: null
@@ -1694,7 +1694,7 @@ values:
     network: dev-0
     private_ip_google_access: true
     project: fast-dev-net-spoke-0
-    region: europe-west8
+    region: europe-west1
     reserved_internal_range: null
     role: null
     send_secondary_ip_range_if_empty: true
@@ -1750,7 +1750,7 @@ values:
     project: fast-prod-net-core-0
     tags: null
     timeouts: null
-  module.vpcs["hub"].google_compute_subnetwork.subnetwork["europe-west8/hub-default"]:
+  module.vpcs["hub"].google_compute_subnetwork.subnetwork["europe-west1/hub-default"]:
     description: Default primary-region subnet for hub
     ip_cidr_range: 10.71.0.0/24
     ip_collection: null
@@ -1760,7 +1760,7 @@ values:
     network: hub-0
     private_ip_google_access: true
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     reserved_internal_range: null
     role: null
     send_secondary_ip_range_if_empty: true
@@ -1837,7 +1837,7 @@ values:
     project: fast-prod-net-spoke-0
     tags: null
     timeouts: null
-  module.vpcs["prod"].google_compute_subnetwork.proxy_only["europe-west8/primary-region-proxy-only"]:
+  module.vpcs["prod"].google_compute_subnetwork.proxy_only["europe-west1/primary-region-proxy-only"]:
     description: Terraform-managed proxy-only subnet for Regional HTTPS, Internal
       HTTPS or Cross-Regional HTTPS Internal LB.
     ip_cidr_range: 10.72.240.0/24
@@ -1848,12 +1848,12 @@ values:
     network: prod-0
     project: fast-prod-net-spoke-0
     purpose: REGIONAL_MANAGED_PROXY
-    region: europe-west8
+    region: europe-west1
     reserved_internal_range: null
     role: ACTIVE
     send_secondary_ip_range_if_empty: null
     timeouts: null
-  module.vpcs["prod"].google_compute_subnetwork.subnetwork["europe-west8/prod-default"]:
+  module.vpcs["prod"].google_compute_subnetwork.subnetwork["europe-west1/prod-default"]:
     description: Default primary-region subnet for prod
     ip_cidr_range: 10.72.0.0/24
     ip_collection: null
@@ -1863,7 +1863,7 @@ values:
     network: prod-0
     private_ip_google_access: true
     project: fast-prod-net-spoke-0
-    region: europe-west8
+    region: europe-west1
     reserved_internal_range: null
     role: null
     send_secondary_ip_range_if_empty: true
@@ -1903,7 +1903,7 @@ values:
     name: hub-to-onprem-remote-0
     private_ip_address: null
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     router: hub-vpn-router
     subnetwork: null
     timeouts: null
@@ -1914,7 +1914,7 @@ values:
     name: hub-to-onprem-remote-1
     private_ip_address: null
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     router: hub-vpn-router
     subnetwork: null
     timeouts: null
@@ -1936,7 +1936,7 @@ values:
     peer_asn: 64513
     peer_ip_address: 169.254.128.1
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     router: hub-vpn-router
     router_appliance_instance: null
     timeouts: null
@@ -1959,7 +1959,7 @@ values:
     peer_asn: 64513
     peer_ip_address: 169.254.128.5
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     router: hub-vpn-router
     router_appliance_instance: null
     timeouts: null
@@ -1976,7 +1976,7 @@ values:
     peer_external_gateway_interface: 0
     peer_gcp_gateway: null
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     router: hub-vpn-router
     shared_secret: mySecret
     shared_secret_wo: null
@@ -1997,7 +1997,7 @@ values:
     peer_external_gateway_interface: 0
     peer_gcp_gateway: null
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     router: hub-vpn-router
     shared_secret: mySecret
     shared_secret_wo: null

--- a/tests/fast/stages/s2_networking/vpns.yaml
+++ b/tests/fast/stages/s2_networking/vpns.yaml
@@ -22,7 +22,7 @@ values:
     name: dev-to-hub
     network: dev-0
     project: fast-dev-net-spoke-0
-    region: europe-west8
+    region: europe-west1
     stack_type: IPV4_ONLY
     terraform_labels:
       goog-terraform-provisioned: 'true'
@@ -36,7 +36,7 @@ values:
     name: hub-to-dev
     network: hub-0
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     stack_type: IPV4_ONLY
     terraform_labels:
       goog-terraform-provisioned: 'true'
@@ -50,7 +50,7 @@ values:
     name: hub-to-onprem
     network: hub-0
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     stack_type: IPV4_ONLY
     terraform_labels:
       goog-terraform-provisioned: 'true'
@@ -64,7 +64,7 @@ values:
     name: hub-to-prod
     network: hub-0
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     stack_type: IPV4_ONLY
     terraform_labels:
       goog-terraform-provisioned: 'true'
@@ -78,7 +78,7 @@ values:
     name: prod-to-hub
     network: prod-0
     project: fast-prod-net-spoke-0
-    region: europe-west8
+    region: europe-west1
     stack_type: IPV4_ONLY
     terraform_labels:
       goog-terraform-provisioned: 'true'
@@ -95,7 +95,7 @@ values:
     md5_authentication_keys: []
     name: dev-vpn-router
     project: fast-dev-net-spoke-0
-    region: europe-west8
+    region: europe-west1
     timeouts: null
   google_compute_router.default["hub/vpn-router"]:
     bgp:
@@ -115,7 +115,7 @@ values:
     md5_authentication_keys: []
     name: hub-vpn-router
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     timeouts: null
   google_compute_router.default["prod/vpn-router"]:
     bgp:
@@ -129,7 +129,7 @@ values:
     md5_authentication_keys: []
     name: prod-vpn-router
     project: fast-prod-net-spoke-0
-    region: europe-west8
+    region: europe-west1
     timeouts: null
   google_storage_bucket_object.tfvars[0]:
     bucket: test
@@ -1161,7 +1161,7 @@ values:
     md5_authentication_keys: []
     name: hub-nat-ew8-nat
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     timeouts: null
   module.nat["hub/nat-ew8"].google_compute_router_nat.nat:
     enable_dynamic_port_allocation: false
@@ -1176,7 +1176,7 @@ values:
     nat64_subnetwork: []
     nat_ip_allocate_option: AUTO_ONLY
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     router: hub-nat-ew8-nat
     rules: []
     source_subnetwork_ip_ranges_to_nat: ALL_SUBNETWORKS_ALL_IP_RANGES
@@ -1670,7 +1670,7 @@ values:
     project: fast-dev-net-spoke-0
     tags: null
     timeouts: null
-  module.vpcs["dev"].google_compute_subnetwork.subnetwork["europe-west8/dev-default"]:
+  module.vpcs["dev"].google_compute_subnetwork.subnetwork["europe-west1/dev-default"]:
     description: Default primary-region subnet for dev
     ip_cidr_range: 10.73.0.0/24
     ip_collection: null
@@ -1680,7 +1680,7 @@ values:
     network: dev-0
     private_ip_google_access: true
     project: fast-dev-net-spoke-0
-    region: europe-west8
+    region: europe-west1
     reserved_internal_range: null
     role: null
     send_secondary_ip_range_if_empty: true
@@ -1736,7 +1736,7 @@ values:
     project: fast-prod-net-core-0
     tags: null
     timeouts: null
-  module.vpcs["hub"].google_compute_subnetwork.subnetwork["europe-west8/hub-default"]:
+  module.vpcs["hub"].google_compute_subnetwork.subnetwork["europe-west1/hub-default"]:
     description: Default primary-region subnet for hub
     ip_cidr_range: 10.71.0.0/24
     ip_collection: null
@@ -1746,7 +1746,7 @@ values:
     network: hub-0
     private_ip_google_access: true
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     reserved_internal_range: null
     role: null
     send_secondary_ip_range_if_empty: true
@@ -1802,7 +1802,7 @@ values:
     project: fast-prod-net-spoke-0
     tags: null
     timeouts: null
-  module.vpcs["prod"].google_compute_subnetwork.subnetwork["europe-west8/prod-default"]:
+  module.vpcs["prod"].google_compute_subnetwork.subnetwork["europe-west1/prod-default"]:
     description: Default primary-region subnet for prod
     ip_cidr_range: 10.72.0.0/24
     ip_collection: null
@@ -1812,7 +1812,7 @@ values:
     network: prod-0
     private_ip_google_access: true
     project: fast-prod-net-spoke-0
-    region: europe-west8
+    region: europe-west1
     reserved_internal_range: null
     role: null
     send_secondary_ip_range_if_empty: true
@@ -1823,7 +1823,7 @@ values:
     name: dev-to-hub-remote-0
     private_ip_address: null
     project: fast-dev-net-spoke-0
-    region: europe-west8
+    region: europe-west1
     router: dev-vpn-router
     subnetwork: null
     timeouts: null
@@ -1834,7 +1834,7 @@ values:
     name: dev-to-hub-remote-1
     private_ip_address: null
     project: fast-dev-net-spoke-0
-    region: europe-west8
+    region: europe-west1
     router: dev-vpn-router
     subnetwork: null
     timeouts: null
@@ -1856,7 +1856,7 @@ values:
     peer_asn: 64514
     peer_ip_address: 169.254.3.2
     project: fast-dev-net-spoke-0
-    region: europe-west8
+    region: europe-west1
     router: dev-vpn-router
     router_appliance_instance: null
     timeouts: null
@@ -1879,7 +1879,7 @@ values:
     peer_asn: 64514
     peer_ip_address: 169.254.3.6
     project: fast-dev-net-spoke-0
-    region: europe-west8
+    region: europe-west1
     router: dev-vpn-router
     router_appliance_instance: null
     timeouts: null
@@ -1896,7 +1896,7 @@ values:
     peer_external_gateway: null
     peer_external_gateway_interface: null
     project: fast-dev-net-spoke-0
-    region: europe-west8
+    region: europe-west1
     router: dev-vpn-router
     shared_secret: foobar
     shared_secret_wo: null
@@ -1917,7 +1917,7 @@ values:
     peer_external_gateway: null
     peer_external_gateway_interface: null
     project: fast-dev-net-spoke-0
-    region: europe-west8
+    region: europe-west1
     router: dev-vpn-router
     shared_secret: foobar
     shared_secret_wo: null
@@ -1945,7 +1945,7 @@ values:
     name: hub-to-dev-remote-0
     private_ip_address: null
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     router: hub-vpn-router
     subnetwork: null
     timeouts: null
@@ -1956,7 +1956,7 @@ values:
     name: hub-to-dev-remote-1
     private_ip_address: null
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     router: hub-vpn-router
     subnetwork: null
     timeouts: null
@@ -1978,7 +1978,7 @@ values:
     peer_asn: 64516
     peer_ip_address: 169.254.3.1
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     router: hub-vpn-router
     router_appliance_instance: null
     timeouts: null
@@ -2001,7 +2001,7 @@ values:
     peer_asn: 64516
     peer_ip_address: 169.254.3.5
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     router: hub-vpn-router
     router_appliance_instance: null
     timeouts: null
@@ -2018,7 +2018,7 @@ values:
     peer_external_gateway: null
     peer_external_gateway_interface: null
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     router: hub-vpn-router
     shared_secret: foobar
     shared_secret_wo: null
@@ -2039,7 +2039,7 @@ values:
     peer_external_gateway: null
     peer_external_gateway_interface: null
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     router: hub-vpn-router
     shared_secret: foobar
     shared_secret_wo: null
@@ -2082,7 +2082,7 @@ values:
     name: hub-to-onprem-remote-0
     private_ip_address: null
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     router: hub-vpn-router
     subnetwork: null
     timeouts: null
@@ -2093,7 +2093,7 @@ values:
     name: hub-to-onprem-remote-1
     private_ip_address: null
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     router: hub-vpn-router
     subnetwork: null
     timeouts: null
@@ -2115,7 +2115,7 @@ values:
     peer_asn: 64513
     peer_ip_address: 169.254.128.1
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     router: hub-vpn-router
     router_appliance_instance: null
     timeouts: null
@@ -2138,7 +2138,7 @@ values:
     peer_asn: 64513
     peer_ip_address: 169.254.128.5
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     router: hub-vpn-router
     router_appliance_instance: null
     timeouts: null
@@ -2155,7 +2155,7 @@ values:
     peer_external_gateway_interface: 0
     peer_gcp_gateway: null
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     router: hub-vpn-router
     shared_secret: mySecret
     shared_secret_wo: null
@@ -2176,7 +2176,7 @@ values:
     peer_external_gateway_interface: 0
     peer_gcp_gateway: null
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     router: hub-vpn-router
     shared_secret: mySecret
     shared_secret_wo: null
@@ -2204,7 +2204,7 @@ values:
     name: hub-to-prod-remote-0
     private_ip_address: null
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     router: hub-vpn-router
     subnetwork: null
     timeouts: null
@@ -2215,7 +2215,7 @@ values:
     name: hub-to-prod-remote-1
     private_ip_address: null
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     router: hub-vpn-router
     subnetwork: null
     timeouts: null
@@ -2237,7 +2237,7 @@ values:
     peer_asn: 64515
     peer_ip_address: 169.254.2.1
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     router: hub-vpn-router
     router_appliance_instance: null
     timeouts: null
@@ -2260,7 +2260,7 @@ values:
     peer_asn: 64515
     peer_ip_address: 169.254.2.5
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     router: hub-vpn-router
     router_appliance_instance: null
     timeouts: null
@@ -2277,7 +2277,7 @@ values:
     peer_external_gateway: null
     peer_external_gateway_interface: null
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     router: hub-vpn-router
     shared_secret: foobar
     shared_secret_wo: null
@@ -2298,7 +2298,7 @@ values:
     peer_external_gateway: null
     peer_external_gateway_interface: null
     project: fast-prod-net-core-0
-    region: europe-west8
+    region: europe-west1
     router: hub-vpn-router
     shared_secret: foobar
     shared_secret_wo: null
@@ -2326,7 +2326,7 @@ values:
     name: prod-to-hub-remote-0
     private_ip_address: null
     project: fast-prod-net-spoke-0
-    region: europe-west8
+    region: europe-west1
     router: prod-vpn-router
     subnetwork: null
     timeouts: null
@@ -2337,7 +2337,7 @@ values:
     name: prod-to-hub-remote-1
     private_ip_address: null
     project: fast-prod-net-spoke-0
-    region: europe-west8
+    region: europe-west1
     router: prod-vpn-router
     subnetwork: null
     timeouts: null
@@ -2359,7 +2359,7 @@ values:
     peer_asn: 64514
     peer_ip_address: 169.254.2.2
     project: fast-prod-net-spoke-0
-    region: europe-west8
+    region: europe-west1
     router: prod-vpn-router
     router_appliance_instance: null
     timeouts: null
@@ -2382,7 +2382,7 @@ values:
     peer_asn: 64514
     peer_ip_address: 169.254.2.6
     project: fast-prod-net-spoke-0
-    region: europe-west8
+    region: europe-west1
     router: prod-vpn-router
     router_appliance_instance: null
     timeouts: null
@@ -2399,7 +2399,7 @@ values:
     peer_external_gateway: null
     peer_external_gateway_interface: null
     project: fast-prod-net-spoke-0
-    region: europe-west8
+    region: europe-west1
     router: prod-vpn-router
     shared_secret: foobar
     shared_secret_wo: null
@@ -2420,7 +2420,7 @@ values:
     peer_external_gateway: null
     peer_external_gateway_interface: null
     project: fast-prod-net-spoke-0
-    region: europe-west8
+    region: europe-west1
     router: prod-vpn-router
     shared_secret: foobar
     shared_secret_wo: null


### PR DESCRIPTION
We got a drift between locations (primary and secondary used in various stages.
- 0-org-setup used europe-west1 and europe-west3
- 2-security used europe-west1 and europe-west3
- 2-project-factory: used europe-west1 and europe-west3

But networking was using europe-west8 and europe-west12

<img width="696" height="728" alt="image" src="https://github.com/user-attachments/assets/b0b4beed-6907-44f4-9f82-973f208f9630" />

I did this PR to align locations as it might create issues such as:
- using CMEK on key ring with one location, and using the key on a VM for subnet in other location (2-networking stage) ....

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass