### PR TITLE
Fix failing CICD setup from bad provider file name in fast datasets

### DIFF
--- a/fast/stages/0-org-setup/README.md
+++ b/fast/stages/0-org-setup/README.md
@@ -739,7 +739,7 @@ Once one or more providers have been defined they can be referenced in the CI/CD
 org-setup:
   provider_files:
     apply: 0-org-setup-providers.tf
-    plan: 0-org-setup-providers-ro.tf
+    plan: 0-org-setup-ro-providers.tf
   repository:
     name: example/0-org-setup
     type: github

--- a/fast/stages/0-org-setup/datasets/classic-gcd/cicd.yaml
+++ b/fast/stages/0-org-setup/datasets/classic-gcd/cicd.yaml
@@ -17,7 +17,7 @@
 org-setup:
   provider_files:
     apply: 0-org-setup-providers.tf
-    plan: 0-org-setup-providers-ro.tf
+    plan: 0-org-setup-ro-providers.tf
   repository:
     name: myorg/0-org-setup
     type: github

--- a/fast/stages/0-org-setup/datasets/classic/cicd.yaml
+++ b/fast/stages/0-org-setup/datasets/classic/cicd.yaml
@@ -17,7 +17,7 @@
 org-setup:
   provider_files:
     apply: 0-org-setup-providers.tf
-    plan: 0-org-setup-providers-ro.tf
+    plan: 0-org-setup-ro-providers.tf
   repository:
     name: myorg/0-org-setup
     type: github


### PR DESCRIPTION
Fixes GitHub Action workflow failing after the FAST setup stage due to an older output file name.

The example FAST stage 0 datasets have a cicd.yaml file referencing a non-existent "0-org-setup-providers-ro.tf" output file. This is an old output file naming convention. TF currently outputs the same file as "0-org-setup-ro-providers.tf". (See the "ro" moves?) The generated CI/CD workflow configuration file looks for output files using the older name.

It's easy to fix, but can be tricky to figure out what exactly went wrong, especially for folks new to this setup.

This updates the README and dataset cicd.yaml files to use the correct output file name. This generates a workflow config that runs on GitHub.

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [ ] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
