### PR TITLE
bugfix: Fix Apigee organization properties assignments

### DIFF
--- a/modules/apigee/main.tf
+++ b/modules/apigee/main.tf
@@ -38,8 +38,8 @@ resource "google_apigee_organization" "organization" {
       dynamic "property" {
         for_each = var.organization.properties
         content {
-          name  = properties.key
-          value = properties.value
+          name  = property.key
+          value = property.value
         }
       }
     }


### PR DESCRIPTION
Hi team, I noticed that the Apigee organization properties were not set properly.

I've fixed the dynamic block.

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
