### PR TITLE
Mark VPN shared secret as sensitive

### DIFF
--- a/modules/net-vpn-ha/recipe-vpn-aws-gcp/variables.tf
+++ b/modules/net-vpn-ha/recipe-vpn-aws-gcp/variables.tf
@@ -63,4 +63,5 @@ variable "propagate_routes" {
 variable "shared_secret" {
   description = "Shared secret."
   type        = string
+  sensitive   = true
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here -->

Fixes #3921.

Marks the `shared_secret` variable in `modules/net-vpn-ha/recipe-vpn-aws-gcp` as sensitive.

The variable is used as VPN shared secret key material in the AWS and GCP VPN tunnel configuration, so marking it as sensitive helps avoid accidental disclosure in Terraform CLI output or CI/CD logs.

I was not able to regenerate the README with `tfdoc.py`. The tool fails when `sensitive = true` is added to a variable block: `KeyError : 'sensitive'`. I believe this happens because variable parsing does not currently include `sensitive` in `VAR_TEMPLATE` in `tfdoc.py` (while output parsing already supports `sensitive`).

Any guidance on how to proceed? Should the `tfdoc.py` issue also be addressed in this PR, or would you prefer a separate issue/PR for that change?

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass

