### PR TITLE
ci: remove automated-review label after PR review workflow

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -95,3 +95,20 @@ jobs:
               repo: context.repo.repo,
               body: output
             })
+
+      - id: remove-label
+        name: Remove automated-review label
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'automated-review'
+              });
+            } catch (error) {
+              console.log('Error removing label', error);
+            }


### PR DESCRIPTION
This PR adds a step to the PR review workflow to unconditionally remove the `automated-review` label after the workflow runs. This prevents a potential security issue where a user could inject code into the PR while the label is still present.