### PR TITLE
fixed project-factory module to pass service account description

### DIFF
--- a/modules/project-factory/projects-service-accounts.tf
+++ b/modules/project-factory/projects-service-accounts.tf
@@ -20,6 +20,7 @@ locals {
       for name, opts in lookup(project, "service_accounts", {}) : {
         project_key = k
         name        = name
+        description = try(opts.description, null)
         display_name = coalesce(
           try(local.data_defaults.overrides.service_accounts.display_name, null),
           try(opts.display_name, null),
@@ -78,6 +79,7 @@ module "service-accounts" {
   }
   project_id   = module.projects[each.value.project_key].project_id
   name         = each.value.name
+  description  = each.value.description
   display_name = each.value.display_name
   context = merge(local.ctx, {
     project_ids = local.ctx_project_ids


### PR DESCRIPTION
<!-- Put a description of what this PR is for here -->

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [x] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
Added 2 lines to the module so description is now passed forward when creating a service account