### PR TITLE
Support context interpolation for PAM email recipients

### DIFF
--- a/modules/folder/pam.tf
+++ b/modules/folder/pam.tf
@@ -117,8 +117,15 @@ resource "google_privileged_access_manager_entitlement" "default" {
               ]
             }
 
-            approvals_needed          = step.value.approvals_needed
-            approver_email_recipients = step.value.approver_email_recipients
+            approvals_needed = step.value.approvals_needed
+            approver_email_recipients = (
+              step.value.approver_email_recipients == null
+              ? null
+              : [
+                for e in step.value.approver_email_recipients :
+                lookup(local.ctx.email_addresses, e, e)
+              ]
+            )
           }
         }
       }
@@ -128,8 +135,22 @@ resource "google_privileged_access_manager_entitlement" "default" {
   dynamic "additional_notification_targets" {
     for_each = each.value.additional_notification_targets == null ? [] : [""]
     content {
-      admin_email_recipients     = each.value.additional_notification_targets.admin_email_recipients
-      requester_email_recipients = each.value.additional_notification_targets.requester_email_recipients
+      admin_email_recipients = (
+        each.value.additional_notification_targets.admin_email_recipients == null
+        ? null
+        : [
+          for e in each.value.additional_notification_targets.admin_email_recipients :
+          lookup(local.ctx.email_addresses, e, e)
+        ]
+      )
+      requester_email_recipients = (
+        each.value.additional_notification_targets.requester_email_recipients == null
+        ? null
+        : [
+          for e in each.value.additional_notification_targets.requester_email_recipients :
+          lookup(local.ctx.email_addresses, e, e)
+        ]
+      )
     }
   }
 

--- a/modules/organization/pam.tf
+++ b/modules/organization/pam.tf
@@ -117,8 +117,15 @@ resource "google_privileged_access_manager_entitlement" "default" {
               ]
             }
 
-            approvals_needed          = step.value.approvals_needed
-            approver_email_recipients = step.value.approver_email_recipients
+            approvals_needed = step.value.approvals_needed
+            approver_email_recipients = (
+              step.value.approver_email_recipients == null
+              ? null
+              : [
+                for e in step.value.approver_email_recipients :
+                lookup(local.ctx.email_addresses, e, e)
+              ]
+            )
           }
         }
       }
@@ -128,8 +135,22 @@ resource "google_privileged_access_manager_entitlement" "default" {
   dynamic "additional_notification_targets" {
     for_each = each.value.additional_notification_targets == null ? [] : [""]
     content {
-      admin_email_recipients     = each.value.additional_notification_targets.admin_email_recipients
-      requester_email_recipients = each.value.additional_notification_targets.requester_email_recipients
+      admin_email_recipients = (
+        each.value.additional_notification_targets.admin_email_recipients == null
+        ? null
+        : [
+          for e in each.value.additional_notification_targets.admin_email_recipients :
+          lookup(local.ctx.email_addresses, e, e)
+        ]
+      )
+      requester_email_recipients = (
+        each.value.additional_notification_targets.requester_email_recipients == null
+        ? null
+        : [
+          for e in each.value.additional_notification_targets.requester_email_recipients :
+          lookup(local.ctx.email_addresses, e, e)
+        ]
+      )
     }
   }
 

--- a/modules/project/pam.tf
+++ b/modules/project/pam.tf
@@ -117,8 +117,15 @@ resource "google_privileged_access_manager_entitlement" "default" {
               ]
             }
 
-            approvals_needed          = step.value.approvals_needed
-            approver_email_recipients = step.value.approver_email_recipients
+            approvals_needed = step.value.approvals_needed
+            approver_email_recipients = (
+              step.value.approver_email_recipients == null
+              ? null
+              : [
+                for e in step.value.approver_email_recipients :
+                lookup(local.ctx.email_addresses, e, e)
+              ]
+            )
           }
         }
       }
@@ -128,8 +135,22 @@ resource "google_privileged_access_manager_entitlement" "default" {
   dynamic "additional_notification_targets" {
     for_each = each.value.additional_notification_targets == null ? [] : [""]
     content {
-      admin_email_recipients     = each.value.additional_notification_targets.admin_email_recipients
-      requester_email_recipients = each.value.additional_notification_targets.requester_email_recipients
+      admin_email_recipients = (
+        each.value.additional_notification_targets.admin_email_recipients == null
+        ? null
+        : [
+          for e in each.value.additional_notification_targets.admin_email_recipients :
+          lookup(local.ctx.email_addresses, e, e)
+        ]
+      )
+      requester_email_recipients = (
+        each.value.additional_notification_targets.requester_email_recipients == null
+        ? null
+        : [
+          for e in each.value.additional_notification_targets.requester_email_recipients :
+          lookup(local.ctx.email_addresses, e, e)
+        ]
+      )
     }
   }
   depends_on = [

--- a/tests/modules/organization/context.tfvars
+++ b/tests/modules/organization/context.tfvars
@@ -149,8 +149,13 @@ pam_entitlements = {
     manual_approvals = {
       require_approver_justification = true
       steps = [{
-        approvers = ["$iam_principals:mygroup"]
+        approvers                 = ["$iam_principals:mygroup"]
+        approver_email_recipients = ["$email_addresses:default"]
       }]
+    }
+    additional_notification_targets = {
+      admin_email_recipients     = ["$email_addresses:default"]
+      requester_email_recipients = ["$email_addresses:default"]
     }
     eligible_users = ["$iam_principals:mygroup"]
     privileged_access = [

--- a/tests/modules/organization/context.yaml
+++ b/tests/modules/organization/context.yaml
@@ -165,13 +165,18 @@ values:
     org_id: '1234567890'
     role: organizations/366118655033/roles/myRoleTwo
   google_privileged_access_manager_entitlement.default["net-admins"]:
-    additional_notification_targets: []
+    additional_notification_targets:
+    - admin_email_recipients:
+      - foo@example.com
+      requester_email_recipients:
+      - foo@example.com
     approval_workflow:
     - manual_approvals:
       - require_approver_justification: true
         steps:
         - approvals_needed: 1
-          approver_email_recipients: null
+          approver_email_recipients:
+          - foo@example.com
           approvers:
           - principals:
             - group:test-group@example.com


### PR DESCRIPTION
Adds support for resolving symbolic email addresses in PAM entitlement email recipient fields (`approver_email_recipients`, `admin_email_recipients`, `requester_email_recipients`) across the organization, folder, and project modules.