### PR TITLE
Fix regression in compute-vm module

### DIFF
--- a/fast/project-templates/devops-azure-wif/project.yaml
+++ b/fast/project-templates/devops-azure-wif/project.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# yaml-language-server: $schema=https://cdn.jsdelivr.net/gh/GoogleCloudPlatform/cloud-foundation-fabric@fast-dev/modules/project-factory/schemas/project.schema.json
+# yaml-language-server: $schema=https://cdn.jsdelivr.net/gh/GoogleCloudPlatform/cloud-foundation-fabric@master/modules/project-factory/schemas/project.schema.json
 
 # TODO: set a parent folder if needed
 # parent: $folder_ids:shared

--- a/modules/compute-vm/variables.tf
+++ b/modules/compute-vm/variables.tf
@@ -285,7 +285,7 @@ variable "lifecycle_config" {
   type = object({
     allow_stopping_for_update  = optional(bool, true)
     deletion_protection        = optional(bool, false)
-    key_revocation_action_type = optional(string, "NONE")
+    key_revocation_action_type = optional(string)
     graceful_shutdown = optional(object({
       enabled           = optional(bool, false)
       max_duration_secs = optional(number)

--- a/tests/modules/compute_mig/examples/flexible.yaml
+++ b/tests/modules/compute_mig/examples/flexible.yaml
@@ -72,7 +72,7 @@ values:
     enable_display: null
     guest_accelerator: []
     instance_description: null
-    key_revocation_action_type: NONE
+    key_revocation_action_type: null
     labels: null
     machine_type: e2-micro
     metadata:

--- a/tests/modules/compute_vm/context-template-regional.yaml
+++ b/tests/modules/compute_vm/context-template-regional.yaml
@@ -66,7 +66,6 @@ values:
     enable_display: null
     guest_accelerator: []
     instance_description: null
-    key_revocation_action_type: NONE
     labels: null
     machine_type: e2-micro
     metadata: null

--- a/tests/modules/compute_vm/context-template.yaml
+++ b/tests/modules/compute_vm/context-template.yaml
@@ -66,7 +66,6 @@ values:
     enable_display: null
     guest_accelerator: []
     instance_description: null
-    key_revocation_action_type: NONE
     labels: null
     machine_type: e2-micro
     metadata: null

--- a/tests/modules/compute_vm/context-vm.yaml
+++ b/tests/modules/compute_vm/context-vm.yaml
@@ -88,7 +88,6 @@ values:
     enable_display: false
     hostname: null
     instance_encryption_key: []
-    key_revocation_action_type: NONE
     labels: null
     machine_type: e2-micro
     metadata: null

--- a/tests/modules/compute_vm/examples/disk-hyperdisk-arm.yaml
+++ b/tests/modules/compute_vm/examples/disk-hyperdisk-arm.yaml
@@ -130,7 +130,6 @@ values:
     enable_display: false
     hostname: null
     instance_encryption_key: []
-    key_revocation_action_type: NONE
     labels: null
     machine_type: c4a-standard-1
     metadata: null

--- a/tests/modules/compute_vm/examples/disk-hyperdisk-cust-performance.yaml
+++ b/tests/modules/compute_vm/examples/disk-hyperdisk-cust-performance.yaml
@@ -128,7 +128,6 @@ values:
     enable_display: false
     hostname: null
     instance_encryption_key: []
-    key_revocation_action_type: NONE
     labels: null
     machine_type: n4-standard-2
     metadata: null

--- a/tests/modules/compute_vm/examples/disk-hyperdisk-pool.yaml
+++ b/tests/modules/compute_vm/examples/disk-hyperdisk-pool.yaml
@@ -165,7 +165,6 @@ values:
     enable_display: false
     hostname: null
     instance_encryption_key: []
-    key_revocation_action_type: NONE
     labels: null
     machine_type: c4d-standard-2
     metadata: null

--- a/tests/modules/compute_vm/examples/disks-example-template.yaml
+++ b/tests/modules/compute_vm/examples/disks-example-template.yaml
@@ -52,7 +52,6 @@ values:
     enable_display: null
     guest_accelerator: []
     instance_description: null
-    key_revocation_action_type: NONE
     labels: null
     machine_type: e2-micro
     metadata: null

--- a/tests/modules/compute_vm/examples/snapshot-schedule-create.yaml
+++ b/tests/modules/compute_vm/examples/snapshot-schedule-create.yaml
@@ -55,7 +55,6 @@ values:
     enable_display: false
     hostname: null
     instance_encryption_key: []
-    key_revocation_action_type: NONE
     labels: null
     machine_type: e2-micro
     metadata: null

--- a/tests/modules/net_lb_app_ext/examples/http-https-redirect.yaml
+++ b/tests/modules/net_lb_app_ext/examples/http-https-redirect.yaml
@@ -57,7 +57,7 @@ values:
     enable_display: false
     hostname: null
     instance_encryption_key: []
-    key_revocation_action_type: NONE
+    key_revocation_action_type: null
     labels: null
     machine_type: e2-micro
     metadata: null
@@ -143,7 +143,7 @@ values:
     enable_display: false
     hostname: null
     instance_encryption_key: []
-    key_revocation_action_type: NONE
+    key_revocation_action_type: null
     labels: null
     machine_type: e2-micro
     metadata: null

--- a/tests/modules/net_lb_app_ext/examples/tls-settings.yaml
+++ b/tests/modules/net_lb_app_ext/examples/tls-settings.yaml
@@ -43,7 +43,7 @@ values:
     enable_display: false
     hostname: null
     instance_encryption_key: []
-    key_revocation_action_type: NONE
+    key_revocation_action_type: null
     labels: null
     machine_type: e2-micro
     metadata: null
@@ -130,7 +130,7 @@ values:
     enable_display: false
     hostname: null
     instance_encryption_key: []
-    key_revocation_action_type: NONE
+    key_revocation_action_type: null
     labels: null
     machine_type: e2-micro
     metadata: null

--- a/tests/modules/net_lb_app_ext_regional/examples/tls-settings.yaml
+++ b/tests/modules/net_lb_app_ext_regional/examples/tls-settings.yaml
@@ -43,7 +43,7 @@ values:
     enable_display: false
     hostname: null
     instance_encryption_key: []
-    key_revocation_action_type: NONE
+    key_revocation_action_type: null
     labels: null
     machine_type: e2-micro
     metadata: null
@@ -130,7 +130,7 @@ values:
     enable_display: false
     hostname: null
     instance_encryption_key: []
-    key_revocation_action_type: NONE
+    key_revocation_action_type: null
     labels: null
     machine_type: e2-micro
     metadata: null

--- a/tests/modules/net_vpn_dynamic/examples/vpn-single-tunnel-custom-ciphers.yaml
+++ b/tests/modules/net_vpn_dynamic/examples/vpn-single-tunnel-custom-ciphers.yaml
@@ -43,7 +43,7 @@ values:
     enable_display: false
     hostname: null
     instance_encryption_key: []
-    key_revocation_action_type: NONE
+    key_revocation_action_type: null
     labels: null
     machine_type: e2-micro
     metadata: null

--- a/tests/modules/net_vpn_dynamic/examples/vpn-single-tunnel.yaml
+++ b/tests/modules/net_vpn_dynamic/examples/vpn-single-tunnel.yaml
@@ -43,7 +43,7 @@ values:
     enable_display: false
     hostname: null
     instance_encryption_key: []
-    key_revocation_action_type: NONE
+    key_revocation_action_type: null
     labels: null
     machine_type: e2-micro
     metadata: null

--- a/tools/update_schema_links.py
+++ b/tools/update_schema_links.py
@@ -39,7 +39,7 @@ def get_yaml_files(folder):
 @click.argument('folder', type=click.Path(exists=True, file_okay=False))
 @click.option(
     '--format', default=
-    'https://cdn.jsdelivr.net/gh/GoogleCloudPlatform/cloud-foundation-fabric@fast-dev/fast/stages/{parent}/schemas/',
+    'https://cdn.jsdelivr.net/gh/GoogleCloudPlatform/cloud-foundation-fabric@master/fast/stages/{parent}/schemas/',
     help='Format string for the new schema path. Use {parent} placeholder. '
     'Example: https://example.com/{parent}/schemas')
 @click.option('--dry-run', is_flag=True, default=False,


### PR DESCRIPTION
Reinstates a `null` default for `key_revocation_action_type` to avoid recreation. Also fixes a couple stray links to the now deleted `fast-dev` branch.