### PR TITLE
Add example for context on net-lb-int readme; updated copyright

### DIFF
--- a/modules/net-lb-int/README.md
+++ b/modules/net-lb-int/README.md
@@ -12,6 +12,7 @@ This module allows managing a GCE Internal Load Balancer and integrates the forw
   - [PSC service attachments](#psc-service-attachments)
   - [Regional health check](#regional-health-check)
   - [End to end example](#end-to-end-example)
+  - [Context](#context)
 - [Deploying changes to load balancer configurations](#deploying-changes-to-load-balancer-configurations)
 - [Issues](#issues)
 - [Recipes](#recipes)
@@ -376,6 +377,62 @@ module "ilb" {
   }
 }
 # tftest modules=3 resources=7 e2e
+```
+
+### Context
+
+The module supports the contexts interpolation. For example:
+
+```hcl
+module "ilb" {
+  source        = "./fabric/modules/net-lb-int"
+  project_id    = "$project_ids:my-prj"
+  region        = "$locations:primary-region"
+  name          = "ilb-test"
+  service_label = "ilb-test"
+  forwarding_rules_config = {
+    default = {
+      address = "$addresses:lb-ip-addr"
+    }
+  }
+  vpc_config = {
+    network    = "$networks:shared-vpc"
+    subnetwork = "$subnets:my-subnet"
+  }
+  group_configs = {
+    my-group = {
+      zone = "$locations:primary-zone"
+      instances = [
+        "instance-1-self-link",
+        "instance-2-self-link"
+      ]
+    }
+  }
+  health_check_config = {
+    http = {
+      port = 80
+    }
+  }
+  context = {
+    addresses = {
+      lb-ip-addr = "192.168.0.1"
+    }
+    locations = {
+      primary-region = "us-central1"
+      primary-zone   = "us-central1-b"
+    }
+    networks = {
+      shared-vpc = "projects/prj-host/global/networks/shared-vpc"
+    }
+    project_ids = {
+      my-prj = "my-project-1"
+    }
+    subnets = {
+      my-subnet = "projects/prj-host/regions/us-central1/subnetworks/sub-1"
+    }
+  }
+}
+# tftest modules=1 resources=4 inventory=context.yaml
 ```
 
 ## Deploying changes to load balancer configurations

--- a/modules/net-lb-int/groups.tf
+++ b/modules/net-lb-int/groups.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/net-lb-int/health-check.tf
+++ b/modules/net-lb-int/health-check.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/net-lb-int/main.tf
+++ b/modules/net-lb-int/main.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/net-lb-int/outputs.tf
+++ b/modules/net-lb-int/outputs.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/net-lb-int/recipe-ilb-next-hop/assets/gw.yaml
+++ b/modules/net-lb-int/recipe-ilb-next-hop/assets/gw.yaml
@@ -1,6 +1,6 @@
 #cloud-config
 
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/net-lb-int/recipe-ilb-next-hop/backend.tf.sample
+++ b/modules/net-lb-int/recipe-ilb-next-hop/backend.tf.sample
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/net-lb-int/recipe-ilb-next-hop/gateways.tf
+++ b/modules/net-lb-int/recipe-ilb-next-hop/gateways.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/net-lb-int/recipe-ilb-next-hop/main.tf
+++ b/modules/net-lb-int/recipe-ilb-next-hop/main.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/net-lb-int/recipe-ilb-next-hop/outputs.tf
+++ b/modules/net-lb-int/recipe-ilb-next-hop/outputs.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/net-lb-int/recipe-ilb-next-hop/variables.tf
+++ b/modules/net-lb-int/recipe-ilb-next-hop/variables.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/net-lb-int/recipe-ilb-next-hop/vms.tf
+++ b/modules/net-lb-int/recipe-ilb-next-hop/vms.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/net-lb-int/recipe-ilb-next-hop/vpc-left.tf
+++ b/modules/net-lb-int/recipe-ilb-next-hop/vpc-left.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/net-lb-int/recipe-ilb-next-hop/vpc-right.tf
+++ b/modules/net-lb-int/recipe-ilb-next-hop/vpc-right.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/net-lb-int/variables.tf
+++ b/modules/net-lb-int/variables.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/modules/net_lb_int/context.tfvars
+++ b/tests/modules/net_lb_int/context.tfvars
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 context = {
   addresses = {
     test = "10.0.0.10"

--- a/tests/modules/net_lb_int/defaults.tfvars
+++ b/tests/modules/net_lb_int/defaults.tfvars
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 project_id = "my-project"
 region     = "europe-west1"
 name       = "ilb-test"

--- a/tests/modules/net_lb_int/defaults.yaml
+++ b/tests/modules/net_lb_int/defaults.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/modules/net_lb_int/examples/context.yaml
+++ b/tests/modules/net_lb_int/examples/context.yaml
@@ -13,68 +13,65 @@
 # limitations under the License.
 
 values:
-  google_compute_forwarding_rule.default[""]:
+  module.ilb.google_compute_forwarding_rule.default["default"]:
     all_ports: true
     allow_global_access: true
     allow_psc_global_access: null
     description: null
-    ip_address: 10.0.0.10
+    ip_address: 192.168.0.1
     ip_collection: null
     ip_protocol: TCP
     is_mirroring_collector: null
     labels: null
     load_balancing_scheme: INTERNAL
-    name: test
-    network: projects/foo-dev-net-spoke-0/global/networks/dev-spoke-0
+    name: ilb-test-default
+    network: projects/prj-host/global/networks/shared-vpc
     no_automate_dns_zone: null
     ports: null
-    project: foo-test-0
+    project: my-project-1
     recreate_closed_psc: false
-    region: europe-west8
-    service_label: null
+    region: us-central1
+    service_label: ilb-test
     source_ip_ranges: null
-    subnetwork: projects/foo-dev-net-spoke-0/regions/europe-west8/subnetworks/gce
+    subnetwork: projects/prj-host/regions/us-central1/subnetworks/sub-1
     target: null
     timeouts: null
-  google_compute_health_check.default[0]:
+  module.ilb.google_compute_health_check.default[0]:
     check_interval_sec: 5
     description: Terraform managed.
     grpc_health_check: []
     grpc_tls_health_check: []
     healthy_threshold: 2
     http2_health_check: []
-    http_health_check: []
+    http_health_check:
+    - host: null
+      port: 80
+      port_name: null
+      port_specification: null
+      proxy_header: NONE
+      request_path: /
+      response: null
     https_health_check: []
-    name: test
-    project: foo-test-0
+    name: ilb-test
+    project: my-project-1
     source_regions: null
     ssl_health_check: []
-    tcp_health_check:
-    - port: null
-      port_name: null
-      port_specification: USE_SERVING_PORT
-      proxy_header: NONE
-      request: null
-      response: null
+    tcp_health_check: []
     timeout_sec: 5
     timeouts: null
     unhealthy_threshold: 2
-  google_compute_region_backend_service.default:
+  module.ilb.google_compute_instance_group.default["my-group"]:
+    description: Terraform managed.
+    instances:
+    - instance-2-self-link
+    name: ilb-test-my-group
+    named_port: []
+    project: my-project-1
+    timeouts: null
+    zone: us-central1-b
+  module.ilb.google_compute_region_backend_service.default:
     affinity_cookie_ttl_sec: null
-    backend:
-    - balancing_mode: CONNECTION
-      capacity_scaler: null
-      custom_metrics: []
-      description: Terraform managed.
-      failover: false
-      group: foo
-      max_connections: null
-      max_connections_per_endpoint: null
-      max_connections_per_instance: null
-      max_rate: null
-      max_rate_per_endpoint: null
-      max_rate_per_instance: null
-      max_utilization: null
+    backend: []
     circuit_breakers: []
     connection_draining_timeout_sec: 300
     connection_tracking_policy: []
@@ -92,35 +89,26 @@ values:
     ip_address_selection_policy: null
     load_balancing_scheme: INTERNAL
     locality_lb_policy: null
-    name: test
-    network: projects/foo-dev-net-spoke-0/global/networks/dev-spoke-0
+    name: ilb-test
+    network: projects/prj-host/global/networks/shared-vpc
+    network_pass_through_lb_traffic_policy: []
     outlier_detection: []
-    project: foo-test-0
+    params: []
+    project: my-project-1
     protocol: UNSPECIFIED
-    region: europe-west8
+    region: us-central1
     security_policy: null
     strong_session_affinity_cookie: []
     subsetting: []
     timeouts: null
-  google_compute_service_attachment.default[""]:
-    connection_preference: ACCEPT_MANUAL
-    consumer_accept_lists: []
-    consumer_reject_lists: null
-    description: Terraform managed.
-    domain_names: null
-    enable_proxy_protocol: false
-    name: test
-    nat_subnets:
-    - projects/foo-dev-net-spoke-0/regions/europe-west8/subnetworks/test-nat
-    project: foo-test-0
-    region: europe-west8
-    send_propagated_connection_limit_if_zero: false
-    timeouts: null
+    tls_settings: []
 
 counts:
   google_compute_forwarding_rule: 1
   google_compute_health_check: 1
+  google_compute_instance_group: 1
   google_compute_region_backend_service: 1
-  google_compute_service_attachment: 1
-  modules: 0
+  modules: 1
   resources: 4
+
+outputs: {}

--- a/tests/modules/net_lb_int/forwarding-rule.tfvars
+++ b/tests/modules/net_lb_int/forwarding-rule.tfvars
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 project_id = "my-project"
 region     = "europe-west1"
 name       = "ilb-test"

--- a/tests/modules/net_lb_int/forwarding-rule.yaml
+++ b/tests/modules/net_lb_int/forwarding-rule.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/modules/net_lb_int/health-checks-grpc.tfvars
+++ b/tests/modules/net_lb_int/health-checks-grpc.tfvars
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 project_id = "my-project"
 region     = "europe-west1"
 name       = "ilb-test"

--- a/tests/modules/net_lb_int/health-checks-grpc.yaml
+++ b/tests/modules/net_lb_int/health-checks-grpc.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/modules/net_lb_int/health-checks-http.tfvars
+++ b/tests/modules/net_lb_int/health-checks-http.tfvars
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 project_id = "my-project"
 region     = "europe-west1"
 name       = "ilb-test"

--- a/tests/modules/net_lb_int/health-checks-http.yaml
+++ b/tests/modules/net_lb_int/health-checks-http.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/modules/net_lb_int/health-checks-http2.tfvars
+++ b/tests/modules/net_lb_int/health-checks-http2.tfvars
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 project_id = "my-project"
 region     = "europe-west1"
 name       = "ilb-test"

--- a/tests/modules/net_lb_int/health-checks-http2.yaml
+++ b/tests/modules/net_lb_int/health-checks-http2.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/modules/net_lb_int/health-checks-https.tfvars
+++ b/tests/modules/net_lb_int/health-checks-https.tfvars
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 project_id = "my-project"
 region     = "europe-west1"
 name       = "ilb-test"

--- a/tests/modules/net_lb_int/health-checks-https.yaml
+++ b/tests/modules/net_lb_int/health-checks-https.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/modules/net_lb_int/health-checks-ssl.tfvars
+++ b/tests/modules/net_lb_int/health-checks-ssl.tfvars
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 project_id = "my-project"
 region     = "europe-west1"
 name       = "ilb-test"

--- a/tests/modules/net_lb_int/health-checks-ssl.yaml
+++ b/tests/modules/net_lb_int/health-checks-ssl.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/modules/net_lb_int/health-checks-tcp.tfvars
+++ b/tests/modules/net_lb_int/health-checks-tcp.tfvars
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 project_id = "my-project"
 region     = "europe-west1"
 name       = "ilb-test"

--- a/tests/modules/net_lb_int/health-checks-tcp.yaml
+++ b/tests/modules/net_lb_int/health-checks-tcp.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/modules/net_lb_int/tftest.yaml
+++ b/tests/modules/net_lb_int/tftest.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Adds example for context on net-lb-int readme; updated copyright

---
**Checklist**

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass