### PR TITLE
Add more context to dns-response-policy module

### DIFF
--- a/modules/dns-response-policy/README.md
+++ b/modules/dns-response-policy/README.md
@@ -9,6 +9,7 @@ The module also allows setting rules via a factory. An example is given below.
   - [Manage policy and override resolution for specific names](#manage-policy-and-override-resolution-for-specific-names)
   - [Use existing policy and override resolution via wildcard with exceptions](#use-existing-policy-and-override-resolution-via-wildcard-with-exceptions)
   - [Define policy rules via a factory file](#define-policy-rules-via-a-factory-file)
+  - [Context](#context)
 - [Variables](#variables)
 - [Outputs](#outputs)
 - [Fixtures](#fixtures)
@@ -140,20 +141,61 @@ restricted:
         - 199.36.153.7
 # tftest-file id=rules-file path=config/rules.yaml
 ```
+
+### Context
+
+The module supports the contexts interpolation. For example:
+
+```hcl
+module "dns-policy" {
+  source     = "./fabric/modules/dns-response-policy"
+  project_id = "$project_ids:test-project"
+  name       = "googleapis"
+  networks = {
+    landing = "$networks:landing"
+  }
+  rules = {
+    model-armor = {
+      dns_name = "$dns_names:rep-model-armor"
+      local_data = {
+        A = {
+          name    = "$dns_names:rep-model-armor"
+          rrdatas = ["$addresses:psc-address-rep"]
+        }
+      }
+    }
+  }
+  context = {
+    addresses = {
+      psc-address-rep = "10.24.32.25"
+    }
+    dns_names = {
+      rep-model-armor = "modelarmor.europe-west1.rep.googleapis.com."
+    }
+    networks = {
+      landing = "projects/my-project/global/networks/shared-vpc"
+    }
+    project_ids = {
+      test-project = "my-project"
+    }
+  }
+}
+# tftest
+```
 <!-- BEGIN TFDOC -->
 ## Variables
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [name](variables.tf#L49) | Policy name. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L68) | Project id for the zone. | <code>string</code> | ✓ |  |
+| [name](variables.tf#L51) | Policy name. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L70) | Project id for the zone. | <code>string</code> | ✓ |  |
 | [clusters](variables.tf#L17) | Map of GKE clusters to which this policy is applied in name => id format. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
 | [context](variables.tf#L24) | Context-specific interpolations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [description](variables.tf#L34) | Policy description. | <code>string</code> |  | <code>&#34;Terraform managed.&#34;</code> |
-| [factories_config](variables.tf#L40) | Path to folder containing rules data files for the optional factory. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [networks](variables.tf#L54) | Map of VPC self links to which this policy is applied in name => self link format. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
-| [policy_create](variables.tf#L61) | Set to false to use the existing policy matching name and only manage rules. | <code>bool</code> |  | <code>true</code> |
-| [rules](variables.tf#L73) | Map of policy rules in name => rule format. Local data takes precedence over behavior and is in the form record type => attributes. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [description](variables.tf#L36) | Policy description. | <code>string</code> |  | <code>&#34;Terraform managed.&#34;</code> |
+| [factories_config](variables.tf#L42) | Path to folder containing rules data files for the optional factory. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [networks](variables.tf#L56) | Map of VPC self links to which this policy is applied in name => self link format. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [policy_create](variables.tf#L63) | Set to false to use the existing policy matching name and only manage rules. | <code>bool</code> |  | <code>true</code> |
+| [rules](variables.tf#L75) | Map of policy rules in name => rule format. Local data takes precedence over behavior and is in the form record type => attributes. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 
 ## Outputs
 

--- a/modules/dns-response-policy/main.tf
+++ b/modules/dns-response-policy/main.tf
@@ -71,7 +71,11 @@ resource "google_dns_response_policy_rule" "default" {
   project         = local.project_id
   response_policy = local.policy_name
   rule_name       = each.key
-  dns_name        = each.value.dns_name
+  dns_name = lookup(
+    local.ctx.dns_names,
+    each.value.dns_name,
+    each.value.dns_name
+  )
   behavior = (
     length(each.value.local_data) == 0 ? each.value.behavior : null
   )
@@ -86,10 +90,21 @@ resource "google_dns_response_policy_rule" "default" {
           # so we comply with the console UI and set it to the rule dns name
           # name    = split(" ", data.key)[1]
           # type    = split(" ", data.key)[0]
-          name    = each.value.dns_name
-          type    = data.key
-          ttl     = data.value.ttl
-          rrdatas = data.value.rrdatas
+          name = lookup(
+            local.ctx.dns_names,
+            each.value.dns_name,
+            each.value.dns_name
+          )
+          type = data.key
+          ttl  = data.value.ttl
+          rrdatas = [
+            for rrdata in data.value.rrdatas
+            : lookup(
+              local.ctx.addresses,
+              rrdata,
+              rrdata
+            )
+          ]
         }
       }
     }

--- a/modules/dns-response-policy/variables.tf
+++ b/modules/dns-response-policy/variables.tf
@@ -24,6 +24,8 @@ variable "clusters" {
 variable "context" {
   description = "Context-specific interpolations."
   type = object({
+    addresses   = optional(map(string), {})
+    dns_names   = optional(map(string), {})
     networks    = optional(map(string), {})
     project_ids = optional(map(string), {})
   })

--- a/tests/modules/dns_response_policy/examples/context.yaml
+++ b/tests/modules/dns_response_policy/examples/context.yaml
@@ -1,0 +1,45 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values:
+  module.dns-policy.google_dns_response_policy.default[0]:
+    description: Terraform managed.
+    gke_clusters: []
+    networks:
+    - network_url: projects/my-project/global/networks/shared-vpc
+    project: my-project
+    response_policy_name: googleapis
+    timeouts: null
+  module.dns-policy.google_dns_response_policy_rule.default["model-armor"]:
+    behavior: null
+    dns_name: modelarmor.europe-west1.rep.googleapis.com.
+    local_data:
+    - local_datas:
+      - name: modelarmor.europe-west1.rep.googleapis.com.
+        rrdatas:
+        - 10.24.32.25
+        ttl: null
+        type: A
+    project: my-project
+    response_policy: googleapis
+    rule_name: model-armor
+    timeouts: null
+
+counts:
+  google_dns_response_policy: 1
+  google_dns_response_policy_rule: 1
+  modules: 1
+  resources: 2
+
+outputs: {}


### PR DESCRIPTION
Adds more context to dns-response-policy module.

---
**Checklist**

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass