### PR TITLE
Fixed psc connection id in net-address module output

### DIFF
--- a/modules/net-address/outputs.tf
+++ b/modules/net-address/outputs.tf
@@ -91,7 +91,7 @@ output "psc" {
         forwarding_rule = {
           id                = try(google_compute_forwarding_rule.psc_consumer[k].id, null)
           name              = try(google_compute_forwarding_rule.psc_consumer[k].name, null)
-          psc_connection_id = try(google_compute_global_forwarding_rule.psc_consumer[k].psc_connection_id, null)
+          psc_connection_id = try(google_compute_forwarding_rule.psc_consumer[k].psc_connection_id, null)
         }
       }
     }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here -->

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
