### PR TITLE
Move org policies lower in the project factory dependency chain to support extended context

### DIFF
--- a/modules/project-factory/folders.tf
+++ b/modules/project-factory/folders.tf
@@ -65,9 +65,8 @@ module "folder-1" {
       ? v :
       "${var.factories_config.basepath}/${v}"
     ), null)
-    if contains(["org_policies", "scc_sha_custom_modules"], k)
+    if contains(["scc_sha_custom_modules"], k)
   }
-  org_policies            = lookup(each.value, "org_policies", {})
   pam_entitlements        = lookup(each.value, "pam_entitlements", {})
   assured_workload_config = lookup(each.value, "assured_workload_config", null)
   logging_settings = anytrue([
@@ -87,6 +86,7 @@ module "folder-1-iam" {
   id            = module.folder-1[each.key].id
   asset_feeds   = lookup(each.value, "asset_feeds", {})
   asset_search  = lookup(each.value, "asset_search", {})
+  org_policies  = lookup(each.value, "org_policies", {})
   # we do anything that can refer to IAM and custom roles in this call
   factories_config = {
     for k, v in lookup(each.value, "factories_config", {}) : k => try(pathexpand(
@@ -94,7 +94,7 @@ module "folder-1-iam" {
       ? v :
       "${var.factories_config.basepath}/${v}"
     ), null)
-    if contains(["pam_entitlements"], k)
+    if contains(["pam_entitlements", "org_policies"], k)
   }
   autokey_config                = lookup(each.value, "autokey_config", null)
   contacts                      = lookup(each.value, "contacts", {})
@@ -137,9 +137,8 @@ module "folder-2" {
       ? v :
       "${var.factories_config.basepath}/${v}"
     ), null)
-    if contains(["org_policies", "scc_sha_custom_modules"], k)
+    if contains(["scc_sha_custom_modules"], k)
   }
-  org_policies            = lookup(each.value, "org_policies", {})
   pam_entitlements        = lookup(each.value, "pam_entitlements", {})
   assured_workload_config = lookup(each.value, "assured_workload_config", null)
   logging_settings = anytrue([
@@ -164,6 +163,7 @@ module "folder-2-iam" {
   id            = module.folder-2[each.key].id
   asset_feeds   = lookup(each.value, "asset_feeds", {})
   asset_search  = lookup(each.value, "asset_search", {})
+  org_policies  = lookup(each.value, "org_policies", {})
   # we do anything that can refer to IAM and custom roles in this call
   factories_config = {
     for k, v in lookup(each.value, "factories_config", {}) : k => try(pathexpand(
@@ -171,7 +171,7 @@ module "folder-2-iam" {
       ? v :
       "${var.factories_config.basepath}/${v}"
     ), null)
-    if contains(["pam_entitlements"], k)
+    if contains(["pam_entitlements", "org_policies"], k)
   }
   autokey_config                = lookup(each.value, "autokey_config", null)
   contacts                      = lookup(each.value, "contacts", {})
@@ -217,9 +217,8 @@ module "folder-3" {
       ? v :
       "${var.factories_config.basepath}/${v}"
     ), null)
-    if contains(["org_policies", "scc_sha_custom_modules"], k)
+    if contains(["scc_sha_custom_modules"], k)
   }
-  org_policies            = lookup(each.value, "org_policies", {})
   pam_entitlements        = lookup(each.value, "pam_entitlements", {})
   assured_workload_config = lookup(each.value, "assured_workload_config", null)
   logging_settings = anytrue([
@@ -244,6 +243,7 @@ module "folder-3-iam" {
   id            = module.folder-3[each.key].id
   asset_feeds   = lookup(each.value, "asset_feeds", {})
   asset_search  = lookup(each.value, "asset_search", {})
+  org_policies  = lookup(each.value, "org_policies", {})
   # we do anything that can refer to IAM and custom roles in this call
   factories_config = {
     for k, v in lookup(each.value, "factories_config", {}) : k => try(pathexpand(
@@ -251,7 +251,7 @@ module "folder-3-iam" {
       ? v :
       "${var.factories_config.basepath}/${v}"
     ), null)
-    if contains(["pam_entitlements"], k)
+    if contains(["pam_entitlements", "org_policies"], k)
   }
   autokey_config                = lookup(each.value, "autokey_config", null)
   contacts                      = lookup(each.value, "contacts", {})
@@ -297,9 +297,8 @@ module "folder-4" {
       ? v :
       "${var.factories_config.basepath}/${v}"
     ), null)
-    if contains(["org_policies", "scc_sha_custom_modules"], k)
+    if contains(["scc_sha_custom_modules"], k)
   }
-  org_policies            = lookup(each.value, "org_policies", {})
   pam_entitlements        = lookup(each.value, "pam_entitlements", {})
   assured_workload_config = lookup(each.value, "assured_workload_config", null)
   logging_settings = anytrue([
@@ -324,6 +323,7 @@ module "folder-4-iam" {
   id            = module.folder-4[each.key].id
   asset_feeds   = lookup(each.value, "asset_feeds", {})
   asset_search  = lookup(each.value, "asset_search", {})
+  org_policies  = lookup(each.value, "org_policies", {})
   # we do anything that can refer to IAM and custom roles in this call
   factories_config = {
     for k, v in lookup(each.value, "factories_config", {}) : k => try(pathexpand(
@@ -331,7 +331,7 @@ module "folder-4-iam" {
       ? v :
       "${var.factories_config.basepath}/${v}"
     ), null)
-    if contains(["pam_entitlements"], k)
+    if contains(["pam_entitlements", "org_policies"], k)
   }
   autokey_config                = lookup(each.value, "autokey_config", null)
   contacts                      = lookup(each.value, "contacts", {})

--- a/modules/project-factory/projects.tf
+++ b/modules/project-factory/projects.tf
@@ -157,7 +157,6 @@ module "projects" {
   logging_metrics       = try(each.value.logging_metrics, null)
   logging_sinks         = try(each.value.logging_sinks, {})
   notification_channels = try(each.value.notification_channels, null)
-  org_policies          = each.value.org_policies
   quotas                = each.value.quotas
   services = distinct(concat(
     each.value.services,
@@ -173,10 +172,11 @@ module "projects" {
 }
 
 module "projects-iam" {
-  source   = "../project"
-  for_each = local.projects_input
-  name     = each.value.name
-  prefix   = each.value.prefix
+  source       = "../project"
+  for_each     = local.projects_input
+  name         = each.value.name
+  prefix       = each.value.prefix
+  org_policies = each.value.org_policies
   project_reuse = {
     use_data_source = false
     attributes = {
@@ -186,6 +186,13 @@ module "projects-iam" {
     }
   }
   context = merge(local.ctx, {
+    condition_vars = merge(
+      local.ctx.condition_vars, {
+        projects = {
+          for k, v in module.projects : k => v.project_id
+        }
+      }
+    )
     tag_vars = {
       projects     = merge(try(local.ctx.tag_vars.projects, {}), local.tag_vars_projects)
       organization = try(local.ctx.tag_vars.organization, {})

--- a/modules/project-factory/projects.tf
+++ b/modules/project-factory/projects.tf
@@ -146,6 +146,7 @@ module "projects" {
       ? v :
       "${var.factories_config.basepath}/${v}"
     ), null)
+    if k != "org_policies"
   }
   kms_autokeys = try(each.value.kms.autokeys, {})
   labels = merge(
@@ -188,6 +189,9 @@ module "projects-iam" {
   context = merge(local.ctx, {
     condition_vars = merge(
       local.ctx.condition_vars, {
+        folder_ids = {
+          for k, v in local.ctx_folder_ids : replace(k, "$folder_ids:", "") => v
+        }
         projects = {
           for k, v in module.projects : k => v.project_id
         }
@@ -197,7 +201,7 @@ module "projects-iam" {
       projects     = merge(try(local.ctx.tag_vars.projects, {}), local.tag_vars_projects)
       organization = try(local.ctx.tag_vars.organization, {})
     }
-    folder_ids = local.ctx.folder_ids
+    folder_ids = local.ctx_folder_ids
     kms_keys   = merge(local.ctx.kms_keys, local.kms_keys)
     iam_principals = merge(
       local.ctx_iam_principals,
@@ -215,6 +219,11 @@ module "projects-iam" {
   factories_config = {
     # we do anything that can refer to IAM and custom roles in this call
     pam_entitlements = try(each.value.factories_config.pam_entitlements, null)
+    org_policies = lookup(each.value.factories_config, "org_policies", null) == null ? null : try(pathexpand(
+      var.factories_config.basepath == null || startswith(each.value.factories_config.org_policies, "/") || startswith(each.value.factories_config.org_policies, ".")
+      ? each.value.factories_config.org_policies :
+      "${var.factories_config.basepath}/${each.value.factories_config.org_policies}"
+    ), null)
   }
   iam                           = lookup(each.value, "iam", {})
   iam_bindings                  = lookup(each.value, "iam_bindings", {})

--- a/tests/fast/stages/s0_org_setup/hardened.yaml
+++ b/tests/fast/stages/s0_org_setup/hardened.yaml
@@ -1676,7 +1676,7 @@ values:
   module.factory.module.projects["billing-0"].data.google_storage_project_service_account.gcs_sa[0]:
     project: ft0-prod-billing-exp-0
     user_project: null
-  module.factory.module.projects["billing-0"].google_org_policy_policy.default["gcp.restrictCmekCryptoKeyProjects"]:
+  module.factory.module.projects-iam["billing-0"].google_org_policy_policy.default["gcp.restrictCmekCryptoKeyProjects"]:
     dry_run_spec: []
     name: projects/ft0-prod-billing-exp-0/policies/gcp.restrictCmekCryptoKeyProjects
     parent: projects/ft0-prod-billing-exp-0
@@ -1759,7 +1759,7 @@ values:
   module.factory.module.projects["iac-0"].data.google_storage_project_service_account.gcs_sa[0]:
     project: ft0-prod-iac-core-0
     user_project: null
-  module.factory.module.projects["iac-0"].google_org_policy_policy.default["gcp.restrictCmekCryptoKeyProjects"]:
+  module.factory.module.projects-iam["iac-0"].google_org_policy_policy.default["gcp.restrictCmekCryptoKeyProjects"]:
     dry_run_spec: []
     name: projects/ft0-prod-iac-core-0/policies/gcp.restrictCmekCryptoKeyProjects
     parent: projects/ft0-prod-iac-core-0
@@ -1774,7 +1774,7 @@ values:
         parameters: null
         values: []
     timeouts: null
-  module.factory.module.projects["iac-0"].google_org_policy_policy.default["iam.workloadIdentityPoolProviders"]:
+  module.factory.module.projects-iam["iac-0"].google_org_policy_policy.default["iam.workloadIdentityPoolProviders"]:
     dry_run_spec: []
     name: projects/ft0-prod-iac-core-0/policies/iam.workloadIdentityPoolProviders
     parent: projects/ft0-prod-iac-core-0
@@ -2050,7 +2050,7 @@ values:
   module.factory.module.projects["log-0"].data.google_storage_project_service_account.gcs_sa[0]:
     project: ft0-prod-audit-logs-0
     user_project: null
-  module.factory.module.projects["log-0"].google_org_policy_policy.default["gcp.restrictCmekCryptoKeyProjects"]:
+  module.factory.module.projects-iam["log-0"].google_org_policy_policy.default["gcp.restrictCmekCryptoKeyProjects"]:
     dry_run_spec: []
     name: projects/ft0-prod-audit-logs-0/policies/gcp.restrictCmekCryptoKeyProjects
     parent: projects/ft0-prod-audit-logs-0

--- a/tests/fast/stages/s0_org_setup/simple.yaml
+++ b/tests/fast/stages/s0_org_setup/simple.yaml
@@ -1176,7 +1176,7 @@ values:
   module.factory.module.projects["iac-0"].data.google_storage_project_service_account.gcs_sa[0]:
     project: ft0-prod-iac-core-0
     user_project: null
-  module.factory.module.projects["iac-0"].google_org_policy_policy.default["iam.workloadIdentityPoolProviders"]:
+  module.factory.module.projects-iam["iac-0"].google_org_policy_policy.default["iam.workloadIdentityPoolProviders"]:
     dry_run_spec: []
     name: projects/ft0-prod-iac-core-0/policies/iam.workloadIdentityPoolProviders
     parent: projects/ft0-prod-iac-core-0

--- a/tests/modules/project_factory/examples/example.yaml
+++ b/tests/modules/project_factory/examples/example.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,9 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# yamllint disable rule:line-length
-
 values:
+  module.project-factory.google_network_security_dns_threat_detector.dns_threat_detector["dev-ta-app0-be"]:
+    effective_labels:
+      goog-terraform-provisioned: 'true'
+    excluded_networks: []
+    labels: null
+    location: global
+    name: test-pf-dev-ta-app0-be
+    project: test-pf-dev-ta-app0-be
+    terraform_labels:
+      goog-terraform-provisioned: 'true'
+    threat_detector_provider: null
+    timeouts: null
   module.project-factory.module.automation-bucket["dev-tb-app0-0/automation/tf-state"].google_storage_bucket.bucket[0]:
     autoclass: []
     cors: []
@@ -239,13 +249,8 @@ values:
     parent: folders/5678901234
     tags: null
     timeouts: null
-  module.project-factory.module.folder-2["team-a/app-0"].google_folder.folder[0]:
-    deletion_protection: false
-    display_name: App 0
-    tags: null
-    timeouts: null
-  module.project-factory.module.folder-2["team-a/app-0"].google_org_policy_policy.default["compute.disableSerialPortAccess"]:
-    dry_run_spec: []
+  ? module.project-factory.module.folder-2-iam["team-a/app-0"].google_org_policy_policy.default["compute.disableSerialPortAccess"]
+  : dry_run_spec: []
     spec:
     - inherit_from_parent: null
       reset: null
@@ -256,6 +261,14 @@ values:
         enforce: 'FALSE'
         parameters: null
         values: []
+    timeouts: null
+  module.project-factory.module.folder-2-iam["team-b/app-0"].google_tags_tag_binding.binding["drs-allow-all"]:
+    tag_value: tagValues/123456
+    timeouts: null
+  module.project-factory.module.folder-2["team-a/app-0"].google_folder.folder[0]:
+    deletion_protection: false
+    display_name: App 0
+    tags: null
     timeouts: null
   ? module.project-factory.module.folder-2["team-a/app-0"].google_privileged_access_manager_entitlement.default["app-0-admins"]
   : additional_notification_targets: []
@@ -289,9 +302,6 @@ values:
     deletion_protection: false
     display_name: App 0
     tags: null
-    timeouts: null
-  module.project-factory.module.folder-2-iam["team-b/app-0"].google_tags_tag_binding.binding["drs-allow-all"]:
-    tag_value: tagValues/123456
     timeouts: null
   module.project-factory.module.folder-2["team-c/apps"].google_folder.folder[0]:
     deletion_protection: false
@@ -451,6 +461,37 @@ values:
     - serviceAccount:app-0-be@test-pf-dev-tb-app0-1.iam.gserviceaccount.com
     project: test-pf-dev-tb-app0-1
     role: roles/run.developer
+  ? module.project-factory.module.projects-iam["teams-iac-0"].google_org_policy_policy.default["compute.disableSerialPortAccess"]
+  : dry_run_spec: []
+    name: projects/test-pf-teams-iac-0/policies/compute.disableSerialPortAccess
+    parent: projects/test-pf-teams-iac-0
+    spec:
+    - inherit_from_parent: null
+      reset: null
+      rules:
+      - allow_all: null
+        condition: []
+        deny_all: null
+        enforce: 'FALSE'
+        parameters: null
+        values: []
+    timeouts: null
+  ? module.project-factory.module.projects-iam["teams-iac-0"].google_org_policy_policy.default["gcp.restrictCmekCryptoKeyProjects"]
+  : dry_run_spec: []
+    name: projects/test-pf-teams-iac-0/policies/gcp.restrictCmekCryptoKeyProjects
+    parent: projects/test-pf-teams-iac-0
+    spec:
+    - inherit_from_parent: null
+      reset: null
+      rules:
+      - allow_all: null
+        condition: []
+        deny_all: null
+        enforce: null
+        parameters: null
+        values:
+        - denied_values: null
+    timeouts: null
   module.project-factory.module.projects["dev-ta-app0-be"].data.google_storage_project_service_account.gcs_sa[0]:
     project: test-pf-dev-ta-app0-be
     user_project: null
@@ -681,9 +722,12 @@ values:
     parent: projects/test-pf-teams-iac-0
     timeouts: null
   module.project-factory.module.projects["teams-iac-0"].google_iam_workload_identity_pool.default["test-0"]:
+    attestation_rules: []
     description: null
     disabled: null
     display_name: Test pool.
+    inline_certificate_issuance_config: []
+    inline_trust_config: []
     project: test-pf-teams-iac-0
     timeouts: null
     workload_identity_pool_id: test-0
@@ -691,11 +735,15 @@ values:
   : attribute_condition: attribute.repository_owner=="my_org"
     attribute_mapping:
       attribute.actor: assertion.actor
+      attribute.event_name: assertion.event_name
       attribute.fast_sub: '"repo:" + assertion.repository + ":ref:" + assertion.ref'
+      attribute.job_workflow_ref: assertion.job_workflow_ref
+      attribute.pr_review_sub: '"event:" + assertion.event_name + ":workflow:" + assertion.workflow'
       attribute.ref: assertion.ref
       attribute.repository: assertion.repository
       attribute.repository_owner: assertion.repository_owner
       attribute.sub: assertion.sub
+      attribute.workflow: assertion.workflow
       google.subject: assertion.sub
     aws: []
     description: null
@@ -711,37 +759,6 @@ values:
     workload_identity_pool_id: test-0
     workload_identity_pool_provider_id: github-test
     x509: []
-  module.project-factory.module.projects["teams-iac-0"].google_org_policy_policy.default["compute.disableSerialPortAccess"]:
-    dry_run_spec: []
-    name: projects/test-pf-teams-iac-0/policies/compute.disableSerialPortAccess
-    parent: projects/test-pf-teams-iac-0
-    spec:
-    - inherit_from_parent: null
-      reset: null
-      rules:
-      - allow_all: null
-        condition: []
-        deny_all: null
-        enforce: 'FALSE'
-        parameters: null
-        values: []
-    timeouts: null
-  ? module.project-factory.module.projects["teams-iac-0"].google_org_policy_policy.default["gcp.restrictCmekCryptoKeyProjects"]
-  : dry_run_spec: []
-    name: projects/test-pf-teams-iac-0/policies/gcp.restrictCmekCryptoKeyProjects
-    parent: projects/test-pf-teams-iac-0
-    spec:
-    - inherit_from_parent: null
-      reset: null
-      rules:
-      - allow_all: null
-        condition: []
-        deny_all: null
-        enforce: null
-        parameters: null
-        values:
-        - denied_values: null
-    timeouts: null
   module.project-factory.module.projects["teams-iac-0"].google_project.project[0]:
     auto_create_network: false
     billing_account: 012345-67890A-BCDEF0
@@ -847,6 +864,22 @@ values:
     terraform_labels:
       goog-terraform-provisioned: 'true'
     timeouts: null
+  ? module.project-factory.module.service-accounts-iam["dev-ta-app0-be/app-0-be"].google_service_account_iam_binding.authoritative["roles/iam.serviceAccountUser"]
+  : condition: []
+    role: roles/iam.serviceAccountUser
+  ? module.project-factory.module.service-accounts-iam["dev-ta-app0-be/app-0-be"].google_service_account_iam_member.additive["$service_account_ids:_self_/app-0-fe-roles/iam.serviceAccountUser"]
+  : condition: []
+    role: roles/iam.serviceAccountUser
+    service_account_id: projects/test-pf-dev-ta-app0-be/serviceAccounts/app-0-fe@test-pf-dev-ta-app0-be.iam.gserviceaccount.com
+  ? module.project-factory.module.service-accounts-iam["dev-ta-app0-be/app-0-be"].google_service_account_iam_member.bindings["test"]
+  : condition: []
+    member: group:team-a-admins@example.org
+    role: roles/iam.serviceAccountUser
+  ? module.project-factory.module.service-accounts-iam["dev-tb-app0-0/vm-default"].google_service_account_iam_binding.authoritative["roles/iam.serviceAccountTokenCreator"]
+  : condition: []
+    members:
+    - serviceAccount:dev-tb-app0-0-rw@test-pf-teams-iac-0.iam.gserviceaccount.com
+    role: roles/iam.serviceAccountTokenCreator
   ? module.project-factory.module.service-accounts["dev-ta-app0-be/app-0-be"].google_project_iam_member.project_roles["$project_ids:dev-spoke-0-roles/compute.networkUser"]
   : condition: []
     project: $project_ids:dev-spoke-0
@@ -930,22 +963,6 @@ values:
     member: serviceAccount:app-0-be@test-pf-dev-tb-app0-1.iam.gserviceaccount.com
     project: test-pf-dev-tb-app0-1
     timeouts: null
-  ? module.project-factory.module.service-accounts-iam["dev-ta-app0-be/app-0-be"].google_service_account_iam_binding.authoritative["roles/iam.serviceAccountUser"]
-  : condition: []
-    role: roles/iam.serviceAccountUser
-  ? module.project-factory.module.service-accounts-iam["dev-ta-app0-be/app-0-be"].google_service_account_iam_member.additive["$service_account_ids:_self_/app-0-fe-roles/iam.serviceAccountUser"]
-  : condition: []
-    role: roles/iam.serviceAccountUser
-    service_account_id: projects/test-pf-dev-ta-app0-be/serviceAccounts/app-0-fe@test-pf-dev-ta-app0-be.iam.gserviceaccount.com
-  ? module.project-factory.module.service-accounts-iam["dev-ta-app0-be/app-0-be"].google_service_account_iam_member.bindings["test"]
-  : condition: []
-    member: group:team-a-admins@example.org
-    role: roles/iam.serviceAccountUser
-  ? module.project-factory.module.service-accounts-iam["dev-tb-app0-0/vm-default"].google_service_account_iam_binding.authoritative["roles/iam.serviceAccountTokenCreator"]
-  : condition: []
-    members:
-    - serviceAccount:dev-tb-app0-0-rw@test-pf-teams-iac-0.iam.gserviceaccount.com
-    role: roles/iam.serviceAccountTokenCreator
   module.project-factory.terraform_data.defaults_preconditions:
     input: null
     output: null
@@ -995,6 +1012,8 @@ counts:
   google_tags_tag_key: 1
   google_tags_tag_value: 2
   google_tags_tag_value_iam_binding: 1
-  modules: 35
+  modules: 37
   resources: 119
   terraform_data: 2
+
+outputs: {}


### PR DESCRIPTION
This enables the following use case:

```yaml
org_policies:
  compute.restrictSharedVpcSubnetworks:
    rules:
    - allow:
        values:
        - projects/${projects["host"]}/regions/${user_config["region"]}/subnetworks/${user_config["subnet_name"]}
```