### PR TITLE
Add ephemeral_storage_local_ssd_config support to modules/gke-nodepool

### DIFF
--- a/modules/gke-nodepool/README.md
+++ b/modules/gke-nodepool/README.md
@@ -218,7 +218,7 @@ module "cluster-1-nodepool-hyperdisk" {
 |---|---|:---:|:---:|:---:|
 | [cluster_name](variables.tf#L23) | Cluster name. | <code>string</code> | ✓ |  |
 | [location](variables.tf#L48) | Cluster location. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L223) | Cluster project id. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L224) | Cluster project id. | <code>string</code> | ✓ |  |
 | [cluster_id](variables.tf#L17) | Cluster id. Optional, but providing cluster_id is recommended to prevent cluster misconfiguration in some of the edge cases. | <code>string</code> |  | <code>null</code> |
 | [gke_version](variables.tf#L28) | Kubernetes nodes version. Ignored if auto_upgrade is set in management_config. | <code>string</code> |  | <code>null</code> |
 | [k8s_labels](variables.tf#L34) | Kubernetes labels applied to each node. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
@@ -227,15 +227,15 @@ module "cluster-1-nodepool-hyperdisk" {
 | [name](variables.tf#L59) | Optional nodepool name. | <code>string</code> |  | <code>null</code> |
 | [network_config](variables.tf#L65) | Network configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
 | [node_config](variables.tf#L89) | Node-level configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [node_count](variables.tf#L169) | Number of nodes per instance group. Initial value can only be changed by recreation, current is ignored when autoscaling is used. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#8230;&#125;</code> |
-| [node_locations](variables.tf#L181) | Node locations. | <code>list&#40;string&#41;</code> |  | <code>null</code> |
-| [nodepool_config](variables.tf#L187) | Nodepool-level configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [reservation_affinity](variables.tf#L228) | Configuration of the desired reservation which instances could take capacity from. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [resource_manager_tags](variables.tf#L238) | A map of resource manager tag keys and values to be attached to the nodes for managing Compute Engine firewalls using Network Firewall Policies. | <code>map&#40;string&#41;</code> |  | <code>null</code> |
-| [service_account](variables.tf#L244) | Nodepool service account. If this variable is set to null, the default GCE service account will be used. If set and email is null, a service account will be created. If scopes are null a default will be used. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [sole_tenant_nodegroup](variables.tf#L256) | Sole tenant node group. | <code>string</code> |  | <code>null</code> |
-| [tags](variables.tf#L262) | Network tags applied to nodes. | <code>list&#40;string&#41;</code> |  | <code>null</code> |
-| [taints](variables.tf#L268) | Kubernetes taints applied to all nodes. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [node_count](variables.tf#L170) | Number of nodes per instance group. Initial value can only be changed by recreation, current is ignored when autoscaling is used. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#8230;&#125;</code> |
+| [node_locations](variables.tf#L182) | Node locations. | <code>list&#40;string&#41;</code> |  | <code>null</code> |
+| [nodepool_config](variables.tf#L188) | Nodepool-level configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [reservation_affinity](variables.tf#L229) | Configuration of the desired reservation which instances could take capacity from. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [resource_manager_tags](variables.tf#L239) | A map of resource manager tag keys and values to be attached to the nodes for managing Compute Engine firewalls using Network Firewall Policies. | <code>map&#40;string&#41;</code> |  | <code>null</code> |
+| [service_account](variables.tf#L245) | Nodepool service account. If this variable is set to null, the default GCE service account will be used. If set and email is null, a service account will be created. If scopes are null a default will be used. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [sole_tenant_nodegroup](variables.tf#L257) | Sole tenant node group. | <code>string</code> |  | <code>null</code> |
+| [tags](variables.tf#L263) | Network tags applied to nodes. | <code>list&#40;string&#41;</code> |  | <code>null</code> |
+| [taints](variables.tf#L269) | Kubernetes taints applied to all nodes. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 
 ## Outputs
 

--- a/modules/gke-nodepool/main.tf
+++ b/modules/gke-nodepool/main.tf
@@ -226,6 +226,12 @@ resource "google_container_node_pool" "nodepool" {
         local_ssd_count = var.node_config.ephemeral_ssd_count
       }
     }
+    dynamic "ephemeral_storage_local_ssd_config" {
+      for_each = var.node_config.ephemeral_storage_local_ssd_count != null ? [""] : []
+      content {
+        local_ssd_count = var.node_config.ephemeral_storage_local_ssd_count
+      }
+    }
     dynamic "gcfs_config" {
       for_each = var.node_config.gcfs && local.image.is_cos_containerd ? [""] : []
       content {

--- a/modules/gke-nodepool/variables.tf
+++ b/modules/gke-nodepool/variables.tf
@@ -96,11 +96,12 @@ variable "node_config" {
       provisioned_iops       = optional(number)
       provisioned_throughput = optional(number)
     }))
-    boot_disk_kms_key   = optional(string)                # usage of this is discouraged
-    disk_size_gb        = optional(number)                # usage of this is discouraged
-    disk_type           = optional(string, "pd-balanced") # usage of this is discouraged
-    ephemeral_ssd_count = optional(number)
-    gcfs                = optional(bool, false)
+    boot_disk_kms_key                 = optional(string)                # usage of this is discouraged
+    disk_size_gb                      = optional(number)                # usage of this is discouraged
+    disk_type                         = optional(string, "pd-balanced") # usage of this is discouraged
+    ephemeral_ssd_count               = optional(number)
+    ephemeral_storage_local_ssd_count = optional(number)
+    gcfs                              = optional(bool, false)
     guest_accelerator = optional(object({
       count = number
       type  = string


### PR DESCRIPTION
Adds ephemeral_storage_local_ssd_count to node_config variable and the corresponding dynamic ephemeral_storage_local_ssd_config block in the node pool resource, enabling use of local SSDs as ephemeral storage.

<!-- Put a description of what this PR is for here -->

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [x] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
