### PR TITLE
Allow simple project exclusions in project factory module

### DIFF
--- a/modules/cloud-function-v2/README.md
+++ b/modules/cloud-function-v2/README.md
@@ -351,7 +351,7 @@ module "cf_http" {
 # tftest fixtures=fixtures/vpc-connector.tf inventory=service-vpc-access-connector.yaml
 ```
 
-If creation of the VPC Access Connector is required, use the `vpc_connector.create` and `vpc_connector_create` variable which also supports optional attributes like number of instances, machine type, or throughput.
+If creation of the VPC Access Connector is required, set `vpc_connector_create` to configure the connector with optional attributes like number of instances, machine type, or throughput.
 
 ```hcl
 module "cf_http" {
@@ -362,9 +362,6 @@ module "cf_http" {
   bucket_name = var.bucket
   bundle_config = {
     path = "assets/sample-function/"
-  }
-  vpc_connector = {
-    create = true
   }
   vpc_connector_create = {
     ip_cidr_range = "10.10.10.0/28"
@@ -389,9 +386,6 @@ module "cf_http" {
   bucket_name = var.bucket
   bundle_config = {
     path = "assets/sample-function/"
-  }
-  vpc_connector = {
-    create = true
   }
   vpc_connector_create = {
     machine_type = "e2-standard-4"

--- a/modules/project-factory/README.md
+++ b/modules/project-factory/README.md
@@ -483,7 +483,7 @@ module "project-factory" {
     }
   }
 }
-# tftest files=t0,0,1,2,2.1,2.2,2.3,3,4,5,6,7,8,9,10 inventory=example.yaml
+# tftest files=t0,0,1,2,2.1,2.2,2.3,3,4,5,6,7,8,9,10,99 inventory=example.yaml
 ```
 
 A project template for GKE projects:

--- a/modules/project-factory/README.md
+++ b/modules/project-factory/README.md
@@ -469,6 +469,9 @@ module "project-factory" {
     budgets = {
       billing_account = var.billing_account_id
     }
+    exclusions = {
+      projects = ["staging/"]
+    }
   }
   notification_channels = {
     billing-default = {
@@ -609,6 +612,16 @@ workload_identity_pools:
             template: github
 
 # tftest-file id=5 path=data/folders/teams-iac-0.yaml schema=project.schema.json
+```
+
+A project definition ignored via `factories_config.exclusions.projects`.
+
+```yaml
+billing_account: 012345-67890A-BCDEF0
+services:
+  - container.googleapis.com
+  - storage.googleapis.com
+# tftest-file id=99 path=data/projects/staging/unused-0.yaml schema=project.schema.json
 ```
 
 More traditional project definitions via the project factory data:
@@ -881,7 +894,7 @@ compute.disableSerialPortAccess:
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [factories_config](variables.tf#L170) | Path to folder with YAML resource description data files. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
+| [factories_config](variables.tf#L170) | Path to folder with YAML resource description data files. Exclusions match the start of file paths, relative to their containing folder. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
 | [context](variables.tf#L17) | Context-specific interpolations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [data_defaults](variables.tf#L47) | Optional default values used when corresponding project or folder data from files are missing. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [data_merges](variables.tf#L112) | Optional values that will be merged with corresponding data from files. Combines with `data_defaults`, file data, and `data_overrides`. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |

--- a/modules/project-factory/projects.tf
+++ b/modules/project-factory/projects.tf
@@ -31,7 +31,12 @@ locals {
       try(local._templates_raw[v.project_template], {}),
       v
     )
+    # apply exclusions
+    if alltrue([
+      for x in var.factories_config.exclusions.projects : !startswith(k, x)
+    ])
   }
+  # project data from projects folder
   _projects_raw = {
     for f in try(fileset(local.paths.projects, "**/*.yaml"), []) :
     trimsuffix(f, ".yaml") => yamldecode(file("${local.paths.projects}/${f}"))

--- a/modules/project-factory/variables.tf
+++ b/modules/project-factory/variables.tf
@@ -168,11 +168,14 @@ variable "data_overrides" {
 }
 
 variable "factories_config" {
-  description = "Path to folder with YAML resource description data files."
+  description = "Path to folder with YAML resource description data files. Exclusions match the start of file paths, relative to their containing folder."
   type = object({
     basepath = string
     budgets = optional(object({
       billing_account = optional(string)
+    }), {})
+    exclusions = optional(object({
+      projects = optional(list(string), [])
     }), {})
     paths = optional(object({
       budgets           = optional(string, "budgets")


### PR DESCRIPTION
This PR allows consumers of the project factory module to optionally exclude (or include) specific projects, by definining simple match strings in `var.factories_config.exclusions.projects`. Exclusions are matched via `startswith()` so entire trees can be included/excluded.

The project factory ignores project files paths in keys (except for projects embedded in the folder hierarchy), so moving project files in and out of excluded folders only impacts the exclusion match, not the underlying resources.

An example is provided in the README.