### PR TITLE
Fix cloud-function-v1 E2E test collision

### DIFF
--- a/modules/cloud-function-v1/README.md
+++ b/modules/cloud-function-v1/README.md
@@ -57,6 +57,7 @@ module "cf-http" {
   source      = "./fabric/modules/cloud-function-v1"
   project_id  = var.project_id
   region      = var.regions.secondary
+  prefix      = var.prefix
   name        = "test-cf-http"
   bucket_name = var.bucket
   bundle_config = {

--- a/tests/modules/cloud_function_v1/examples/pubsub-non-http-trigger.yaml
+++ b/tests/modules/cloud_function_v1/examples/pubsub-non-http-trigger.yaml
@@ -33,7 +33,7 @@ values:
     labels: null
     max_instances: 1
     min_instances: null
-    name: test-cf-http
+    name: test-test-cf-http
     on_deploy_update_policy: []
     project: project-id
     region: europe-west9


### PR DESCRIPTION
This PR fixes the failing E2E test in cloud-function-v1 by adding prefix to the example in README.md and updating the inventory file.