### PR TITLE
Add support for min_instance_count in cloud-function-v2 module

### DIFF
--- a/modules/cloud-function-v2/README.md
+++ b/modules/cloud-function-v2/README.md
@@ -458,9 +458,9 @@ module "cf-http" {
 |---|---|:---:|:---:|:---:|
 | [bucket_name](variables.tf#L27) | Name of the bucket that will be used for the function code. It will be created with prefix prepended if bucket_config is not null. | <code>string</code> | ✓ |  |
 | [bundle_config](variables.tf#L51) | Cloud function source. Path can point to a GCS object URI, or a local path. A local path to a zip archive will generate a GCS object using its basename, a folder will be zipped and the GCS object name inferred when not specified. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
-| [name](variables.tf#L189) | Name used for cloud function and associated resources. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L204) | Project id used for all resources. | <code>string</code> | ✓ |  |
-| [region](variables.tf#L209) | Region used for all resources. | <code>string</code> | ✓ |  |
+| [name](variables.tf#L190) | Name used for cloud function and associated resources. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L205) | Project id used for all resources. | <code>string</code> | ✓ |  |
+| [region](variables.tf#L210) | Region used for all resources. | <code>string</code> | ✓ |  |
 | [bucket_config](variables.tf#L17) | Enable and configure auto-created bucket. Set fields to null to use defaults. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
 | [build_environment_variables](variables.tf#L33) | A set of key/value environment variable pairs available during build time. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
 | [build_service_account](variables.tf#L39) | Build service account email. | <code>string</code> |  | <code>null</code> |
@@ -471,15 +471,15 @@ module "cf-http" {
 | [docker_repository_id](variables.tf#L126) | User managed repository created in Artifact Registry. | <code>string</code> |  | <code>null</code> |
 | [environment_variables](variables.tf#L132) | Cloud function environment variables. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#8230;&#125;</code> |
 | [function_config](variables.tf#L140) | Cloud function configuration. Defaults to using main as entrypoint, 1 instance with 256MiB of memory, and 180 second timeout. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [iam](variables.tf#L165) | IAM bindings for topic in {ROLE => [MEMBERS]} format. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [ingress_settings](variables.tf#L171) | Control traffic that reaches the cloud function. Allowed values are ALLOW_ALL, ALLOW_INTERNAL_AND_GCLB and ALLOW_INTERNAL_ONLY . | <code>string</code> |  | <code>null</code> |
-| [kms_key](variables.tf#L177) | Resource name of a KMS crypto key (managed by the user) used to encrypt/decrypt function resources in key id format. If specified, you must also provide an artifact registry repository using the docker_repository_id field that was created with the same KMS crypto key. | <code>string</code> |  | <code>null</code> |
-| [labels](variables.tf#L183) | Resource labels. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
-| [prefix](variables.tf#L194) | Optional prefix used for resource names. | <code>string</code> |  | <code>null</code> |
-| [secrets](variables.tf#L214) | Secret Manager secrets. Key is the variable name or mountpoint, volume versions are in version:path format. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [iam](variables.tf#L166) | IAM bindings for topic in {ROLE => [MEMBERS]} format. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [ingress_settings](variables.tf#L172) | Control traffic that reaches the cloud function. Allowed values are ALLOW_ALL, ALLOW_INTERNAL_AND_GCLB and ALLOW_INTERNAL_ONLY . | <code>string</code> |  | <code>null</code> |
+| [kms_key](variables.tf#L178) | Resource name of a KMS crypto key (managed by the user) used to encrypt/decrypt function resources in key id format. If specified, you must also provide an artifact registry repository using the docker_repository_id field that was created with the same KMS crypto key. | <code>string</code> |  | <code>null</code> |
+| [labels](variables.tf#L184) | Resource labels. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [prefix](variables.tf#L195) | Optional prefix used for resource names. | <code>string</code> |  | <code>null</code> |
+| [secrets](variables.tf#L215) | Secret Manager secrets. Key is the variable name or mountpoint, volume versions are in version:path format. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [service_account_config](variables-serviceaccount.tf#L17) | Service account configurations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [trigger_config](variables.tf#L226) | Function trigger configuration. Leave null for HTTP trigger. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [vpc_connector](variables.tf#L244) | VPC connector configuration. Set create to 'true' if a new connector needs to be created. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [trigger_config](variables.tf#L227) | Function trigger configuration. Leave null for HTTP trigger. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [vpc_connector](variables.tf#L245) | VPC connector configuration. Set create to 'true' if a new connector needs to be created. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [vpc_connector_create](variables-vpcconnector.tf#L17) | VPC connector network configuration. Must be provided if new VPC connector is being created. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
 
 ## Outputs

--- a/modules/cloud-function-v2/main.tf
+++ b/modules/cloud-function-v2/main.tf
@@ -112,7 +112,7 @@ resource "google_cloudfunctions2_function" "function" {
     ingress_settings                 = var.ingress_settings
     max_instance_count               = var.function_config.instance_count
     max_instance_request_concurrency = var.function_config.max_instance_request_concurrency
-    min_instance_count               = 0
+    min_instance_count               = var.function_config.min_instance_count
     service_account_email            = local.service_account_email
     timeout_seconds                  = var.function_config.timeout_seconds
     vpc_connector                    = local.vpc_connector

--- a/modules/cloud-function-v2/variables.tf
+++ b/modules/cloud-function-v2/variables.tf
@@ -146,6 +146,7 @@ variable "function_config" {
     entry_point                      = optional(string, "main")
     instance_count                   = optional(number, 1)
     max_instance_request_concurrency = optional(number)
+    min_instance_count               = optional(number, 0)
     memory_mb                        = optional(number, 256) # Memory in MB
     on_deploy_update_policy          = optional(bool)
     runtime                          = optional(string, "python310")


### PR DESCRIPTION
Reroll of https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/pull/3883
From https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/issues/3833

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [x] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->
