### PR TITLE
Support org_policies in folders variable

### DIFF
--- a/modules/project-factory/variables-folders.tf
+++ b/modules/project-factory/variables-folders.tf
@@ -106,6 +106,28 @@ variable "folders" {
         description = optional(string)
       })
     })), {})
+    org_policies = optional(map(object({
+      inherit_from_parent = optional(bool)
+      reset               = optional(bool)
+      rules = optional(list(object({
+        allow = optional(object({
+          all    = optional(bool)
+          values = optional(list(string))
+        }))
+        deny = optional(object({
+          all    = optional(bool)
+          values = optional(list(string))
+        }))
+        enforce = optional(bool)
+        condition = optional(object({
+          description = optional(string)
+          expression  = optional(string)
+          location    = optional(string)
+          title       = optional(string)
+        }), {})
+        parameters = optional(string)
+      })), [])
+    })), {})
     pam_entitlements = optional(map(object({
       max_request_duration = string
       eligible_users       = list(string)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here -->

Support `org_policies` in folders variable. It's in the [schema](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/modules/project-factory/schemas/folder.schema.md) already just not supported in variables-folders.tf

We have a split level project-factory and are trying to do something like (read: not using `factories_config` on this level):
```
  folders = {
    "foo" = yamldecode(file("data/bar/.config.yaml"))
  }
```
Where the folder config contains `org_policies`, which are currently silently being dropped.

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
