### PR TITLE
fix: mark VPN module secret outputs as sensitive

### DIFF
--- a/modules/net-vpn-dynamic/README.md
+++ b/modules/net-vpn-dynamic/README.md
@@ -144,11 +144,11 @@ module "vpn-dynamic" {
 | [gateway](outputs.tf#L22) | VPN gateway resource. |  |
 | [id](outputs.tf#L27) | Fully qualified VPN gateway id. |  |
 | [name](outputs.tf#L32) | VPN gateway name. |  |
-| [random_secret](outputs.tf#L37) | Generated secret. |  |
-| [router](outputs.tf#L43) | Router resource (only if auto-created). |  |
-| [router_name](outputs.tf#L48) | Router name. |  |
-| [self_link](outputs.tf#L53) | VPN gateway self link. |  |
-| [tunnel_names](outputs.tf#L58) | VPN tunnel names. |  |
-| [tunnel_self_links](outputs.tf#L66) | VPN tunnel self links. |  |
-| [tunnels](outputs.tf#L74) | VPN tunnel resources. |  |
+| [random_secret](outputs.tf#L37) | Generated secret. | ✓ |
+| [router](outputs.tf#L44) | Router resource (only if auto-created). |  |
+| [router_name](outputs.tf#L49) | Router name. |  |
+| [self_link](outputs.tf#L54) | VPN gateway self link. |  |
+| [tunnel_names](outputs.tf#L59) | VPN tunnel names. |  |
+| [tunnel_self_links](outputs.tf#L67) | VPN tunnel self links. |  |
+| [tunnels](outputs.tf#L75) | VPN tunnel resources. |  |
 <!-- END TFDOC -->

--- a/modules/net-vpn-dynamic/outputs.tf
+++ b/modules/net-vpn-dynamic/outputs.tf
@@ -37,6 +37,7 @@ output "name" {
 output "random_secret" {
   description = "Generated secret."
   value       = local.secret
+  sensitive   = true
 }
 
 

--- a/modules/net-vpn-ha/README.md
+++ b/modules/net-vpn-ha/README.md
@@ -333,14 +333,14 @@ You can optionally avoid to specify MD5 keys and the module will automatically g
 | [external_gateway](outputs.tf#L25) | External VPN gateway resource. |  |
 | [gateway](outputs.tf#L30) | VPN gateway resource (only if auto-created). |  |
 | [id](outputs.tf#L35) | Fully qualified VPN gateway id. |  |
-| [md5_keys](outputs.tf#L42) | BGP tunnels MD5 keys. |  |
-| [name](outputs.tf#L53) | VPN gateway name (only if auto-created). |  |
-| [random_secret](outputs.tf#L58) | Generated secret. |  |
-| [router](outputs.tf#L63) | Router resource (only if auto-created). |  |
-| [router_name](outputs.tf#L68) | Router name. |  |
-| [self_link](outputs.tf#L73) | HA VPN gateway self link. |  |
-| [shared_secrets](outputs.tf#L78) | IPSEC tunnels shared secrets. |  |
-| [tunnel_names](outputs.tf#L86) | VPN tunnel names. |  |
-| [tunnel_self_links](outputs.tf#L94) | VPN tunnel self links. |  |
-| [tunnels](outputs.tf#L102) | VPN tunnel resources. |  |
+| [md5_keys](outputs.tf#L42) | BGP tunnels MD5 keys. | ✓ |
+| [name](outputs.tf#L54) | VPN gateway name (only if auto-created). |  |
+| [random_secret](outputs.tf#L59) | Generated secret. | ✓ |
+| [router](outputs.tf#L65) | Router resource (only if auto-created). |  |
+| [router_name](outputs.tf#L70) | Router name. |  |
+| [self_link](outputs.tf#L75) | HA VPN gateway self link. |  |
+| [shared_secrets](outputs.tf#L80) | IPSEC tunnels shared secrets. | ✓ |
+| [tunnel_names](outputs.tf#L89) | VPN tunnel names. |  |
+| [tunnel_self_links](outputs.tf#L97) | VPN tunnel self links. |  |
+| [tunnels](outputs.tf#L105) | VPN tunnel resources. |  |
 <!-- END TFDOC -->

--- a/modules/net-vpn-ha/outputs.tf
+++ b/modules/net-vpn-ha/outputs.tf
@@ -41,6 +41,7 @@ output "id" {
 
 output "md5_keys" {
   description = "BGP tunnels MD5 keys."
+  sensitive   = true
   value = {
     for k, v in var.tunnels :
     k => try(v.bgp_peer.md5_authentication_key, null) == null ? {} : {
@@ -58,6 +59,7 @@ output "name" {
 output "random_secret" {
   description = "Generated secret."
   value       = local.secret
+  sensitive   = true
 }
 
 output "router" {
@@ -77,6 +79,7 @@ output "self_link" {
 
 output "shared_secrets" {
   description = "IPSEC tunnels shared secrets."
+  sensitive   = true
   value = {
     for k, v in var.tunnels
     : k => coalesce(v.shared_secret, local.secret)

--- a/modules/net-vpn-static/README.md
+++ b/modules/net-vpn-static/README.md
@@ -109,9 +109,9 @@ module "vpn" {
 | [gateway](outputs.tf#L22) | VPN gateway resource. |  |
 | [id](outputs.tf#L27) | Fully qualified VPN gateway id. |  |
 | [name](outputs.tf#L32) | VPN gateway name. |  |
-| [random_secret](outputs.tf#L37) | Generated secret. |  |
-| [self_link](outputs.tf#L42) | VPN gateway self link. |  |
-| [tunnel_names](outputs.tf#L47) | VPN tunnel names. |  |
-| [tunnel_self_links](outputs.tf#L55) | VPN tunnel self links. |  |
-| [tunnels](outputs.tf#L63) | VPN tunnel resources. |  |
+| [random_secret](outputs.tf#L37) | Generated secret. | ✓ |
+| [self_link](outputs.tf#L43) | VPN gateway self link. |  |
+| [tunnel_names](outputs.tf#L48) | VPN tunnel names. |  |
+| [tunnel_self_links](outputs.tf#L56) | VPN tunnel self links. |  |
+| [tunnels](outputs.tf#L64) | VPN tunnel resources. |  |
 <!-- END TFDOC -->

--- a/modules/net-vpn-static/outputs.tf
+++ b/modules/net-vpn-static/outputs.tf
@@ -37,6 +37,7 @@ output "name" {
 output "random_secret" {
   description = "Generated secret."
   value       = local.secret
+  sensitive   = true
 }
 
 output "self_link" {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here -->
Fixes #3863 
Marks secret VPN module ouputs as `sensitive` so they are redacted in normal Terraform CLI output and CI/CD logs. This PR updates the following modules:
- `modules/net-vpn-ha/outputs.tf` (`md5_keys`, `random_secret`, and `shared_secrets`)
- `modules/net-vpn-static/outputs.tf` (`random_secret`)
-  `modules/net-vpn-dynamic/outputs.tf` (`random_secret`)

I also regenerated the affected `README.md` files via `tools/tfdoc.py`.

Unfortunately, I was not able to run the tests locally, as they immediately started to fail. Let me know what you think. I am happy to make further improvements. :)

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
