### PR TITLE
Added custom prefix support for automation SA

### DIFF
--- a/fast/stages/0-org-setup/schemas/project.schema.json
+++ b/fast/stages/0-org-setup/schemas/project.schema.json
@@ -114,6 +114,9 @@
                 "description": {
                   "type": "string"
                 },
+                "prefix": {
+                  "type": "string"
+                },
                 "iam": {
                   "$ref": "#/$defs/iam"
                 },

--- a/fast/stages/0-org-setup/schemas/project.schema.md
+++ b/fast/stages/0-org-setup/schemas/project.schema.md
@@ -38,6 +38,7 @@
     - **`^[a-z0-9-]+$`**: *object*
       <br>*additional properties: false*
       - **description**: *string*
+      - **prefix**: *string*
       - **iam**: *reference([iam](#refs-iam))*
       - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
       - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
@@ -79,6 +80,17 @@
     - **friendly_name**: *string*
     - **location**: *string*
     - **encryption_key**: *string*
+    - **iam**: *reference([iam](#refs-iam))*
+    - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
+    - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
+    - **iam_by_principals**: *reference([iam_by_principals](#refs-iam_by_principals))*
+    - **options**: *object*
+      <br>*additional properties: false*
+      - **default_table_expiration_ms**: *number*
+      - **default_partition_expiration_ms**: *number*
+      - **delete_contents_on_destroy**: *boolean*
+      - **max_time_travel_hours**: *number*
+    - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
 - **deletion_policy**: *string*
   <br>*enum: ['PREVENT', 'DELETE', 'ABANDON']*
 - **factories_config**: *object*
@@ -111,6 +123,7 @@
       - **iam**: *reference([iam](#refs-iam))*
       - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
       - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
+      - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
       - **keys**: *object*
         <br>*additional properties: false*
         - **`^[a-z][a-z0-9-]+[a-z0-9]$`**: *object*
@@ -131,7 +144,7 @@
 - **pam_entitlements**: *reference([pam_entitlements](#refs-pam_entitlements))*
 - **log_buckets**: *object*
   <br>*additional properties: false*
-  - **`^[a-z0-9-]+$`**: *reference([log_bucket](#refs-log_bucket))*
+  - **`^[a-zA-Z0-9_-]+$`**: *reference([log_bucket](#refs-log_bucket))*
 - **metric_scopes**: *array*
   - items: *string*
 - **name**: *string*
@@ -202,6 +215,7 @@
       - items: *string*
     - **iam_project_roles**: *reference([iam_project_roles](#refs-iam_project_roles))*
     - **iam_sa_roles**: *reference([iam_sa_roles](#refs-iam_sa_roles))*
+    - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
 - **service_encryption_key_ids**: *object*
   <br>*additional properties: false*
   - **`^[a-z-]+\.googleapis\.com$`**: *array*
@@ -231,11 +245,11 @@
   - **network_subnet_users**: *object*
     - **`^[a-z0-9_-]+$`**: *array*
       - items: *string*
+- **tags**: *object*
+  <br>*additional properties: object*
 - **tag_bindings**: *object*
   <br>*additional properties: false*
   - **`^[a-z0-9_-]+$`**: *string*
-- **tags**: *object*
-  <br>*additional properties: object*
 - **universe**: *object*
   <br>*additional properties: false*
   - **prefix**: *string*
@@ -331,6 +345,7 @@
     - **is_locked**: *boolean*
   - **soft_delete_retention**: *number*
   - **enable_object_retention**: *boolean*
+  - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
 - **buckets**<a name="refs-buckets"></a>: *object*
   <br>*additional properties: false*
   - **`^[a-z0-9-]+$`**: *reference([bucket](#refs-bucket))*
@@ -522,3 +537,6 @@
         <br>*additional properties: false*
         - **minimum_backoff**: *number*
         - **maximum_backoff**: *number*
+- **tag_bindings**<a name="refs-tag_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *string*

--- a/fast/stages/2-networking/schemas/project.schema.json
+++ b/fast/stages/2-networking/schemas/project.schema.json
@@ -114,6 +114,9 @@
                 "description": {
                   "type": "string"
                 },
+                "prefix": {
+                  "type": "string"
+                },
                 "iam": {
                   "$ref": "#/$defs/iam"
                 },

--- a/fast/stages/2-networking/schemas/project.schema.md
+++ b/fast/stages/2-networking/schemas/project.schema.md
@@ -38,6 +38,7 @@
     - **`^[a-z0-9-]+$`**: *object*
       <br>*additional properties: false*
       - **description**: *string*
+      - **prefix**: *string*
       - **iam**: *reference([iam](#refs-iam))*
       - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
       - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
@@ -79,6 +80,17 @@
     - **friendly_name**: *string*
     - **location**: *string*
     - **encryption_key**: *string*
+    - **iam**: *reference([iam](#refs-iam))*
+    - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
+    - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
+    - **iam_by_principals**: *reference([iam_by_principals](#refs-iam_by_principals))*
+    - **options**: *object*
+      <br>*additional properties: false*
+      - **default_table_expiration_ms**: *number*
+      - **default_partition_expiration_ms**: *number*
+      - **delete_contents_on_destroy**: *boolean*
+      - **max_time_travel_hours**: *number*
+    - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
 - **deletion_policy**: *string*
   <br>*enum: ['PREVENT', 'DELETE', 'ABANDON']*
 - **factories_config**: *object*
@@ -111,6 +123,7 @@
       - **iam**: *reference([iam](#refs-iam))*
       - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
       - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
+      - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
       - **keys**: *object*
         <br>*additional properties: false*
         - **`^[a-z][a-z0-9-]+[a-z0-9]$`**: *object*
@@ -131,7 +144,7 @@
 - **pam_entitlements**: *reference([pam_entitlements](#refs-pam_entitlements))*
 - **log_buckets**: *object*
   <br>*additional properties: false*
-  - **`^[a-z0-9-]+$`**: *reference([log_bucket](#refs-log_bucket))*
+  - **`^[a-zA-Z0-9_-]+$`**: *reference([log_bucket](#refs-log_bucket))*
 - **metric_scopes**: *array*
   - items: *string*
 - **name**: *string*
@@ -202,6 +215,7 @@
       - items: *string*
     - **iam_project_roles**: *reference([iam_project_roles](#refs-iam_project_roles))*
     - **iam_sa_roles**: *reference([iam_sa_roles](#refs-iam_sa_roles))*
+    - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
 - **service_encryption_key_ids**: *object*
   <br>*additional properties: false*
   - **`^[a-z-]+\.googleapis\.com$`**: *array*
@@ -231,11 +245,11 @@
   - **network_subnet_users**: *object*
     - **`^[a-z0-9_-]+$`**: *array*
       - items: *string*
+- **tags**: *object*
+  <br>*additional properties: object*
 - **tag_bindings**: *object*
   <br>*additional properties: false*
   - **`^[a-z0-9_-]+$`**: *string*
-- **tags**: *object*
-  <br>*additional properties: object*
 - **universe**: *object*
   <br>*additional properties: false*
   - **prefix**: *string*
@@ -331,6 +345,7 @@
     - **is_locked**: *boolean*
   - **soft_delete_retention**: *number*
   - **enable_object_retention**: *boolean*
+  - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
 - **buckets**<a name="refs-buckets"></a>: *object*
   <br>*additional properties: false*
   - **`^[a-z0-9-]+$`**: *reference([bucket](#refs-bucket))*
@@ -522,3 +537,6 @@
         <br>*additional properties: false*
         - **minimum_backoff**: *number*
         - **maximum_backoff**: *number*
+- **tag_bindings**<a name="refs-tag_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *string*

--- a/fast/stages/2-project-factory/schemas/project.schema.json
+++ b/fast/stages/2-project-factory/schemas/project.schema.json
@@ -114,6 +114,9 @@
                 "description": {
                   "type": "string"
                 },
+                "prefix": {
+                  "type": "string"
+                },
                 "iam": {
                   "$ref": "#/$defs/iam"
                 },

--- a/fast/stages/2-project-factory/schemas/project.schema.md
+++ b/fast/stages/2-project-factory/schemas/project.schema.md
@@ -38,6 +38,7 @@
     - **`^[a-z0-9-]+$`**: *object*
       <br>*additional properties: false*
       - **description**: *string*
+      - **prefix**: *string*
       - **iam**: *reference([iam](#refs-iam))*
       - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
       - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
@@ -79,6 +80,17 @@
     - **friendly_name**: *string*
     - **location**: *string*
     - **encryption_key**: *string*
+    - **iam**: *reference([iam](#refs-iam))*
+    - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
+    - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
+    - **iam_by_principals**: *reference([iam_by_principals](#refs-iam_by_principals))*
+    - **options**: *object*
+      <br>*additional properties: false*
+      - **default_table_expiration_ms**: *number*
+      - **default_partition_expiration_ms**: *number*
+      - **delete_contents_on_destroy**: *boolean*
+      - **max_time_travel_hours**: *number*
+    - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
 - **deletion_policy**: *string*
   <br>*enum: ['PREVENT', 'DELETE', 'ABANDON']*
 - **factories_config**: *object*
@@ -111,6 +123,7 @@
       - **iam**: *reference([iam](#refs-iam))*
       - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
       - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
+      - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
       - **keys**: *object*
         <br>*additional properties: false*
         - **`^[a-z][a-z0-9-]+[a-z0-9]$`**: *object*
@@ -131,7 +144,7 @@
 - **pam_entitlements**: *reference([pam_entitlements](#refs-pam_entitlements))*
 - **log_buckets**: *object*
   <br>*additional properties: false*
-  - **`^[a-z0-9-]+$`**: *reference([log_bucket](#refs-log_bucket))*
+  - **`^[a-zA-Z0-9_-]+$`**: *reference([log_bucket](#refs-log_bucket))*
 - **metric_scopes**: *array*
   - items: *string*
 - **name**: *string*
@@ -202,6 +215,7 @@
       - items: *string*
     - **iam_project_roles**: *reference([iam_project_roles](#refs-iam_project_roles))*
     - **iam_sa_roles**: *reference([iam_sa_roles](#refs-iam_sa_roles))*
+    - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
 - **service_encryption_key_ids**: *object*
   <br>*additional properties: false*
   - **`^[a-z-]+\.googleapis\.com$`**: *array*
@@ -231,11 +245,11 @@
   - **network_subnet_users**: *object*
     - **`^[a-z0-9_-]+$`**: *array*
       - items: *string*
+- **tags**: *object*
+  <br>*additional properties: object*
 - **tag_bindings**: *object*
   <br>*additional properties: false*
   - **`^[a-z0-9_-]+$`**: *string*
-- **tags**: *object*
-  <br>*additional properties: object*
 - **universe**: *object*
   <br>*additional properties: false*
   - **prefix**: *string*
@@ -331,6 +345,7 @@
     - **is_locked**: *boolean*
   - **soft_delete_retention**: *number*
   - **enable_object_retention**: *boolean*
+  - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
 - **buckets**<a name="refs-buckets"></a>: *object*
   <br>*additional properties: false*
   - **`^[a-z0-9-]+$`**: *reference([bucket](#refs-bucket))*
@@ -522,3 +537,6 @@
         <br>*additional properties: false*
         - **minimum_backoff**: *number*
         - **maximum_backoff**: *number*
+- **tag_bindings**<a name="refs-tag_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *string*

--- a/fast/stages/2-security/schemas/project.schema.json
+++ b/fast/stages/2-security/schemas/project.schema.json
@@ -114,6 +114,9 @@
                 "description": {
                   "type": "string"
                 },
+                "prefix": {
+                  "type": "string"
+                },
                 "iam": {
                   "$ref": "#/$defs/iam"
                 },

--- a/fast/stages/2-security/schemas/project.schema.md
+++ b/fast/stages/2-security/schemas/project.schema.md
@@ -38,6 +38,7 @@
     - **`^[a-z0-9-]+$`**: *object*
       <br>*additional properties: false*
       - **description**: *string*
+      - **prefix**: *string*
       - **iam**: *reference([iam](#refs-iam))*
       - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
       - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
@@ -79,6 +80,17 @@
     - **friendly_name**: *string*
     - **location**: *string*
     - **encryption_key**: *string*
+    - **iam**: *reference([iam](#refs-iam))*
+    - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
+    - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
+    - **iam_by_principals**: *reference([iam_by_principals](#refs-iam_by_principals))*
+    - **options**: *object*
+      <br>*additional properties: false*
+      - **default_table_expiration_ms**: *number*
+      - **default_partition_expiration_ms**: *number*
+      - **delete_contents_on_destroy**: *boolean*
+      - **max_time_travel_hours**: *number*
+    - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
 - **deletion_policy**: *string*
   <br>*enum: ['PREVENT', 'DELETE', 'ABANDON']*
 - **factories_config**: *object*
@@ -111,6 +123,7 @@
       - **iam**: *reference([iam](#refs-iam))*
       - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
       - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
+      - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
       - **keys**: *object*
         <br>*additional properties: false*
         - **`^[a-z][a-z0-9-]+[a-z0-9]$`**: *object*
@@ -131,7 +144,7 @@
 - **pam_entitlements**: *reference([pam_entitlements](#refs-pam_entitlements))*
 - **log_buckets**: *object*
   <br>*additional properties: false*
-  - **`^[a-z0-9-]+$`**: *reference([log_bucket](#refs-log_bucket))*
+  - **`^[a-zA-Z0-9_-]+$`**: *reference([log_bucket](#refs-log_bucket))*
 - **metric_scopes**: *array*
   - items: *string*
 - **name**: *string*
@@ -202,6 +215,7 @@
       - items: *string*
     - **iam_project_roles**: *reference([iam_project_roles](#refs-iam_project_roles))*
     - **iam_sa_roles**: *reference([iam_sa_roles](#refs-iam_sa_roles))*
+    - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
 - **service_encryption_key_ids**: *object*
   <br>*additional properties: false*
   - **`^[a-z-]+\.googleapis\.com$`**: *array*
@@ -231,11 +245,11 @@
   - **network_subnet_users**: *object*
     - **`^[a-z0-9_-]+$`**: *array*
       - items: *string*
+- **tags**: *object*
+  <br>*additional properties: object*
 - **tag_bindings**: *object*
   <br>*additional properties: false*
   - **`^[a-z0-9_-]+$`**: *string*
-- **tags**: *object*
-  <br>*additional properties: object*
 - **universe**: *object*
   <br>*additional properties: false*
   - **prefix**: *string*
@@ -331,6 +345,7 @@
     - **is_locked**: *boolean*
   - **soft_delete_retention**: *number*
   - **enable_object_retention**: *boolean*
+  - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
 - **buckets**<a name="refs-buckets"></a>: *object*
   <br>*additional properties: false*
   - **`^[a-z0-9-]+$`**: *reference([bucket](#refs-bucket))*
@@ -522,3 +537,6 @@
         <br>*additional properties: false*
         - **minimum_backoff**: *number*
         - **maximum_backoff**: *number*
+- **tag_bindings**<a name="refs-tag_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *string*

--- a/modules/project-factory/automation.tf
+++ b/modules/project-factory/automation.tf
@@ -60,7 +60,7 @@ locals {
         automation_project = v.project
         name               = sk
         parent             = k
-        parent_name        = v.parent_name
+        prefix             = try(sv.prefix, v.parent_name)
       })
     ] if v.service_accounts != null
   ]))
@@ -129,7 +129,7 @@ module "automation-service-accounts" {
   source      = "../iam-service-account"
   for_each    = local.automation_sas
   project_id  = each.value.automation_project
-  prefix      = each.value.parent_name
+  prefix      = each.value.prefix
   name        = each.value.name
   description = lookup(each.value, "description", null)
   display_name = lookup(

--- a/modules/project-factory/outputs.tf
+++ b/modules/project-factory/outputs.tf
@@ -19,7 +19,7 @@ locals {
     for k, v in local.automation_buckets : v.parent_name => k
   }
   _outputs_automation_sas = {
-    for k, v in local.automation_sas : v.parent_name => k...
+    for k, v in local.automation_sas : v.prefix => k...
   }
   outputs_projects = {
     for k, v in local.projects_input : k => {

--- a/modules/project-factory/schemas/project.schema.json
+++ b/modules/project-factory/schemas/project.schema.json
@@ -114,6 +114,9 @@
                 "description": {
                   "type": "string"
                 },
+                "prefix": {
+                  "type": "string"
+                },
                 "iam": {
                   "$ref": "#/$defs/iam"
                 },

--- a/modules/project-factory/schemas/project.schema.md
+++ b/modules/project-factory/schemas/project.schema.md
@@ -38,6 +38,7 @@
     - **`^[a-z0-9-]+$`**: *object*
       <br>*additional properties: false*
       - **description**: *string*
+      - **prefix**: *string*
       - **iam**: *reference([iam](#refs-iam))*
       - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
       - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
@@ -79,6 +80,17 @@
     - **friendly_name**: *string*
     - **location**: *string*
     - **encryption_key**: *string*
+    - **iam**: *reference([iam](#refs-iam))*
+    - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
+    - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
+    - **iam_by_principals**: *reference([iam_by_principals](#refs-iam_by_principals))*
+    - **options**: *object*
+      <br>*additional properties: false*
+      - **default_table_expiration_ms**: *number*
+      - **default_partition_expiration_ms**: *number*
+      - **delete_contents_on_destroy**: *boolean*
+      - **max_time_travel_hours**: *number*
+    - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
 - **deletion_policy**: *string*
   <br>*enum: ['PREVENT', 'DELETE', 'ABANDON']*
 - **factories_config**: *object*
@@ -111,6 +123,7 @@
       - **iam**: *reference([iam](#refs-iam))*
       - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
       - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
+      - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
       - **keys**: *object*
         <br>*additional properties: false*
         - **`^[a-z][a-z0-9-]+[a-z0-9]$`**: *object*
@@ -131,7 +144,7 @@
 - **pam_entitlements**: *reference([pam_entitlements](#refs-pam_entitlements))*
 - **log_buckets**: *object*
   <br>*additional properties: false*
-  - **`^[a-z0-9-]+$`**: *reference([log_bucket](#refs-log_bucket))*
+  - **`^[a-zA-Z0-9_-]+$`**: *reference([log_bucket](#refs-log_bucket))*
 - **metric_scopes**: *array*
   - items: *string*
 - **name**: *string*
@@ -202,6 +215,7 @@
       - items: *string*
     - **iam_project_roles**: *reference([iam_project_roles](#refs-iam_project_roles))*
     - **iam_sa_roles**: *reference([iam_sa_roles](#refs-iam_sa_roles))*
+    - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
 - **service_encryption_key_ids**: *object*
   <br>*additional properties: false*
   - **`^[a-z-]+\.googleapis\.com$`**: *array*
@@ -231,11 +245,11 @@
   - **network_subnet_users**: *object*
     - **`^[a-z0-9_-]+$`**: *array*
       - items: *string*
+- **tags**: *object*
+  <br>*additional properties: object*
 - **tag_bindings**: *object*
   <br>*additional properties: false*
   - **`^[a-z0-9_-]+$`**: *string*
-- **tags**: *object*
-  <br>*additional properties: object*
 - **universe**: *object*
   <br>*additional properties: false*
   - **prefix**: *string*
@@ -331,6 +345,7 @@
     - **is_locked**: *boolean*
   - **soft_delete_retention**: *number*
   - **enable_object_retention**: *boolean*
+  - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
 - **buckets**<a name="refs-buckets"></a>: *object*
   <br>*additional properties: false*
   - **`^[a-z0-9-]+$`**: *reference([bucket](#refs-bucket))*
@@ -522,3 +537,6 @@
         <br>*additional properties: false*
         - **minimum_backoff**: *number*
         - **maximum_backoff**: *number*
+- **tag_bindings**<a name="refs-tag_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *string*


### PR DESCRIPTION
<!-- Put a description of what this PR is for here -->
Add support for custom prefix to automation level service accounts.
---
This PR makes the service accounts created with automation in PF to be customizable, alongside of deriving it from the `parent_name`.
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
