### PR TITLE
Add Agent Engine identity type

### DIFF
--- a/modules/agent-engine/README.md
+++ b/modules/agent-engine/README.md
@@ -172,6 +172,7 @@ module "agent_engine" {
 
   agent_engine_config = {
     agent_framework = "google-adk"
+    identity_type   = "SERVICE_ACCOUNT"
   }
 
   deployment_config = {
@@ -194,6 +195,7 @@ module "agent_engine" {
 
   agent_engine_config = {
     agent_framework = "google-adk"
+    identity_type   = "SERVICE_ACCOUNT"
   }
 
   deployment_config = {

--- a/modules/agent-engine/README.md
+++ b/modules/agent-engine/README.md
@@ -445,19 +445,19 @@ module "agent_engine" {
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [name](variables.tf#L178) | The name of the agent. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L197) | The id of the project where to deploy the agent. | <code>string</code> | ✓ |  |
-| [region](variables.tf#L203) | The region where to deploy the agent. | <code>string</code> | ✓ |  |
+| [name](variables.tf#L187) | The name of the agent. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L206) | The id of the project where to deploy the agent. | <code>string</code> | ✓ |  |
+| [region](variables.tf#L212) | The region where to deploy the agent. | <code>string</code> | ✓ |  |
 | [agent_engine_config](variables.tf#L17) | The agent configuration. Supported values for agent_framework: 'google-adk', 'langchain', 'langgraph', 'ag2', 'llama-index', 'custom'. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [bucket_config](variables.tf#L41) | The GCS bucket configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [context](variables.tf#L52) | Context-specific interpolations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [deployment_config](variables.tf#L68) | The deployment configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [description](variables.tf#L128) | The Agent Engine description. | <code>string</code> |  | <code>&#34;Terraform managed.&#34;</code> |
-| [enable_deletion_protection](variables.tf#L135) | Whether deletion protection should be enabled. | <code>bool</code> |  | <code>true</code> |
-| [encryption_key](variables.tf#L142) | The full resource name of the Cloud KMS CryptoKey. | <code>string</code> |  | <code>null</code> |
-| [managed](variables.tf#L148) | Whether the Terraform module should control the code updates. | <code>bool</code> |  | <code>true</code> |
-| [memory_bank_config](variables.tf#L155) | Configuration for the memory bank. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [networking_config](variables.tf#L184) | Networking configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [bucket_config](variables.tf#L50) | The GCS bucket configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [context](variables.tf#L61) | Context-specific interpolations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [deployment_config](variables.tf#L77) | The deployment configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [description](variables.tf#L137) | The Agent Engine description. | <code>string</code> |  | <code>&#34;Terraform managed.&#34;</code> |
+| [enable_deletion_protection](variables.tf#L144) | Whether deletion protection should be enabled. | <code>bool</code> |  | <code>true</code> |
+| [encryption_key](variables.tf#L151) | The full resource name of the Cloud KMS CryptoKey. | <code>string</code> |  | <code>null</code> |
+| [managed](variables.tf#L157) | Whether the Terraform module should control the code updates. | <code>bool</code> |  | <code>true</code> |
+| [memory_bank_config](variables.tf#L164) | Configuration for the memory bank. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [networking_config](variables.tf#L193) | Networking configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
 | [service_account_config](variables-serviceaccount.tf#L18) | Service account configurations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 
 ## Outputs

--- a/modules/agent-engine/README.md
+++ b/modules/agent-engine/README.md
@@ -391,17 +391,17 @@ The module allows you to dynamically reference context values for resources crea
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
 | [agent_engine_config](variables.tf#L17) | The agent configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
-| [name](variables.tf#L146) | The name of the agent. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L165) | The id of the project where to deploy the agent. | <code>string</code> | ✓ |  |
-| [region](variables.tf#L171) | The region where to deploy the agent. | <code>string</code> | ✓ |  |
-| [bucket_config](variables.tf#L40) | The GCS bucket configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [context](variables.tf#L52) | Context-specific interpolations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [deployment_files](variables.tf#L66) | The to source files path and names. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#8230;&#125;</code> |
-| [description](variables.tf#L103) | The Agent Engine description. | <code>string</code> |  | <code>&#34;Terraform managed.&#34;</code> |
-| [encryption_key](variables.tf#L110) | The full resource name of the Cloud KMS CryptoKey. | <code>string</code> |  | <code>null</code> |
-| [managed](variables.tf#L116) | Whether the Terraform module should control the code updates. | <code>bool</code> |  | <code>true</code> |
-| [memory_bank_config](variables.tf#L123) | Configuration for the memory bank. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [networking_config](variables.tf#L152) | Networking configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [name](variables.tf#L155) | The name of the agent. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L174) | The id of the project where to deploy the agent. | <code>string</code> | ✓ |  |
+| [region](variables.tf#L180) | The region where to deploy the agent. | <code>string</code> | ✓ |  |
+| [bucket_config](variables.tf#L49) | The GCS bucket configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [context](variables.tf#L61) | Context-specific interpolations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [deployment_files](variables.tf#L75) | The to source files path and names. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#8230;&#125;</code> |
+| [description](variables.tf#L112) | The Agent Engine description. | <code>string</code> |  | <code>&#34;Terraform managed.&#34;</code> |
+| [encryption_key](variables.tf#L119) | The full resource name of the Cloud KMS CryptoKey. | <code>string</code> |  | <code>null</code> |
+| [managed](variables.tf#L125) | Whether the Terraform module should control the code updates. | <code>bool</code> |  | <code>true</code> |
+| [memory_bank_config](variables.tf#L132) | Configuration for the memory bank. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [networking_config](variables.tf#L161) | Networking configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
 | [service_account_config](variables-serviceaccount.tf#L18) | Service account configurations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 
 ## Outputs

--- a/modules/agent-engine/README.md
+++ b/modules/agent-engine/README.md
@@ -191,6 +191,7 @@ module "agent_engine" {
 
   agent_engine_config = {
     agent_framework = "google-adk"
+    identity_type   = "SERVICE_ACCOUNT"
   }
 
   service_account_config = {
@@ -217,6 +218,7 @@ module "agent_engine" {
 
   agent_engine_config = {
     agent_framework = "google-adk"
+    identity_type   = "SERVICE_ACCOUNT"
   }
 
   service_account_config = {

--- a/modules/agent-engine/README.md
+++ b/modules/agent-engine/README.md
@@ -18,7 +18,7 @@ The module creates Agent Engine and related dependencies.
 - [Minimal deployment](#minimal-deployment)
 - [Serialized Object Deployment](#serialized-object-deployment)
 - [Unmanaged deployments](#unmanaged-deployments)
-- [Service accounts](#service-accounts)
+- [Identities](#identities)
 - [Private networking: setup PSC-I](#private-networking-setup-psc-i)
 - [Specify an encryption key](#specify-an-encryption-key)
 - [Define environment variables and use secrets](#define-environment-variables-and-use-secrets)
@@ -72,6 +72,7 @@ module "agent_engine" {
   deployment_config = {
     source_files_config = {
       source_path = "assets/src/source.tar.gz"
+      python_spec = null
       image_spec = {
         build_args = {
           "ENV" = "production"
@@ -159,9 +160,11 @@ module "agent_engine" {
 # tftest inventory=unmanaged.yaml
 ```
 
-## Service accounts
+## Identities
 
-You can choose to use a custom service account or let the module create one for you.
+By default, the module creates agents with unique **agent identities**.
+
+If you want, you can choose instead to use a custom service account, by changing the `identity_type` to `SERVICE_ACCOUNT`.
 
 ```hcl
 module "agent_engine" {
@@ -181,7 +184,7 @@ module "agent_engine" {
     }
   }
 }
-# tftest inventory=sa-default.yaml
+# tftest inventory=sa-create.yaml
 ```
 
 Using a custom service account.
@@ -209,7 +212,7 @@ module "agent_engine" {
     email  = "my-agent@project-id.iam.gserviceaccount.com"
   }
 }
-# tftest inventory=sa-custom.yaml
+# tftest inventory=sa-external.yaml
 ```
 
 ## Private networking: setup PSC-I
@@ -357,6 +360,7 @@ module "agent_engine" {
     }
   }
 }
+#tftest inventory=memory-bank.yaml
 ```
 
 ## Getting values from context
@@ -447,19 +451,19 @@ module "agent_engine" {
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [name](variables.tf#L187) | The name of the agent. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L206) | The id of the project where to deploy the agent. | <code>string</code> | ✓ |  |
-| [region](variables.tf#L212) | The region where to deploy the agent. | <code>string</code> | ✓ |  |
+| [name](variables.tf#L178) | The name of the agent. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L197) | The id of the project where to deploy the agent. | <code>string</code> | ✓ |  |
+| [region](variables.tf#L203) | The region where to deploy the agent. | <code>string</code> | ✓ |  |
 | [agent_engine_config](variables.tf#L17) | The agent configuration. Supported values for agent_framework: 'google-adk', 'langchain', 'langgraph', 'ag2', 'llama-index', 'custom'. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [bucket_config](variables.tf#L50) | The GCS bucket configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [context](variables.tf#L61) | Context-specific interpolations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [deployment_config](variables.tf#L77) | The deployment configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [description](variables.tf#L137) | The Agent Engine description. | <code>string</code> |  | <code>&#34;Terraform managed.&#34;</code> |
-| [enable_deletion_protection](variables.tf#L144) | Whether deletion protection should be enabled. | <code>bool</code> |  | <code>true</code> |
-| [encryption_key](variables.tf#L151) | The full resource name of the Cloud KMS CryptoKey. | <code>string</code> |  | <code>null</code> |
-| [managed](variables.tf#L157) | Whether the Terraform module should control the code updates. | <code>bool</code> |  | <code>true</code> |
-| [memory_bank_config](variables.tf#L164) | Configuration for the memory bank. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [networking_config](variables.tf#L193) | Networking configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [description](variables.tf#L128) | The Agent Engine description. | <code>string</code> |  | <code>&#34;Terraform managed.&#34;</code> |
+| [enable_deletion_protection](variables.tf#L135) | Whether deletion protection should be enabled. | <code>bool</code> |  | <code>true</code> |
+| [encryption_key](variables.tf#L142) | The full resource name of the Cloud KMS CryptoKey. | <code>string</code> |  | <code>null</code> |
+| [managed](variables.tf#L148) | Whether the Terraform module should control the code updates. | <code>bool</code> |  | <code>true</code> |
+| [memory_bank_config](variables.tf#L155) | Configuration for the memory bank. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [networking_config](variables.tf#L184) | Networking configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
 | [service_account_config](variables-serviceaccount.tf#L18) | Service account configurations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 
 ## Outputs
@@ -468,5 +472,5 @@ module "agent_engine" {
 |---|---|:---:|
 | [agent](outputs.tf#L17) | The Agent Engine object. |  |
 | [id](outputs.tf#L22) | Fully qualified Agent Engine id. |  |
-| [service_account](outputs.tf#L27) | Service account resource. |  |
+| [identity](outputs.tf#L27) | The agent identity. |  |
 <!-- END TFDOC -->

--- a/modules/agent-engine/agent-managed.tf
+++ b/modules/agent-engine/agent-managed.tf
@@ -15,17 +15,13 @@
  */
 
 resource "google_vertex_ai_reasoning_engine" "managed" {
-  provider     = google-beta
-  count        = var.managed ? 1 : 0
-  display_name = var.name
-  project      = local.project_id
-  description  = var.description
-  region       = local.location
-  deletion_policy = (
-    var.enable_deletion_protection
-    ? null
-    : "FORCE"
-  )
+  provider        = google-beta
+  count           = var.managed ? 1 : 0
+  display_name    = var.name
+  project         = local.project_id
+  description     = var.description
+  region          = local.location
+  deletion_policy = var.enable_deletion_protection ? null : "FORCE"
 
   dynamic "encryption_spec" {
     for_each = var.encryption_key == null ? {} : { 1 = 1 }
@@ -127,7 +123,7 @@ resource "google_vertex_ai_reasoning_engine" "managed" {
     }
 
     dynamic "container_spec" {
-      for_each = var.deployment_config.container_config != null ? { 1 = 1 } : {}
+      for_each = var.deployment_config.container_config == null ? {} : { 1 = 1 }
 
       content {
         image_uri = var.deployment_config.container_config.image_uri
@@ -135,7 +131,7 @@ resource "google_vertex_ai_reasoning_engine" "managed" {
     }
 
     dynamic "package_spec" {
-      for_each = var.deployment_config.package_config != null ? { 1 = 1 } : {}
+      for_each = var.deployment_config.package_config == null ? {} : { 1 = 1 }
 
       content {
         python_version = var.agent_engine_config.python_version
@@ -158,14 +154,18 @@ resource "google_vertex_ai_reasoning_engine" "managed" {
     }
 
     dynamic "source_code_spec" {
-      for_each = var.deployment_config.source_files_config != null ? { 1 = 1 } : {}
+      for_each = (
+        var.deployment_config.source_files_config == null
+        ? {}
+        : { 1 = 1 }
+      )
 
       content {
         dynamic "inline_source" {
           for_each = (
-            try(var.deployment_config.source_files_config.source_path, null) != null
-            ? { 1 = 1 }
-            : {}
+            try(var.deployment_config.source_files_config.source_path, null) == null
+            ? {}
+            : { 1 = 1 }
           )
           content {
             source_archive = filebase64(var.deployment_config.source_files_config.source_path)
@@ -174,9 +174,9 @@ resource "google_vertex_ai_reasoning_engine" "managed" {
 
         dynamic "developer_connect_source" {
           for_each = (
-            try(var.deployment_config.source_files_config.developer_connect_config, null) != null
-            ? { 1 = 1 }
-            : {}
+            try(var.deployment_config.source_files_config.developer_connect_config, null) == null
+            ? {}
+            : { 1 = 1 }
           )
           content {
             config {
@@ -189,9 +189,10 @@ resource "google_vertex_ai_reasoning_engine" "managed" {
 
         dynamic "python_spec" {
           for_each = (
-            try(var.deployment_config.source_files_config.python_spec, null) != null
-            ? { 1 = 1 }
-            : {}
+            try(var.deployment_config.source_files_config.python_spec, null) == null
+            || try(var.deployment_config.source_files_config.image_spec, null) != null
+            ? {}
+            : { 1 = 1 }
           )
           content {
             entrypoint_module = var.deployment_config.source_files_config.python_spec.entrypoint_module
@@ -203,9 +204,9 @@ resource "google_vertex_ai_reasoning_engine" "managed" {
 
         dynamic "image_spec" {
           for_each = (
-            try(var.deployment_config.source_files_config.image_spec, null) != null
-            ? { 1 = 1 }
-            : {}
+            try(var.deployment_config.source_files_config.image_spec, null) == null
+            ? {}
+            : { 1 = 1 }
           )
           content {
             build_args = var.deployment_config.source_files_config.image_spec.build_args
@@ -216,7 +217,7 @@ resource "google_vertex_ai_reasoning_engine" "managed" {
   }
 
   dynamic "context_spec" {
-    for_each = var.memory_bank_config != null ? { 1 = 1 } : {}
+    for_each = var.memory_bank_config == null ? {} : { 1 = 1 }
 
     content {
       memory_bank_config {
@@ -224,7 +225,7 @@ resource "google_vertex_ai_reasoning_engine" "managed" {
 
         dynamic "generation_config" {
           for_each = (
-            var.memory_bank_config.generation_config != null ? { 1 = 1 } : {}
+            var.memory_bank_config.generation_config == null ? {} : { 1 = 1 }
           )
           content {
             model = lookup(
@@ -237,7 +238,9 @@ resource "google_vertex_ai_reasoning_engine" "managed" {
 
         dynamic "similarity_search_config" {
           for_each = (
-            var.memory_bank_config.similarity_search_config != null ? { 1 = 1 } : {}
+            var.memory_bank_config.similarity_search_config == null
+            ? {}
+            : { 1 = 1 }
           )
           content {
             embedding_model = lookup(
@@ -250,7 +253,7 @@ resource "google_vertex_ai_reasoning_engine" "managed" {
 
         dynamic "ttl_config" {
           for_each = (
-            var.memory_bank_config.ttl_config != null ? { 1 = 1 } : {}
+            var.memory_bank_config.ttl_config == null ? {} : { 1 = 1 }
           )
           content {
             default_ttl                 = var.memory_bank_config.ttl_config.default_ttl
@@ -258,9 +261,9 @@ resource "google_vertex_ai_reasoning_engine" "managed" {
 
             dynamic "granular_ttl_config" {
               for_each = (
-                var.memory_bank_config.ttl_config.granular_ttl_config != null
-                ? { 1 = 1 }
-                : {}
+                var.memory_bank_config.ttl_config.granular_ttl_config == null
+                ? {}
+                : { 1 = 1 }
               )
               content {
                 create_ttl = (

--- a/modules/agent-engine/agent-managed.tf
+++ b/modules/agent-engine/agent-managed.tf
@@ -41,6 +41,7 @@ resource "google_vertex_ai_reasoning_engine" "managed" {
       ? null
       : var.agent_engine_config.class_methods
     )
+    identity_type   = var.agent_engine_config.identity_type
     service_account = local.service_account_email
 
     dynamic "deployment_spec" {

--- a/modules/agent-engine/agent-managed.tf
+++ b/modules/agent-engine/agent-managed.tf
@@ -46,6 +46,7 @@ resource "google_vertex_ai_reasoning_engine" "managed" {
       ? null
       : var.agent_engine_config.class_methods
     )
+    identity_type   = var.agent_engine_config.identity_type
     service_account = local.service_account_email
 
     dynamic "deployment_spec" {

--- a/modules/agent-engine/agent-unmanaged.tf
+++ b/modules/agent-engine/agent-unmanaged.tf
@@ -41,6 +41,7 @@ resource "google_vertex_ai_reasoning_engine" "unmanaged" {
       ? null
       : var.agent_engine_config.class_methods
     )
+    identity_type   = var.agent_engine_config.identity_type
     service_account = local.service_account_email
 
     dynamic "deployment_spec" {

--- a/modules/agent-engine/agent-unmanaged.tf
+++ b/modules/agent-engine/agent-unmanaged.tf
@@ -15,17 +15,13 @@
  */
 
 resource "google_vertex_ai_reasoning_engine" "unmanaged" {
-  provider     = google-beta
-  count        = var.managed ? 0 : 1
-  display_name = var.name
-  project      = local.project_id
-  description  = var.description
-  region       = local.location
-  deletion_policy = (
-    var.enable_deletion_protection
-    ? null
-    : "FORCE"
-  )
+  provider        = google-beta
+  count           = var.managed ? 0 : 1
+  display_name    = var.name
+  project         = local.project_id
+  description     = var.description
+  region          = local.location
+  deletion_policy = var.enable_deletion_protection ? null : "FORCE"
 
   dynamic "encryption_spec" {
     for_each = var.encryption_key == null ? {} : { 1 = 1 }
@@ -127,7 +123,7 @@ resource "google_vertex_ai_reasoning_engine" "unmanaged" {
     }
 
     dynamic "container_spec" {
-      for_each = var.deployment_config.container_config != null ? { 1 = 1 } : {}
+      for_each = var.deployment_config.container_config == null ? {} : { 1 = 1 }
 
       content {
         image_uri = var.deployment_config.container_config.image_uri
@@ -135,7 +131,7 @@ resource "google_vertex_ai_reasoning_engine" "unmanaged" {
     }
 
     dynamic "package_spec" {
-      for_each = var.deployment_config.package_config != null ? { 1 = 1 } : {}
+      for_each = var.deployment_config.package_config == null ? {} : { 1 = 1 }
 
       content {
         python_version = var.agent_engine_config.python_version
@@ -158,12 +154,16 @@ resource "google_vertex_ai_reasoning_engine" "unmanaged" {
     }
 
     dynamic "source_code_spec" {
-      for_each = var.deployment_config.source_files_config != null ? { 1 = 1 } : {}
+      for_each = (
+        var.deployment_config.source_files_config == null ?
+        {}
+        : { 1 = 1 }
+      )
 
       content {
         dynamic "inline_source" {
           for_each = (
-            try(var.deployment_config.source_files_config.source_path, null) != null
+            try(var.deployment_config.source_files_config.source_path, null) == null
             ? { 1 = 1 }
             : {}
           )
@@ -174,9 +174,9 @@ resource "google_vertex_ai_reasoning_engine" "unmanaged" {
 
         dynamic "developer_connect_source" {
           for_each = (
-            try(var.deployment_config.source_files_config.developer_connect_config, null) != null
-            ? { 1 = 1 }
-            : {}
+            try(var.deployment_config.source_files_config.developer_connect_config, null) == null
+            ? {}
+            : { 1 = 1 }
           )
           content {
             config {
@@ -189,9 +189,9 @@ resource "google_vertex_ai_reasoning_engine" "unmanaged" {
 
         dynamic "python_spec" {
           for_each = (
-            try(var.deployment_config.source_files_config.python_spec, null) != null
-            ? { 1 = 1 }
-            : {}
+            try(var.deployment_config.source_files_config.python_spec, null) == null
+            ? {}
+            : { 1 = 1 }
           )
           content {
             entrypoint_module = var.deployment_config.source_files_config.python_spec.entrypoint_module
@@ -203,9 +203,9 @@ resource "google_vertex_ai_reasoning_engine" "unmanaged" {
 
         dynamic "image_spec" {
           for_each = (
-            try(var.deployment_config.source_files_config.image_spec, null) != null
-            ? { 1 = 1 }
-            : {}
+            try(var.deployment_config.source_files_config.image_spec, null) == null
+            ? {}
+            : { 1 = 1 }
           )
           content {
             build_args = var.deployment_config.source_files_config.image_spec.build_args
@@ -216,7 +216,7 @@ resource "google_vertex_ai_reasoning_engine" "unmanaged" {
   }
 
   dynamic "context_spec" {
-    for_each = var.memory_bank_config != null ? { 1 = 1 } : {}
+    for_each = var.memory_bank_config == null ? {} : { 1 = 1 }
 
     content {
       memory_bank_config {
@@ -224,7 +224,7 @@ resource "google_vertex_ai_reasoning_engine" "unmanaged" {
 
         dynamic "generation_config" {
           for_each = (
-            var.memory_bank_config.generation_config != null ? { 1 = 1 } : {}
+            var.memory_bank_config.generation_config == null ? {} : { 1 = 1 }
           )
           content {
             model = lookup(
@@ -237,7 +237,9 @@ resource "google_vertex_ai_reasoning_engine" "unmanaged" {
 
         dynamic "similarity_search_config" {
           for_each = (
-            var.memory_bank_config.similarity_search_config != null ? { 1 = 1 } : {}
+            var.memory_bank_config.similarity_search_config == null
+            ? {}
+            : { 1 = 1 }
           )
           content {
             embedding_model = lookup(
@@ -250,7 +252,7 @@ resource "google_vertex_ai_reasoning_engine" "unmanaged" {
 
         dynamic "ttl_config" {
           for_each = (
-            var.memory_bank_config.ttl_config != null ? { 1 = 1 } : {}
+            var.memory_bank_config.ttl_config == null ? {} : { 1 = 1 }
           )
           content {
             default_ttl                 = var.memory_bank_config.ttl_config.default_ttl
@@ -258,9 +260,9 @@ resource "google_vertex_ai_reasoning_engine" "unmanaged" {
 
             dynamic "granular_ttl_config" {
               for_each = (
-                var.memory_bank_config.ttl_config.granular_ttl_config != null
-                ? { 1 = 1 }
-                : {}
+                var.memory_bank_config.ttl_config.granular_ttl_config == null
+                ? {}
+                : { 1 = 1 }
               )
               content {
                 create_ttl = (

--- a/modules/agent-engine/agent-unmanaged.tf
+++ b/modules/agent-engine/agent-unmanaged.tf
@@ -46,6 +46,7 @@ resource "google_vertex_ai_reasoning_engine" "unmanaged" {
       ? null
       : var.agent_engine_config.class_methods
     )
+    identity_type   = var.agent_engine_config.identity_type
     service_account = local.service_account_email
 
     dynamic "deployment_spec" {

--- a/modules/agent-engine/identity.tf
+++ b/modules/agent-engine/identity.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,20 @@
  */
 
 locals {
+  _effective_identity = coalesce(
+    try(google_vertex_ai_reasoning_engine.managed[0].spec[0].effective_identity, null),
+    try(google_vertex_ai_reasoning_engine.unmanaged[0].spec[0].effective_identity, null)
+  )
+  effective_identity = (
+    local._effective_identity == null
+    ? "principal://${local._effective_identity}"
+    : null
+  )
+  identity = coalesce(
+    local.effective_identity,
+    local.service_account_email,
+    "service-{your_project_number}@gcp-sa-aiplatform-re.iam.gserviceaccount.com"
+  )
   service_account_email = (
     var.service_account_config.create
     ? try(google_service_account.service_account[0].email, null) # use managed SA, when creating
@@ -47,7 +61,7 @@ resource "google_service_account" "service_account" {
   )
 }
 
-resource "google_project_iam_member" "default" {
+resource "google_project_iam_member" "iam_member_sa" {
   for_each = (
     var.service_account_config.create
     && var.agent_engine_config.identity_type == "SERVICE_ACCOUNT"
@@ -59,15 +73,13 @@ resource "google_project_iam_member" "default" {
   member  = google_service_account.service_account[0].member
 }
 
-resource "google_project_iam_member" "default" {
+resource "google_project_iam_member" "iam_member_identity" {
   for_each = (
-    var.service_account_config.create
-    && var.agent_engine_config.identity_type == "AGENT_IDENTITY"
+    var.agent_engine_config.identity_type == "AGENT_IDENTITY"
     ? toset(local.roles)
     : toset([])
   )
   role    = each.key
   project = local.project_id
-  # TBD once agent identity can be retrieved from Agent Engine
-  member = "xxx"
+  member  = local.effective_identity
 }

--- a/modules/agent-engine/identity.tf
+++ b/modules/agent-engine/identity.tf
@@ -17,23 +17,27 @@
 locals {
   service_account_email = (
     var.service_account_config.create
-    ? google_service_account.service_account[0].email  # use managed SA, when creating
-    : (var.service_account_config.email == null ? null # set to null, if no email provided
-      : lookup(                                        # lookup SA in context
+    ? try(google_service_account.service_account[0].email, null) # use managed SA, when creating
+    : (var.service_account_config.email == null ? null           # set to null, if no email provided
+      : lookup(                                                  # lookup SA in context
         local.ctx.iam_principals,
         var.service_account_config.email,
         var.service_account_config.email
       )
     )
   )
-  service_account_roles = [
+  roles = [
     for role in var.service_account_config.roles
     : lookup(local.ctx.custom_roles, role, role)
   ]
 }
 
 resource "google_service_account" "service_account" {
-  count      = var.service_account_config.create ? 1 : 0
+  count = (
+    var.service_account_config.create
+    && var.agent_engine_config.identity_type == "SERVICE_ACCOUNT"
+    ? 1 : 0
+  )
   project    = local.project_id
   account_id = coalesce(var.service_account_config.name, var.name)
   display_name = coalesce(
@@ -46,10 +50,24 @@ resource "google_service_account" "service_account" {
 resource "google_project_iam_member" "default" {
   for_each = (
     var.service_account_config.create
-    ? toset(local.service_account_roles)
+    && var.agent_engine_config.identity_type == "SERVICE_ACCOUNT"
+    ? toset(local.roles)
     : toset([])
   )
   role    = each.key
   project = local.project_id
   member  = google_service_account.service_account[0].member
+}
+
+resource "google_project_iam_member" "default" {
+  for_each = (
+    var.service_account_config.create
+    && var.agent_engine_config.identity_type == "AGENT_IDENTITY"
+    ? toset(local.roles)
+    : toset([])
+  )
+  role    = each.key
+  project = local.project_id
+  # TBD once agent identity can be retrieved from Agent Engine
+  member = "xxx"
 }

--- a/modules/agent-engine/main.tf
+++ b/modules/agent-engine/main.tf
@@ -43,16 +43,6 @@ locals {
   }
 }
 
-# TODO: fix once eventual consistency issue is solved.
-# AE doesn't retry the deployment (yet) if bindings are still not active.
-resource "time_sleep" "wait_5_minutes" {
-  create_duration = "5m"
-
-  depends_on = [
-    google_project_iam_member.default
-  ]
-}
-
 resource "google_storage_bucket" "default" {
   count = (
     var.bucket_config.create

--- a/modules/agent-engine/outputs.tf
+++ b/modules/agent-engine/outputs.tf
@@ -24,7 +24,7 @@ output "id" {
   value       = local.resource.id
 }
 
-output "service_account" {
-  description = "Service account resource."
-  value       = try(google_service_account.service_account[0], null)
+output "identity" {
+  description = "The agent identity."
+  value       = local.identity
 }

--- a/modules/agent-engine/variables.tf
+++ b/modules/agent-engine/variables.tf
@@ -22,6 +22,7 @@ variable "agent_engine_config" {
     class_methods         = optional(string)
     container_concurrency = optional(number)
     environment_variables = optional(map(string), {})
+    identity_type         = optional(string, "AGENT_IDENTITY")
     max_instances         = optional(number)
     min_instances         = optional(number)
     python_version        = optional(string, "3.13")
@@ -36,6 +37,14 @@ variable "agent_engine_config" {
   })
   nullable = false
   default  = {}
+
+  validation {
+    condition = (
+      var.agent_engine_config.identity_type == "AGENT_IDENTITY"
+      || var.agent_engine_config.identity_type == "SERVICE_ACCOUNT"
+    )
+    error_message = "var.agent_engine_config.identity_type must be either AGENT_IDENTITY or SERVICE_ACCOUNT."
+  }
 }
 
 variable "bucket_config" {

--- a/modules/agent-engine/variables.tf
+++ b/modules/agent-engine/variables.tf
@@ -97,7 +97,7 @@ variable "deployment_config" {
         entrypoint_module = optional(string, "agent")
         entrypoint_object = optional(string, "agent")
         requirements_file = optional(string, "requirements.txt")
-      }))
+      }), {})
       image_spec = optional(object({
         build_args = optional(map(string), {})
       }))
@@ -122,15 +122,6 @@ variable "deployment_config" {
       ) <= 1
     )
     error_message = "Only one of 'source_path' or 'developer_connect_config' can be specified within 'source_files_config'."
-  }
-  validation {
-    condition = (
-      var.deployment_config.source_files_config == null ? true : (
-        (var.deployment_config.source_files_config.python_spec != null ? 1 : 0) +
-        (var.deployment_config.source_files_config.image_spec != null ? 1 : 0)
-      ) <= 1
-    )
-    error_message = "Only one of 'python_spec' or 'image_spec' can be specified within 'source_files_config'."
   }
 }
 

--- a/modules/agent-engine/variables.tf
+++ b/modules/agent-engine/variables.tf
@@ -22,6 +22,7 @@ variable "agent_engine_config" {
     class_methods         = optional(string)
     container_concurrency = optional(number)
     environment_variables = optional(map(string), {})
+    identity_type         = optional(string, "AGENT_IDENTITY")
     max_instances         = optional(number)
     min_instances         = optional(number)
     python_version        = optional(string, "3.13")
@@ -35,6 +36,14 @@ variable "agent_engine_config" {
     })), {})
   })
   nullable = false
+
+  validation {
+    condition = (
+      var.agent_engine_config.identity_type == "AGENT_IDENTITY"
+      || var.agent_engine_config.identity_type == "SERVICE_ACCOUNT"
+    )
+    error_message = "var.agent_engine_config.identity_type must be either AGENT_IDENTITY or SERVICE_ACCOUNT."
+  }
 }
 
 variable "bucket_config" {

--- a/tests/modules/agent_engine/examples/container.yaml
+++ b/tests/modules/agent_engine/examples/container.yaml
@@ -13,26 +13,14 @@
 # limitations under the License.
 
 values:
-  module.agent_engine.google_project_iam_member.default["roles/aiplatform.user"]:
+  module.agent_engine.google_project_iam_member.iam_member_identity["roles/aiplatform.user"]:
     condition: []
-    member: serviceAccount:my-agent@project-id.iam.gserviceaccount.com
     project: project-id
     role: roles/aiplatform.user
-  module.agent_engine.google_project_iam_member.default["roles/storage.objectViewer"]:
+  module.agent_engine.google_project_iam_member.iam_member_identity["roles/storage.objectViewer"]:
     condition: []
-    member: serviceAccount:my-agent@project-id.iam.gserviceaccount.com
     project: project-id
     role: roles/storage.objectViewer
-  module.agent_engine.google_service_account.service_account[0]:
-    account_id: my-agent
-    create_ignore_already_exists: null
-    description: null
-    disabled: false
-    display_name: my-agent
-    email: my-agent@project-id.iam.gserviceaccount.com
-    member: serviceAccount:my-agent@project-id.iam.gserviceaccount.com
-    project: project-id
-    timeouts: null
   module.agent_engine.google_vertex_ai_reasoning_engine.managed[0]:
     context_spec: []
     deletion_policy: null
@@ -55,24 +43,18 @@ values:
           value: bar
         psc_interface_config: []
         secret_env: []
-      identity_type: null
+      identity_type: AGENT_IDENTITY
       package_spec: []
-      service_account: my-agent@project-id.iam.gserviceaccount.com
+      service_account: null
       source_code_spec: []
     terraform_labels:
       goog-terraform-provisioned: 'true'
     timeouts: null
-  module.agent_engine.time_sleep.wait_5_minutes:
-    create_duration: 5m
-    destroy_duration: null
-    triggers: null
 
 counts:
   google_project_iam_member: 2
-  google_service_account: 1
   google_vertex_ai_reasoning_engine: 1
   modules: 1
-  resources: 5
-  time_sleep: 1
+  resources: 3
 
 outputs: {}

--- a/tests/modules/agent_engine/examples/context.yaml
+++ b/tests/modules/agent_engine/examples/context.yaml
@@ -13,6 +13,14 @@
 # limitations under the License.
 
 values:
+  module.agent_engine.google_project_iam_member.iam_member_identity["roles/aiplatform.user"]:
+    condition: []
+    project: test-project-1
+    role: roles/aiplatform.user
+  module.agent_engine.google_project_iam_member.iam_member_identity["roles/storage.objectViewer"]:
+    condition: []
+    project: test-project-1
+    role: roles/storage.objectViewer
   module.agent_engine.google_vertex_ai_reasoning_engine.managed[0]:
     context_spec: []
     deletion_policy: null
@@ -40,7 +48,7 @@ values:
             target_project: company-dns-project
           network_attachment: projects/test-project-1/regions/europe-west1/networkAttachments/core-service
         secret_env: []
-      identity_type: null
+      identity_type: AGENT_IDENTITY
       package_spec: []
       service_account: my-sa@$test-project-1.iam.gserviceaccount.com
       source_code_spec:
@@ -48,19 +56,19 @@ values:
         image_spec: []
         inline_source:
         - source_archive: H4sIAMCUSmkAA+1Y727bNhB3CwzbtM/b55v7oQmQyPprJyk8QE2y1ahrZ7HTriiKgJFom4skqhRV2yj6Hvu8PdL2AgP2CHuAHWXZiZP+C5C4WKsfQNjiHY+/I3l3og7I5AElARU1/VjQFxkTNKKxTHU5kZVrgmEYdceBSiMHVCy34Vo2qP4ZXAdM17Qs1eomGJZp160KTK6LwLuQpZIIpBJmPkkElfQteolgERHToeBZ8ib5zBNY/P5PYDqQsaC5ZWw5DUuzDYgki2jTbNTrzrbrGNt6fatuGbhljvaxuZa4ftxc1J9hHv+24dqGbVyKf8uxl+PfbNgNtwLG9VO5jM88/itffPdl5Xal8oj40O3BL1BA9VW+xmZhe4FNPf/xYSa9fv+w+KtG/Ibtmwsqt876v/V5pJMkCameCP6SxiT2aeXW7cpf//z+1b9/b/15DU6WeBsOFvX/5vLA++o/Bv3F+m869bL+rwJXqf9uA9qt+97h7oPW4319QqQU+puCt+n93PLMbo/tHvRH3c4jzdmGHg5qP33XoHMRX75prAw3X/3fX//Ni/FvNsy6Udb/VWDI+TCkm37Is2CTsCQkcsBF9IwM8UQc03jIYpo+/6Fp6qZl6IZW6JPgNO9zdVPLxybMPw1ps2nrSutje1XiQ3Fw7v6f77meTK97jivc/03LdVX8u65R1v9V4J3139natnXbMvA2ZrlbZVR/gri5qD/DFe7/Rfy7bt0u6/9KUN7/P2uc1f+bywNXuP/P679tO2X9XwWuUv/L+/+nh5uv/u+t/5btXIx/13adsv6vAne+r2WpqJ2wuEbjl5BM5YjHtqbdgV2eTAUbjiSoz3/wU37xh3Z7V7uD0jbzaZzSALIYiwfIEQUvIT7+FJINeExFyngMlm7AmlKoFqLq+j20MOUZRGQKMZeQpRRNsBQGDOegE58mElgMmCiSkKn0AGMmR/k0hREdTTwtTPATSVCboH6CT4PzekBkTlhhJGWS7tRq4/EY849iq3MxrIUzzbTWbu3ud3r7m8g4H3MUhzRNofhGFsDJFFTaYj45QZohGQMXQIaCokxyRXgsmGTxcANSPpBjIihaCVgqBTvJ5NJqzemh0+cVcL1IDFWvB61eFe57vVZvA208afUfdI/68MQ7PPQ6/dZ+D7qHsNvt7LX6rW4Hn34Er/MUHrY6extAca1wGjrBA438kSRT60gDtWg9SpcIDPiMUJpQnw2Yj37FwwzzAgwxN4sY3YGEioilajdTpBeglZBFTBKZ91xySte0geARzD4W6SQ41fM8kyoeXEhoh5GnOmZqOIukE8L0pY9Oc10vOPWSRNO0gA5gSFE+8UdIkR4LIumapjbWz4SgsT89VvZ2AJcTmlA96u1VN5blki+k+0eHF6UBGlzIQ3xIJaqs76BWQUYdBexNsQeXNuFqAZuLXh3pzQgBDKrz00YSpg8EiU8HGfopVOWrvVqa83VBBCAhgkRp85UGC1SVT9WdZR83zitIfl4seSF7rZTWc6YyE/GCsP5ryuO1dS0PckFxfvD2HkK++EWYcR6mmuBczm6H6OJ8x2buRTygYbM6pBGLGYaLuzkISToq3GAxLmHmq8PRrKoYxTjA4BzRMBlkIRA8SJh0Y1moxwRfOO4u+C+2N5/67kwnZ9R8dmn7n+P2aNqc5OyorOWPzTP66+X7RIkSJUpcwn+2Vos4ACgAAA==
-        python_spec: []
+        python_spec:
+        - entrypoint_module: agent
+          entrypoint_object: agent
+          requirements_file: requirements.txt
+          version: '3.13'
     terraform_labels:
       goog-terraform-provisioned: 'true'
     timeouts: null
-  module.agent_engine.time_sleep.wait_5_minutes:
-    create_duration: 5m
-    destroy_duration: null
-    triggers: null
 
 counts:
+  google_project_iam_member: 2
   google_vertex_ai_reasoning_engine: 1
   modules: 1
-  resources: 2
-  time_sleep: 1
+  resources: 3
 
 outputs: {}

--- a/tests/modules/agent_engine/examples/deletion-protection.yaml
+++ b/tests/modules/agent_engine/examples/deletion-protection.yaml
@@ -13,26 +13,14 @@
 # limitations under the License.
 
 values:
-  module.agent_engine.google_project_iam_member.default["roles/aiplatform.user"]:
+  module.agent_engine.google_project_iam_member.iam_member_identity["roles/aiplatform.user"]:
     condition: []
-    member: serviceAccount:my-agent@project-id.iam.gserviceaccount.com
     project: project-id
     role: roles/aiplatform.user
-  module.agent_engine.google_project_iam_member.default["roles/storage.objectViewer"]:
+  module.agent_engine.google_project_iam_member.iam_member_identity["roles/storage.objectViewer"]:
     condition: []
-    member: serviceAccount:my-agent@project-id.iam.gserviceaccount.com
     project: project-id
     role: roles/storage.objectViewer
-  module.agent_engine.google_service_account.service_account[0]:
-    account_id: my-agent
-    create_ignore_already_exists: null
-    description: null
-    disabled: false
-    display_name: my-agent
-    email: my-agent@project-id.iam.gserviceaccount.com
-    member: serviceAccount:my-agent@project-id.iam.gserviceaccount.com
-    project: project-id
-    timeouts: null
   module.agent_engine.google_storage_bucket.default[0]:
     autoclass: []
     cors: []
@@ -131,30 +119,24 @@ values:
       class_methods: null
       container_spec: []
       deployment_spec: []
-      identity_type: null
+      identity_type: AGENT_IDENTITY
       package_spec:
       - dependency_files_gcs_uri: gs://my-agent/dependencies.tar.gz
         pickle_object_gcs_uri: gs://my-agent/pickle.pkl
         python_version: '3.13'
         requirements_gcs_uri: gs://my-agent/requirements.txt
-      service_account: my-agent@project-id.iam.gserviceaccount.com
+      service_account: null
       source_code_spec: []
     terraform_labels:
       goog-terraform-provisioned: 'true'
     timeouts: null
-  module.agent_engine.time_sleep.wait_5_minutes:
-    create_duration: 5m
-    destroy_duration: null
-    triggers: null
 
 counts:
   google_project_iam_member: 2
-  google_service_account: 1
   google_storage_bucket: 1
   google_storage_bucket_object: 3
   google_vertex_ai_reasoning_engine: 1
   modules: 1
-  resources: 9
-  time_sleep: 1
+  resources: 7
 
 outputs: {}

--- a/tests/modules/agent_engine/examples/encryption.yaml
+++ b/tests/modules/agent_engine/examples/encryption.yaml
@@ -13,26 +13,14 @@
 # limitations under the License.
 
 values:
-  module.agent_engine.google_project_iam_member.default["roles/aiplatform.user"]:
+  module.agent_engine.google_project_iam_member.iam_member_identity["roles/aiplatform.user"]:
     condition: []
-    member: serviceAccount:my-agent@project-id.iam.gserviceaccount.com
     project: project-id
     role: roles/aiplatform.user
-  module.agent_engine.google_project_iam_member.default["roles/storage.objectViewer"]:
+  module.agent_engine.google_project_iam_member.iam_member_identity["roles/storage.objectViewer"]:
     condition: []
-    member: serviceAccount:my-agent@project-id.iam.gserviceaccount.com
     project: project-id
     role: roles/storage.objectViewer
-  module.agent_engine.google_service_account.service_account[0]:
-    account_id: my-agent
-    create_ignore_already_exists: null
-    description: null
-    disabled: false
-    display_name: my-agent
-    email: my-agent@project-id.iam.gserviceaccount.com
-    member: serviceAccount:my-agent@project-id.iam.gserviceaccount.com
-    project: project-id
-    timeouts: null
   module.agent_engine.google_vertex_ai_reasoning_engine.managed[0]:
     context_spec: []
     deletion_policy: null
@@ -50,29 +38,27 @@ values:
       class_methods: null
       container_spec: []
       deployment_spec: []
-      identity_type: null
+      identity_type: AGENT_IDENTITY
       package_spec: []
-      service_account: my-agent@project-id.iam.gserviceaccount.com
+      service_account: null
       source_code_spec:
       - developer_connect_source: []
         image_spec: []
         inline_source:
         - source_archive: H4sIAMCUSmkAA+1Y727bNhB3CwzbtM/b55v7oQmQyPprJyk8QE2y1ahrZ7HTriiKgJFom4skqhRV2yj6Hvu8PdL2AgP2CHuAHWXZiZP+C5C4WKsfQNjiHY+/I3l3og7I5AElARU1/VjQFxkTNKKxTHU5kZVrgmEYdceBSiMHVCy34Vo2qP4ZXAdM17Qs1eomGJZp160KTK6LwLuQpZIIpBJmPkkElfQteolgERHToeBZ8ib5zBNY/P5PYDqQsaC5ZWw5DUuzDYgki2jTbNTrzrbrGNt6fatuGbhljvaxuZa4ftxc1J9hHv+24dqGbVyKf8uxl+PfbNgNtwLG9VO5jM88/itffPdl5Xal8oj40O3BL1BA9VW+xmZhe4FNPf/xYSa9fv+w+KtG/Ibtmwsqt876v/V5pJMkCameCP6SxiT2aeXW7cpf//z+1b9/b/15DU6WeBsOFvX/5vLA++o/Bv3F+m869bL+rwJXqf9uA9qt+97h7oPW4319QqQU+puCt+n93PLMbo/tHvRH3c4jzdmGHg5qP33XoHMRX75prAw3X/3fX//Ni/FvNsy6Udb/VWDI+TCkm37Is2CTsCQkcsBF9IwM8UQc03jIYpo+/6Fp6qZl6IZW6JPgNO9zdVPLxybMPw1ps2nrSutje1XiQ3Fw7v6f77meTK97jivc/03LdVX8u65R1v9V4J3139natnXbMvA2ZrlbZVR/gri5qD/DFe7/Rfy7bt0u6/9KUN7/P2uc1f+bywNXuP/P679tO2X9XwWuUv/L+/+nh5uv/u+t/5btXIx/13adsv6vAne+r2WpqJ2wuEbjl5BM5YjHtqbdgV2eTAUbjiSoz3/wU37xh3Z7V7uD0jbzaZzSALIYiwfIEQUvIT7+FJINeExFyngMlm7AmlKoFqLq+j20MOUZRGQKMZeQpRRNsBQGDOegE58mElgMmCiSkKn0AGMmR/k0hREdTTwtTPATSVCboH6CT4PzekBkTlhhJGWS7tRq4/EY849iq3MxrIUzzbTWbu3ud3r7m8g4H3MUhzRNofhGFsDJFFTaYj45QZohGQMXQIaCokxyRXgsmGTxcANSPpBjIihaCVgqBTvJ5NJqzemh0+cVcL1IDFWvB61eFe57vVZvA208afUfdI/68MQ7PPQ6/dZ+D7qHsNvt7LX6rW4Hn34Er/MUHrY6extAca1wGjrBA438kSRT60gDtWg9SpcIDPiMUJpQnw2Yj37FwwzzAgwxN4sY3YGEioilajdTpBeglZBFTBKZ91xySte0geARzD4W6SQ41fM8kyoeXEhoh5GnOmZqOIukE8L0pY9Oc10vOPWSRNO0gA5gSFE+8UdIkR4LIumapjbWz4SgsT89VvZ2AJcTmlA96u1VN5blki+k+0eHF6UBGlzIQ3xIJaqs76BWQUYdBexNsQeXNuFqAZuLXh3pzQgBDKrz00YSpg8EiU8HGfopVOWrvVqa83VBBCAhgkRp85UGC1SVT9WdZR83zitIfl4seSF7rZTWc6YyE/GCsP5ryuO1dS0PckFxfvD2HkK++EWYcR6mmuBczm6H6OJ8x2buRTygYbM6pBGLGYaLuzkISToq3GAxLmHmq8PRrKoYxTjA4BzRMBlkIRA8SJh0Y1moxwRfOO4u+C+2N5/67kwnZ9R8dmn7n+P2aNqc5OyorOWPzTP66+X7RIkSJUpcwn+2Vos4ACgAAA==
-        python_spec: []
+        python_spec:
+        - entrypoint_module: agent
+          entrypoint_object: agent
+          requirements_file: requirements.txt
+          version: '3.13'
     terraform_labels:
       goog-terraform-provisioned: 'true'
     timeouts: null
-  module.agent_engine.time_sleep.wait_5_minutes:
-    create_duration: 5m
-    destroy_duration: null
-    triggers: null
 
 counts:
   google_project_iam_member: 2
-  google_service_account: 1
   google_vertex_ai_reasoning_engine: 1
   modules: 1
-  resources: 5
-  time_sleep: 1
+  resources: 3
 
 outputs: {}

--- a/tests/modules/agent_engine/examples/image-spec.yaml
+++ b/tests/modules/agent_engine/examples/image-spec.yaml
@@ -13,26 +13,14 @@
 # limitations under the License.
 
 values:
-  module.agent_engine.google_project_iam_member.default["roles/aiplatform.user"]:
+  module.agent_engine.google_project_iam_member.iam_member_identity["roles/aiplatform.user"]:
     condition: []
-    member: serviceAccount:my-agent@project-id.iam.gserviceaccount.com
     project: project-id
     role: roles/aiplatform.user
-  module.agent_engine.google_project_iam_member.default["roles/storage.objectViewer"]:
+  module.agent_engine.google_project_iam_member.iam_member_identity["roles/storage.objectViewer"]:
     condition: []
-    member: serviceAccount:my-agent@project-id.iam.gserviceaccount.com
     project: project-id
     role: roles/storage.objectViewer
-  module.agent_engine.google_service_account.service_account[0]:
-    account_id: my-agent
-    create_ignore_already_exists: null
-    description: null
-    disabled: false
-    display_name: my-agent
-    email: my-agent@project-id.iam.gserviceaccount.com
-    member: serviceAccount:my-agent@project-id.iam.gserviceaccount.com
-    project: project-id
-    timeouts: null
   module.agent_engine.google_vertex_ai_reasoning_engine.managed[0]:
     context_spec: []
     deletion_policy: null
@@ -49,9 +37,9 @@ values:
       class_methods: null
       container_spec: []
       deployment_spec: []
-      identity_type: null
+      identity_type: AGENT_IDENTITY
       package_spec: []
-      service_account: my-agent@project-id.iam.gserviceaccount.com
+      service_account: null
       source_code_spec:
       - developer_connect_source: []
         image_spec:
@@ -63,17 +51,11 @@ values:
     terraform_labels:
       goog-terraform-provisioned: 'true'
     timeouts: null
-  module.agent_engine.time_sleep.wait_5_minutes:
-    create_duration: 5m
-    destroy_duration: null
-    triggers: null
 
 counts:
   google_project_iam_member: 2
-  google_service_account: 1
   google_vertex_ai_reasoning_engine: 1
   modules: 1
-  resources: 5
-  time_sleep: 1
+  resources: 3
 
 outputs: {}

--- a/tests/modules/agent_engine/examples/memory-bank.yaml
+++ b/tests/modules/agent_engine/examples/memory-bank.yaml
@@ -13,28 +13,26 @@
 # limitations under the License.
 
 values:
-  module.agent_engine.google_project_iam_member.default["roles/aiplatform.user"]:
+  module.agent_engine.google_project_iam_member.iam_member_identity["roles/aiplatform.user"]:
     condition: []
-    member: serviceAccount:my-agent@project-id.iam.gserviceaccount.com
     project: project-id
     role: roles/aiplatform.user
-  module.agent_engine.google_project_iam_member.default["roles/storage.objectViewer"]:
+  module.agent_engine.google_project_iam_member.iam_member_identity["roles/storage.objectViewer"]:
     condition: []
-    member: serviceAccount:my-agent@project-id.iam.gserviceaccount.com
     project: project-id
     role: roles/storage.objectViewer
-  module.agent_engine.google_service_account.service_account[0]:
-    account_id: my-agent
-    create_ignore_already_exists: null
-    description: null
-    disabled: false
-    display_name: my-agent
-    email: my-agent@project-id.iam.gserviceaccount.com
-    member: serviceAccount:my-agent@project-id.iam.gserviceaccount.com
-    project: project-id
-    timeouts: null
   module.agent_engine.google_vertex_ai_reasoning_engine.managed[0]:
-    context_spec: []
+    context_spec:
+    - memory_bank_config:
+      - disable_memory_revisions: false
+        generation_config:
+        - model: projects/my-project/locations/us-central1/publishers/google/models/gemini-2.0-flash-001
+        similarity_search_config:
+        - embedding_model: projects/my-project/locations/us-central1/publishers/google/models/text-embedding-005
+        ttl_config:
+        - default_ttl: 2592000s
+          granular_ttl_config: []
+          memory_revision_default_ttl: null
     deletion_policy: null
     description: Terraform managed.
     display_name: my-agent
@@ -49,29 +47,27 @@ values:
       class_methods: null
       container_spec: []
       deployment_spec: []
-      identity_type: null
+      identity_type: AGENT_IDENTITY
       package_spec: []
-      service_account: my-agent@project-id.iam.gserviceaccount.com
+      service_account: null
       source_code_spec:
       - developer_connect_source: []
         image_spec: []
         inline_source:
         - source_archive: H4sIAMCUSmkAA+1Y727bNhB3CwzbtM/b55v7oQmQyPprJyk8QE2y1ahrZ7HTriiKgJFom4skqhRV2yj6Hvu8PdL2AgP2CHuAHWXZiZP+C5C4WKsfQNjiHY+/I3l3og7I5AElARU1/VjQFxkTNKKxTHU5kZVrgmEYdceBSiMHVCy34Vo2qP4ZXAdM17Qs1eomGJZp160KTK6LwLuQpZIIpBJmPkkElfQteolgERHToeBZ8ib5zBNY/P5PYDqQsaC5ZWw5DUuzDYgki2jTbNTrzrbrGNt6fatuGbhljvaxuZa4ftxc1J9hHv+24dqGbVyKf8uxl+PfbNgNtwLG9VO5jM88/itffPdl5Xal8oj40O3BL1BA9VW+xmZhe4FNPf/xYSa9fv+w+KtG/Ibtmwsqt876v/V5pJMkCameCP6SxiT2aeXW7cpf//z+1b9/b/15DU6WeBsOFvX/5vLA++o/Bv3F+m869bL+rwJXqf9uA9qt+97h7oPW4319QqQU+puCt+n93PLMbo/tHvRH3c4jzdmGHg5qP33XoHMRX75prAw3X/3fX//Ni/FvNsy6Udb/VWDI+TCkm37Is2CTsCQkcsBF9IwM8UQc03jIYpo+/6Fp6qZl6IZW6JPgNO9zdVPLxybMPw1ps2nrSutje1XiQ3Fw7v6f77meTK97jivc/03LdVX8u65R1v9V4J3139natnXbMvA2ZrlbZVR/gri5qD/DFe7/Rfy7bt0u6/9KUN7/P2uc1f+bywNXuP/P679tO2X9XwWuUv/L+/+nh5uv/u+t/5btXIx/13adsv6vAne+r2WpqJ2wuEbjl5BM5YjHtqbdgV2eTAUbjiSoz3/wU37xh3Z7V7uD0jbzaZzSALIYiwfIEQUvIT7+FJINeExFyngMlm7AmlKoFqLq+j20MOUZRGQKMZeQpRRNsBQGDOegE58mElgMmCiSkKn0AGMmR/k0hREdTTwtTPATSVCboH6CT4PzekBkTlhhJGWS7tRq4/EY849iq3MxrIUzzbTWbu3ud3r7m8g4H3MUhzRNofhGFsDJFFTaYj45QZohGQMXQIaCokxyRXgsmGTxcANSPpBjIihaCVgqBTvJ5NJqzemh0+cVcL1IDFWvB61eFe57vVZvA208afUfdI/68MQ7PPQ6/dZ+D7qHsNvt7LX6rW4Hn34Er/MUHrY6extAca1wGjrBA438kSRT60gDtWg9SpcIDPiMUJpQnw2Yj37FwwzzAgwxN4sY3YGEioilajdTpBeglZBFTBKZ91xySte0geARzD4W6SQ41fM8kyoeXEhoh5GnOmZqOIukE8L0pY9Oc10vOPWSRNO0gA5gSFE+8UdIkR4LIumapjbWz4SgsT89VvZ2AJcTmlA96u1VN5blki+k+0eHF6UBGlzIQ3xIJaqs76BWQUYdBexNsQeXNuFqAZuLXh3pzQgBDKrz00YSpg8EiU8HGfopVOWrvVqa83VBBCAhgkRp85UGC1SVT9WdZR83zitIfl4seSF7rZTWc6YyE/GCsP5ryuO1dS0PckFxfvD2HkK++EWYcR6mmuBczm6H6OJ8x2buRTygYbM6pBGLGYaLuzkISToq3GAxLmHmq8PRrKoYxTjA4BzRMBlkIRA8SJh0Y1moxwRfOO4u+C+2N5/67kwnZ9R8dmn7n+P2aNqc5OyorOWPzTP66+X7RIkSJUpcwn+2Vos4ACgAAA==
-        python_spec: []
+        python_spec:
+        - entrypoint_module: agent
+          entrypoint_object: agent
+          requirements_file: requirements.txt
+          version: '3.13'
     terraform_labels:
       goog-terraform-provisioned: 'true'
     timeouts: null
-  module.agent_engine.time_sleep.wait_5_minutes:
-    create_duration: 5m
-    destroy_duration: null
-    triggers: null
 
 counts:
   google_project_iam_member: 2
-  google_service_account: 1
   google_vertex_ai_reasoning_engine: 1
   modules: 1
-  resources: 5
-  time_sleep: 1
+  resources: 3
 
 outputs: {}

--- a/tests/modules/agent_engine/examples/minimal-pickle.yaml
+++ b/tests/modules/agent_engine/examples/minimal-pickle.yaml
@@ -13,26 +13,14 @@
 # limitations under the License.
 
 values:
-  module.agent_engine.google_project_iam_member.default["roles/aiplatform.user"]:
+  module.agent_engine.google_project_iam_member.iam_member_identity["roles/aiplatform.user"]:
     condition: []
-    member: serviceAccount:my-agent@project-id.iam.gserviceaccount.com
     project: project-id
     role: roles/aiplatform.user
-  module.agent_engine.google_project_iam_member.default["roles/storage.objectViewer"]:
+  module.agent_engine.google_project_iam_member.iam_member_identity["roles/storage.objectViewer"]:
     condition: []
-    member: serviceAccount:my-agent@project-id.iam.gserviceaccount.com
     project: project-id
     role: roles/storage.objectViewer
-  module.agent_engine.google_service_account.service_account[0]:
-    account_id: my-agent
-    create_ignore_already_exists: null
-    description: null
-    disabled: false
-    display_name: my-agent
-    email: my-agent@project-id.iam.gserviceaccount.com
-    member: serviceAccount:my-agent@project-id.iam.gserviceaccount.com
-    project: project-id
-    timeouts: null
   module.agent_engine.google_storage_bucket.default[0]:
     autoclass: []
     cors: []
@@ -131,30 +119,24 @@ values:
       class_methods: null
       container_spec: []
       deployment_spec: []
-      identity_type: null
+      identity_type: AGENT_IDENTITY
       package_spec:
       - dependency_files_gcs_uri: gs://my-agent/dependencies.tar.gz
         pickle_object_gcs_uri: gs://my-agent/pickle.pkl
         python_version: '3.13'
         requirements_gcs_uri: gs://my-agent/requirements.txt
-      service_account: my-agent@project-id.iam.gserviceaccount.com
+      service_account: null
       source_code_spec: []
     terraform_labels:
       goog-terraform-provisioned: 'true'
     timeouts: null
-  module.agent_engine.time_sleep.wait_5_minutes:
-    create_duration: 5m
-    destroy_duration: null
-    triggers: null
 
 counts:
   google_project_iam_member: 2
-  google_service_account: 1
   google_storage_bucket: 1
   google_storage_bucket_object: 3
   google_vertex_ai_reasoning_engine: 1
   modules: 1
-  resources: 9
-  time_sleep: 1
+  resources: 7
 
 outputs: {}

--- a/tests/modules/agent_engine/examples/minimal.yaml
+++ b/tests/modules/agent_engine/examples/minimal.yaml
@@ -13,26 +13,14 @@
 # limitations under the License.
 
 values:
-  module.agent_engine.google_project_iam_member.default["roles/aiplatform.user"]:
+  module.agent_engine.google_project_iam_member.iam_member_identity["roles/aiplatform.user"]:
     condition: []
-    member: serviceAccount:my-agent@project-id.iam.gserviceaccount.com
     project: project-id
     role: roles/aiplatform.user
-  module.agent_engine.google_project_iam_member.default["roles/storage.objectViewer"]:
+  module.agent_engine.google_project_iam_member.iam_member_identity["roles/storage.objectViewer"]:
     condition: []
-    member: serviceAccount:my-agent@project-id.iam.gserviceaccount.com
     project: project-id
     role: roles/storage.objectViewer
-  module.agent_engine.google_service_account.service_account[0]:
-    account_id: my-agent
-    create_ignore_already_exists: null
-    description: null
-    disabled: false
-    display_name: my-agent
-    email: my-agent@project-id.iam.gserviceaccount.com
-    member: serviceAccount:my-agent@project-id.iam.gserviceaccount.com
-    project: project-id
-    timeouts: null
   module.agent_engine.google_vertex_ai_reasoning_engine.managed[0]:
     context_spec: []
     deletion_policy: null
@@ -49,29 +37,27 @@ values:
       class_methods: null
       container_spec: []
       deployment_spec: []
-      identity_type: null
+      identity_type: AGENT_IDENTITY
       package_spec: []
-      service_account: my-agent@project-id.iam.gserviceaccount.com
+      service_account: null
       source_code_spec:
       - developer_connect_source: []
         image_spec: []
         inline_source:
         - source_archive: H4sIAMCUSmkAA+1Y727bNhB3CwzbtM/b55v7oQmQyPprJyk8QE2y1ahrZ7HTriiKgJFom4skqhRV2yj6Hvu8PdL2AgP2CHuAHWXZiZP+C5C4WKsfQNjiHY+/I3l3og7I5AElARU1/VjQFxkTNKKxTHU5kZVrgmEYdceBSiMHVCy34Vo2qP4ZXAdM17Qs1eomGJZp160KTK6LwLuQpZIIpBJmPkkElfQteolgERHToeBZ8ib5zBNY/P5PYDqQsaC5ZWw5DUuzDYgki2jTbNTrzrbrGNt6fatuGbhljvaxuZa4ftxc1J9hHv+24dqGbVyKf8uxl+PfbNgNtwLG9VO5jM88/itffPdl5Xal8oj40O3BL1BA9VW+xmZhe4FNPf/xYSa9fv+w+KtG/Ibtmwsqt876v/V5pJMkCameCP6SxiT2aeXW7cpf//z+1b9/b/15DU6WeBsOFvX/5vLA++o/Bv3F+m869bL+rwJXqf9uA9qt+97h7oPW4319QqQU+puCt+n93PLMbo/tHvRH3c4jzdmGHg5qP33XoHMRX75prAw3X/3fX//Ni/FvNsy6Udb/VWDI+TCkm37Is2CTsCQkcsBF9IwM8UQc03jIYpo+/6Fp6qZl6IZW6JPgNO9zdVPLxybMPw1ps2nrSutje1XiQ3Fw7v6f77meTK97jivc/03LdVX8u65R1v9V4J3139natnXbMvA2ZrlbZVR/gri5qD/DFe7/Rfy7bt0u6/9KUN7/P2uc1f+bywNXuP/P679tO2X9XwWuUv/L+/+nh5uv/u+t/5btXIx/13adsv6vAne+r2WpqJ2wuEbjl5BM5YjHtqbdgV2eTAUbjiSoz3/wU37xh3Z7V7uD0jbzaZzSALIYiwfIEQUvIT7+FJINeExFyngMlm7AmlKoFqLq+j20MOUZRGQKMZeQpRRNsBQGDOegE58mElgMmCiSkKn0AGMmR/k0hREdTTwtTPATSVCboH6CT4PzekBkTlhhJGWS7tRq4/EY849iq3MxrIUzzbTWbu3ud3r7m8g4H3MUhzRNofhGFsDJFFTaYj45QZohGQMXQIaCokxyRXgsmGTxcANSPpBjIihaCVgqBTvJ5NJqzemh0+cVcL1IDFWvB61eFe57vVZvA208afUfdI/68MQ7PPQ6/dZ+D7qHsNvt7LX6rW4Hn34Er/MUHrY6extAca1wGjrBA438kSRT60gDtWg9SpcIDPiMUJpQnw2Yj37FwwzzAgwxN4sY3YGEioilajdTpBeglZBFTBKZ91xySte0geARzD4W6SQ41fM8kyoeXEhoh5GnOmZqOIukE8L0pY9Oc10vOPWSRNO0gA5gSFE+8UdIkR4LIumapjbWz4SgsT89VvZ2AJcTmlA96u1VN5blki+k+0eHF6UBGlzIQ3xIJaqs76BWQUYdBexNsQeXNuFqAZuLXh3pzQgBDKrz00YSpg8EiU8HGfopVOWrvVqa83VBBCAhgkRp85UGC1SVT9WdZR83zitIfl4seSF7rZTWc6YyE/GCsP5ryuO1dS0PckFxfvD2HkK++EWYcR6mmuBczm6H6OJ8x2buRTygYbM6pBGLGYaLuzkISToq3GAxLmHmq8PRrKoYxTjA4BzRMBlkIRA8SJh0Y1moxwRfOO4u+C+2N5/67kwnZ9R8dmn7n+P2aNqc5OyorOWPzTP66+X7RIkSJUpcwn+2Vos4ACgAAA==
-        python_spec: []
+        python_spec:
+        - entrypoint_module: agent
+          entrypoint_object: agent
+          requirements_file: requirements.txt
+          version: '3.13'
     terraform_labels:
       goog-terraform-provisioned: 'true'
     timeouts: null
-  module.agent_engine.time_sleep.wait_5_minutes:
-    create_duration: 5m
-    destroy_duration: null
-    triggers: null
 
 counts:
   google_project_iam_member: 2
-  google_service_account: 1
   google_vertex_ai_reasoning_engine: 1
   modules: 1
-  resources: 5
-  time_sleep: 1
+  resources: 3
 
 outputs: {}

--- a/tests/modules/agent_engine/examples/minimal.yaml
+++ b/tests/modules/agent_engine/examples/minimal.yaml
@@ -69,7 +69,7 @@ counts:
   google_service_account: 1
   google_vertex_ai_reasoning_engine: 1
   modules: 1
-  resources: 6
+  resources: 5
   time_sleep: 1
 
 outputs: {}

--- a/tests/modules/agent_engine/examples/pickle-gcs.yaml
+++ b/tests/modules/agent_engine/examples/pickle-gcs.yaml
@@ -13,26 +13,14 @@
 # limitations under the License.
 
 values:
-  module.agent_engine.google_project_iam_member.default["roles/aiplatform.user"]:
+  module.agent_engine.google_project_iam_member.iam_member_identity["roles/aiplatform.user"]:
     condition: []
-    member: serviceAccount:my-agent@project-id.iam.gserviceaccount.com
     project: project-id
     role: roles/aiplatform.user
-  module.agent_engine.google_project_iam_member.default["roles/storage.objectViewer"]:
+  module.agent_engine.google_project_iam_member.iam_member_identity["roles/storage.objectViewer"]:
     condition: []
-    member: serviceAccount:my-agent@project-id.iam.gserviceaccount.com
     project: project-id
     role: roles/storage.objectViewer
-  module.agent_engine.google_service_account.service_account[0]:
-    account_id: my-agent
-    create_ignore_already_exists: null
-    description: null
-    disabled: false
-    display_name: my-agent
-    email: my-agent@project-id.iam.gserviceaccount.com
-    member: serviceAccount:my-agent@project-id.iam.gserviceaccount.com
-    project: project-id
-    timeouts: null
   module.agent_engine.google_storage_bucket.default[0]:
     autoclass: []
     cors: []
@@ -74,29 +62,23 @@ values:
       class_methods: null
       container_spec: []
       deployment_spec: []
-      identity_type: null
+      identity_type: AGENT_IDENTITY
       package_spec:
       - dependency_files_gcs_uri: gs://my-bucket/dependencies.tar.gz
         pickle_object_gcs_uri: gs://my-bucket/pickle.pkl
         python_version: '3.13'
         requirements_gcs_uri: gs://my-bucket/requirements.txt
-      service_account: my-agent@project-id.iam.gserviceaccount.com
+      service_account: null
       source_code_spec: []
     terraform_labels:
       goog-terraform-provisioned: 'true'
     timeouts: null
-  module.agent_engine.time_sleep.wait_5_minutes:
-    create_duration: 5m
-    destroy_duration: null
-    triggers: null
 
 counts:
   google_project_iam_member: 2
-  google_service_account: 1
   google_storage_bucket: 1
   google_vertex_ai_reasoning_engine: 1
   modules: 1
-  resources: 6
-  time_sleep: 1
+  resources: 4
 
 outputs: {}

--- a/tests/modules/agent_engine/examples/psc-i.yaml
+++ b/tests/modules/agent_engine/examples/psc-i.yaml
@@ -13,26 +13,14 @@
 # limitations under the License.
 
 values:
-  module.agent_engine.google_project_iam_member.default["roles/aiplatform.user"]:
+  module.agent_engine.google_project_iam_member.iam_member_identity["roles/aiplatform.user"]:
     condition: []
-    member: serviceAccount:my-agent@project-id.iam.gserviceaccount.com
     project: project-id
     role: roles/aiplatform.user
-  module.agent_engine.google_project_iam_member.default["roles/storage.objectViewer"]:
+  module.agent_engine.google_project_iam_member.iam_member_identity["roles/storage.objectViewer"]:
     condition: []
-    member: serviceAccount:my-agent@project-id.iam.gserviceaccount.com
     project: project-id
     role: roles/storage.objectViewer
-  module.agent_engine.google_service_account.service_account[0]:
-    account_id: my-agent
-    create_ignore_already_exists: null
-    description: null
-    disabled: false
-    display_name: my-agent
-    email: my-agent@project-id.iam.gserviceaccount.com
-    member: serviceAccount:my-agent@project-id.iam.gserviceaccount.com
-    project: project-id
-    timeouts: null
   module.agent_engine.google_vertex_ai_reasoning_engine.managed[0]:
     context_spec: []
     deletion_policy: null
@@ -57,29 +45,27 @@ values:
             target_project: project-id
           network_attachment: projects/project-id/regions/europe-west8/networkAttachments/my-nat
         secret_env: []
-      identity_type: null
+      identity_type: AGENT_IDENTITY
       package_spec: []
-      service_account: my-agent@project-id.iam.gserviceaccount.com
+      service_account: null
       source_code_spec:
       - developer_connect_source: []
         image_spec: []
         inline_source:
         - source_archive: H4sIAMCUSmkAA+1Y727bNhB3CwzbtM/b55v7oQmQyPprJyk8QE2y1ahrZ7HTriiKgJFom4skqhRV2yj6Hvu8PdL2AgP2CHuAHWXZiZP+C5C4WKsfQNjiHY+/I3l3og7I5AElARU1/VjQFxkTNKKxTHU5kZVrgmEYdceBSiMHVCy34Vo2qP4ZXAdM17Qs1eomGJZp160KTK6LwLuQpZIIpBJmPkkElfQteolgERHToeBZ8ib5zBNY/P5PYDqQsaC5ZWw5DUuzDYgki2jTbNTrzrbrGNt6fatuGbhljvaxuZa4ftxc1J9hHv+24dqGbVyKf8uxl+PfbNgNtwLG9VO5jM88/itffPdl5Xal8oj40O3BL1BA9VW+xmZhe4FNPf/xYSa9fv+w+KtG/Ibtmwsqt876v/V5pJMkCameCP6SxiT2aeXW7cpf//z+1b9/b/15DU6WeBsOFvX/5vLA++o/Bv3F+m869bL+rwJXqf9uA9qt+97h7oPW4319QqQU+puCt+n93PLMbo/tHvRH3c4jzdmGHg5qP33XoHMRX75prAw3X/3fX//Ni/FvNsy6Udb/VWDI+TCkm37Is2CTsCQkcsBF9IwM8UQc03jIYpo+/6Fp6qZl6IZW6JPgNO9zdVPLxybMPw1ps2nrSutje1XiQ3Fw7v6f77meTK97jivc/03LdVX8u65R1v9V4J3139natnXbMvA2ZrlbZVR/gri5qD/DFe7/Rfy7bt0u6/9KUN7/P2uc1f+bywNXuP/P679tO2X9XwWuUv/L+/+nh5uv/u+t/5btXIx/13adsv6vAne+r2WpqJ2wuEbjl5BM5YjHtqbdgV2eTAUbjiSoz3/wU37xh3Z7V7uD0jbzaZzSALIYiwfIEQUvIT7+FJINeExFyngMlm7AmlKoFqLq+j20MOUZRGQKMZeQpRRNsBQGDOegE58mElgMmCiSkKn0AGMmR/k0hREdTTwtTPATSVCboH6CT4PzekBkTlhhJGWS7tRq4/EY849iq3MxrIUzzbTWbu3ud3r7m8g4H3MUhzRNofhGFsDJFFTaYj45QZohGQMXQIaCokxyRXgsmGTxcANSPpBjIihaCVgqBTvJ5NJqzemh0+cVcL1IDFWvB61eFe57vVZvA208afUfdI/68MQ7PPQ6/dZ+D7qHsNvt7LX6rW4Hn34Er/MUHrY6extAca1wGjrBA438kSRT60gDtWg9SpcIDPiMUJpQnw2Yj37FwwzzAgwxN4sY3YGEioilajdTpBeglZBFTBKZ91xySte0geARzD4W6SQ41fM8kyoeXEhoh5GnOmZqOIukE8L0pY9Oc10vOPWSRNO0gA5gSFE+8UdIkR4LIumapjbWz4SgsT89VvZ2AJcTmlA96u1VN5blki+k+0eHF6UBGlzIQ3xIJaqs76BWQUYdBexNsQeXNuFqAZuLXh3pzQgBDKrz00YSpg8EiU8HGfopVOWrvVqa83VBBCAhgkRp85UGC1SVT9WdZR83zitIfl4seSF7rZTWc6YyE/GCsP5ryuO1dS0PckFxfvD2HkK++EWYcR6mmuBczm6H6OJ8x2buRTygYbM6pBGLGYaLuzkISToq3GAxLmHmq8PRrKoYxTjA4BzRMBlkIRA8SJh0Y1moxwRfOO4u+C+2N5/67kwnZ9R8dmn7n+P2aNqc5OyorOWPzTP66+X7RIkSJUpcwn+2Vos4ACgAAA==
-        python_spec: []
+        python_spec:
+        - entrypoint_module: agent
+          entrypoint_object: agent
+          requirements_file: requirements.txt
+          version: '3.13'
     terraform_labels:
       goog-terraform-provisioned: 'true'
     timeouts: null
-  module.agent_engine.time_sleep.wait_5_minutes:
-    create_duration: 5m
-    destroy_duration: null
-    triggers: null
 
 counts:
   google_project_iam_member: 2
-  google_service_account: 1
   google_vertex_ai_reasoning_engine: 1
   modules: 1
-  resources: 5
-  time_sleep: 1
+  resources: 3
 
 outputs: {}

--- a/tests/modules/agent_engine/examples/sa-create.yaml
+++ b/tests/modules/agent_engine/examples/sa-create.yaml
@@ -13,14 +13,26 @@
 # limitations under the License.
 
 values:
-  module.agent_engine.google_project_iam_member.iam_member_identity["roles/aiplatform.user"]:
+  module.agent_engine.google_project_iam_member.iam_member_sa["roles/aiplatform.user"]:
     condition: []
+    member: serviceAccount:my-agent@project-id.iam.gserviceaccount.com
     project: project-id
     role: roles/aiplatform.user
-  module.agent_engine.google_project_iam_member.iam_member_identity["roles/storage.objectViewer"]:
+  module.agent_engine.google_project_iam_member.iam_member_sa["roles/storage.objectViewer"]:
     condition: []
+    member: serviceAccount:my-agent@project-id.iam.gserviceaccount.com
     project: project-id
     role: roles/storage.objectViewer
+  module.agent_engine.google_service_account.service_account[0]:
+    account_id: my-agent
+    create_ignore_already_exists: null
+    description: null
+    disabled: false
+    display_name: my-agent
+    email: my-agent@project-id.iam.gserviceaccount.com
+    member: serviceAccount:my-agent@project-id.iam.gserviceaccount.com
+    project: project-id
+    timeouts: null
   module.agent_engine.google_vertex_ai_reasoning_engine.managed[0]:
     context_spec: []
     deletion_policy: null
@@ -36,19 +48,10 @@ values:
     - agent_framework: google-adk
       class_methods: null
       container_spec: []
-      deployment_spec:
-      - env:
-        - name: FOO
-          value: bar
-        psc_interface_config: []
-        secret_env:
-        - name: MY_SECRET
-          secret_ref:
-          - secret: projects/project-id/secrets/my-secret
-            version: latest
-      identity_type: AGENT_IDENTITY
+      deployment_spec: []
+      identity_type: SERVICE_ACCOUNT
       package_spec: []
-      service_account: null
+      service_account: my-agent@project-id.iam.gserviceaccount.com
       source_code_spec:
       - developer_connect_source: []
         image_spec: []
@@ -65,8 +68,9 @@ values:
 
 counts:
   google_project_iam_member: 2
+  google_service_account: 1
   google_vertex_ai_reasoning_engine: 1
   modules: 1
-  resources: 3
+  resources: 4
 
 outputs: {}

--- a/tests/modules/agent_engine/examples/sa-external.yaml
+++ b/tests/modules/agent_engine/examples/sa-external.yaml
@@ -29,7 +29,7 @@ values:
       class_methods: null
       container_spec: []
       deployment_spec: []
-      identity_type: null
+      identity_type: SERVICE_ACCOUNT
       package_spec: []
       service_account: my-agent@project-id.iam.gserviceaccount.com
       source_code_spec:
@@ -37,19 +37,18 @@ values:
         image_spec: []
         inline_source:
         - source_archive: H4sIAMCUSmkAA+1Y727bNhB3CwzbtM/b55v7oQmQyPprJyk8QE2y1ahrZ7HTriiKgJFom4skqhRV2yj6Hvu8PdL2AgP2CHuAHWXZiZP+C5C4WKsfQNjiHY+/I3l3og7I5AElARU1/VjQFxkTNKKxTHU5kZVrgmEYdceBSiMHVCy34Vo2qP4ZXAdM17Qs1eomGJZp160KTK6LwLuQpZIIpBJmPkkElfQteolgERHToeBZ8ib5zBNY/P5PYDqQsaC5ZWw5DUuzDYgki2jTbNTrzrbrGNt6fatuGbhljvaxuZa4ftxc1J9hHv+24dqGbVyKf8uxl+PfbNgNtwLG9VO5jM88/itffPdl5Xal8oj40O3BL1BA9VW+xmZhe4FNPf/xYSa9fv+w+KtG/Ibtmwsqt876v/V5pJMkCameCP6SxiT2aeXW7cpf//z+1b9/b/15DU6WeBsOFvX/5vLA++o/Bv3F+m869bL+rwJXqf9uA9qt+97h7oPW4319QqQU+puCt+n93PLMbo/tHvRH3c4jzdmGHg5qP33XoHMRX75prAw3X/3fX//Ni/FvNsy6Udb/VWDI+TCkm37Is2CTsCQkcsBF9IwM8UQc03jIYpo+/6Fp6qZl6IZW6JPgNO9zdVPLxybMPw1ps2nrSutje1XiQ3Fw7v6f77meTK97jivc/03LdVX8u65R1v9V4J3139natnXbMvA2ZrlbZVR/gri5qD/DFe7/Rfy7bt0u6/9KUN7/P2uc1f+bywNXuP/P679tO2X9XwWuUv/L+/+nh5uv/u+t/5btXIx/13adsv6vAne+r2WpqJ2wuEbjl5BM5YjHtqbdgV2eTAUbjiSoz3/wU37xh3Z7V7uD0jbzaZzSALIYiwfIEQUvIT7+FJINeExFyngMlm7AmlKoFqLq+j20MOUZRGQKMZeQpRRNsBQGDOegE58mElgMmCiSkKn0AGMmR/k0hREdTTwtTPATSVCboH6CT4PzekBkTlhhJGWS7tRq4/EY849iq3MxrIUzzbTWbu3ud3r7m8g4H3MUhzRNofhGFsDJFFTaYj45QZohGQMXQIaCokxyRXgsmGTxcANSPpBjIihaCVgqBTvJ5NJqzemh0+cVcL1IDFWvB61eFe57vVZvA208afUfdI/68MQ7PPQ6/dZ+D7qHsNvt7LX6rW4Hn34Er/MUHrY6extAca1wGjrBA438kSRT60gDtWg9SpcIDPiMUJpQnw2Yj37FwwzzAgwxN4sY3YGEioilajdTpBeglZBFTBKZ91xySte0geARzD4W6SQ41fM8kyoeXEhoh5GnOmZqOIukE8L0pY9Oc10vOPWSRNO0gA5gSFE+8UdIkR4LIumapjbWz4SgsT89VvZ2AJcTmlA96u1VN5blki+k+0eHF6UBGlzIQ3xIJaqs76BWQUYdBexNsQeXNuFqAZuLXh3pzQgBDKrz00YSpg8EiU8HGfopVOWrvVqa83VBBCAhgkRp85UGC1SVT9WdZR83zitIfl4seSF7rZTWc6YyE/GCsP5ryuO1dS0PckFxfvD2HkK++EWYcR6mmuBczm6H6OJ8x2buRTygYbM6pBGLGYaLuzkISToq3GAxLmHmq8PRrKoYxTjA4BzRMBlkIRA8SJh0Y1moxwRfOO4u+C+2N5/67kwnZ9R8dmn7n+P2aNqc5OyorOWPzTP66+X7RIkSJUpcwn+2Vos4ACgAAA==
-        python_spec: []
+        python_spec:
+        - entrypoint_module: agent
+          entrypoint_object: agent
+          requirements_file: requirements.txt
+          version: '3.13'
     terraform_labels:
       goog-terraform-provisioned: 'true'
     timeouts: null
-  module.agent_engine.time_sleep.wait_5_minutes:
-    create_duration: 5m
-    destroy_duration: null
-    triggers: null
 
 counts:
   google_vertex_ai_reasoning_engine: 1
   modules: 1
-  resources: 2
-  time_sleep: 1
+  resources: 1
 
 outputs: {}

--- a/tests/modules/agent_engine/examples/unmanaged.yaml
+++ b/tests/modules/agent_engine/examples/unmanaged.yaml
@@ -13,26 +13,14 @@
 # limitations under the License.
 
 values:
-  module.agent_engine.google_project_iam_member.default["roles/aiplatform.user"]:
+  module.agent_engine.google_project_iam_member.iam_member_identity["roles/aiplatform.user"]:
     condition: []
-    member: serviceAccount:my-agent@project-id.iam.gserviceaccount.com
     project: project-id
     role: roles/aiplatform.user
-  module.agent_engine.google_project_iam_member.default["roles/storage.objectViewer"]:
+  module.agent_engine.google_project_iam_member.iam_member_identity["roles/storage.objectViewer"]:
     condition: []
-    member: serviceAccount:my-agent@project-id.iam.gserviceaccount.com
     project: project-id
     role: roles/storage.objectViewer
-  module.agent_engine.google_service_account.service_account[0]:
-    account_id: my-agent
-    create_ignore_already_exists: null
-    description: null
-    disabled: false
-    display_name: my-agent
-    email: my-agent@project-id.iam.gserviceaccount.com
-    member: serviceAccount:my-agent@project-id.iam.gserviceaccount.com
-    project: project-id
-    timeouts: null
   module.agent_engine.google_vertex_ai_reasoning_engine.unmanaged[0]:
     context_spec: []
     deletion_policy: null
@@ -49,29 +37,26 @@ values:
       class_methods: null
       container_spec: []
       deployment_spec: []
-      identity_type: null
+      identity_type: AGENT_IDENTITY
       package_spec: []
-      service_account: my-agent@project-id.iam.gserviceaccount.com
+      service_account: null
       source_code_spec:
       - developer_connect_source: []
         image_spec: []
-        inline_source:
-        - source_archive: H4sIAMCUSmkAA+1Y727bNhB3CwzbtM/b55v7oQmQyPprJyk8QE2y1ahrZ7HTriiKgJFom4skqhRV2yj6Hvu8PdL2AgP2CHuAHWXZiZP+C5C4WKsfQNjiHY+/I3l3og7I5AElARU1/VjQFxkTNKKxTHU5kZVrgmEYdceBSiMHVCy34Vo2qP4ZXAdM17Qs1eomGJZp160KTK6LwLuQpZIIpBJmPkkElfQteolgERHToeBZ8ib5zBNY/P5PYDqQsaC5ZWw5DUuzDYgki2jTbNTrzrbrGNt6fatuGbhljvaxuZa4ftxc1J9hHv+24dqGbVyKf8uxl+PfbNgNtwLG9VO5jM88/itffPdl5Xal8oj40O3BL1BA9VW+xmZhe4FNPf/xYSa9fv+w+KtG/Ibtmwsqt876v/V5pJMkCameCP6SxiT2aeXW7cpf//z+1b9/b/15DU6WeBsOFvX/5vLA++o/Bv3F+m869bL+rwJXqf9uA9qt+97h7oPW4319QqQU+puCt+n93PLMbo/tHvRH3c4jzdmGHg5qP33XoHMRX75prAw3X/3fX//Ni/FvNsy6Udb/VWDI+TCkm37Is2CTsCQkcsBF9IwM8UQc03jIYpo+/6Fp6qZl6IZW6JPgNO9zdVPLxybMPw1ps2nrSutje1XiQ3Fw7v6f77meTK97jivc/03LdVX8u65R1v9V4J3139natnXbMvA2ZrlbZVR/gri5qD/DFe7/Rfy7bt0u6/9KUN7/P2uc1f+bywNXuP/P679tO2X9XwWuUv/L+/+nh5uv/u+t/5btXIx/13adsv6vAne+r2WpqJ2wuEbjl5BM5YjHtqbdgV2eTAUbjiSoz3/wU37xh3Z7V7uD0jbzaZzSALIYiwfIEQUvIT7+FJINeExFyngMlm7AmlKoFqLq+j20MOUZRGQKMZeQpRRNsBQGDOegE58mElgMmCiSkKn0AGMmR/k0hREdTTwtTPATSVCboH6CT4PzekBkTlhhJGWS7tRq4/EY849iq3MxrIUzzbTWbu3ud3r7m8g4H3MUhzRNofhGFsDJFFTaYj45QZohGQMXQIaCokxyRXgsmGTxcANSPpBjIihaCVgqBTvJ5NJqzemh0+cVcL1IDFWvB61eFe57vVZvA208afUfdI/68MQ7PPQ6/dZ+D7qHsNvt7LX6rW4Hn34Er/MUHrY6extAca1wGjrBA438kSRT60gDtWg9SpcIDPiMUJpQnw2Yj37FwwzzAgwxN4sY3YGEioilajdTpBeglZBFTBKZ91xySte0geARzD4W6SQ41fM8kyoeXEhoh5GnOmZqOIukE8L0pY9Oc10vOPWSRNO0gA5gSFE+8UdIkR4LIumapjbWz4SgsT89VvZ2AJcTmlA96u1VN5blki+k+0eHF6UBGlzIQ3xIJaqs76BWQUYdBexNsQeXNuFqAZuLXh3pzQgBDKrz00YSpg8EiU8HGfopVOWrvVqa83VBBCAhgkRp85UGC1SVT9WdZR83zitIfl4seSF7rZTWc6YyE/GCsP5ryuO1dS0PckFxfvD2HkK++EWYcR6mmuBczm6H6OJ8x2buRTygYbM6pBGLGYaLuzkISToq3GAxLmHmq8PRrKoYxTjA4BzRMBlkIRA8SJh0Y1moxwRfOO4u+C+2N5/67kwnZ9R8dmn7n+P2aNqc5OyorOWPzTP66+X7RIkSJUpcwn+2Vos4ACgAAA==
-        python_spec: []
+        inline_source: []
+        python_spec:
+        - entrypoint_module: agent
+          entrypoint_object: agent
+          requirements_file: requirements.txt
+          version: '3.13'
     terraform_labels:
       goog-terraform-provisioned: 'true'
     timeouts: null
-  module.agent_engine.time_sleep.wait_5_minutes:
-    create_duration: 5m
-    destroy_duration: null
-    triggers: null
 
 counts:
   google_project_iam_member: 2
-  google_service_account: 1
   google_vertex_ai_reasoning_engine: 1
   modules: 1
-  resources: 5
-  time_sleep: 1
+  resources: 3
 
 outputs: {}

--- a/tools/duplicate-diff.py
+++ b/tools/duplicate-diff.py
@@ -119,7 +119,6 @@ duplicates = [
         "modules/cloud-function-v2/bundle.tf",
     ],
     [
-        "modules/agent-engine/serviceaccount.tf",
         "modules/cloud-function-v1/serviceaccount.tf",
         "modules/cloud-function-v2/serviceaccount.tf",
         "modules/cloud-run-v2/serviceaccount.tf",


### PR DESCRIPTION
- Uses by default agent identities for agents and allows users to optionally use service accounts
- Fixes missing defaults in variables
- Replaces the `service_account` output with the generic `identity` output
- Minor improvements to conditional logic for readability / formatting

---
**Checklist**

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass