### PR TITLE
Support project_id context for metric_scopes

### DIFF
--- a/modules/project-factory/projects.tf
+++ b/modules/project-factory/projects.tf
@@ -128,14 +128,11 @@ module "projects" {
   labels = merge(
     each.value.labels, var.data_merges.labels
   )
-  lien_reason        = try(each.value.lien_reason, null)
-  log_scopes         = try(each.value.log_scopes, null)
-  logging_exclusions = try(each.value.logging_exclusions, {})
-  logging_metrics    = try(each.value.logging_metrics, null)
-  logging_sinks      = try(each.value.logging_sinks, {})
-  metric_scopes = distinct(concat(
-    each.value.metric_scopes, var.data_merges.metric_scopes
-  ))
+  lien_reason           = try(each.value.lien_reason, null)
+  log_scopes            = try(each.value.log_scopes, null)
+  logging_exclusions    = try(each.value.logging_exclusions, {})
+  logging_metrics       = try(each.value.logging_metrics, null)
+  logging_sinks         = try(each.value.logging_sinks, {})
   notification_channels = try(each.value.notification_channels, null)
   org_policies          = each.value.org_policies
   quotas                = each.value.quotas
@@ -191,7 +188,10 @@ module "projects-iam" {
   iam_by_principals_conditional = lookup(each.value, "iam_by_principals_conditional", {})
   iam_by_principals_additive    = lookup(each.value, "iam_by_principals_additive", {})
   logging_data_access           = lookup(each.value, "logging_data_access", {})
-  pam_entitlements              = try(each.value.pam_entitlements, {})
+  metric_scopes = distinct(concat(
+    each.value.metric_scopes, var.data_merges.metric_scopes
+  ))
+  pam_entitlements = try(each.value.pam_entitlements, {})
   service_agents_config = {
     create_primary_agents = false
     grant_default_roles   = false

--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -197,7 +197,7 @@ resource "google_essential_contacts_contact" "contact" {
 resource "google_monitoring_monitored_project" "primary" {
   provider      = google-beta
   for_each      = toset(var.metric_scopes)
-  metrics_scope = each.value
+  metrics_scope = lookup(local.ctx.project_ids, each.value, each.value)
   name          = local.project.project_id
 }
 


### PR DESCRIPTION
This moves metrics scopes in project factory to the second project module call, and implements context substitution for metric scopes in the project module.

Test breakage will be checked here and assessed for actual feasibility.