### PR TITLE
Update README.md

### DIFF
--- a/fast/stages/0-org-setup/README.md
+++ b/fast/stages/0-org-setup/README.md
@@ -267,7 +267,7 @@ If local output files are available adjust the path, run the script, then copy/p
 ln -s /home/user/fast-configs/test-0/providers/0-org-setup-providers.tf ./
 
 # conventional location for this stage terraform.tfvars (manually managed)
-ln -s /home/user/fast-configs/test-0/0-org-setup.auto.tfvars ./
+ln -s /home/user/fast-configs/test-0/tfvars/0-org-setup.auto.tfvars ./
 ```
 
 If you did not configure local output files use the GCS bucket to fetch output files. The bucket name can be derived from the `tfvars.org_setup.automation.outputs_bucket` Terraform output. Adjust the path, run the script, then copy/paste the resulting commands.
@@ -280,7 +280,7 @@ If you did not configure local output files use the GCS bucket to fetch output f
 gcloud storage cp gs://test0-prod-iac-core-0-iac-outputs/providers/0-org-setup-providers.tf ./
 
 # conventional location for this stage terraform.tfvars (manually managed)
-gcloud storage cp gs://test0-prod-iac-core-0-iac-outputs/0-org-setup.auto.tfvars ./
+gcloud storage cp gs://test0-prod-iac-core-0-iac-outputs/tfvars/0-org-setup.auto.tfvars ./
 ```
 
 If you had previously configured a temporary project in `gcloud`, you should now set the `iac-0` project as default.


### PR DESCRIPTION
The path to the generated .tfvars file was wrong in the linking/copying commands

<!-- Put a description of what this PR is for here -->

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [ ] Ran `terraform fmt` on all modified files -> not necessary, only a README change
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools) -> not necessary, only a README change
- [ ] Made sure all relevant tests pass -> not necessary, only a README change