### PR TITLE
Update `labels` field in schemas from `map(list(string)))` to `map(string)`

### DIFF
--- a/fast/stages/0-org-setup/schemas/defaults.schema.json
+++ b/fast/stages/0-org-setup/schemas/defaults.schema.json
@@ -98,10 +98,7 @@
               "additionalProperties": false,
               "patternProperties": {
                 "^[a-z0-9_-]+$": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
+                  "type": "string"
                 }
               }
             },

--- a/fast/stages/0-org-setup/schemas/defaults.schema.md
+++ b/fast/stages/0-org-setup/schemas/defaults.schema.md
@@ -34,8 +34,7 @@
       <br>*enum: ['PREVENT', 'DELETE', 'ABANDON']*
     - **labels**: *object*
       <br>*additional properties: false*
-      - **`^[a-z0-9_-]+$`**: *array*
-        - items: *string*
+      - **`^[a-z0-9_-]+$`**: *string*
     - **locations**: *object*
       <br>*additional properties: false*
       - **bigquery**: *string*

--- a/fast/stages/2-networking/schemas/defaults.schema.json
+++ b/fast/stages/2-networking/schemas/defaults.schema.json
@@ -66,10 +66,7 @@
               "additionalProperties": false,
               "patternProperties": {
                 "^[a-z0-9_-]+$": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
+                  "type": "string"
                 }
               }
             },

--- a/fast/stages/2-networking/schemas/defaults.schema.md
+++ b/fast/stages/2-networking/schemas/defaults.schema.md
@@ -28,8 +28,7 @@
       <br>*enum: ['PREVENT', 'DELETE', 'ABANDON']*
     - **labels**: *object*
       <br>*additional properties: false*
-      - **`^[a-z0-9_-]+$`**: *array*
-        - items: *string*
+      - **`^[a-z0-9_-]+$`**: *string*
     - **locations**: *object*
       <br>*additional properties: false*
       - **bigquery**: *string*

--- a/fast/stages/2-project-factory/schemas/defaults.schema.json
+++ b/fast/stages/2-project-factory/schemas/defaults.schema.json
@@ -51,10 +51,7 @@
               "additionalProperties": false,
               "patternProperties": {
                 "^[a-z0-9_-]+$": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
+                  "type": "string"
                 }
               }
             },
@@ -282,10 +279,7 @@
               "additionalProperties": false,
               "patternProperties": {
                 "^[a-z0-9_-]+$": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
+                  "type": "string"
                 }
               }
             },

--- a/fast/stages/2-project-factory/schemas/defaults.schema.md
+++ b/fast/stages/2-project-factory/schemas/defaults.schema.md
@@ -22,8 +22,7 @@
       <br>*enum: ['PREVENT', 'DELETE', 'ABANDON']*
     - **labels**: *object*
       <br>*additional properties: false*
-      - **`^[a-z0-9_-]+$`**: *array*
-        - items: *string*
+      - **`^[a-z0-9_-]+$`**: *string*
     - **locations**: *object*
       <br>*additional properties: false*
       - **bigquery**: *string*
@@ -82,8 +81,7 @@
         - items: *string*
     - **labels**: *object*
       <br>*additional properties: false*
-      - **`^[a-z0-9_-]+$`**: *array*
-        - items: *string*
+      - **`^[a-z0-9_-]+$`**: *string*
     - **metric_scopes**: *array*
       - items: *string*
     - **service_encryption_key_ids**: *object*

--- a/fast/stages/2-security/schemas/defaults.schema.json
+++ b/fast/stages/2-security/schemas/defaults.schema.json
@@ -66,10 +66,7 @@
               "additionalProperties": false,
               "patternProperties": {
                 "^[a-z0-9_-]+$": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
+                  "type": "string"
                 }
               }
             },

--- a/fast/stages/2-security/schemas/defaults.schema.md
+++ b/fast/stages/2-security/schemas/defaults.schema.md
@@ -28,8 +28,7 @@
       <br>*enum: ['PREVENT', 'DELETE', 'ABANDON']*
     - **labels**: *object*
       <br>*additional properties: false*
-      - **`^[a-z0-9_-]+$`**: *array*
-        - items: *string*
+      - **`^[a-z0-9_-]+$`**: *string*
     - **locations**: *object*
       <br>*additional properties: false*
       - **bigquery**: *string*


### PR DESCRIPTION
Following the schema, a validator fails a valid `defaults.yaml` file while it is valid for terraform plan and also work with terraform apply.

This PR fixes what is expected of labels (key:value) in `default.schema.json` with value being a `string` instead of an `array` of `string` items.

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [x] Made sure all relevant tests pass
