### PR TITLE
Support common_repository in artifact-registry module.

### DIFF
--- a/modules/artifact-registry/README.md
+++ b/modules/artifact-registry/README.md
@@ -12,6 +12,8 @@ This module simplifies the creation of repositories using Google Cloud Artifact 
 - [IAM](#iam)
 - [Variables](#variables)
 - [Outputs](#outputs)
+- [Tests](#tests)
+  - [Legacy Custom Repository (Deprecated)](#legacy-custom-repository-deprecated)
 <!-- END TOC -->
 
 ## Simple Docker Repository
@@ -121,7 +123,7 @@ module "registry-mirror" {
   format = {
     docker = {
       remote = {
-        custom_repository = "https://example.com"
+        common_repository = "https://example.com"
         upstream_credentials = {
           username                = "myuser"
           password_secret_version = "${module.secret-manager.ids["example-com-password"]}/versions/latest"
@@ -368,9 +370,9 @@ module "additive_iam" {
 |---|---|:---:|:---:|:---:|
 | [cleanup_policies](variables.tf#L17) | Object containing details about the cleanup policies for an Artifact Registry repository. | <code>map&#40;object&#40;&#123;&#8230;default &#61; null</code> | ✓ |  |
 | [format](variables.tf#L83) | Repository format. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
-| [location](variables.tf#L233) | Registry location. Use `gcloud beta artifacts locations list' to get valid values. | <code>string</code> | ✓ |  |
-| [name](variables.tf#L238) | Registry name. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L243) | Registry project id. | <code>string</code> | ✓ |  |
+| [location](variables.tf#L236) | Registry location. Use `gcloud beta artifacts locations list' to get valid values. | <code>string</code> | ✓ |  |
+| [name](variables.tf#L241) | Registry name. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L246) | Registry project id. | <code>string</code> | ✓ |  |
 | [cleanup_policy_dry_run](variables.tf#L38) | If true, the cleanup pipeline is prevented from deleting versions in this repository. | <code>bool</code> |  | <code>null</code> |
 | [context](variables.tf#L44) | Context-specific interpolations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [description](variables.tf#L65) | An optional description for the repository. | <code>string</code> |  | <code>&#34;Terraform-managed registry&#34;</code> |
@@ -380,9 +382,9 @@ module "additive_iam" {
 | [iam_bindings](variables-iam.tf#L43) | Authoritative IAM bindings in {KEY => {role = ROLE, members = [], condition = {}}}. Keys are arbitrary. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_bindings_additive](variables-iam.tf#L58) | Individual additive IAM bindings. Keys are arbitrary. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_by_principals](variables-iam.tf#L73) | Authoritative IAM binding in {PRINCIPAL => [ROLES]} format. Principals need to be statically defined to avoid cycle errors. Merged internally with the `iam` variable. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [labels](variables.tf#L227) | Labels to be attached to the registry. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
-| [tag_bindings](variables.tf#L248) | Tag bindings for this repository, in key => tag value id format. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
-| [universe](variables.tf#L255) | GCP universe where to deploy the project. The prefix will be prepended to the project id. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [labels](variables.tf#L230) | Labels to be attached to the registry. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [tag_bindings](variables.tf#L251) | Tag bindings for this repository, in key => tag value id format. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [universe](variables.tf#L258) | GCP universe where to deploy the project. The prefix will be prepended to the project id. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
 
 ## Outputs
 
@@ -393,3 +395,28 @@ module "additive_iam" {
 | [repository](outputs.tf#L54) | Repository object. |  |
 | [url](outputs.tf#L64) | Repository URL. |  |
 <!-- END TFDOC -->
+## Tests
+
+These tests are used to verify specific behaviors and backward compatibility. They are not intended as general examples.
+
+### Legacy Custom Repository (Deprecated)
+
+This test ensures that the deprecated `custom_repository` configuration still works for backward compatibility. It should be removed once support for `custom_repository` is fully dropped.
+
+```hcl
+module "legacy_custom_repo" {
+  source     = "./fabric/modules/artifact-registry"
+  project_id = "myproject"
+  location   = "europe-west1"
+  name       = "legacy-custom"
+  format = {
+    maven = {
+      remote = {
+        custom_repository = "https://example.com"
+      }
+    }
+  }
+}
+# tftest modules=1 resources=1 inventory=legacy-custom.yaml
+```
+

--- a/modules/artifact-registry/main.tf
+++ b/modules/artifact-registry/main.tf
@@ -134,7 +134,8 @@ resource "google_artifact_registry_repository" "registry" {
       }
       dynamic "common_repository" {
         for_each = (
-          local.format_string == "docker" && try(local.format_obj.remote.common_repository, null) != null
+          contains(["docker", "maven", "npm", "python"], local.format_string) &&
+          try(local.format_obj.remote.common_repository, null) != null
           ? [""] : []
         )
         content {
@@ -157,7 +158,10 @@ resource "google_artifact_registry_repository" "registry" {
         }
       }
       dynamic "maven_repository" {
-        for_each = local.format_string == "maven" ? [""] : []
+        for_each = (
+          local.format_string == "maven" && try(local.format_obj.remote.common_repository, null) == null
+          ? [""] : []
+        )
         content {
           public_repository = local.format_obj.remote.public_repository
           dynamic "custom_repository" {
@@ -169,7 +173,10 @@ resource "google_artifact_registry_repository" "registry" {
         }
       }
       dynamic "npm_repository" {
-        for_each = local.format_string == "npm" ? [""] : []
+        for_each = (
+          local.format_string == "npm" && try(local.format_obj.remote.common_repository, null) == null
+          ? [""] : []
+        )
         content {
           public_repository = local.format_obj.remote.public_repository
           dynamic "custom_repository" {
@@ -181,7 +188,10 @@ resource "google_artifact_registry_repository" "registry" {
         }
       }
       dynamic "python_repository" {
-        for_each = local.format_string == "python" ? [""] : []
+        for_each = (
+          local.format_string == "python" && try(local.format_obj.remote.common_repository, null) == null
+          ? [""] : []
+        )
         content {
           public_repository = local.format_obj.remote.public_repository
           dynamic "custom_repository" {

--- a/modules/artifact-registry/variables.tf
+++ b/modules/artifact-registry/variables.tf
@@ -131,6 +131,7 @@ variable "format" {
     maven = optional(object({
       remote = optional(object({
         public_repository = optional(string)
+        common_repository = optional(string)
         custom_repository = optional(string)
 
         disable_upstream_validation = optional(bool)
@@ -151,6 +152,7 @@ variable "format" {
     npm = optional(object({
       remote = optional(object({
         public_repository = optional(string)
+        common_repository = optional(string)
         custom_repository = optional(string)
 
         disable_upstream_validation = optional(bool)
@@ -168,6 +170,7 @@ variable "format" {
     python = optional(object({
       remote = optional(object({
         public_repository = optional(string)
+        common_repository = optional(string)
         custom_repository = optional(string)
 
         disable_upstream_validation = optional(bool)

--- a/tests/modules/artifact_registry/examples/legacy-custom.yaml
+++ b/tests/modules/artifact_registry/examples/legacy-custom.yaml
@@ -1,0 +1,57 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values:
+  module.legacy_custom_repo.google_artifact_registry_repository.registry:
+    cleanup_policies: []
+    cleanup_policy_dry_run: null
+    description: Terraform-managed registry
+    docker_config: []
+    effective_labels:
+      goog-terraform-provisioned: 'true'
+    format: MAVEN
+    kms_key_name: null
+    labels: null
+    location: europe-west1
+    maven_config: []
+    mode: REMOTE_REPOSITORY
+    project: myproject
+    remote_repository_config:
+    - apt_repository: []
+      common_repository: []
+      description: null
+      disable_upstream_validation: null
+      docker_repository: []
+      maven_repository:
+      - custom_repository:
+        - uri: https://example.com
+        public_repository: null
+      npm_repository: []
+      python_repository: []
+      upstream_credentials: []
+      yum_repository: []
+    repository_id: legacy-custom
+    terraform_labels:
+      goog-terraform-provisioned: 'true'
+    timeouts: null
+    virtual_repository_config: []
+    vulnerability_scanning_config:
+    - enablement_config: null
+
+counts:
+  google_artifact_registry_repository: 1
+  modules: 1
+  resources: 1
+
+outputs: {}

--- a/tests/modules/artifact_registry/examples/remote-credentials.yaml
+++ b/tests/modules/artifact_registry/examples/remote-credentials.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -58,13 +58,11 @@ values:
     project: test-ar
     remote_repository_config:
     - apt_repository: []
-      common_repository: []
+      common_repository:
+      - uri: https://example.com
       description: null
       disable_upstream_validation: null
-      docker_repository:
-      - custom_repository:
-        - uri: https://example.com
-        public_repository: null
+      docker_repository: []
       maven_repository: []
       npm_repository: []
       python_repository: []

--- a/tests/modules/artifact_registry/remote_maven_common.tfvars
+++ b/tests/modules/artifact_registry/remote_maven_common.tfvars
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+project_id = "my-project"
+location   = "europe-west1"
+name       = "maven-remote"
+format = {
+  maven = {
+    remote = {
+      common_repository = "https://repo1.maven.org/maven2/"
+    }
+  }
+}

--- a/tests/modules/artifact_registry/remote_maven_common.yaml
+++ b/tests/modules/artifact_registry/remote_maven_common.yaml
@@ -12,9 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-module: modules/artifact-registry
-
-tests:
-  context:
-  universe:
-  remote_maven_common:
+values:
+  google_artifact_registry_repository.registry:
+    format: MAVEN
+    mode: REMOTE_REPOSITORY
+    location: europe-west1
+    project: my-project
+    repository_id: maven-remote
+    remote_repository_config:
+    - common_repository:
+      - uri: https://repo1.maven.org/maven2/


### PR DESCRIPTION
This PR resolves #3941 by adding support for the `common_repository` configuration to `maven`, `npm`, and `python` remote formats in the `artifact-registry` module.

### Context
The `custom_repository` block in `remote_repository_config` is deprecated by the GCP provider in favor of `common_repository`. Previously, the module only implemented `common_repository` for `docker`. This PR extends this support to all other formats that previously supported `custom_repository` (`maven`, `npm`, `python`), enabling users to migrate away from the deprecated feature.

### Changes
- **Module variables**: Added `common_repository = optional(string)` to `maven.remote`, `npm.remote`, and `python.remote` configurations in `variables.tf`.
- **Module resources**: Updated `main.tf` to use the generic `common_repository` block when it is specified for any of the supported formats, and ensured that format-specific blocks (which contain `custom_repository`) are only created when `common_repository` is *not* set.
- **Documentation**:
  - Updated the `registry-mirror` example in `README.md` to use `common_repository` (best practice).
  - Added a `legacy_custom_repo` test case at the bottom of `README.md` to verify that the deprecated `custom_repository` continues to work for backward compatibility.
  - Regenerated variables table and TOC.
- **Tests**:
  - Added a new unit test `remote_maven_common` for the new feature.
  - Regenerated test inventories.

### Verification
All tests (unit tests and README examples) have been verified and pass successfully. Linting and formatting checks have also passed.

TAG=agy
CONV=ffe77e65-ccef-4701-95e6-4ba2d2446f1b
