### PR TITLE
Fix custom_roles not permeating when used in dns zone IAM

### DIFF
--- a/fast/stages/2-networking/factory-dns.tf
+++ b/fast/stages/2-networking/factory-dns.tf
@@ -133,8 +133,9 @@ module "dns-zones" {
   zone_config   = each.value.zone_config
   recordsets    = each.value.recordsets
   context = {
-    project_ids = local.ctx_projects.project_ids
-    networks    = local.ctx_vpcs.self_links
+    custom_roles = local.ctx.custom_roles
+    project_ids  = local.ctx_projects.project_ids
+    networks     = local.ctx_vpcs.self_links
   }
   depends_on = [module.vpc-factory]
 }
@@ -146,8 +147,9 @@ module "dns-delegations" {
   name       = replace(each.key, "/", "-")
   recordsets = each.value
   context = {
-    project_ids = local.ctx_projects.project_ids
-    networks    = local.ctx_vpcs.self_links
+    custom_roles = local.ctx.custom_roles
+    project_ids  = local.ctx_projects.project_ids
+    networks     = local.ctx_vpcs.self_links
   }
   depends_on = [module.dns-zones]
 }

--- a/tests/fast/stages/s2_networking/data-testdns-delegation/dns/zones/net-core-0/pub-child.yaml
+++ b/tests/fast/stages/s2_networking/data-testdns-delegation/dns/zones/net-core-0/pub-child.yaml
@@ -9,3 +9,8 @@ domain: child.example.com.
 public:
   dnssec_config:
     state: "off"
+iam:
+  roles/dns.reader:
+    - serviceAccount:config-plane-dev-rw@fast-config-plane-dev.iam.gserviceaccount.com
+  $custom_roles:dns_resource_record_sets_adder:
+    - serviceAccount:config-plane-dev-rw@fast-config-plane-dev.iam.gserviceaccount.com

--- a/tests/fast/stages/s2_networking/dns_delegations.tfvars
+++ b/tests/fast/stages/s2_networking/dns_delegations.tfvars
@@ -4,6 +4,9 @@ automation = {
 billing_account = {
   id = "000000-111111-222222"
 }
+custom_roles = {
+  dns_resource_record_sets_adder = "organizations/123456789012/roles/DNSResourceRecordSetsAdder"
+}
 factories_config = {
   dataset = "./data-testdns-delegation"
   paths = {

--- a/tests/fast/stages/s2_networking/dns_delegations.yaml
+++ b/tests/fast/stages/s2_networking/dns_delegations.yaml
@@ -17,15 +17,18 @@ counts:
   google_compute_route: 3
   google_compute_shared_vpc_host_project: 1
   google_compute_subnetwork: 1
+  google_dns_keys: 1
   google_dns_managed_zone: 4
+  google_dns_managed_zone_iam_binding: 2
   google_dns_record_set: 3
+  google_logging_project_settings: 1
   google_project: 1
   google_project_iam_member: 8
   google_project_service: 10
   google_project_service_identity: 8
   google_storage_bucket_object: 2
   modules: 9
-  resources: 46
+  resources: 48
   terraform_data: 2
 values:
   module.dns-delegations["net-core-0/pub-parent"].google_dns_record_set.dns_record_set["NS child.example.com."]:
@@ -49,3 +52,15 @@ values:
     routing_policy: []
     ttl: 300
     type: DS
+  module.dns-zones["net-core-0/pub-child"].google_dns_managed_zone_iam_binding.iam_bindings["$custom_roles:dns_resource_record_sets_adder"]:
+    condition: []
+    members:
+      - serviceAccount:config-plane-dev-rw@fast-config-plane-dev.iam.gserviceaccount.com
+    project: fast-prod-net-core-0
+    role: organizations/123456789012/roles/DNSResourceRecordSetsAdder
+  module.dns-zones["net-core-0/pub-child"].google_dns_managed_zone_iam_binding.iam_bindings["roles/dns.reader"]:
+    condition: []
+    members:
+      - serviceAccount:config-plane-dev-rw@fast-config-plane-dev.iam.gserviceaccount.com
+    project: fast-prod-net-core-0
+    role: roles/dns.reader


### PR DESCRIPTION
In case that you want to use custom roles for the IAM Binding of the dns zones, those custom roles needs to be passed down to the DNS factory in the context. Currently, there is a bug preventing it that this PR solves. 

---
**Checklist**

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [x]  Made sure all relevant tests pass