### PR TITLE
Bump minimum OpenTofu version to 1.11.00

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ env:
   TFTEST_COPY: 1
   DEFAULT_TERRAFORM_FLAVOUR: terraform
   DEFAULT_TERRAFORM_VERSION: ${{ inputs.terraform_version || '1.12.2' }}
-  DEFAULT_TOFU_VERSION: "1.10.0"
+  DEFAULT_TOFU_VERSION: "1.11.0"
 
 jobs:
   setup-tf-providers:

--- a/default-versions.tofu
+++ b/default-versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/__experimental_deprecated/alloydb-instance/versions.tofu
+++ b/modules/__experimental_deprecated/alloydb-instance/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/__experimental_deprecated/net-neg/versions.tofu
+++ b/modules/__experimental_deprecated/net-neg/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/__experimental_deprecated/project-iam-magic/versions.tofu
+++ b/modules/__experimental_deprecated/project-iam-magic/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/agent-engine/versions.tofu
+++ b/modules/agent-engine/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/ai-applications/versions.tofu
+++ b/modules/ai-applications/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/alloydb/versions.tofu
+++ b/modules/alloydb/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/analytics-hub/versions.tofu
+++ b/modules/analytics-hub/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/api-gateway/versions.tofu
+++ b/modules/api-gateway/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/apigee/versions.tofu
+++ b/modules/apigee/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/artifact-registry/README.md
+++ b/modules/artifact-registry/README.md
@@ -5,6 +5,7 @@ This module simplifies the creation of repositories using Google Cloud Artifact 
 <!-- BEGIN TOC -->
 - [Simple Docker Repository](#simple-docker-repository)
 - [Remote and Virtual Repositories](#remote-and-virtual-repositories)
+- [Remote Docker registry with credentials](#remote-docker-registry-with-credentials)
 - [Additional Docker and Maven Options](#additional-docker-and-maven-options)
 - [Other Formats](#other-formats)
 - [Cleanup Policies](#cleanup-policies)
@@ -148,7 +149,7 @@ module "secret-manager" {
   }
 }
 
-# tftest modules=3 resources=3 inventory=remote-credentials.yaml
+# tftest modules=3 resources=7 inventory=remote-credentials.yaml
 ```
 
 ## Additional Docker and Maven Options

--- a/modules/artifact-registry/versions.tofu
+++ b/modules/artifact-registry/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/backup-dr/versions.tofu
+++ b/modules/backup-dr/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/bigquery-connection/versions.tofu
+++ b/modules/bigquery-connection/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/bigquery-dataset/versions.tofu
+++ b/modules/bigquery-dataset/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/bigtable-instance/versions.tofu
+++ b/modules/bigtable-instance/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/billing-account/versions.tofu
+++ b/modules/billing-account/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/binauthz/versions.tofu
+++ b/modules/binauthz/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/certificate-authority-service/versions.tofu
+++ b/modules/certificate-authority-service/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/certificate-manager/versions.tofu
+++ b/modules/certificate-manager/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/cloud-build-v2-connection/versions.tofu
+++ b/modules/cloud-build-v2-connection/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/cloud-config-container/__need_fixing/onprem/versions.tofu
+++ b/modules/cloud-config-container/__need_fixing/onprem/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/cloud-config-container/__need_fixing/squid/versions.tofu
+++ b/modules/cloud-config-container/__need_fixing/squid/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/cloud-config-container/bindplane/versions.tofu
+++ b/modules/cloud-config-container/bindplane/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/cloud-config-container/coredns/versions.tofu
+++ b/modules/cloud-config-container/coredns/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/cloud-config-container/cos-generic-metadata/versions.tofu
+++ b/modules/cloud-config-container/cos-generic-metadata/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/cloud-config-container/envoy-sni-dyn-fwd-proxy/versions.tofu
+++ b/modules/cloud-config-container/envoy-sni-dyn-fwd-proxy/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/cloud-config-container/envoy-traffic-director/versions.tofu
+++ b/modules/cloud-config-container/envoy-traffic-director/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/cloud-config-container/mysql/versions.tofu
+++ b/modules/cloud-config-container/mysql/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/cloud-config-container/nginx-tls/versions.tofu
+++ b/modules/cloud-config-container/nginx-tls/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/cloud-config-container/nginx/versions.tofu
+++ b/modules/cloud-config-container/nginx/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/cloud-config-container/simple-nva/versions.tofu
+++ b/modules/cloud-config-container/simple-nva/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/cloud-deploy/versions.tofu
+++ b/modules/cloud-deploy/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/cloud-function-v1/versions.tofu
+++ b/modules/cloud-function-v1/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/cloud-function-v2/versions.tofu
+++ b/modules/cloud-function-v2/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/cloud-identity-group/versions.tofu
+++ b/modules/cloud-identity-group/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/cloud-run-v2/versions.tofu
+++ b/modules/cloud-run-v2/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/cloudsql-instance/versions.tofu
+++ b/modules/cloudsql-instance/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/compute-mig/versions.tofu
+++ b/modules/compute-mig/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/compute-vm/versions.tofu
+++ b/modules/compute-vm/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/container-registry/versions.tofu
+++ b/modules/container-registry/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/data-catalog-policy-tag/versions.tofu
+++ b/modules/data-catalog-policy-tag/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/data-catalog-tag-template/versions.tofu
+++ b/modules/data-catalog-tag-template/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/data-catalog-tag/versions.tofu
+++ b/modules/data-catalog-tag/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/dataform-repository/versions.tofu
+++ b/modules/dataform-repository/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/datafusion/versions.tofu
+++ b/modules/datafusion/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/dataplex-aspect-types/versions.tofu
+++ b/modules/dataplex-aspect-types/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/dataplex-datascan/versions.tofu
+++ b/modules/dataplex-datascan/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/dataplex/versions.tofu
+++ b/modules/dataplex/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/dataproc/versions.tofu
+++ b/modules/dataproc/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/dns-response-policy/versions.tofu
+++ b/modules/dns-response-policy/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/dns/versions.tofu
+++ b/modules/dns/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/endpoints/versions.tofu
+++ b/modules/endpoints/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/firestore/versions.tofu
+++ b/modules/firestore/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/folder/versions.tofu
+++ b/modules/folder/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/gcs/versions.tofu
+++ b/modules/gcs/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/gcve-private-cloud/versions.tofu
+++ b/modules/gcve-private-cloud/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/gke-cluster-autopilot/versions.tofu
+++ b/modules/gke-cluster-autopilot/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/gke-cluster-standard/versions.tofu
+++ b/modules/gke-cluster-standard/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/gke-hub/versions.tofu
+++ b/modules/gke-hub/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/gke-nodepool/versions.tofu
+++ b/modules/gke-nodepool/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/iam-service-account/versions.tofu
+++ b/modules/iam-service-account/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/kms/versions.tofu
+++ b/modules/kms/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/logging-bucket/versions.tofu
+++ b/modules/logging-bucket/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/looker-core/versions.tofu
+++ b/modules/looker-core/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/managed-kafka/versions.tofu
+++ b/modules/managed-kafka/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/ncc-spoke-ra/versions.tofu
+++ b/modules/ncc-spoke-ra/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/net-address/versions.tofu
+++ b/modules/net-address/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/net-cloudnat/versions.tofu
+++ b/modules/net-cloudnat/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/net-firewall-policy/versions.tofu
+++ b/modules/net-firewall-policy/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/net-ipsec-over-interconnect/versions.tofu
+++ b/modules/net-ipsec-over-interconnect/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/net-lb-app-ext-regional/versions.tofu
+++ b/modules/net-lb-app-ext-regional/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/net-lb-app-ext/versions.tofu
+++ b/modules/net-lb-app-ext/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/net-lb-app-int-cross-region/versions.tofu
+++ b/modules/net-lb-app-int-cross-region/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/net-lb-app-int/versions.tofu
+++ b/modules/net-lb-app-int/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/net-lb-ext/versions.tofu
+++ b/modules/net-lb-ext/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/net-lb-int/versions.tofu
+++ b/modules/net-lb-int/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/net-lb-proxy-int/versions.tofu
+++ b/modules/net-lb-proxy-int/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/net-swp/versions.tofu
+++ b/modules/net-swp/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/net-vlan-attachment/versions.tofu
+++ b/modules/net-vlan-attachment/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/net-vpc-firewall/versions.tofu
+++ b/modules/net-vpc-firewall/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/net-vpc-peering/versions.tofu
+++ b/modules/net-vpc-peering/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/net-vpc/versions.tofu
+++ b/modules/net-vpc/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/net-vpn-dynamic/versions.tofu
+++ b/modules/net-vpn-dynamic/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/net-vpn-ha/versions.tofu
+++ b/modules/net-vpn-ha/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/net-vpn-static/versions.tofu
+++ b/modules/net-vpn-static/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/organization/versions.tofu
+++ b/modules/organization/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/project/versions.tofu
+++ b/modules/project/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/projects-data-source/versions.tofu
+++ b/modules/projects-data-source/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/pubsub/versions.tofu
+++ b/modules/pubsub/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/secops-rules/versions.tofu
+++ b/modules/secops-rules/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/secret-manager/versions.tofu
+++ b/modules/secret-manager/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/secure-source-manager-instance/versions.tofu
+++ b/modules/secure-source-manager-instance/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/service-directory/versions.tofu
+++ b/modules/service-directory/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/source-repository/versions.tofu
+++ b/modules/source-repository/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/spanner-instance/versions.tofu
+++ b/modules/spanner-instance/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/vpc-sc/versions.tofu
+++ b/modules/vpc-sc/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/workstation-cluster/versions.tofu
+++ b/modules/workstation-cluster/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/tests/examples_e2e/setup_module/versions.tofu
+++ b/tests/examples_e2e/setup_module/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/tools/lockfile/versions.tofu
+++ b/tools/lockfile/versions.tofu
@@ -15,7 +15,7 @@
 # Fabric release: v55.3.0
 
 terraform {
-  required_version = ">= 1.10.0"
+  required_version = ">= 1.11.0"
   required_providers {
     google = {
       source  = "hashicorp/google"


### PR DESCRIPTION
Fixes artifact-error error exposed by #3887 (write-only attributes not supported in 1.10.0)

```upgrade-note
`modules`: Bump minimum OpenTofu version to 1.11.00
```
