### PR TITLE
Add advanced_datapath_observability_config to gke-cluster-autopilot module

### DIFF
--- a/modules/gke-cluster-autopilot/README.md
+++ b/modules/gke-cluster-autopilot/README.md
@@ -292,9 +292,9 @@ module "cluster-1" {
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
 | [location](variables.tf#L186) | Autopilot clusters are always regional. | <code>string</code> | ✓ |  |
-| [name](variables.tf#L265) | Cluster name. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L298) | Cluster project ID. | <code>string</code> | ✓ |  |
-| [vpc_config](variables.tf#L314) | VPC-level configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
+| [name](variables.tf#L269) | Cluster name. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L302) | Cluster project ID. | <code>string</code> | ✓ |  |
+| [vpc_config](variables.tf#L318) | VPC-level configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
 | [access_config](variables.tf#L17) | Control plane endpoint and nodes access configurations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [backup_configs](variables.tf#L49) | Configuration for Backup for GKE. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [deletion_protection](variables.tf#L71) | Whether or not to allow Terraform to destroy the cluster. Unless this field is set to false in Terraform state, a terraform destroy or terraform apply that would delete the cluster will fail. | <code>bool</code> |  | <code>true</code> |
@@ -308,9 +308,9 @@ module "cluster-1" {
 | [maintenance_config](variables.tf#L202) | Maintenance window configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#8230;&#125;</code> |
 | [min_master_version](variables.tf#L225) | Minimum version of the master, defaults to the version of the most recent official release. | <code>string</code> |  | <code>null</code> |
 | [monitoring_config](variables.tf#L231) | Monitoring configuration. System metrics collection cannot be disabled. Control plane metrics are optional. Kube state metrics are optional. Google Cloud Managed Service for Prometheus is enabled by default. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [node_config](variables.tf#L270) | Configuration for nodes and nodepools. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [node_locations](variables.tf#L291) | Zones in which the cluster's nodes are located. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
-| [release_channel](variables.tf#L303) | Release channel for GKE upgrades. Clusters created in the Autopilot mode must use a release channel. Choose between \"RAPID\", \"REGULAR\", and \"STABLE\". | <code>string</code> |  | <code>&#34;REGULAR&#34;</code> |
+| [node_config](variables.tf#L274) | Configuration for nodes and nodepools. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [node_locations](variables.tf#L295) | Zones in which the cluster's nodes are located. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
+| [release_channel](variables.tf#L307) | Release channel for GKE upgrades. Clusters created in the Autopilot mode must use a release channel. Choose between \"RAPID\", \"REGULAR\", and \"STABLE\". | <code>string</code> |  | <code>&#34;REGULAR&#34;</code> |
 
 ## Outputs
 

--- a/modules/gke-cluster-autopilot/main.tf
+++ b/modules/gke-cluster-autopilot/main.tf
@@ -270,6 +270,21 @@ resource "google_container_cluster" "cluster" {
     managed_prometheus {
       enabled = var.monitoring_config.enable_managed_prometheus
     }
+    dynamic "advanced_datapath_observability_config" {
+      for_each = (
+        var.monitoring_config.advanced_datapath_observability == null
+        ? []
+        : [""]
+      )
+      content {
+        enable_metrics = (
+          var.monitoring_config.advanced_datapath_observability.enable_metrics
+        )
+        enable_relay = (
+          var.monitoring_config.advanced_datapath_observability.enable_relay
+        )
+      }
+    }
   }
   dynamic "notification_config" {
     for_each = var.enable_features.upgrade_notifications != null ? [""] : []

--- a/modules/gke-cluster-autopilot/variables.tf
+++ b/modules/gke-cluster-autopilot/variables.tf
@@ -245,6 +245,10 @@ variable "monitoring_config" {
     enable_cadvisor_metrics    = optional(bool, false)
     # Google Cloud Managed Service for Prometheus. Autopilot clusters version >= 1.25 must have this on.
     enable_managed_prometheus = optional(bool, true)
+    advanced_datapath_observability = optional(object({
+      enable_metrics = bool
+      enable_relay   = bool
+    }))
   })
   default  = {}
   nullable = false

--- a/tests/modules/gke_cluster_autopilot/monitoring.tfvars
+++ b/tests/modules/gke_cluster_autopilot/monitoring.tfvars
@@ -1,0 +1,13 @@
+project_id = "my-project"
+location   = "europe-west1"
+name       = "cluster-1"
+vpc_config = {
+  network    = "default"
+  subnetwork = "default"
+}
+monitoring_config = {
+  advanced_datapath_observability = {
+    enable_metrics = true
+    enable_relay   = true
+  }
+}

--- a/tests/modules/gke_cluster_autopilot/monitoring.yaml
+++ b/tests/modules/gke_cluster_autopilot/monitoring.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,8 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-module: modules/gke-cluster-autopilot
+values:
+  google_container_cluster.cluster:
+    monitoring_config:
+    - advanced_datapath_observability_config:
+      - enable_metrics: true
+        enable_relay: true
 
-tests:
-  network_tags:
-  monitoring:
+counts:
+  google_container_cluster: 1


### PR DESCRIPTION
Adds support for `advanced_datapath_observability_config` to the `gke-cluster-autopilot` module, matching the standard cluster module implementation.

Closes #3936