### PR TITLE
Add audiences for cicd_workflows local in 0-org-setup

### DIFF
--- a/fast/stages/0-org-setup/cicd-workflows.tf
+++ b/fast/stages/0-org-setup/cicd-workflows.tf
@@ -81,6 +81,7 @@ locals {
             plan  = try(v.workload_identity.iam_principalsets.plan)
           }
         )
+        audiences = try(v.workload_identity.audiences, [])
       }
     }
   }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here -->
Add audiences for cicd_workflows local in 0-org-setup
---
Needed for gitlab, it fails otherwise:
```
│ Error: Error in function call
│ 
│   on cicd-workflows.tf line 89, in locals:
│   89:     for k, v in local.cicd_workflows : k => templatefile(
│   90:       "assets/workflow-${v.repository.type}.yaml", merge(v, {
│   91:         outputs_bucket             = local.of_outputs_bucket
│   92:         stage_name                 = k
│   93:         workload_identity_provider = v.workload_identity.provider
│   94:       })
│   95:     )
│     ├────────────────
│     │ local.of_outputs_bucket is "updt-prod-iac-core-0-iac-outputs"
│     │ v.repository.type is "gitlab"
│ 
│ Call to function "templatefile" failed: assets/workflow-gitlab.yaml:59,39-49: Unsupported attribute; This object does not have an attribute named
│ "audiences"., and 1 other diagnostic(s).
╵
```
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
