### PR TITLE
reprovision IAM only on function replacement

### DIFF
--- a/modules/cloud-function-v1/main.tf
+++ b/modules/cloud-function-v1/main.tf
@@ -118,6 +118,6 @@ resource "google_cloudfunctions_function_iam_binding" "default" {
   role           = lookup(local.ctx.custom_roles, each.key, each.key)
   members        = [for member in each.value : lookup(local.ctx.iam_principals, member, member)]
   lifecycle {
-    replace_triggered_by = [google_cloudfunctions_function.function]
+    replace_triggered_by = [google_cloudfunctions_function.function.id]
   }
 }

--- a/modules/cloud-function-v2/main.tf
+++ b/modules/cloud-function-v2/main.tf
@@ -165,7 +165,7 @@ resource "google_cloudfunctions2_function_iam_binding" "binding" {
   role           = lookup(local.ctx.custom_roles, each.key, each.key)
   members        = [for member in each.value : lookup(local.ctx.iam_principals, member, member)]
   lifecycle {
-    replace_triggered_by = [google_cloudfunctions2_function.function]
+    replace_triggered_by = [google_cloudfunctions2_function.function.id]
   }
 }
 
@@ -189,7 +189,7 @@ resource "google_cloud_run_service_iam_binding" "invoker" {
   role     = "roles/run.invoker"
   members  = [for member in local.run_invoker_members : lookup(local.ctx.iam_principals, member, member)]
   lifecycle {
-    replace_triggered_by = [google_cloudfunctions2_function.function]
+    replace_triggered_by = [google_cloudfunctions2_function.function.id]
   }
 }
 
@@ -206,7 +206,7 @@ resource "google_cloud_run_service_iam_member" "invoker" {
   role     = "roles/run.invoker"
   member   = "serviceAccount:${local.trigger_sa_email}"
   lifecycle {
-    replace_triggered_by = [google_cloudfunctions2_function.function]
+    replace_triggered_by = [google_cloudfunctions2_function.function.id]
   }
 }
 


### PR DESCRIPTION
Currently, IAM is reprovisioned on any function change, which might be disruptive. 

Change this to only execute on function replacement, by triggering on `id` change (which changes to `known after apply` on replacement)

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [ ] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [ ] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
