### PR TITLE
Fix project factory service agents outputs from iamEmail to iam_email

### DIFF
--- a/modules/project-factory/outputs.tf
+++ b/modules/project-factory/outputs.tf
@@ -165,8 +165,8 @@ output "service_agents" {
   value = {
     for k, v in local.projects_service_agents
     : trimprefix(k, "service_agents/") => {
-      email    = trimprefix(v, "serviceAccount:")
-      iamEmail = v
+      email     = trimprefix(v, "serviceAccount:")
+      iam_email = v
     }
   }
 }


### PR DESCRIPTION
Fixes service agents outputs from iamEmail to iam_email in the project factory module.

---
**Checklist**

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass