### PR TITLE
fix(logging): consolidate bucketWriter IAM conditions

### DIFF
--- a/modules/billing-account/logging.tf
+++ b/modules/billing-account/logging.tf
@@ -42,6 +42,31 @@ locals {
       }
     }
   )
+
+  logging_bucket_sinks_by_project = {
+    for project_id in distinct([
+      for name, sink in local.sink_bindings["logging"] : split("/", sink.destination)[1]
+    ]) :
+    project_id => sort([
+      for name, sink in local.sink_bindings["logging"] : name
+      if split("/", sink.destination)[1] == project_id
+    ])
+  }
+  # 13 destinations => 12 "||" operators (max allowed).
+  logging_bucket_sink_chunks_by_project = {
+    for project_id, names in local.logging_bucket_sinks_by_project :
+    project_id => chunklist(names, 13)
+  }
+  logging_bucket_sink_chunks = merge([
+    for project_id, chunks in local.logging_bucket_sink_chunks_by_project : {
+      for index, names in chunks :
+      "${project_id}-${index}" => {
+        project_id = project_id
+        index      = index + 1
+        sink_names = names
+      }
+    }
+  ]...)
 }
 
 resource "google_logging_billing_account_sink" "sink" {
@@ -96,15 +121,19 @@ resource "google_pubsub_topic_iam_member" "pubsub-sinks-binding" {
 }
 
 resource "google_project_iam_member" "bucket-sinks-binding" {
-  for_each = local.sink_bindings["logging"]
-  project  = split("/", each.value.destination)[1]
+  for_each = local.logging_bucket_sink_chunks
+  project  = each.value.project_id
   role     = "roles/logging.bucketWriter"
-  member   = google_logging_billing_account_sink.sink[each.key].writer_identity
+
+  member = google_logging_billing_account_sink.sink[each.value.sink_names[0]].writer_identity
 
   condition {
-    title       = "${each.key} bucket writer"
-    description = "Grants bucketWriter to ${google_logging_billing_account_sink.sink[each.key].writer_identity} used by log sink ${each.key} on billing account ${var.id}"
-    expression  = "resource.name.endsWith('${each.value.destination}')"
+    title       = "log_bucket_writer_${each.value.index}"
+    description = "Grants bucketWriter to ${google_logging_billing_account_sink.sink[each.value.sink_names[0]].writer_identity} for ${length(each.value.sink_names)} logging bucket(s) (chunk ${each.value.index}) on billing account ${var.id}."
+    expression = join(" || ", [
+      for name in each.value.sink_names :
+      "resource.name.endsWith('${local.sink_bindings["logging"][name].destination}')"
+    ])
   }
 }
 

--- a/modules/organization/logging.tf
+++ b/modules/organization/logging.tf
@@ -54,6 +54,31 @@ locals {
       name => sink if sink.iam && sink.type == type
     }
   }
+
+  logging_bucket_sinks_by_project = {
+    for project_id in distinct([
+      for name, sink in local.sink_bindings["logging"] : split("/", sink.destination)[1]
+    ]) :
+    project_id => sort([
+      for name, sink in local.sink_bindings["logging"] : name
+      if split("/", sink.destination)[1] == project_id
+    ])
+  }
+  # 13 destinations => 12 "||" operators (max allowed).
+  logging_bucket_sink_chunks_by_project = {
+    for project_id, names in local.logging_bucket_sinks_by_project :
+    project_id => chunklist(names, 13)
+  }
+  logging_bucket_sink_chunks = merge([
+    for project_id, chunks in local.logging_bucket_sink_chunks_by_project : {
+      for index, names in chunks :
+      "${project_id}-${index}" => {
+        project_id = project_id
+        index      = index + 1
+        sink_names = names
+      }
+    }
+  ]...)
 }
 
 resource "google_logging_organization_settings" "default" {
@@ -139,14 +164,21 @@ resource "google_pubsub_topic_iam_member" "pubsub-sinks-binding" {
 }
 
 resource "google_project_iam_member" "bucket-sinks-binding" {
-  for_each = local.sink_bindings["logging"]
-  project  = split("/", each.value.destination)[1]
+  for_each = local.logging_bucket_sink_chunks
+  project  = each.value.project_id
   role     = "roles/logging.bucketWriter"
-  member   = google_logging_organization_sink.sink[each.key].writer_identity
+
+  # Organization sinks typically share a single writer identity.
+  # We reference the first sink in the chunk to obtain the principal.
+  member = google_logging_organization_sink.sink[each.value.sink_names[0]].writer_identity
+
   condition {
-    title       = "${each.key} bucket writer"
-    description = "Grants bucketWriter to ${google_logging_organization_sink.sink[each.key].writer_identity} used by log sink ${each.key} on ${var.organization_id}"
-    expression  = "resource.name.endsWith('${each.value.destination}')"
+    title       = "log_bucket_writer_${each.value.index}"
+    description = "Grants bucketWriter to ${google_logging_organization_sink.sink[each.value.sink_names[0]].writer_identity} for ${length(each.value.sink_names)} logging bucket(s) (chunk ${each.value.index}) on ${var.organization_id}."
+    expression = join(" || ", [
+      for name in each.value.sink_names :
+      "resource.name.endsWith('${local.sink_bindings["logging"][name].destination}')"
+    ])
   }
 }
 

--- a/modules/project/logging.tf
+++ b/modules/project/logging.tf
@@ -55,6 +55,31 @@ locals {
     }
   }
 
+  logging_bucket_sinks_by_project = {
+    for project_id in distinct([
+      for name, sink in local.sink_bindings["logging"] : split("/", sink.destination)[1]
+    ]) :
+    project_id => sort([
+      for name, sink in local.sink_bindings["logging"] : name
+      if split("/", sink.destination)[1] == project_id
+    ])
+  }
+  # 13 destinations => 12 "||" operators (max allowed).
+  logging_bucket_sink_chunks_by_project = {
+    for project_id, names in local.logging_bucket_sinks_by_project :
+    project_id => chunklist(names, 13)
+  }
+  logging_bucket_sink_chunks = merge([
+    for project_id, chunks in local.logging_bucket_sink_chunks_by_project : {
+      for index, names in chunks :
+      "${project_id}-${index}" => {
+        project_id = project_id
+        index      = index + 1
+        sink_names = names
+      }
+    }
+  ]...)
+
   log_scopes = {
     for k, v in var.log_scopes :
     k => merge(v, {
@@ -141,15 +166,19 @@ resource "google_pubsub_topic_iam_member" "pubsub-sinks-binding" {
 }
 
 resource "google_project_iam_member" "bucket-sinks-binding" {
-  for_each = local.sink_bindings["logging"]
-  project  = split("/", each.value.destination)[1]
+  for_each = local.logging_bucket_sink_chunks
+  project  = each.value.project_id
   role     = "roles/logging.bucketWriter"
-  member   = google_logging_project_sink.sink[each.key].writer_identity
+
+  member = google_logging_project_sink.sink[each.value.sink_names[0]].writer_identity
 
   condition {
-    title       = "${each.key} bucket writer"
-    description = "Grants bucketWriter to ${google_logging_project_sink.sink[each.key].writer_identity} used by log sink ${each.key} on ${local.project.project_id}"
-    expression  = "resource.name.endsWith('${each.value.destination}')"
+    title       = "log_bucket_writer_${each.value.index}"
+    description = "Grants bucketWriter to ${google_logging_project_sink.sink[each.value.sink_names[0]].writer_identity} for ${length(each.value.sink_names)} logging bucket(s) (chunk ${each.value.index}) on ${local.project.project_id}."
+    expression = join(" || ", [
+      for name in each.value.sink_names :
+      "resource.name.endsWith('${local.sink_bindings["logging"][name].destination}')"
+    ])
   }
 }
 


### PR DESCRIPTION
## Summary
Consolidate per-sink `roles/logging.bucketWriter` IAM Conditions into a small number of chunked bindings per destination project.
## Problem
When many logging sinks of type `logging` target the same destination project, the sink writer identity can be shared and the module creates one conditional IAM binding per sink (e.g.):
- `resource.name.endsWith('<bucket>')`
This can exceed IAM quotas (for example, max 20 conditional bindings for the same role+principal) and cause apply failures.
## Approach
- Group logging sink destinations by destination project.
- Create chunked IAM members keyed by `<project>-<chunkIndex>`.
- Each condition expression ORs `resource.name.endsWith(...)` across up to 13 destinations per binding.
## Scope
Updated modules:
- `modules/organization/logging.tf`
- `modules/folder/logging.tf`
- `modules/project/logging.tf`
- `modules/billing-account/logging.tf`
## Notes
This preserves least-privilege scoping to specific bucket resources while reducing the total number of conditional bindings created.
