### PR TITLE
Bump GH template action versions to avoid GHA Node 20 deprecation

### DIFF
--- a/fast/stages/0-org-setup/assets/workflow-github.yaml
+++ b/fast/stages/0-org-setup/assets/workflow-github.yaml
@@ -49,7 +49,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # set up SSH key authentication to the modules repository
 
@@ -80,7 +80,7 @@ jobs:
 
       - id: gcp-auth
         name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: $${{env.FAST_WIF_PROVIDER}}
           service_account: $${{env.service_account}}
@@ -88,7 +88,7 @@ jobs:
 
       - id: gcp-sdk
         name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
         with:
           install_components: alpha
 
@@ -106,7 +106,7 @@ jobs:
 
       - id: tf-setup
         name: Set up Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: $${{env.TF_VERSION}}
 
@@ -142,7 +142,7 @@ jobs:
       - id: pr-comment
         name: Post comment to Pull Request
         continue-on-error: true
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         if: github.event_name == 'pull_request'
         env:
           PLAN: $${{steps.tf-plan.outputs.stdout}}\n$${{steps.tf-plan.outputs.stderr}}
@@ -183,7 +183,7 @@ jobs:
 
       - id: pr-short-comment
         name: Post comment to Pull Request (abbreviated)
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         if: github.event_name == 'pull_request' && steps.pr-comment.outcome != 'success'
         with:
           script: |

--- a/tests/fast/stages/s0_org_setup/hardened.yaml
+++ b/tests/fast/stages/s0_org_setup/hardened.yaml
@@ -287,7 +287,7 @@ values:
       \ == 'synchronize'\n    permissions:\n      contents: read\n      id-token:\
       \ write\n      issues: write\n      pull-requests: write\n    runs-on: ubuntu-latest\n\
       \    steps:\n      - id: checkout\n        name: Checkout repository\n     \
-      \   uses: actions/checkout@v4\n\n      # set up SSH key authentication to the\
+      \   uses: actions/checkout@v6\n\n      # set up SSH key authentication to the\
       \ modules repository\n\n      - id: ssh-config\n        name: Configure SSH\
       \ authentication\n        run: |\n          ssh-agent -a \"$SSH_AUTH_SOCK\"\
       \ > /dev/null\n          ssh-add - <<< \"${{ secrets.CICD_MODULES_KEY }}\"\n\
@@ -302,16 +302,16 @@ values:
       \n          echo \"service_account=${{env.FAST_SERVICE_ACCOUNT}}\" >> \"$GITHUB_ENV\"\
       \n\n      # set up authentication via Workload identity Federation and gcloud\n\
       \n      - id: gcp-auth\n        name: Authenticate to Google Cloud\n       \
-      \ uses: google-github-actions/auth@v2\n        with:\n          workload_identity_provider:\
+      \ uses: google-github-actions/auth@v3\n        with:\n          workload_identity_provider:\
       \ ${{env.FAST_WIF_PROVIDER}}\n          service_account: ${{env.service_account}}\n\
       \          access_token_lifetime: 900s\n\n      - id: gcp-sdk\n        name:\
-      \ Set up Cloud SDK\n        uses: google-github-actions/setup-gcloud@v2\n  \
+      \ Set up Cloud SDK\n        uses: google-github-actions/setup-gcloud@v3\n  \
       \      with:\n          install_components: alpha\n\n      # copy provider file\n\
       \n      - id: tf-config-provider\n        name: Copy Terraform provider file\n\
       \        run: |\n          gcloud storage cp -r \\\n            \"gs://ft0-prod-iac-core-0-iac-outputs/providers/${{env.provider_file}}\"\
       \ ./\n          gcloud storage cp -r \\\n            \"gs://ft0-prod-iac-core-0-iac-outputs/tfvars/0-org-setup.auto.tfvars\"\
       \ ./\n\n      - id: tf-setup\n        name: Set up Terraform\n        uses:\
-      \ hashicorp/setup-terraform@v3\n        with:\n          terraform_version:\
+      \ hashicorp/setup-terraform@v4\n        with:\n          terraform_version:\
       \ ${{env.TF_VERSION}}\n\n      # run Terraform init/validate/plan\n\n      -\
       \ id: tf-init\n        name: Terraform init\n        continue-on-error: true\n\
       \        run: |\n          terraform init -no-color\n\n      - id: tf-validate\n\
@@ -325,7 +325,7 @@ values:
       \n      # PR comment with Terraform result from previous steps\n      # length\
       \ is checked and trimmed for length so as to stay within the limit\n\n     \
       \ - id: pr-comment\n        name: Post comment to Pull Request\n        continue-on-error:\
-      \ true\n        uses: actions/github-script@v7\n        if: github.event_name\
+      \ true\n        uses: actions/github-script@v9\n        if: github.event_name\
       \ == 'pull_request'\n        env:\n          PLAN: ${{steps.tf-plan.outputs.stdout}}\\\
       n${{steps.tf-plan.outputs.stderr}}\n        with:\n          script: |\n   \
       \         const output = `### Terraform Initialization \\`${{steps.tf-init.outcome}}\\\
@@ -343,7 +343,7 @@ values:
       \ context.issue.number,\n              owner: context.repo.owner,\n        \
       \      repo: context.repo.repo,\n              body: output\n            })\n\
       \n      - id: pr-short-comment\n        name: Post comment to Pull Request (abbreviated)\n\
-      \        uses: actions/github-script@v7\n        if: github.event_name == 'pull_request'\
+      \        uses: actions/github-script@v9\n        if: github.event_name == 'pull_request'\
       \ && steps.pr-comment.outcome != 'success'\n        with:\n          script:\
       \ |\n            const output = `### Terraform Initialization \\`${{steps.tf-init.outcome}}\\\
       `\n\n            ### Terraform Validation \\`${{steps.tf-validate.outcome}}\\\
@@ -543,7 +543,7 @@ values:
       \ == 'synchronize'\n    permissions:\n      contents: read\n      id-token:\
       \ write\n      issues: write\n      pull-requests: write\n    runs-on: ubuntu-latest\n\
       \    steps:\n      - id: checkout\n        name: Checkout repository\n     \
-      \   uses: actions/checkout@v4\n\n      # set up SSH key authentication to the\
+      \   uses: actions/checkout@v6\n\n      # set up SSH key authentication to the\
       \ modules repository\n\n      - id: ssh-config\n        name: Configure SSH\
       \ authentication\n        run: |\n          ssh-agent -a \"$SSH_AUTH_SOCK\"\
       \ > /dev/null\n          ssh-add - <<< \"${{ secrets.CICD_MODULES_KEY }}\"\n\
@@ -558,16 +558,16 @@ values:
       \n          echo \"service_account=${{env.FAST_SERVICE_ACCOUNT}}\" >> \"$GITHUB_ENV\"\
       \n\n      # set up authentication via Workload identity Federation and gcloud\n\
       \n      - id: gcp-auth\n        name: Authenticate to Google Cloud\n       \
-      \ uses: google-github-actions/auth@v2\n        with:\n          workload_identity_provider:\
+      \ uses: google-github-actions/auth@v3\n        with:\n          workload_identity_provider:\
       \ ${{env.FAST_WIF_PROVIDER}}\n          service_account: ${{env.service_account}}\n\
       \          access_token_lifetime: 900s\n\n      - id: gcp-sdk\n        name:\
-      \ Set up Cloud SDK\n        uses: google-github-actions/setup-gcloud@v2\n  \
+      \ Set up Cloud SDK\n        uses: google-github-actions/setup-gcloud@v3\n  \
       \      with:\n          install_components: alpha\n\n      # copy provider file\n\
       \n      - id: tf-config-provider\n        name: Copy Terraform provider file\n\
       \        run: |\n          gcloud storage cp -r \\\n            \"gs://ft0-prod-iac-core-0-iac-outputs/providers/${{env.provider_file}}\"\
       \ ./\n          gcloud storage cp -r \\\n            \"gs://ft0-prod-iac-core-0-iac-outputs/tfvars/0-org-setup.auto.tfvars\"\
       \ ./\n\n      - id: tf-setup\n        name: Set up Terraform\n        uses:\
-      \ hashicorp/setup-terraform@v3\n        with:\n          terraform_version:\
+      \ hashicorp/setup-terraform@v4\n        with:\n          terraform_version:\
       \ ${{env.TF_VERSION}}\n\n      # run Terraform init/validate/plan\n\n      -\
       \ id: tf-init\n        name: Terraform init\n        continue-on-error: true\n\
       \        run: |\n          terraform init -no-color\n\n      - id: tf-validate\n\
@@ -581,7 +581,7 @@ values:
       \n      # PR comment with Terraform result from previous steps\n      # length\
       \ is checked and trimmed for length so as to stay within the limit\n\n     \
       \ - id: pr-comment\n        name: Post comment to Pull Request\n        continue-on-error:\
-      \ true\n        uses: actions/github-script@v7\n        if: github.event_name\
+      \ true\n        uses: actions/github-script@v9\n        if: github.event_name\
       \ == 'pull_request'\n        env:\n          PLAN: ${{steps.tf-plan.outputs.stdout}}\\\
       n${{steps.tf-plan.outputs.stderr}}\n        with:\n          script: |\n   \
       \         const output = `### Terraform Initialization \\`${{steps.tf-init.outcome}}\\\
@@ -599,7 +599,7 @@ values:
       \ context.issue.number,\n              owner: context.repo.owner,\n        \
       \      repo: context.repo.repo,\n              body: output\n            })\n\
       \n      - id: pr-short-comment\n        name: Post comment to Pull Request (abbreviated)\n\
-      \        uses: actions/github-script@v7\n        if: github.event_name == 'pull_request'\
+      \        uses: actions/github-script@v9\n        if: github.event_name == 'pull_request'\
       \ && steps.pr-comment.outcome != 'success'\n        with:\n          script:\
       \ |\n            const output = `### Terraform Initialization \\`${{steps.tf-init.outcome}}\\\
       `\n\n            ### Terraform Validation \\`${{steps.tf-validate.outcome}}\\\

--- a/tests/fast/stages/s0_org_setup/simple.yaml
+++ b/tests/fast/stages/s0_org_setup/simple.yaml
@@ -287,7 +287,7 @@ values:
       \ == 'synchronize'\n    permissions:\n      contents: read\n      id-token:\
       \ write\n      issues: write\n      pull-requests: write\n    runs-on: ubuntu-latest\n\
       \    steps:\n      - id: checkout\n        name: Checkout repository\n     \
-      \   uses: actions/checkout@v4\n\n      # set up SSH key authentication to the\
+      \   uses: actions/checkout@v6\n\n      # set up SSH key authentication to the\
       \ modules repository\n\n      - id: ssh-config\n        name: Configure SSH\
       \ authentication\n        run: |\n          ssh-agent -a \"$SSH_AUTH_SOCK\"\
       \ > /dev/null\n          ssh-add - <<< \"${{ secrets.CICD_MODULES_KEY }}\"\n\
@@ -302,16 +302,16 @@ values:
       \n          echo \"service_account=${{env.FAST_SERVICE_ACCOUNT}}\" >> \"$GITHUB_ENV\"\
       \n\n      # set up authentication via Workload identity Federation and gcloud\n\
       \n      - id: gcp-auth\n        name: Authenticate to Google Cloud\n       \
-      \ uses: google-github-actions/auth@v2\n        with:\n          workload_identity_provider:\
+      \ uses: google-github-actions/auth@v3\n        with:\n          workload_identity_provider:\
       \ ${{env.FAST_WIF_PROVIDER}}\n          service_account: ${{env.service_account}}\n\
       \          access_token_lifetime: 900s\n\n      - id: gcp-sdk\n        name:\
-      \ Set up Cloud SDK\n        uses: google-github-actions/setup-gcloud@v2\n  \
+      \ Set up Cloud SDK\n        uses: google-github-actions/setup-gcloud@v3\n  \
       \      with:\n          install_components: alpha\n\n      # copy provider file\n\
       \n      - id: tf-config-provider\n        name: Copy Terraform provider file\n\
       \        run: |\n          gcloud storage cp -r \\\n            \"gs://ft0-prod-iac-core-0-iac-outputs/providers/${{env.provider_file}}\"\
       \ ./\n          gcloud storage cp -r \\\n            \"gs://ft0-prod-iac-core-0-iac-outputs/tfvars/0-org-setup.auto.tfvars\"\
       \ ./\n\n      - id: tf-setup\n        name: Set up Terraform\n        uses:\
-      \ hashicorp/setup-terraform@v3\n        with:\n          terraform_version:\
+      \ hashicorp/setup-terraform@v4\n        with:\n          terraform_version:\
       \ ${{env.TF_VERSION}}\n\n      # run Terraform init/validate/plan\n\n      -\
       \ id: tf-init\n        name: Terraform init\n        continue-on-error: true\n\
       \        run: |\n          terraform init -no-color\n\n      - id: tf-validate\n\
@@ -325,7 +325,7 @@ values:
       \n      # PR comment with Terraform result from previous steps\n      # length\
       \ is checked and trimmed for length so as to stay within the limit\n\n     \
       \ - id: pr-comment\n        name: Post comment to Pull Request\n        continue-on-error:\
-      \ true\n        uses: actions/github-script@v7\n        if: github.event_name\
+      \ true\n        uses: actions/github-script@v9\n        if: github.event_name\
       \ == 'pull_request'\n        env:\n          PLAN: ${{steps.tf-plan.outputs.stdout}}\\\
       n${{steps.tf-plan.outputs.stderr}}\n        with:\n          script: |\n   \
       \         const output = `### Terraform Initialization \\`${{steps.tf-init.outcome}}\\\
@@ -343,7 +343,7 @@ values:
       \ context.issue.number,\n              owner: context.repo.owner,\n        \
       \      repo: context.repo.repo,\n              body: output\n            })\n\
       \n      - id: pr-short-comment\n        name: Post comment to Pull Request (abbreviated)\n\
-      \        uses: actions/github-script@v7\n        if: github.event_name == 'pull_request'\
+      \        uses: actions/github-script@v9\n        if: github.event_name == 'pull_request'\
       \ && steps.pr-comment.outcome != 'success'\n        with:\n          script:\
       \ |\n            const output = `### Terraform Initialization \\`${{steps.tf-init.outcome}}\\\
       `\n\n            ### Terraform Validation \\`${{steps.tf-validate.outcome}}\\\
@@ -543,7 +543,7 @@ values:
       \ == 'synchronize'\n    permissions:\n      contents: read\n      id-token:\
       \ write\n      issues: write\n      pull-requests: write\n    runs-on: ubuntu-latest\n\
       \    steps:\n      - id: checkout\n        name: Checkout repository\n     \
-      \   uses: actions/checkout@v4\n\n      # set up SSH key authentication to the\
+      \   uses: actions/checkout@v6\n\n      # set up SSH key authentication to the\
       \ modules repository\n\n      - id: ssh-config\n        name: Configure SSH\
       \ authentication\n        run: |\n          ssh-agent -a \"$SSH_AUTH_SOCK\"\
       \ > /dev/null\n          ssh-add - <<< \"${{ secrets.CICD_MODULES_KEY }}\"\n\
@@ -558,16 +558,16 @@ values:
       \n          echo \"service_account=${{env.FAST_SERVICE_ACCOUNT}}\" >> \"$GITHUB_ENV\"\
       \n\n      # set up authentication via Workload identity Federation and gcloud\n\
       \n      - id: gcp-auth\n        name: Authenticate to Google Cloud\n       \
-      \ uses: google-github-actions/auth@v2\n        with:\n          workload_identity_provider:\
+      \ uses: google-github-actions/auth@v3\n        with:\n          workload_identity_provider:\
       \ ${{env.FAST_WIF_PROVIDER}}\n          service_account: ${{env.service_account}}\n\
       \          access_token_lifetime: 900s\n\n      - id: gcp-sdk\n        name:\
-      \ Set up Cloud SDK\n        uses: google-github-actions/setup-gcloud@v2\n  \
+      \ Set up Cloud SDK\n        uses: google-github-actions/setup-gcloud@v3\n  \
       \      with:\n          install_components: alpha\n\n      # copy provider file\n\
       \n      - id: tf-config-provider\n        name: Copy Terraform provider file\n\
       \        run: |\n          gcloud storage cp -r \\\n            \"gs://ft0-prod-iac-core-0-iac-outputs/providers/${{env.provider_file}}\"\
       \ ./\n          gcloud storage cp -r \\\n            \"gs://ft0-prod-iac-core-0-iac-outputs/tfvars/0-org-setup.auto.tfvars\"\
       \ ./\n\n      - id: tf-setup\n        name: Set up Terraform\n        uses:\
-      \ hashicorp/setup-terraform@v3\n        with:\n          terraform_version:\
+      \ hashicorp/setup-terraform@v4\n        with:\n          terraform_version:\
       \ ${{env.TF_VERSION}}\n\n      # run Terraform init/validate/plan\n\n      -\
       \ id: tf-init\n        name: Terraform init\n        continue-on-error: true\n\
       \        run: |\n          terraform init -no-color\n\n      - id: tf-validate\n\
@@ -581,7 +581,7 @@ values:
       \n      # PR comment with Terraform result from previous steps\n      # length\
       \ is checked and trimmed for length so as to stay within the limit\n\n     \
       \ - id: pr-comment\n        name: Post comment to Pull Request\n        continue-on-error:\
-      \ true\n        uses: actions/github-script@v7\n        if: github.event_name\
+      \ true\n        uses: actions/github-script@v9\n        if: github.event_name\
       \ == 'pull_request'\n        env:\n          PLAN: ${{steps.tf-plan.outputs.stdout}}\\\
       n${{steps.tf-plan.outputs.stderr}}\n        with:\n          script: |\n   \
       \         const output = `### Terraform Initialization \\`${{steps.tf-init.outcome}}\\\
@@ -599,7 +599,7 @@ values:
       \ context.issue.number,\n              owner: context.repo.owner,\n        \
       \      repo: context.repo.repo,\n              body: output\n            })\n\
       \n      - id: pr-short-comment\n        name: Post comment to Pull Request (abbreviated)\n\
-      \        uses: actions/github-script@v7\n        if: github.event_name == 'pull_request'\
+      \        uses: actions/github-script@v9\n        if: github.event_name == 'pull_request'\
       \ && steps.pr-comment.outcome != 'success'\n        with:\n          script:\
       \ |\n            const output = `### Terraform Initialization \\`${{steps.tf-init.outcome}}\\\
       `\n\n            ### Terraform Validation \\`${{steps.tf-validate.outcome}}\\\


### PR DESCRIPTION
[Github Actions runners have deprecated and are removing Node20 soon](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) as Node20 is EOL in April, 2026.

This bumps all the GHAs in the FAST stage 0 CI/CD template to use newer releases not using node 20. This avoids the EOL and clears deprecation warnings in GHA when users run any GHA workflows generated in stage 0.

In short, the bumps are:
* checkout v4 -> v6
* google auth v2 -> v3
* setup-gcloud v2 -> v3
* setup-terraform v3 -> v4
* github-script v7 -> v9

I just ran stage 0 using GHA generated from the template with these bumps. It seems to work fine.

Thanks! Appreciate what y'all do.

<!-- Put a description of what this PR is for here -->

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [ ] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
