### PR TITLE
[pubsub] updating .name to .id to fix IAM replacement

### DIFF
--- a/modules/pubsub/iam.tf
+++ b/modules/pubsub/iam.tf
@@ -65,7 +65,7 @@ locals {
 resource "google_pubsub_topic_iam_binding" "authoritative" {
   for_each = local.iam
   project  = local.project_id
-  topic    = google_pubsub_topic.default.name
+  topic    = google_pubsub_topic.default.id
   role     = lookup(local.ctx.custom_roles, each.key, each.key)
   members = [
     for v in each.value : lookup(local.ctx.iam_principals, v, v)
@@ -74,7 +74,7 @@ resource "google_pubsub_topic_iam_binding" "authoritative" {
 
 resource "google_pubsub_topic_iam_binding" "bindings" {
   for_each = var.iam_bindings
-  topic    = google_pubsub_topic.default.name
+  topic    = google_pubsub_topic.default.id
   role     = lookup(local.ctx.custom_roles, each.value.role, each.value.role)
   members = [
     for v in each.value.members : lookup(local.ctx.iam_principals, v, v)
@@ -91,7 +91,7 @@ resource "google_pubsub_topic_iam_binding" "bindings" {
 
 resource "google_pubsub_topic_iam_member" "bindings" {
   for_each = var.iam_bindings_additive
-  topic    = google_pubsub_topic.default.name
+  topic    = google_pubsub_topic.default.id
   role     = lookup(local.ctx.custom_roles, each.value.role, each.value.role)
   member = lookup(
     local.ctx.iam_principals, each.value.member, each.value.member
@@ -112,7 +112,7 @@ resource "google_pubsub_subscription_iam_binding" "authoritative" {
     "${binding.subscription}.${binding.role}" => binding
   }
   project      = local.project_id
-  subscription = google_pubsub_subscription.default[each.value.subscription].name
+  subscription = google_pubsub_subscription.default[each.value.subscription].id
   role         = lookup(local.ctx.custom_roles, each.value.role, each.value.role)
   members = [
     for v in each.value.members : lookup(local.ctx.iam_principals, v, v)
@@ -122,7 +122,7 @@ resource "google_pubsub_subscription_iam_binding" "authoritative" {
 resource "google_pubsub_subscription_iam_binding" "bindings" {
   for_each     = local.subscription_iam_bindings
   project      = local.project_id
-  subscription = google_pubsub_subscription.default[each.value.subscription].name
+  subscription = google_pubsub_subscription.default[each.value.subscription].id
   role         = lookup(local.ctx.custom_roles, each.value.role, each.value.role)
   members = [
     for v in each.value.members : lookup(local.ctx.iam_principals, v, v)
@@ -140,7 +140,7 @@ resource "google_pubsub_subscription_iam_binding" "bindings" {
 resource "google_pubsub_subscription_iam_member" "members" {
   for_each     = local.subscription_iam_bindings_additive
   project      = local.project_id
-  subscription = google_pubsub_subscription.default[each.value.subscription].name
+  subscription = google_pubsub_subscription.default[each.value.subscription].id
   role         = lookup(local.ctx.custom_roles, each.value.role, each.value.role)
   member = lookup(
     local.ctx.iam_principals, each.value.member, each.value.member

--- a/modules/pubsub/main.tf
+++ b/modules/pubsub/main.tf
@@ -65,7 +65,7 @@ resource "google_pubsub_subscription" "default" {
   for_each                     = var.subscriptions
   project                      = local.project_id
   name                         = each.key
-  topic                        = google_pubsub_topic.default.name
+  topic                        = google_pubsub_topic.default.id
   labels                       = coalesce(each.value.labels, var.labels)
   ack_deadline_seconds         = each.value.ack_deadline_seconds
   message_retention_duration   = each.value.message_retention_duration

--- a/tests/modules/cloud_function_v1/examples/pubsub-non-http-trigger.yaml
+++ b/tests/modules/cloud_function_v1/examples/pubsub-non-http-trigger.yaml
@@ -69,7 +69,6 @@ values:
     - serviceAccount:123-compute@developer.gserviceaccount.com
     project: project-id
     role: roles/pubsub.subscriber
-    topic: topic
 
 counts:
   archive_file: 1

--- a/tests/modules/cloud_function_v2/examples/pubsub-non-http-trigger.yaml
+++ b/tests/modules/cloud_function_v2/examples/pubsub-non-http-trigger.yaml
@@ -76,7 +76,6 @@ values:
     - serviceAccount:123-compute@developer.gserviceaccount.com
     project: project-id
     role: roles/pubsub.subscriber
-    topic: topic
 
 counts:
   archive_file: 1

--- a/tests/modules/project_factory/examples/example.yaml
+++ b/tests/modules/project_factory/examples/example.yaml
@@ -811,7 +811,6 @@ values:
     - group:team-a-admins@example.org
     project: test-pf-dev-ta-app0-be
     role: roles/pubsub.subscriber
-    topic: app-0-topic-a
   ? module.project-factory.module.pubsub["dev-ta-app0-be/app-0-topic-b"].google_pubsub_subscription.default["app-0-topic-b-sub"]
   : bigquery_config: []
     cloud_storage_config: []
@@ -833,7 +832,6 @@ values:
     terraform_labels:
       goog-terraform-provisioned: 'true'
     timeouts: null
-    topic: app-0-topic-b
   module.project-factory.module.pubsub["dev-ta-app0-be/app-0-topic-b"].google_pubsub_topic.default:
     effective_labels:
       goog-terraform-provisioned: 'true'

--- a/tests/modules/pubsub/context.yaml
+++ b/tests/modules/pubsub/context.yaml
@@ -37,7 +37,6 @@ values:
     - group:test-group@example.com
     project: foo-logging-0
     role: organizations/366118655033/roles/myRoleOne
-    topic: my-topic
 
 counts:
   google_pubsub_topic: 1

--- a/tests/modules/pubsub/examples/bigquery-subscription-with-service-account.yaml
+++ b/tests/modules/pubsub/examples/bigquery-subscription-with-service-account.yaml
@@ -39,7 +39,6 @@ values:
     push_config: []
     retain_acked_messages: false
     retry_policy: []
-    topic: my-topic
   module.pubsub.google_pubsub_topic.default:
     ingestion_data_source_settings: []
     kms_key_name: null

--- a/tests/modules/pubsub/examples/bigquery-subscription.yaml
+++ b/tests/modules/pubsub/examples/bigquery-subscription.yaml
@@ -21,7 +21,6 @@ values:
       write_metadata: false
     name: test-bigquery
     project: project-id
-    topic: my-topic
   module.pubsub.google_pubsub_topic.default:
     name: my-topic
     project: project-id

--- a/tests/modules/pubsub/examples/cloud-storage-subscription.yaml
+++ b/tests/modules/pubsub/examples/cloud-storage-subscription.yaml
@@ -35,7 +35,6 @@ values:
     retain_acked_messages: false
     retry_policy: []
     timeouts: null
-    topic: my-topic
   module.pubsub.google_pubsub_topic.default:
     kms_key_name: null
     labels: null

--- a/tests/modules/pubsub/examples/push-subscription.yaml
+++ b/tests/modules/pubsub/examples/push-subscription.yaml
@@ -33,7 +33,6 @@ values:
     retain_acked_messages: false
     retry_policy: []
     timeouts: null
-    topic: my-topic
   module.pubsub.google_pubsub_topic.default:
     kms_key_name: null
     labels: null

--- a/tests/modules/pubsub/examples/simple.yaml
+++ b/tests/modules/pubsub/examples/simple.yaml
@@ -26,14 +26,12 @@ values:
     - serviceAccount:sa1@sa.example
     project: project-id
     role: roles/pubsub.subscriber
-    topic: my-topic
   module.pubsub.google_pubsub_topic_iam_binding.authoritative["roles/pubsub.viewer"]:
     condition: []
     members:
     - group:organization-admins@example.org
     project: project-id
     role: roles/pubsub.viewer
-    topic: my-topic
 
 counts:
   google_pubsub_topic: 1

--- a/tests/modules/pubsub/examples/subscription-iam.yaml
+++ b/tests/modules/pubsub/examples/subscription-iam.yaml
@@ -29,14 +29,12 @@ values:
     retain_acked_messages: false
     retry_policy: []
     timeouts: null
-    topic: my-topic
   module.pubsub.google_pubsub_subscription_iam_binding.authoritative["test-1.roles/pubsub.subscriber"]:
     condition: []
     members:
     - serviceAccount:sa1@sa.example
     project: project-id
     role: roles/pubsub.subscriber
-    subscription: test-1
   module.pubsub.google_pubsub_topic.default:
     kms_key_name: null
     labels: null

--- a/tests/modules/pubsub/examples/subscriptions.yaml
+++ b/tests/modules/pubsub/examples/subscriptions.yaml
@@ -29,7 +29,6 @@ values:
     retain_acked_messages: false
     retry_policy: []
     timeouts: null
-    topic: my-topic
   module.pubsub.google_pubsub_subscription.default["test-pull-override"]:
     bigquery_config: []
     cloud_storage_config: []
@@ -50,7 +49,6 @@ values:
     terraform_labels:
       test: override
     timeouts: null
-    topic: my-topic
   module.pubsub.google_pubsub_topic.default:
     kms_key_name: null
     labels:


### PR DESCRIPTION
Fixes for pubsub topic and subscription IAM when subscription or topic is replaced (destroy and re-created) with same name.

See discussion in #3837 

Closes: #3861

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [ ] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [ ] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
