### PR TITLE
Declare contents: read on linting and tests workflows

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -23,6 +23,10 @@ on:
     branches:
       - master
       - fast-dev
+
+permissions:
+  contents: read
+
 jobs:
   linting:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,6 +41,9 @@ env:
   DEFAULT_TERRAFORM_VERSION: ${{ inputs.terraform_version || '1.12.2' }}
   DEFAULT_TOFU_VERSION: "1.11.0"
 
+permissions:
+  contents: read
+
 jobs:
   setup-tf-providers:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Two CI workflows ran without a `permissions:` block. Linting is yaml/style/boilerplate checks, tests is terraform/tofu plan + unit tests with a provider matrix. Both are pure read — no commit/comment/release writes.

`contents: read` covers the checkout step. YAML validates.