### PR TITLE
fix: extract and validate links within HTML blocks in Markdown files

### DIFF
--- a/tools/check_links.py
+++ b/tools/check_links.py
@@ -71,9 +71,9 @@ def check_docs(dir_name, external=False):
         links.append(check_link(el.dest, readme_path, external))
       elif isinstance(el, marko.block.HTMLBlock):
         pattern = r'(?:href|src)=([\'"])(.*?)\1'
-        extracted_links = [ match[1] for match in re.findall(pattern, el.body) ]
+        extracted_links = [match[1] for match in re.findall(pattern, el.body)]
         for link in extracted_links:
-            links.append(check_link(link, readme_path, external))
+          links.append(check_link(link, readme_path, external))
       elif hasattr(el, 'children'):
         elements.extend(el.children)
 


### PR DESCRIPTION
Hi team! I noticed that the `check_links.py` tool wasn't inspecting HTMLBlocks, but only Markdown links.

So, I updated the Markdown links checker to parse links in HTML blocks in addition to standard Markdown links.

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [ ] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
