### PR TITLE
Add PAM service agent configuration to stages/0-org-setup

### DIFF
--- a/fast/stages/0-org-setup/datasets/classic-gcd/organization/.config.yaml
+++ b/fast/stages/0-org-setup/datasets/classic-gcd/organization/.config.yaml
@@ -61,6 +61,7 @@ iam_by_principals:
     - roles/iam.workforcePoolAdmin
     - roles/logging.admin
     - roles/orgpolicy.policyAdmin
+    - roles/privilegedaccessmanager.admin
     - roles/resourcemanager.folderAdmin
     - roles/resourcemanager.organizationAdmin
     - roles/resourcemanager.projectCreator
@@ -112,6 +113,10 @@ iam_by_principals:
   # Uncomment if you want to use PAM.
   # $service_agents:pam:
   #   - roles/privilegedaccessmanager.serviceAgent
+service_agents_config:
+  services:
+    - privilegedaccessmanager.googleapis.com
+
 data_access_logs:
   sts.googleapis.com:
     ADMIN_READ: {}

--- a/fast/stages/0-org-setup/datasets/classic/organization/.config.yaml
+++ b/fast/stages/0-org-setup/datasets/classic/organization/.config.yaml
@@ -61,6 +61,7 @@ iam_by_principals:
     - roles/iam.workforcePoolAdmin
     - roles/logging.admin
     - roles/orgpolicy.policyAdmin
+    - roles/privilegedaccessmanager.admin
     - roles/resourcemanager.folderAdmin
     - roles/resourcemanager.organizationAdmin
     - roles/resourcemanager.projectCreator
@@ -112,6 +113,9 @@ iam_by_principals:
   # Uncomment if you want to use PAM.
   # $service_agents:pam:
   #   - roles/privilegedaccessmanager.serviceAgent
+service_agents_config:
+  services:
+    - privilegedaccessmanager.googleapis.com
 data_access_logs:
   sts.googleapis.com:
     ADMIN_READ: {}

--- a/fast/stages/0-org-setup/datasets/hardened/organization/.config.yaml
+++ b/fast/stages/0-org-setup/datasets/hardened/organization/.config.yaml
@@ -61,6 +61,7 @@ iam_by_principals:
     - roles/iam.workforcePoolAdmin
     - roles/logging.admin
     - roles/orgpolicy.policyAdmin
+    - roles/privilegedaccessmanager.admin
     - roles/resourcemanager.folderAdmin
     - roles/resourcemanager.organizationAdmin
     - roles/resourcemanager.projectCreator
@@ -115,6 +116,10 @@ iam_by_principals:
   # Uncomment if you want to use PAM.
   # $service_agents:pam:
   #   - roles/privilegedaccessmanager.serviceAgent
+service_agents_config:
+  services:
+    - privilegedaccessmanager.googleapis.com
+
 data_access_logs:
   allServices:
     ADMIN_READ: {}

--- a/fast/stages/0-org-setup/organization.tf
+++ b/fast/stages/0-org-setup/organization.tf
@@ -168,4 +168,5 @@ module "organization-iam" {
   tags_config = {
     force_context_ids = true
   }
+  service_agents_config = try(local.organization.service_agents_config, {})
 }

--- a/fast/stages/0-org-setup/schemas/organization.schema.json
+++ b/fast/stages/0-org-setup/schemas/organization.schema.json
@@ -577,6 +577,19 @@
           }
         }
       }
+    },
+    "service_agents_config": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "services": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[a-z][a-z-]+\\.googleapis\\.com$"
+          }
+        }
+      }
     }
   },
   "$defs": {

--- a/tests/fast/stages/s0_org_setup/hardened.yaml
+++ b/tests/fast/stages/s0_org_setup/hardened.yaml
@@ -8392,8 +8392,9 @@ counts:
   google_org_policy_custom_constraint: 89
   google_org_policy_policy: 167
   google_organization_iam_audit_config: 1
-  google_organization_iam_binding: 40
+  google_organization_iam_binding: 41
   google_organization_iam_custom_role: 14
+  google_organization_service_identity: 1
   google_project: 3
   google_project_iam_binding: 64
   google_project_iam_member: 17
@@ -8415,7 +8416,7 @@ counts:
   google_tags_tag_value_iam_binding: 4
   local_file: 9
   modules: 54
-  resources: 671
+  resources: 673
   terraform_data: 4
 
 outputs:

--- a/tests/fast/stages/s0_org_setup/simple.yaml
+++ b/tests/fast/stages/s0_org_setup/simple.yaml
@@ -2845,8 +2845,9 @@ counts:
   google_org_policy_custom_constraint: 1
   google_org_policy_policy: 37
   google_organization_iam_audit_config: 1
-  google_organization_iam_binding: 37
+  google_organization_iam_binding: 38
   google_organization_iam_custom_role: 9
+  google_organization_service_identity: 1
   google_project: 3
   google_project_iam_audit_config: 3
   google_project_iam_binding: 17
@@ -2868,7 +2869,7 @@ counts:
   google_tags_tag_value_iam_binding: 4
   local_file: 9
   modules: 47
-  resources: 304
+  resources: 306
   terraform_data: 4
 
 outputs:


### PR DESCRIPTION
Resolves [#3958 ](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/issues/3958)by configuring the PAM service agent and adding the roles/privilegedaccessmanager.admin role to the iac-org-rw service account to the datasets.


I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [x] Made sure all relevant tests pass