### PR TITLE
Expose bigquery encryption in project schemas

### DIFF
--- a/fast/stages/0-org-setup/schemas/project.schema.json
+++ b/fast/stages/0-org-setup/schemas/project.schema.json
@@ -158,6 +158,9 @@
             },
             "location": {
               "type": "string"
+            },
+            "encryption_key": {
+              "type": "string"
             }
           }
         }
@@ -179,9 +182,6 @@
           "type": "string"
         },
         "observability": {
-          "type": "string"
-        },
-        "org_policies": {
           "type": "string"
         },
         "org_policies": {

--- a/fast/stages/0-org-setup/schemas/project.schema.md
+++ b/fast/stages/0-org-setup/schemas/project.schema.md
@@ -56,6 +56,7 @@
     <br>*additional properties: false*
     - **friendly_name**: *string*
     - **location**: *string*
+    - **encryption_key**: *string*
 - **deletion_policy**: *string*
   <br>*enum: ['PREVENT', 'DELETE', 'ABANDON']*
 - **factories_config**: *object*

--- a/fast/stages/2-networking/schemas/dns.schema.md
+++ b/fast/stages/2-networking/schemas/dns.schema.md
@@ -15,6 +15,7 @@
 - **private**: *reference([private_zone](#refs-private_zone))*
 - **peering**: *reference([peering_zone](#refs-peering_zone))*
 - **forwarding**: *reference([forwarding_zone](#refs-forwarding_zone))*
+- **public**: *reference([public_zone](#refs-public_zone))*
 
 ## Definitions
 
@@ -41,3 +42,19 @@
     - **`^.*$`**: *string*
   - ⁺**client_networks**: *array*
     - items: *string*
+- **public_zone**<a name="refs-public_zone"></a>: *object*
+  <br>*additional properties: false*
+  - **enable_logging**: *boolean*
+  - **dnssec_config**: *object*
+    <br>*additional properties: false*
+    - **state**: *string*
+    - **non_existence**: *string*
+      <br>*enum: ['nsec', 'nsec3']*
+    - **key_signing_key**: *object*
+      <br>*additional properties: false*
+      - **algorithm**: *string*
+      - **key_length**: *number*
+    - **zone_signing_key**: *object*
+      <br>*additional properties: false*
+      - **algorithm**: *string*
+      - **key_length**: *number*

--- a/fast/stages/2-networking/schemas/project.schema.json
+++ b/fast/stages/2-networking/schemas/project.schema.json
@@ -158,6 +158,9 @@
             },
             "location": {
               "type": "string"
+            },
+            "encryption_key": {
+              "type": "string"
             }
           }
         }
@@ -179,9 +182,6 @@
           "type": "string"
         },
         "observability": {
-          "type": "string"
-        },
-        "org_policies": {
           "type": "string"
         },
         "org_policies": {

--- a/fast/stages/2-networking/schemas/project.schema.md
+++ b/fast/stages/2-networking/schemas/project.schema.md
@@ -56,6 +56,7 @@
     <br>*additional properties: false*
     - **friendly_name**: *string*
     - **location**: *string*
+    - **encryption_key**: *string*
 - **deletion_policy**: *string*
   <br>*enum: ['PREVENT', 'DELETE', 'ABANDON']*
 - **factories_config**: *object*

--- a/fast/stages/2-project-factory/schemas/project.schema.json
+++ b/fast/stages/2-project-factory/schemas/project.schema.json
@@ -158,6 +158,9 @@
             },
             "location": {
               "type": "string"
+            },
+            "encryption_key": {
+              "type": "string"
             }
           }
         }
@@ -179,9 +182,6 @@
           "type": "string"
         },
         "observability": {
-          "type": "string"
-        },
-        "org_policies": {
           "type": "string"
         },
         "org_policies": {

--- a/fast/stages/2-project-factory/schemas/project.schema.md
+++ b/fast/stages/2-project-factory/schemas/project.schema.md
@@ -56,6 +56,7 @@
     <br>*additional properties: false*
     - **friendly_name**: *string*
     - **location**: *string*
+    - **encryption_key**: *string*
 - **deletion_policy**: *string*
   <br>*enum: ['PREVENT', 'DELETE', 'ABANDON']*
 - **factories_config**: *object*

--- a/fast/stages/2-security/schemas/project.schema.json
+++ b/fast/stages/2-security/schemas/project.schema.json
@@ -158,6 +158,9 @@
             },
             "location": {
               "type": "string"
+            },
+            "encryption_key": {
+              "type": "string"
             }
           }
         }
@@ -179,9 +182,6 @@
           "type": "string"
         },
         "observability": {
-          "type": "string"
-        },
-        "org_policies": {
           "type": "string"
         },
         "org_policies": {

--- a/fast/stages/2-security/schemas/project.schema.md
+++ b/fast/stages/2-security/schemas/project.schema.md
@@ -56,6 +56,7 @@
     <br>*additional properties: false*
     - **friendly_name**: *string*
     - **location**: *string*
+    - **encryption_key**: *string*
 - **deletion_policy**: *string*
   <br>*enum: ['PREVENT', 'DELETE', 'ABANDON']*
 - **factories_config**: *object*

--- a/modules/net-firewall-policy/schemas/firewall-policy-mirroring-rules.schema.md
+++ b/modules/net-firewall-policy/schemas/firewall-policy-mirroring-rules.schema.md
@@ -1,0 +1,36 @@
+# Firewall Policy Mirroring Rules
+
+<!-- markdownlint-disable MD036 -->
+
+## Properties
+
+*additional properties: false*
+
+- **`^[a-z0-9_-]+$`**: *reference([rule](#refs-rule))*
+
+## Definitions
+
+- **rule**<a name="refs-rule"></a>: *object*
+  <br>*additional properties: false*
+  - ⁺**priority**: *number*
+  - **action**: *string*
+    <br>*enum: ['mirror', 'do_not_mirror', 'goto_next']*
+  - **description**: *string*
+  - **disabled**: *boolean*
+  - **security_profile_group**: *string*
+  - **target_tags**: *array*
+    - items: *string*
+  - **tls_inspect**: *boolean*
+  - **match**: *object*
+    <br>*additional properties: false*
+    - **destination_ranges**: *array*
+      - items: *string*
+    - **source_ranges**: *array*
+      - items: *string*
+    - **source_tags**: *array*
+      - items: *string*
+    - **layer4_configs**: *array*
+      - items: *object*
+        <br>*additional properties: false*
+        - **protocol**: *string*
+        - **ports**: *array*

--- a/modules/project-factory/schemas/project.schema.json
+++ b/modules/project-factory/schemas/project.schema.json
@@ -158,6 +158,9 @@
             },
             "location": {
               "type": "string"
+            },
+            "encryption_key": {
+              "type": "string"
             }
           }
         }
@@ -179,9 +182,6 @@
           "type": "string"
         },
         "observability": {
-          "type": "string"
-        },
-        "org_policies": {
           "type": "string"
         },
         "org_policies": {

--- a/modules/project-factory/schemas/project.schema.md
+++ b/modules/project-factory/schemas/project.schema.md
@@ -56,6 +56,7 @@
     <br>*additional properties: false*
     - **friendly_name**: *string*
     - **location**: *string*
+    - **encryption_key**: *string*
 - **deletion_policy**: *string*
   <br>*enum: ['PREVENT', 'DELETE', 'ABANDON']*
 - **factories_config**: *object*


### PR DESCRIPTION
This also adds a missing md file for the new `firewall-policy-mirroring-rule` schema introduced in a previous commit.