### PR TITLE
Fix E2E test failures for Cloud Run v2, KMS, Compute VM, and update GEMINI.md

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -113,6 +113,9 @@ pytest tests
 # Run specific module examples
 pytest -k 'modules and <module-name>:' tests/examples
 
+# Run a single specific example test (useful for debugging)
+pytest -s 'tests/examples/test_plan.py::test_example[terraform:modules/<module-name>:Heading Name:Index]'
+
 # Automatically generate an inventory file from a successful plan
 pytest -s 'tests/examples/test_plan.py::test_example[terraform:modules/<module-name>:Heading Name:Index]'
 ```

--- a/modules/cloud-run-v2/README.md
+++ b/modules/cloud-run-v2/README.md
@@ -887,11 +887,10 @@ GPU support is available for all types of Cloud Run resources: jobs, services an
 
 ```hcl
 module "job" {
-  source       = "./fabric/modules/cloud-run-v2"
-  project_id   = var.project_id
-  name         = "example-job"
-  region       = var.region
-  launch_stage = "BETA"
+  source     = "./fabric/modules/cloud-run-v2"
+  project_id = var.project_id
+  name       = "example-job"
+  region     = var.region
   revision = {
     gpu_zonal_redundancy_disabled = true
     node_selector = {
@@ -950,11 +949,10 @@ module "service" {
 
 ```hcl
 module "worker" {
-  source       = "./fabric/modules/cloud-run-v2"
-  project_id   = var.project_id
-  name         = "worker"
-  region       = var.region
-  launch_stage = "BETA"
+  source     = "./fabric/modules/cloud-run-v2"
+  project_id = var.project_id
+  name       = "worker"
+  region     = var.region
   revision = {
     gpu_zonal_redundancy_disabled = true
     node_selector = {

--- a/modules/compute-vm/README.md
+++ b/modules/compute-vm/README.md
@@ -318,7 +318,6 @@ module "vm-disk-options-example" {
       }
     }
     data2 = {
-      mode = "READ_ONLY"
       initialize_params = {
         type = "hyperdisk-balanced"
         hyperdisk = {

--- a/modules/kms/README.md
+++ b/modules/kms/README.md
@@ -57,7 +57,7 @@ module "kms" {
         key-b-iam1 = {
           key    = "key-b"
           member = "group:${var.group_email}"
-          role   = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+          role   = "roles/cloudkms.viewer"
         }
       }
     }

--- a/tests/modules/compute_vm/examples/disk-hyperdisk-cust-performance.yaml
+++ b/tests/modules/compute_vm/examples/disk-hyperdisk-cust-performance.yaml
@@ -99,7 +99,7 @@ values:
       disk_encryption_key_rsa: null
       disk_encryption_service_account: null
       force_attach: null
-      mode: READ_ONLY
+      mode: READ_WRITE
       source: test-data2
     boot_disk:
     - auto_delete: true

--- a/tests/modules/kms/examples/basic.yaml
+++ b/tests/modules/kms/examples/basic.yaml
@@ -67,7 +67,7 @@ values:
   module.kms.google_kms_crypto_key_iam_member.members["key-b:key-b-iam1"]:
     condition: []
     member: group:organization-admins@example.org
-    role: roles/cloudkms.cryptoKeyEncrypterDecrypter
+    role: roles/cloudkms.viewer
   module.kms.google_kms_key_ring.default[0]:
     location: europe-west8
     name: test-test


### PR DESCRIPTION
This PR fixes several E2E test failures and updates instructions in GEMINI.md:

1.  **Cloud Run v2**: Removes `launch_stage = "BETA"` from GPU examples as it now defaults to GA in the provider.
2.  **KMS**: Changes the role in the additive IAM binding example to avoid conflict with the authoritative binding (`roles/cloudkms.viewer`).
3.  **Compute VM**: Removes `mode = "READ_ONLY"` from the hyperdisk example as it is not supported by the API for `hyperdisk-balanced` disks.
4.  **GEMINI.md**: Adds instruction to run a single specific example test for debugging, making it explicit and not just for inventory generation.

All changes have been verified by unit tests.
The E2E tests have also run successfully on branch `ludo/e2e-cloud-run-v2-gpu-ga` in the `fast-e2e` repository (Run ID: 25623470823).

Relevant Magic Modules PR for Cloud Run v2: https://github.com/GoogleCloudPlatform/magic-modules/pull/17029

TAG=agy
