### PR TITLE
Reintroduce support for resource sets in VPC SC module additive perimeters

### DIFF
--- a/tests/modules/vpc_sc/context.yaml
+++ b/tests/modules/vpc_sc/context.yaml
@@ -105,13 +105,16 @@ values:
   google_access_context_manager_service_perimeter_resource.default["default/$project_numbers:test-1"]:
     resource: projects/222222
     timeouts: null
-  google_access_context_manager_service_perimeter_resource.default["default/$resource_sets:test"]:
-    resource: $resource_sets:test
+  google_access_context_manager_service_perimeter_resource.default["default/projects/321"]:
+    resource: projects/321
+    timeouts: null
+  google_access_context_manager_service_perimeter_resource.default["default/projects/654"]:
+    resource: projects/654
     timeouts: null
 
 counts:
   google_access_context_manager_access_level: 1
   google_access_context_manager_service_perimeter: 1
-  google_access_context_manager_service_perimeter_resource: 3
+  google_access_context_manager_service_perimeter_resource: 4
   modules: 0
-  resources: 5
+  resources: 6


### PR DESCRIPTION
This fixes an issue with #3628 where resource set context items were not properly expanded in additive perimeters.