### PR TITLE
Add template revision to ignore_changes list

### DIFF
--- a/modules/cloud-run-v2/service-unmanaged.tf
+++ b/modules/cloud-run-v2/service-unmanaged.tf
@@ -266,6 +266,7 @@ resource "google_cloud_run_v2_service" "service_unmanaged" {
       build_config,
       client,
       client_version,
+      template[0].revision,
       template[0].annotations["run.googleapis.com/operation-id"],
       template[0].containers,
       template[0].labels


### PR DESCRIPTION
<!-- Put a description of what this PR is for here --> 

**Fix `ignore_changes` for unmanaged cloud run services**

When using the `cloud-run-v2` module I noticed that terraform will still track the deployed revision. If you deploy a new revision manually and then run `terraform apply` again, it will try to overwrite the revision.

Example:

```
# module.cloud-run.google_cloud_run_v2_service.service_unmanaged[0] will be updated in-place
  ~ resource "google_cloud_run_v2_service" "service_unmanaged" {
        id                      = "<redacted>"
        name                    = "<redacted>"
        # (32 unchanged attributes hidden)

      ~ template {
          - revision                         = "<redacted>-c45d65f-080706" -> null
            # (9 unchanged attributes hidden)

            # (2 unchanged blocks hidden)
        }

        # (2 unchanged blocks hidden)
    }
```

By adding the `template[0].revision` field to the `lifecycle` block this behaviour is fixed.

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [ ] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [ ] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass
