### PR TITLE
Add access_mode support for regional disks in compute-vm module

### DIFF
--- a/modules/compute-vm/main.tf
+++ b/modules/compute-vm/main.tf
@@ -168,6 +168,9 @@ resource "google_compute_region_disk" "disks" {
   name          = "${var.name}-${each.key}"
   type          = each.value.options.type
   size          = each.value.size
+  access_mode            = each.value.options.access_mode
+  provisioned_iops       = each.value.options.provisioned_iops
+  provisioned_throughput = each.value.options.provisioned_throughput
   # image         = each.value.source_type == "image" ? each.value.source : null
   snapshot = each.value.source_type == "snapshot" ? each.value.source : null
   labels = merge(var.labels, {

--- a/modules/compute-vm/variables.tf
+++ b/modules/compute-vm/variables.tf
@@ -17,12 +17,14 @@
 variable "attached_disk_defaults" {
   description = "Defaults for attached disks options."
   type = object({
+    access_mode  = optional(string)
     auto_delete  = optional(bool, false)
     mode         = string
     replica_zone = string
     type         = string
   })
   default = {
+    access_mode  = null
     auto_delete  = true
     mode         = "READ_WRITE"
     replica_zone = null
@@ -46,6 +48,7 @@ variable "attached_disks" {
     source_type       = optional(string)
     options = optional(
       object({
+        access_mode            = optional(string)
         architecture           = optional(string)
         auto_delete            = optional(bool, false) # applies only to vm templates
         mode                   = optional(string, "READ_WRITE")
@@ -56,6 +59,7 @@ variable "attached_disks" {
         type                   = optional(string, "pd-balanced")
       }),
       {
+        access_mode  = null
         auto_delete  = true
         mode         = "READ_WRITE"
         replica_zone = null
@@ -86,6 +90,16 @@ variable "attached_disks" {
       (d.options.architecture == null || contains(["ARM64", "X86_64"], d.options.architecture))
     ])
     error_message = "Architecture can be null, 'X86_64' or 'ARM64'."
+  }
+  validation {
+    condition = alltrue([
+      for d in var.attached_disks :
+      d.options == null || d.options.access_mode == null || contains(
+        ["READ_WRITE_SINGLE", "READ_ONLY_MANY", "READ_WRITE_MANY"],
+        d.options.access_mode
+      )
+    ])
+    error_message = "access_mode must be null, 'READ_WRITE_SINGLE', 'READ_ONLY_MANY', or 'READ_WRITE_MANY'."
   }
 }
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here -->

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [ ] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [ ] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
