### PR TITLE
Fix project-factory stage version output file name

### DIFF
--- a/fast/stages/2-project-factory/outputs.tf
+++ b/fast/stages/2-project-factory/outputs.tf
@@ -22,6 +22,6 @@ output "projects" {
 resource "google_storage_bucket_object" "version" {
   count  = fileexists("fast_version.txt") ? 1 : 0
   bucket = var.automation.outputs_bucket
-  name   = "versions/2-${var.stage_name}-version.txt"
+  name   = "versions/${var.stage_name}-version.txt"
   source = "fast_version.txt"
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here -->
Fix project-factory stage version output file name
---
Fix project-factory stage version output file name to match with the one on other stages.

**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
