### PR TITLE
Add IAM deny policies support

### DIFF
--- a/fast/stages/0-org-setup/organization.tf
+++ b/fast/stages/0-org-setup/organization.tf
@@ -173,4 +173,7 @@ module "organization-iam" {
   tags_config = {
     force_context_ids = true
   }
+  iam_deny_policies = lookup(
+    local.organization, "iam_deny_policies", {}
+  )
 }

--- a/fast/stages/0-org-setup/schemas/folder.schema.json
+++ b/fast/stages/0-org-setup/schemas/folder.schema.json
@@ -357,6 +357,85 @@
     "iam_by_principals_conditional": {
       "$ref": "#/$defs/iam_by_principals_conditional"
     },
+    "iam_deny_policies": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "rules"
+          ],
+          "properties": {
+            "display_name": {
+              "type": "string"
+            },
+            "rules": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "denied_permissions",
+                  "denied_principals"
+                ],
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "denied_permissions": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "denied_principals": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "denial_condition": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "expression"
+                    ],
+                    "properties": {
+                      "expression": {
+                        "type": "string"
+                      },
+                      "title": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "location": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "exception_permissions": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "exception_principals": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "name": {
       "type": "string"
     },

--- a/fast/stages/0-org-setup/schemas/folder.schema.md
+++ b/fast/stages/0-org-setup/schemas/folder.schema.md
@@ -112,6 +112,29 @@
 - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
 - **iam_by_principals**: *reference([iam_by_principals](#refs-iam_by_principals))*
 - **iam_by_principals_conditional**: *reference([iam_by_principals_conditional](#refs-iam_by_principals_conditional))*
+- **iam_deny_policies**: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9-]+$`**: *object*
+    <br>*additional properties: false*
+    - **display_name**: *string*
+    - ⁺**rules**: *array*
+      - items: *object*
+        <br>*additional properties: false*
+        - **description**: *string*
+        - ⁺**denied_permissions**: *array*
+          - items: *string*
+        - ⁺**denied_principals**: *array*
+          - items: *string*
+        - **denial_condition**: *object*
+          <br>*additional properties: false*
+          - ⁺**expression**: *string*
+          - **title**: *string*
+          - **description**: *string*
+          - **location**: *string*
+        - **exception_permissions**: *array*
+          - items: *string*
+        - **exception_principals**: *array*
+          - items: *string*
 - **name**: *string*
 - **org_policies**: *object*
   <br>*additional properties: false*

--- a/fast/stages/0-org-setup/schemas/project.schema.json
+++ b/fast/stages/0-org-setup/schemas/project.schema.json
@@ -344,6 +344,85 @@
     "iam_by_principals_additive": {
       "$ref": "#/$defs/iam_by_principals"
     },
+    "iam_deny_policies": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "rules"
+          ],
+          "properties": {
+            "display_name": {
+              "type": "string"
+            },
+            "rules": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "denied_permissions",
+                  "denied_principals"
+                ],
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "denied_permissions": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "denied_principals": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "denial_condition": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "expression"
+                    ],
+                    "properties": {
+                      "expression": {
+                        "type": "string"
+                      },
+                      "title": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "location": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "exception_permissions": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "exception_principals": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "kms": {
       "type": "object",
       "additionalProperties": false,

--- a/fast/stages/0-org-setup/schemas/project.schema.md
+++ b/fast/stages/0-org-setup/schemas/project.schema.md
@@ -110,6 +110,29 @@
 - **iam_by_principals**: *reference([iam_by_principals](#refs-iam_by_principals))*
 - **iam_by_principals_conditional**: *reference([iam_by_principals_conditional](#refs-iam_by_principals_conditional))*
 - **iam_by_principals_additive**: *reference([iam_by_principals](#refs-iam_by_principals))*
+- **iam_deny_policies**: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9-]+$`**: *object*
+    <br>*additional properties: false*
+    - **display_name**: *string*
+    - ⁺**rules**: *array*
+      - items: *object*
+        <br>*additional properties: false*
+        - **description**: *string*
+        - ⁺**denied_permissions**: *array*
+          - items: *string*
+        - ⁺**denied_principals**: *array*
+          - items: *string*
+        - **denial_condition**: *object*
+          <br>*additional properties: false*
+          - ⁺**expression**: *string*
+          - **title**: *string*
+          - **description**: *string*
+          - **location**: *string*
+        - **exception_permissions**: *array*
+          - items: *string*
+        - **exception_principals**: *array*
+          - items: *string*
 - **kms**: *object*
   <br>*additional properties: false*
   - **autokeys**: *object*

--- a/fast/stages/2-networking/schemas/folder.schema.json
+++ b/fast/stages/2-networking/schemas/folder.schema.json
@@ -357,6 +357,85 @@
     "iam_by_principals_conditional": {
       "$ref": "#/$defs/iam_by_principals_conditional"
     },
+    "iam_deny_policies": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "rules"
+          ],
+          "properties": {
+            "display_name": {
+              "type": "string"
+            },
+            "rules": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "denied_permissions",
+                  "denied_principals"
+                ],
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "denied_permissions": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "denied_principals": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "denial_condition": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "expression"
+                    ],
+                    "properties": {
+                      "expression": {
+                        "type": "string"
+                      },
+                      "title": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "location": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "exception_permissions": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "exception_principals": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "name": {
       "type": "string"
     },

--- a/fast/stages/2-networking/schemas/folder.schema.md
+++ b/fast/stages/2-networking/schemas/folder.schema.md
@@ -112,6 +112,29 @@
 - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
 - **iam_by_principals**: *reference([iam_by_principals](#refs-iam_by_principals))*
 - **iam_by_principals_conditional**: *reference([iam_by_principals_conditional](#refs-iam_by_principals_conditional))*
+- **iam_deny_policies**: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9-]+$`**: *object*
+    <br>*additional properties: false*
+    - **display_name**: *string*
+    - ⁺**rules**: *array*
+      - items: *object*
+        <br>*additional properties: false*
+        - **description**: *string*
+        - ⁺**denied_permissions**: *array*
+          - items: *string*
+        - ⁺**denied_principals**: *array*
+          - items: *string*
+        - **denial_condition**: *object*
+          <br>*additional properties: false*
+          - ⁺**expression**: *string*
+          - **title**: *string*
+          - **description**: *string*
+          - **location**: *string*
+        - **exception_permissions**: *array*
+          - items: *string*
+        - **exception_principals**: *array*
+          - items: *string*
 - **name**: *string*
 - **org_policies**: *object*
   <br>*additional properties: false*

--- a/fast/stages/2-networking/schemas/project.schema.json
+++ b/fast/stages/2-networking/schemas/project.schema.json
@@ -344,6 +344,85 @@
     "iam_by_principals_additive": {
       "$ref": "#/$defs/iam_by_principals"
     },
+    "iam_deny_policies": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "rules"
+          ],
+          "properties": {
+            "display_name": {
+              "type": "string"
+            },
+            "rules": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "denied_permissions",
+                  "denied_principals"
+                ],
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "denied_permissions": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "denied_principals": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "denial_condition": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "expression"
+                    ],
+                    "properties": {
+                      "expression": {
+                        "type": "string"
+                      },
+                      "title": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "location": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "exception_permissions": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "exception_principals": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "kms": {
       "type": "object",
       "additionalProperties": false,

--- a/fast/stages/2-networking/schemas/project.schema.md
+++ b/fast/stages/2-networking/schemas/project.schema.md
@@ -110,6 +110,29 @@
 - **iam_by_principals**: *reference([iam_by_principals](#refs-iam_by_principals))*
 - **iam_by_principals_conditional**: *reference([iam_by_principals_conditional](#refs-iam_by_principals_conditional))*
 - **iam_by_principals_additive**: *reference([iam_by_principals](#refs-iam_by_principals))*
+- **iam_deny_policies**: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9-]+$`**: *object*
+    <br>*additional properties: false*
+    - **display_name**: *string*
+    - ⁺**rules**: *array*
+      - items: *object*
+        <br>*additional properties: false*
+        - **description**: *string*
+        - ⁺**denied_permissions**: *array*
+          - items: *string*
+        - ⁺**denied_principals**: *array*
+          - items: *string*
+        - **denial_condition**: *object*
+          <br>*additional properties: false*
+          - ⁺**expression**: *string*
+          - **title**: *string*
+          - **description**: *string*
+          - **location**: *string*
+        - **exception_permissions**: *array*
+          - items: *string*
+        - **exception_principals**: *array*
+          - items: *string*
 - **kms**: *object*
   <br>*additional properties: false*
   - **autokeys**: *object*

--- a/fast/stages/2-project-factory/schemas/folder.schema.json
+++ b/fast/stages/2-project-factory/schemas/folder.schema.json
@@ -357,6 +357,85 @@
     "iam_by_principals_conditional": {
       "$ref": "#/$defs/iam_by_principals_conditional"
     },
+    "iam_deny_policies": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "rules"
+          ],
+          "properties": {
+            "display_name": {
+              "type": "string"
+            },
+            "rules": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "denied_permissions",
+                  "denied_principals"
+                ],
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "denied_permissions": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "denied_principals": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "denial_condition": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "expression"
+                    ],
+                    "properties": {
+                      "expression": {
+                        "type": "string"
+                      },
+                      "title": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "location": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "exception_permissions": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "exception_principals": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "name": {
       "type": "string"
     },

--- a/fast/stages/2-project-factory/schemas/folder.schema.md
+++ b/fast/stages/2-project-factory/schemas/folder.schema.md
@@ -112,6 +112,29 @@
 - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
 - **iam_by_principals**: *reference([iam_by_principals](#refs-iam_by_principals))*
 - **iam_by_principals_conditional**: *reference([iam_by_principals_conditional](#refs-iam_by_principals_conditional))*
+- **iam_deny_policies**: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9-]+$`**: *object*
+    <br>*additional properties: false*
+    - **display_name**: *string*
+    - ⁺**rules**: *array*
+      - items: *object*
+        <br>*additional properties: false*
+        - **description**: *string*
+        - ⁺**denied_permissions**: *array*
+          - items: *string*
+        - ⁺**denied_principals**: *array*
+          - items: *string*
+        - **denial_condition**: *object*
+          <br>*additional properties: false*
+          - ⁺**expression**: *string*
+          - **title**: *string*
+          - **description**: *string*
+          - **location**: *string*
+        - **exception_permissions**: *array*
+          - items: *string*
+        - **exception_principals**: *array*
+          - items: *string*
 - **name**: *string*
 - **org_policies**: *object*
   <br>*additional properties: false*

--- a/fast/stages/2-project-factory/schemas/project.schema.json
+++ b/fast/stages/2-project-factory/schemas/project.schema.json
@@ -344,6 +344,85 @@
     "iam_by_principals_additive": {
       "$ref": "#/$defs/iam_by_principals"
     },
+    "iam_deny_policies": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "rules"
+          ],
+          "properties": {
+            "display_name": {
+              "type": "string"
+            },
+            "rules": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "denied_permissions",
+                  "denied_principals"
+                ],
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "denied_permissions": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "denied_principals": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "denial_condition": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "expression"
+                    ],
+                    "properties": {
+                      "expression": {
+                        "type": "string"
+                      },
+                      "title": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "location": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "exception_permissions": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "exception_principals": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "kms": {
       "type": "object",
       "additionalProperties": false,

--- a/fast/stages/2-project-factory/schemas/project.schema.md
+++ b/fast/stages/2-project-factory/schemas/project.schema.md
@@ -110,6 +110,29 @@
 - **iam_by_principals**: *reference([iam_by_principals](#refs-iam_by_principals))*
 - **iam_by_principals_conditional**: *reference([iam_by_principals_conditional](#refs-iam_by_principals_conditional))*
 - **iam_by_principals_additive**: *reference([iam_by_principals](#refs-iam_by_principals))*
+- **iam_deny_policies**: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9-]+$`**: *object*
+    <br>*additional properties: false*
+    - **display_name**: *string*
+    - ⁺**rules**: *array*
+      - items: *object*
+        <br>*additional properties: false*
+        - **description**: *string*
+        - ⁺**denied_permissions**: *array*
+          - items: *string*
+        - ⁺**denied_principals**: *array*
+          - items: *string*
+        - **denial_condition**: *object*
+          <br>*additional properties: false*
+          - ⁺**expression**: *string*
+          - **title**: *string*
+          - **description**: *string*
+          - **location**: *string*
+        - **exception_permissions**: *array*
+          - items: *string*
+        - **exception_principals**: *array*
+          - items: *string*
 - **kms**: *object*
   <br>*additional properties: false*
   - **autokeys**: *object*

--- a/fast/stages/2-security/schemas/folder.schema.json
+++ b/fast/stages/2-security/schemas/folder.schema.json
@@ -357,6 +357,85 @@
     "iam_by_principals_conditional": {
       "$ref": "#/$defs/iam_by_principals_conditional"
     },
+    "iam_deny_policies": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "rules"
+          ],
+          "properties": {
+            "display_name": {
+              "type": "string"
+            },
+            "rules": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "denied_permissions",
+                  "denied_principals"
+                ],
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "denied_permissions": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "denied_principals": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "denial_condition": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "expression"
+                    ],
+                    "properties": {
+                      "expression": {
+                        "type": "string"
+                      },
+                      "title": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "location": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "exception_permissions": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "exception_principals": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "name": {
       "type": "string"
     },

--- a/fast/stages/2-security/schemas/folder.schema.md
+++ b/fast/stages/2-security/schemas/folder.schema.md
@@ -112,6 +112,29 @@
 - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
 - **iam_by_principals**: *reference([iam_by_principals](#refs-iam_by_principals))*
 - **iam_by_principals_conditional**: *reference([iam_by_principals_conditional](#refs-iam_by_principals_conditional))*
+- **iam_deny_policies**: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9-]+$`**: *object*
+    <br>*additional properties: false*
+    - **display_name**: *string*
+    - ⁺**rules**: *array*
+      - items: *object*
+        <br>*additional properties: false*
+        - **description**: *string*
+        - ⁺**denied_permissions**: *array*
+          - items: *string*
+        - ⁺**denied_principals**: *array*
+          - items: *string*
+        - **denial_condition**: *object*
+          <br>*additional properties: false*
+          - ⁺**expression**: *string*
+          - **title**: *string*
+          - **description**: *string*
+          - **location**: *string*
+        - **exception_permissions**: *array*
+          - items: *string*
+        - **exception_principals**: *array*
+          - items: *string*
 - **name**: *string*
 - **org_policies**: *object*
   <br>*additional properties: false*

--- a/fast/stages/2-security/schemas/project.schema.json
+++ b/fast/stages/2-security/schemas/project.schema.json
@@ -344,6 +344,85 @@
     "iam_by_principals_additive": {
       "$ref": "#/$defs/iam_by_principals"
     },
+    "iam_deny_policies": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "rules"
+          ],
+          "properties": {
+            "display_name": {
+              "type": "string"
+            },
+            "rules": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "denied_permissions",
+                  "denied_principals"
+                ],
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "denied_permissions": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "denied_principals": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "denial_condition": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "expression"
+                    ],
+                    "properties": {
+                      "expression": {
+                        "type": "string"
+                      },
+                      "title": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "location": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "exception_permissions": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "exception_principals": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "kms": {
       "type": "object",
       "additionalProperties": false,

--- a/fast/stages/2-security/schemas/project.schema.md
+++ b/fast/stages/2-security/schemas/project.schema.md
@@ -110,6 +110,29 @@
 - **iam_by_principals**: *reference([iam_by_principals](#refs-iam_by_principals))*
 - **iam_by_principals_conditional**: *reference([iam_by_principals_conditional](#refs-iam_by_principals_conditional))*
 - **iam_by_principals_additive**: *reference([iam_by_principals](#refs-iam_by_principals))*
+- **iam_deny_policies**: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9-]+$`**: *object*
+    <br>*additional properties: false*
+    - **display_name**: *string*
+    - ⁺**rules**: *array*
+      - items: *object*
+        <br>*additional properties: false*
+        - **description**: *string*
+        - ⁺**denied_permissions**: *array*
+          - items: *string*
+        - ⁺**denied_principals**: *array*
+          - items: *string*
+        - **denial_condition**: *object*
+          <br>*additional properties: false*
+          - ⁺**expression**: *string*
+          - **title**: *string*
+          - **description**: *string*
+          - **location**: *string*
+        - **exception_permissions**: *array*
+          - items: *string*
+        - **exception_principals**: *array*
+          - items: *string*
 - **kms**: *object*
   <br>*additional properties: false*
   - **autokeys**: *object*

--- a/modules/folder/README.md
+++ b/modules/folder/README.md
@@ -782,7 +782,7 @@ module "folder" {
 | name | description | resources |
 |---|---|---|
 | [assets.tf](./assets.tf) | None | <code>google_cloud_asset_folder_feed</code> |
-| [deny-policies.tf](./deny-policies.tf) | None | <code>google_iam_deny_policy</code> |
+| [deny-policies.tf](./deny-policies.tf) | IAM Deny policies. | <code>google_iam_deny_policy</code> |
 | [iam.tf](./iam.tf) | IAM bindings. | <code>google_folder_iam_binding</code> · <code>google_folder_iam_member</code> |
 | [logging.tf](./logging.tf) | Log sinks and supporting resources. | <code>google_bigquery_dataset_iam_member</code> · <code>google_folder_iam_audit_config</code> · <code>google_logging_folder_exclusion</code> · <code>google_logging_folder_settings</code> · <code>google_logging_folder_sink</code> · <code>google_project_iam_member</code> · <code>google_pubsub_topic_iam_member</code> · <code>google_storage_bucket_iam_member</code> |
 | [main.tf](./main.tf) | Module-level locals and resources. | <code>google_assured_workloads_workload</code> · <code>google_compute_firewall_policy_association</code> · <code>google_essential_contacts_contact</code> · <code>google_folder</code> · <code>google_kms_autokey_config</code> |
@@ -820,7 +820,7 @@ module "folder" {
 | [iam_by_principals](variables-iam.tf#L61) | Authoritative IAM binding in {PRINCIPAL => [ROLES]} format. Principals need to be statically defined to avoid errors. Merged internally with the `iam` variable. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_by_principals_additive](variables-iam.tf#L54) | Additive IAM binding in {PRINCIPAL => [ROLES]} format. Principals need to be statically defined to avoid errors. Merged internally with the `iam_bindings_additive` variable. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_by_principals_conditional](variables-iam.tf#L68) | Authoritative IAM binding in {PRINCIPAL => {roles = [roles], condition = {cond}}} format. Principals need to be statically defined to avoid errors. Condition is required. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [iam_deny_policies](variables-iam.tf#L98) | IAM Deny policies to be applied to the folder. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>null</code> |
+| [iam_deny_policies](variables-iam.tf#L98) | IAM Deny policies to be applied to the folder. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [id](variables.tf#L236) | Folder ID in case you use folder_create=false. | <code>string</code> |  | <code>null</code> |
 | [logging_data_access](variables-logging.tf#L17) | Control activation of data access logs. The special 'allServices' key denotes configuration for all services. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [logging_exclusions](variables-logging.tf#L28) | Logging exclusions for this folder in the form {NAME -> FILTER}. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |

--- a/modules/folder/README.md
+++ b/modules/folder/README.md
@@ -23,6 +23,7 @@ This module allows the creation and management of folders, including support for
 - [Cloud Asset Search](#cloud-asset-search)
 - [Cloud Asset Inventory Feeds](#cloud-asset-inventory-feeds)
 - [Tags](#tags)
+- [IAM Deny Policies](#iam-deny-policies)
 - [Files](#files)
 - [Variables](#variables)
 - [Outputs](#outputs)
@@ -726,6 +727,54 @@ module "folder" {
 # tftest modules=2 resources=5 inventory=tags.yaml e2e serial
 ```
 
+## IAM Deny Policies
+
+[IAM Deny policies](https://cloud.google.com/iam/docs/deny-overview) allow you to set centralized guardrails that prevent principals from using specific permissions within the folder and all of its descendants, regardless of the roles they have been granted. 
+
+You can define Deny policies using the `iam_deny_policies` variable. Each policy requires you to specify the principals and permissions to deny. You can optionally define exception principals, exception permissions, and conditions to tailor the restriction.
+
+Note that IAM Deny policies require a specific prefix for principal definitions (e.g., `principalSet://goog/public:all` or `principalSet://goog/group/group-email@example.com`), and permissions must be prefixed with the service fully qualified domain name (e.g., `iam.googleapis.com/serviceAccountKeys.create`). 
+
+```hcl
+module "folder" {
+  source = "./fabric/modules/folder"
+  parent = var.folder_id
+  name   = "Folder name"
+
+  iam_deny_policies = {
+    "prevent-key-creation" = {
+      display_name = "Prevent SA key creation"
+      rules = [
+        {
+          description        = "Deny service account key creation to all except the folder admin group."
+          denied_principals  = ["principalSet://goog/public:all"]
+          denied_permissions = ["iam.googleapis.com/serviceAccountKeys.create"]
+          exception_principals = [
+            "principalSet://goog/group/gcp-folder-admins@example.com"
+          ]
+        }
+      ]
+    }
+    "conditional-delete-deny" = {
+      display_name = "Conditional instance deletion deny"
+      rules = [
+        {
+          description        = "Deny deletion of compute instances based on resource tags."
+          denied_principals  = ["principalSet://goog/public:all"]
+          denied_permissions = ["compute.googleapis.com/instances.delete"]
+          denial_condition = {
+            title       = "prevent_prod_deletion"
+            description = "Prevent deletion of instances tagged as production."
+            expression  = "resource.matchTag('123456789012/environment', 'prod')"
+          }
+        }
+      ]
+    }
+  }
+}
+# tftest modules=1 resources=3 inventory=iam-deny-policies.yaml
+```
+
 <!-- TFDOC OPTS files:1 -->
 <!-- BEGIN TFDOC -->
 ## Files
@@ -733,6 +782,7 @@ module "folder" {
 | name | description | resources |
 |---|---|---|
 | [assets.tf](./assets.tf) | None | <code>google_cloud_asset_folder_feed</code> |
+| [deny-policies.tf](./deny-policies.tf) | None | <code>google_iam_deny_policy</code> |
 | [iam.tf](./iam.tf) | IAM bindings. | <code>google_folder_iam_binding</code> · <code>google_folder_iam_member</code> |
 | [logging.tf](./logging.tf) | Log sinks and supporting resources. | <code>google_bigquery_dataset_iam_member</code> · <code>google_folder_iam_audit_config</code> · <code>google_logging_folder_exclusion</code> · <code>google_logging_folder_settings</code> · <code>google_logging_folder_sink</code> · <code>google_project_iam_member</code> · <code>google_pubsub_topic_iam_member</code> · <code>google_storage_bucket_iam_member</code> |
 | [main.tf](./main.tf) | Module-level locals and resources. | <code>google_assured_workloads_workload</code> · <code>google_compute_firewall_policy_association</code> · <code>google_essential_contacts_contact</code> · <code>google_folder</code> · <code>google_kms_autokey_config</code> |
@@ -770,6 +820,7 @@ module "folder" {
 | [iam_by_principals](variables-iam.tf#L61) | Authoritative IAM binding in {PRINCIPAL => [ROLES]} format. Principals need to be statically defined to avoid errors. Merged internally with the `iam` variable. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_by_principals_additive](variables-iam.tf#L54) | Additive IAM binding in {PRINCIPAL => [ROLES]} format. Principals need to be statically defined to avoid errors. Merged internally with the `iam_bindings_additive` variable. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_by_principals_conditional](variables-iam.tf#L68) | Authoritative IAM binding in {PRINCIPAL => {roles = [roles], condition = {cond}}} format. Principals need to be statically defined to avoid errors. Condition is required. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [iam_deny_policies](variables-iam.tf#L98) | IAM Deny policies to be applied to the folder. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>null</code> |
 | [id](variables.tf#L236) | Folder ID in case you use folder_create=false. | <code>string</code> |  | <code>null</code> |
 | [logging_data_access](variables-logging.tf#L17) | Control activation of data access logs. The special 'allServices' key denotes configuration for all services. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [logging_exclusions](variables-logging.tf#L28) | Logging exclusions for this folder in the form {NAME -> FILTER}. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |

--- a/modules/folder/deny-policies.tf
+++ b/modules/folder/deny-policies.tf
@@ -1,5 +1,5 @@
 resource "google_iam_deny_policy" "default" {
-  for_each     = var.iam_deny_policies == null ? {} : var.iam_deny_policies
+  for_each     = var.iam_deny_policies
   parent       = urlencode("cloudresourcemanager.googleapis.com/folders/${local.folder_number}")
   name         = each.key
   display_name = each.value.display_name

--- a/modules/folder/deny-policies.tf
+++ b/modules/folder/deny-policies.tf
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# tfdoc:file:description IAM Deny policies.
+
 resource "google_iam_deny_policy" "default" {
   for_each     = var.iam_deny_policies
   parent       = urlencode("cloudresourcemanager.googleapis.com/folders/${local.folder_number}")
@@ -9,7 +27,9 @@ resource "google_iam_deny_policy" "default" {
     content {
       description = rule.value.description
       deny_rule {
-        denied_principals = rule.value.denied_principals
+        denied_principals = [
+          for p in rule.value.denied_principals : lookup(local.ctx.iam_principals, p, p)
+        ]
         dynamic "denial_condition" {
           for_each = rule.value.denial_condition == null ? [] : [""]
           content {
@@ -21,8 +41,10 @@ resource "google_iam_deny_policy" "default" {
             location    = rule.value.denial_condition.location
           }
         }
-        denied_permissions    = rule.value.denied_permissions
-        exception_principals  = rule.value.exception_principals
+        denied_permissions = rule.value.denied_permissions
+        exception_principals = [
+          for p in rule.value.exception_principals : lookup(local.ctx.iam_principals, p, p)
+        ]
         exception_permissions = rule.value.exception_permissions
       }
     }

--- a/modules/folder/deny-policies.tf
+++ b/modules/folder/deny-policies.tf
@@ -1,0 +1,28 @@
+resource "google_iam_deny_policy" "default" {
+  for_each     = var.iam_deny_policies == null ? {} : var.iam_deny_policies
+  parent       = urlencode("cloudresourcemanager.googleapis.com/folders/${local.folder_number}")
+  name         = each.key
+  display_name = each.value.display_name
+  dynamic "rules" {
+    for_each = each.value.rules
+    iterator = rule
+    content {
+      description = rule.value.description
+      deny_rule {
+        denied_principals = rule.value.denied_principals
+        dynamic "denial_condition" {
+          for_each = try(rule.value.denial_condition, null) == null ? [] : [""]
+          content {
+            title       = try(rule.value.denial_condition.title, null)
+            expression  = rule.value.denial_condition.expression
+            description = try(rule.value.denial_condition.description, null)
+            location    = try(rule.value.denial_condition.location, null)
+          }
+        }
+        denied_permissions    = rule.value.denied_permissions
+        exception_principals  = try(rule.value.exception_principals, [])
+        exception_permissions = try(rule.value.exception_permissions, [])
+      }
+    }
+  }
+}

--- a/modules/folder/deny-policies.tf
+++ b/modules/folder/deny-policies.tf
@@ -11,17 +11,17 @@ resource "google_iam_deny_policy" "default" {
       deny_rule {
         denied_principals = rule.value.denied_principals
         dynamic "denial_condition" {
-          for_each = try(rule.value.denial_condition, null) == null ? [] : [""]
+          for_each = rule.value.denial_condition == null ? [] : [""]
           content {
-            title       = try(rule.value.denial_condition.title, null)
-            expression  = rule.value.denial_condition.expression
-            description = try(rule.value.denial_condition.description, null)
-            location    = try(rule.value.denial_condition.location, null)
+            title       = rule.value.denial_condition.title
+            expression  = templatestring(rule.value.denial_condition.expression, var.context.condition_vars)
+            description = rule.value.denial_condition.description
+            location    = rule.value.denial_condition.location
           }
         }
         denied_permissions    = rule.value.denied_permissions
-        exception_principals  = try(rule.value.exception_principals, [])
-        exception_permissions = try(rule.value.exception_permissions, [])
+        exception_principals  = rule.value.exception_principals
+        exception_permissions = rule.value.exception_permissions
       }
     }
   }

--- a/modules/folder/deny-policies.tf
+++ b/modules/folder/deny-policies.tf
@@ -13,8 +13,10 @@ resource "google_iam_deny_policy" "default" {
         dynamic "denial_condition" {
           for_each = rule.value.denial_condition == null ? [] : [""]
           content {
-            title       = rule.value.denial_condition.title
-            expression  = templatestring(rule.value.denial_condition.expression, var.context.condition_vars)
+            title = rule.value.denial_condition.title
+            expression = templatestring(
+              rule.value.denial_condition.expression, var.context.condition_vars
+            )
             description = rule.value.denial_condition.description
             location    = rule.value.denial_condition.location
           }

--- a/modules/folder/variables-iam.tf
+++ b/modules/folder/variables-iam.tf
@@ -113,5 +113,6 @@ variable "iam_deny_policies" {
       exception_permissions = optional(list(string), [])
     }))
   }))
-  default = null
+  default  = {}
+  nullable = false
 }

--- a/modules/folder/variables-iam.tf
+++ b/modules/folder/variables-iam.tf
@@ -115,4 +115,18 @@ variable "iam_deny_policies" {
   }))
   default  = {}
   nullable = false
+  validation {
+    # Ensure denied_principals and denied_permissions are explicitly not null
+    # (to prevent HCL evaluation errors in loops) and contain at least one
+    # element (required by the GCP API).
+    condition = alltrue(flatten([
+      for k, v in var.iam_deny_policies : [
+        for r in v.rules : (
+          try(length(r.denied_principals) > 0, false) &&
+          try(length(r.denied_permissions) > 0, false)
+        )
+      ]
+    ]))
+    error_message = "Each rule in iam_deny_policies must have at least one denied principal and one denied permission."
+  }
 }

--- a/modules/folder/variables-iam.tf
+++ b/modules/folder/variables-iam.tf
@@ -94,3 +94,24 @@ variable "iam_by_principals_conditional" {
     error_message = "IAM bindings with the same condition title must have identical expressions and descriptions."
   }
 }
+
+variable "iam_deny_policies" {
+  description = "IAM Deny policies to be applied to the folder."
+  type = map(object({
+    display_name = optional(string)
+    rules = list(object({
+      description        = optional(string)
+      denied_principals  = list(string)
+      denied_permissions = list(string)
+      denial_condition = optional(object({
+        expression  = string
+        title       = optional(string)
+        description = optional(string)
+        location    = optional(string)
+      }))
+      exception_principals  = optional(list(string), [])
+      exception_permissions = optional(list(string), [])
+    }))
+  }))
+  default = null
+}

--- a/modules/organization/README.md
+++ b/modules/organization/README.md
@@ -1065,7 +1065,7 @@ module "organization" {
 | name | description | resources |
 |---|---|---|
 | [assets.tf](./assets.tf) | None | <code>google_cloud_asset_organization_feed</code> |
-| [deny-policies.tf](./deny-policies.tf) | None | <code>google_iam_deny_policy</code> |
+| [deny-policies.tf](./deny-policies.tf) | IAM Deny policies. | <code>google_iam_deny_policy</code> |
 | [iam.tf](./iam.tf) | IAM bindings. | <code>google_organization_iam_binding</code> · <code>google_organization_iam_custom_role</code> · <code>google_organization_iam_member</code> |
 | [identity-providers.tf](./identity-providers.tf) | Workforce Identity Federation provider definitions. | <code>google_iam_workforce_pool</code> · <code>google_iam_workforce_pool_provider</code> · <code>google_iam_workforce_pool_provider_scim_tenant</code> |
 | [logging.tf](./logging.tf) | Log sinks and data access logs. | <code>google_bigquery_dataset_iam_member</code> · <code>google_logging_organization_exclusion</code> · <code>google_logging_organization_settings</code> · <code>google_logging_organization_sink</code> · <code>google_organization_iam_audit_config</code> · <code>google_project_iam_member</code> · <code>google_pubsub_topic_iam_member</code> · <code>google_storage_bucket_iam_member</code> |
@@ -1105,7 +1105,7 @@ module "organization" {
 | [iam_by_principals](variables-iam.tf#L61) | Authoritative IAM binding in {PRINCIPAL => [ROLES]} format. Principals need to be statically defined to avoid errors. Merged internally with the `iam` variable. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_by_principals_additive](variables-iam.tf#L54) | Additive IAM binding in {PRINCIPAL => [ROLES]} format. Principals need to be statically defined to avoid errors. Merged internally with the `iam_bindings_additive` variable. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_by_principals_conditional](variables-iam.tf#L68) | Authoritative IAM binding in {PRINCIPAL => {roles = [roles], condition = {cond}}} format. Principals need to be statically defined to avoid errors. Condition is required. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [iam_deny_policies](variables-iam.tf#L98) | IAM Deny policies to be applied to the organization. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>null</code> |
+| [iam_deny_policies](variables-iam.tf#L98) | IAM Deny policies to be applied to the organization. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [logging_data_access](variables-logging.tf#L17) | Control activation of data access logs. The special 'allServices' key denotes configuration for all services. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [logging_exclusions](variables-logging.tf#L28) | Logging exclusions for this organization in the form {NAME -> FILTER}. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
 | [logging_settings](variables-logging.tf#L35) | Default settings for logging resources. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |

--- a/modules/organization/README.md
+++ b/modules/organization/README.md
@@ -40,6 +40,7 @@ To manage organization policies, the `orgpolicy.googleapis.com` service should b
 - [Tags](#tags)
   - [Tags Factory](#tags-factory)
 - [Workforce Identity](#workforce-identity)
+- [IAM Deny Policies](#iam-deny-policies)
 - [Files](#files)
 - [Variables](#variables)
 - [Outputs](#outputs)
@@ -1010,6 +1011,53 @@ module "org" {
 # tftest inventory=wfif.yaml
 ```
 
+## IAM Deny Policies
+
+[IAM Deny policies](https://cloud.google.com/iam/docs/deny-overview) allow you to set centralized guardrails that prevent principals from using specific permissions, regardless of the roles they have been granted. 
+
+You can define Deny policies using the `iam_deny_policies` variable. Each policy requires you to specify the principals and permissions to deny, and optionally allows you to define exception principals, exception permissions, and conditions.
+
+Note that IAM Deny policies require a specific prefix for principal definitions (e.g., `principalSet://goog/public:all` or `principalSet://goog/group/group-email@example.com`).
+
+```hcl
+module "organization" {
+  source          = "./fabric/modules/organization"
+  organization_id = var.organization_id
+
+  iam_deny_policies = {
+    "prevent-sa-token-creation" = {
+      display_name = "Prevent SA token creation"
+      rules = [
+        {
+          description        = "Deny service account token creation to all except the central admin group."
+          denied_principals  = ["principalSet://goog/public:all"]
+          denied_permissions = ["iam.serviceAccounts.getAccessToken"]
+          exception_principals = [
+            "principalSet://goog/group/gcp-admins@example.com"
+          ]
+        }
+      ]
+    }
+    "conditional-key-deny" = {
+      display_name = "Conditional SA Key Deny"
+      rules = [
+        {
+          description        = "Deny key creation outside of authorized IPs using a condition."
+          denied_principals  = ["principalSet://goog/public:all"]
+          denied_permissions = ["iam.serviceAccountKeys.create"]
+          denial_condition = {
+            title       = "ip-restriction"
+            description = "Restrict access to specific IP ranges"
+            expression  = "!inIpRange(request.auth.access_levels, 'accessPolicies/123456789/accessLevels/trusted_ips')"
+          }
+        }
+      ]
+    }
+  }
+}
+# tftest modules=1 resources=2 inventory=iam-deny-policies.yaml
+```
+
 <!-- TFDOC OPTS files:1 -->
 <!-- BEGIN TFDOC -->
 ## Files
@@ -1017,6 +1065,7 @@ module "org" {
 | name | description | resources |
 |---|---|---|
 | [assets.tf](./assets.tf) | None | <code>google_cloud_asset_organization_feed</code> |
+| [deny-policies.tf](./deny-policies.tf) | None | <code>google_iam_deny_policy</code> |
 | [iam.tf](./iam.tf) | IAM bindings. | <code>google_organization_iam_binding</code> · <code>google_organization_iam_custom_role</code> · <code>google_organization_iam_member</code> |
 | [identity-providers.tf](./identity-providers.tf) | Workforce Identity Federation provider definitions. | <code>google_iam_workforce_pool</code> · <code>google_iam_workforce_pool_provider</code> · <code>google_iam_workforce_pool_provider_scim_tenant</code> |
 | [logging.tf](./logging.tf) | Log sinks and data access logs. | <code>google_bigquery_dataset_iam_member</code> · <code>google_logging_organization_exclusion</code> · <code>google_logging_organization_settings</code> · <code>google_logging_organization_sink</code> · <code>google_organization_iam_audit_config</code> · <code>google_project_iam_member</code> · <code>google_pubsub_topic_iam_member</code> · <code>google_storage_bucket_iam_member</code> |
@@ -1056,6 +1105,7 @@ module "org" {
 | [iam_by_principals](variables-iam.tf#L61) | Authoritative IAM binding in {PRINCIPAL => [ROLES]} format. Principals need to be statically defined to avoid errors. Merged internally with the `iam` variable. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_by_principals_additive](variables-iam.tf#L54) | Additive IAM binding in {PRINCIPAL => [ROLES]} format. Principals need to be statically defined to avoid errors. Merged internally with the `iam_bindings_additive` variable. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_by_principals_conditional](variables-iam.tf#L68) | Authoritative IAM binding in {PRINCIPAL => {roles = [roles], condition = {cond}}} format. Principals need to be statically defined to avoid errors. Condition is required. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [iam_deny_policies](variables-iam.tf#L98) | IAM Deny policies to be applied to the organization. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>null</code> |
 | [logging_data_access](variables-logging.tf#L17) | Control activation of data access logs. The special 'allServices' key denotes configuration for all services. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [logging_exclusions](variables-logging.tf#L28) | Logging exclusions for this organization in the form {NAME -> FILTER}. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
 | [logging_settings](variables-logging.tf#L35) | Default settings for logging resources. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |

--- a/modules/organization/deny-policies.tf
+++ b/modules/organization/deny-policies.tf
@@ -1,0 +1,28 @@
+resource "google_iam_deny_policy" "default" {
+  for_each     = var.iam_deny_policies == null ? {} : var.iam_deny_policies
+  parent       = urlencode("cloudresourcemanager.googleapis.com/organizations/${local.organization_id_numeric}")
+  name         = each.key
+  display_name = each.value.display_name
+  dynamic "rules" {
+    for_each = each.value.rules
+    iterator = rule
+    content {
+      description = rule.value.description
+      deny_rule {
+        denied_principals = rule.value.denied_principals
+        dynamic "denial_condition" {
+          for_each = try(rule.value.denial_condition, null) == null ? [] : [""]
+          content {
+            title       = try(rule.value.denial_condition.title, null)
+            expression  = rule.value.denial_condition.expression
+            description = try(rule.value.denial_condition.description, null)
+            location    = try(rule.value.denial_condition.location, null)
+          }
+        }
+        denied_permissions    = rule.value.denied_permissions
+        exception_principals  = try(rule.value.exception_principals, [])
+        exception_permissions = try(rule.value.exception_permissions, [])
+      }
+    }
+  }
+}

--- a/modules/organization/deny-policies.tf
+++ b/modules/organization/deny-policies.tf
@@ -11,17 +11,17 @@ resource "google_iam_deny_policy" "default" {
       deny_rule {
         denied_principals = rule.value.denied_principals
         dynamic "denial_condition" {
-          for_each = try(rule.value.denial_condition, null) == null ? [] : [""]
+          for_each = rule.value.denial_condition == null ? [] : [""]
           content {
-            title       = try(rule.value.denial_condition.title, null)
-            expression  = rule.value.denial_condition.expression
-            description = try(rule.value.denial_condition.description, null)
-            location    = try(rule.value.denial_condition.location, null)
+            title       = rule.value.denial_condition.title
+            expression  = templatestring(rule.value.denial_condition.expression, var.context.condition_vars)
+            description = rule.value.denial_condition.description
+            location    = rule.value.denial_condition.location
           }
         }
         denied_permissions    = rule.value.denied_permissions
-        exception_principals  = try(rule.value.exception_principals, [])
-        exception_permissions = try(rule.value.exception_permissions, [])
+        exception_principals  = rule.value.exception_principals
+        exception_permissions = rule.value.exception_permissions
       }
     }
   }

--- a/modules/organization/deny-policies.tf
+++ b/modules/organization/deny-policies.tf
@@ -13,8 +13,10 @@ resource "google_iam_deny_policy" "default" {
         dynamic "denial_condition" {
           for_each = rule.value.denial_condition == null ? [] : [""]
           content {
-            title       = rule.value.denial_condition.title
-            expression  = templatestring(rule.value.denial_condition.expression, var.context.condition_vars)
+            title = rule.value.denial_condition.title
+            expression = templatestring(
+              rule.value.denial_condition.expression, var.context.condition_vars
+            )
             description = rule.value.denial_condition.description
             location    = rule.value.denial_condition.location
           }

--- a/modules/organization/deny-policies.tf
+++ b/modules/organization/deny-policies.tf
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# tfdoc:file:description IAM Deny policies.
+
 resource "google_iam_deny_policy" "default" {
   for_each     = var.iam_deny_policies
   parent       = urlencode("cloudresourcemanager.googleapis.com/organizations/${local.organization_id_numeric}")
@@ -9,7 +27,9 @@ resource "google_iam_deny_policy" "default" {
     content {
       description = rule.value.description
       deny_rule {
-        denied_principals = rule.value.denied_principals
+        denied_principals = [
+          for p in rule.value.denied_principals : lookup(local.ctx.iam_principals, p, p)
+        ]
         dynamic "denial_condition" {
           for_each = rule.value.denial_condition == null ? [] : [""]
           content {
@@ -21,8 +41,10 @@ resource "google_iam_deny_policy" "default" {
             location    = rule.value.denial_condition.location
           }
         }
-        denied_permissions    = rule.value.denied_permissions
-        exception_principals  = rule.value.exception_principals
+        denied_permissions = rule.value.denied_permissions
+        exception_principals = [
+          for p in rule.value.exception_principals : lookup(local.ctx.iam_principals, p, p)
+        ]
         exception_permissions = rule.value.exception_permissions
       }
     }

--- a/modules/organization/deny-policies.tf
+++ b/modules/organization/deny-policies.tf
@@ -1,5 +1,5 @@
 resource "google_iam_deny_policy" "default" {
-  for_each     = var.iam_deny_policies == null ? {} : var.iam_deny_policies
+  for_each     = var.iam_deny_policies
   parent       = urlencode("cloudresourcemanager.googleapis.com/organizations/${local.organization_id_numeric}")
   name         = each.key
   display_name = each.value.display_name

--- a/modules/organization/variables-iam.tf
+++ b/modules/organization/variables-iam.tf
@@ -113,5 +113,6 @@ variable "iam_deny_policies" {
       exception_permissions = optional(list(string), [])
     }))
   }))
-  default = null
+  default  = {}
+  nullable = false
 }

--- a/modules/organization/variables-iam.tf
+++ b/modules/organization/variables-iam.tf
@@ -115,4 +115,18 @@ variable "iam_deny_policies" {
   }))
   default  = {}
   nullable = false
+  validation {
+    # Ensure denied_principals and denied_permissions are explicitly not null
+    # (to prevent HCL evaluation errors in loops) and contain at least one
+    # element (required by the GCP API).
+    condition = alltrue(flatten([
+      for k, v in var.iam_deny_policies : [
+        for r in v.rules : (
+          try(length(r.denied_principals) > 0, false) &&
+          try(length(r.denied_permissions) > 0, false)
+        )
+      ]
+    ]))
+    error_message = "Each rule in iam_deny_policies must have at least one denied principal and one denied permission."
+  }
 }

--- a/modules/organization/variables-iam.tf
+++ b/modules/organization/variables-iam.tf
@@ -94,3 +94,24 @@ variable "iam_by_principals_conditional" {
     error_message = "IAM bindings with the same condition title must have identical expressions and descriptions."
   }
 }
+
+variable "iam_deny_policies" {
+  description = "IAM Deny policies to be applied to the organization."
+  type = map(object({
+    display_name = optional(string)
+    rules = list(object({
+      description        = optional(string)
+      denied_principals  = list(string)
+      denied_permissions = list(string)
+      denial_condition = optional(object({
+        expression  = string
+        title       = optional(string)
+        description = optional(string)
+        location    = optional(string)
+      }))
+      exception_principals  = optional(list(string), [])
+      exception_permissions = optional(list(string), [])
+    }))
+  }))
+  default = null
+}

--- a/modules/project-factory/folders.tf
+++ b/modules/project-factory/folders.tf
@@ -104,6 +104,7 @@ module "folder-1-iam" {
   iam_by_principals             = lookup(each.value, "iam_by_principals", {})
   iam_by_principals_additive    = lookup(each.value, "iam_by_principals_additive", {})
   iam_by_principals_conditional = lookup(each.value, "iam_by_principals_conditional", {})
+  iam_deny_policies             = lookup(each.value, "iam_deny_policies", {})
   logging_data_access           = lookup(each.value, "data_access_logs", {})
   logging_sinks                 = try(each.value.logging.sinks, {})
   tag_bindings                  = lookup(each.value, "tag_bindings", {})
@@ -181,6 +182,7 @@ module "folder-2-iam" {
   iam_by_principals             = lookup(each.value, "iam_by_principals", {})
   iam_by_principals_additive    = lookup(each.value, "iam_by_principals_additive", {})
   iam_by_principals_conditional = lookup(each.value, "iam_by_principals_conditional", {})
+  iam_deny_policies             = lookup(each.value, "iam_deny_policies", {})
   logging_data_access           = lookup(each.value, "data_access_logs", {})
   logging_sinks                 = try(each.value.logging.sinks, {})
   tag_bindings                  = lookup(each.value, "tag_bindings", {})
@@ -261,6 +263,7 @@ module "folder-3-iam" {
   iam_by_principals             = lookup(each.value, "iam_by_principals", {})
   iam_by_principals_additive    = lookup(each.value, "iam_by_principals_additive", {})
   iam_by_principals_conditional = lookup(each.value, "iam_by_principals_conditional", {})
+  iam_deny_policies             = lookup(each.value, "iam_deny_policies", {})
   logging_data_access           = lookup(each.value, "data_access_logs", {})
   logging_sinks                 = try(each.value.logging.sinks, {})
   tag_bindings                  = lookup(each.value, "tag_bindings", {})
@@ -344,6 +347,7 @@ module "folder-4-iam" {
   logging_data_access           = lookup(each.value, "data_access_logs", {})
   logging_sinks                 = try(each.value.logging.sinks, {})
   tag_bindings                  = lookup(each.value, "tag_bindings", {})
+  iam_deny_policies             = lookup(each.value, "iam_deny_policies", {})
   context = merge(local.ctx, {
     folder_ids = merge(local.ctx.folder_ids, {
       for k, v in module.folder-3 : k => v.id

--- a/modules/project-factory/projects.tf
+++ b/modules/project-factory/projects.tf
@@ -260,7 +260,8 @@ module "projects-iam" {
   tags_config = {
     force_context_ids = true
   }
-  universe = each.value.universe
+  iam_deny_policies = lookup(each.value, "iam_deny_policies", {})
+  universe          = each.value.universe
   # we use explicit depends_on as this allows us passing name and prefix
   depends_on = [
     module.projects

--- a/modules/project-factory/schemas/folder.schema.json
+++ b/modules/project-factory/schemas/folder.schema.json
@@ -357,6 +357,85 @@
     "iam_by_principals_conditional": {
       "$ref": "#/$defs/iam_by_principals_conditional"
     },
+    "iam_deny_policies": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "rules"
+          ],
+          "properties": {
+            "display_name": {
+              "type": "string"
+            },
+            "rules": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "denied_permissions",
+                  "denied_principals"
+                ],
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "denied_permissions": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "denied_principals": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "denial_condition": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "expression"
+                    ],
+                    "properties": {
+                      "expression": {
+                        "type": "string"
+                      },
+                      "title": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "location": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "exception_permissions": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "exception_principals": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "name": {
       "type": "string"
     },

--- a/modules/project-factory/schemas/folder.schema.md
+++ b/modules/project-factory/schemas/folder.schema.md
@@ -112,6 +112,29 @@
 - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
 - **iam_by_principals**: *reference([iam_by_principals](#refs-iam_by_principals))*
 - **iam_by_principals_conditional**: *reference([iam_by_principals_conditional](#refs-iam_by_principals_conditional))*
+- **iam_deny_policies**: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9-]+$`**: *object*
+    <br>*additional properties: false*
+    - **display_name**: *string*
+    - ⁺**rules**: *array*
+      - items: *object*
+        <br>*additional properties: false*
+        - **description**: *string*
+        - ⁺**denied_permissions**: *array*
+          - items: *string*
+        - ⁺**denied_principals**: *array*
+          - items: *string*
+        - **denial_condition**: *object*
+          <br>*additional properties: false*
+          - ⁺**expression**: *string*
+          - **title**: *string*
+          - **description**: *string*
+          - **location**: *string*
+        - **exception_permissions**: *array*
+          - items: *string*
+        - **exception_principals**: *array*
+          - items: *string*
 - **name**: *string*
 - **org_policies**: *object*
   <br>*additional properties: false*

--- a/modules/project-factory/schemas/project.schema.json
+++ b/modules/project-factory/schemas/project.schema.json
@@ -344,6 +344,85 @@
     "iam_by_principals_additive": {
       "$ref": "#/$defs/iam_by_principals"
     },
+    "iam_deny_policies": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "rules"
+          ],
+          "properties": {
+            "display_name": {
+              "type": "string"
+            },
+            "rules": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "denied_permissions",
+                  "denied_principals"
+                ],
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "denied_permissions": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "denied_principals": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "denial_condition": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "expression"
+                    ],
+                    "properties": {
+                      "expression": {
+                        "type": "string"
+                      },
+                      "title": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "location": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "exception_permissions": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "exception_principals": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "kms": {
       "type": "object",
       "additionalProperties": false,

--- a/modules/project-factory/schemas/project.schema.md
+++ b/modules/project-factory/schemas/project.schema.md
@@ -110,6 +110,29 @@
 - **iam_by_principals**: *reference([iam_by_principals](#refs-iam_by_principals))*
 - **iam_by_principals_conditional**: *reference([iam_by_principals_conditional](#refs-iam_by_principals_conditional))*
 - **iam_by_principals_additive**: *reference([iam_by_principals](#refs-iam_by_principals))*
+- **iam_deny_policies**: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9-]+$`**: *object*
+    <br>*additional properties: false*
+    - **display_name**: *string*
+    - ⁺**rules**: *array*
+      - items: *object*
+        <br>*additional properties: false*
+        - **description**: *string*
+        - ⁺**denied_permissions**: *array*
+          - items: *string*
+        - ⁺**denied_principals**: *array*
+          - items: *string*
+        - **denial_condition**: *object*
+          <br>*additional properties: false*
+          - ⁺**expression**: *string*
+          - **title**: *string*
+          - **description**: *string*
+          - **location**: *string*
+        - **exception_permissions**: *array*
+          - items: *string*
+        - **exception_principals**: *array*
+          - items: *string*
 - **kms**: *object*
   <br>*additional properties: false*
   - **autokeys**: *object*

--- a/modules/project/README.md
+++ b/modules/project/README.md
@@ -47,6 +47,7 @@ This module implements the creation and management of one GCP project including 
 - [Observability](#observability)
 - [Observability factory](#observability-factory)
 - [Workload Identity Federation](#workload-identity-federation)
+- [IAM Deny Policies](#iam-deny-policies)
 - [Files](#files)
 - [Variables](#variables)
 - [Outputs](#outputs)
@@ -2245,6 +2246,55 @@ module "project" {
 # tftest modules=1 resources=7 inventory=wif.yaml
 ```
 
+## IAM Deny Policies
+
+[IAM Deny policies](https://cloud.google.com/iam/docs/deny-overview) allow you to set centralized guardrails that prevent principals from using specific permissions within the project, regardless of the roles they have been granted. 
+
+You can define Deny policies using the `iam_deny_policies` variable. Each policy requires you to specify the principals and permissions to deny. You can optionally define exception principals, exception permissions, and conditions to tailor the restriction.
+
+Note that IAM Deny policies require a specific prefix for principal definitions (e.g., `principalSet://goog/public:all` or `principalSet://goog/group/group-email@example.com`), and permissions must be prefixed with the service fully qualified domain name (e.g., `iam.googleapis.com/serviceAccountKeys.create`). The module automatically leverages context interpolation for principal formatting if they are defined in your `var.context.iam_principals` mapping.
+
+```hcl
+module "project" {
+  source          = "./fabric/modules/project"
+  name            = "my-project"
+  parent          = var.folder_id
+  billing_account = var.billing_account_id
+
+  iam_deny_policies = {
+    "prevent-kms-destruction" = {
+      display_name = "Prevent KMS Key destruction"
+      rules = [
+        {
+          description        = "Deny destroying KMS key versions to all except the key admins group."
+          denied_principals  = ["principalSet://goog/public:all"]
+          denied_permissions = ["cloudkms.googleapis.com/cryptoKeyVersions.destroy"]
+          exception_principals = [
+            "principalSet://goog/group/gcp-kms-admins@example.com"
+          ]
+        }
+      ]
+    }
+    "prevent-core-bucket-deletion" = {
+      display_name = "Prevent core bucket deletion"
+      rules = [
+        {
+          description        = "Deny deletion of any Cloud Storage bucket with the 'core-' prefix."
+          denied_principals  = ["principalSet://goog/public:all"]
+          denied_permissions = ["storage.googleapis.com/buckets.delete"]
+          denial_condition = {
+            title       = "core_buckets_only"
+            description = "Applies only to buckets starting with 'core-'."
+            expression  = "resource.name.startsWith(\"projects/-/buckets/core-\")"
+          }
+        }
+      ]
+    }
+  }
+}
+# tftest modules=1 resources=3 inventory=iam-deny-policies.yaml
+```
+
 <!-- TFDOC OPTS files:1 -->
 <!-- BEGIN TFDOC -->
 ## Files
@@ -2255,6 +2305,7 @@ module "project" {
 | [assets.tf](./assets.tf) | None | <code>google_cloud_asset_project_feed</code> |
 | [bigquery-reservation.tf](./bigquery-reservation.tf) | None | <code>google_bigquery_reservation</code> · <code>google_bigquery_reservation_assignment</code> |
 | [cmek.tf](./cmek.tf) | Service Agent IAM Bindings for CMEK | <code>google_kms_crypto_key_iam_member</code> |
+| [deny-policies.tf](./deny-policies.tf) | None | <code>google_iam_deny_policy</code> |
 | [iam.tf](./iam.tf) | IAM bindings. | <code>google_project_iam_binding</code> · <code>google_project_iam_custom_role</code> · <code>google_project_iam_member</code> |
 | [identity-providers-defs.tf](./identity-providers-defs.tf) | Workload Identity provider definitions. |  |
 | [identity-providers.tf](./identity-providers.tf) | None | <code>google_iam_workload_identity_pool</code> · <code>google_iam_workload_identity_pool_provider</code> |
@@ -2308,6 +2359,7 @@ module "project" {
 | [iam_by_principals](variables-iam.tf#L61) | Authoritative IAM binding in {PRINCIPAL => [ROLES]} format. Principals need to be statically defined to avoid errors. Merged internally with the `iam` variable. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_by_principals_additive](variables-iam.tf#L54) | Additive IAM binding in {PRINCIPAL => [ROLES]} format. Principals need to be statically defined to avoid errors. Merged internally with the `iam_bindings_additive` variable. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_by_principals_conditional](variables-iam.tf#L68) | Authoritative IAM binding in {PRINCIPAL => {roles = [roles], condition = {cond}}} format. Principals need to be statically defined to avoid errors. Condition is required. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [iam_deny_policies](variables-iam.tf#L98) | IAM Deny policies to be applied to the project. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>null</code> |
 | [kms_autokeys](variables.tf#L221) | KMS Autokey key handles. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [labels](variables.tf#L239) | Resource labels. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
 | [lien_reason](variables.tf#L246) | If non-empty, creates a project lien with this description. | <code>string</code> |  | <code>null</code> |

--- a/modules/project/README.md
+++ b/modules/project/README.md
@@ -2305,7 +2305,7 @@ module "project" {
 | [assets.tf](./assets.tf) | None | <code>google_cloud_asset_project_feed</code> |
 | [bigquery-reservation.tf](./bigquery-reservation.tf) | None | <code>google_bigquery_reservation</code> · <code>google_bigquery_reservation_assignment</code> |
 | [cmek.tf](./cmek.tf) | Service Agent IAM Bindings for CMEK | <code>google_kms_crypto_key_iam_member</code> |
-| [deny-policies.tf](./deny-policies.tf) | None | <code>google_iam_deny_policy</code> |
+| [deny-policies.tf](./deny-policies.tf) | IAM Deny policies. | <code>google_iam_deny_policy</code> |
 | [iam.tf](./iam.tf) | IAM bindings. | <code>google_project_iam_binding</code> · <code>google_project_iam_custom_role</code> · <code>google_project_iam_member</code> |
 | [identity-providers-defs.tf](./identity-providers-defs.tf) | Workload Identity provider definitions. |  |
 | [identity-providers.tf](./identity-providers.tf) | None | <code>google_iam_workload_identity_pool</code> · <code>google_iam_workload_identity_pool_provider</code> |
@@ -2359,7 +2359,7 @@ module "project" {
 | [iam_by_principals](variables-iam.tf#L61) | Authoritative IAM binding in {PRINCIPAL => [ROLES]} format. Principals need to be statically defined to avoid errors. Merged internally with the `iam` variable. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_by_principals_additive](variables-iam.tf#L54) | Additive IAM binding in {PRINCIPAL => [ROLES]} format. Principals need to be statically defined to avoid errors. Merged internally with the `iam_bindings_additive` variable. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_by_principals_conditional](variables-iam.tf#L68) | Authoritative IAM binding in {PRINCIPAL => {roles = [roles], condition = {cond}}} format. Principals need to be statically defined to avoid errors. Condition is required. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [iam_deny_policies](variables-iam.tf#L98) | IAM Deny policies to be applied to the project. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>null</code> |
+| [iam_deny_policies](variables-iam.tf#L98) | IAM Deny policies to be applied to the project. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [kms_autokeys](variables.tf#L221) | KMS Autokey key handles. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [labels](variables.tf#L239) | Resource labels. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
 | [lien_reason](variables.tf#L246) | If non-empty, creates a project lien with this description. | <code>string</code> |  | <code>null</code> |

--- a/modules/project/deny-policies.tf
+++ b/modules/project/deny-policies.tf
@@ -1,0 +1,28 @@
+resource "google_iam_deny_policy" "default" {
+  for_each     = var.iam_deny_policies == null ? {} : var.iam_deny_policies
+  parent       = urlencode("cloudresourcemanager.googleapis.com/projects/${local.project.project_id}")
+  name         = each.key
+  display_name = each.value.display_name
+  dynamic "rules" {
+    for_each = each.value.rules
+    iterator = rule
+    content {
+      description = rule.value.description
+      deny_rule {
+        denied_principals = rule.value.denied_principals
+        dynamic "denial_condition" {
+          for_each = try(rule.value.denial_condition, null) == null ? [] : [""]
+          content {
+            title       = try(rule.value.denial_condition.title, null)
+            expression  = rule.value.denial_condition.expression
+            description = try(rule.value.denial_condition.description, null)
+            location    = try(rule.value.denial_condition.location, null)
+          }
+        }
+        denied_permissions    = rule.value.denied_permissions
+        exception_principals  = try(rule.value.exception_principals, [])
+        exception_permissions = try(rule.value.exception_permissions, [])
+      }
+    }
+  }
+}

--- a/modules/project/deny-policies.tf
+++ b/modules/project/deny-policies.tf
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# tfdoc:file:description IAM Deny policies.
+
 resource "google_iam_deny_policy" "default" {
   for_each     = var.iam_deny_policies
   parent       = urlencode("cloudresourcemanager.googleapis.com/projects/${local.project.project_id}")
@@ -9,7 +27,9 @@ resource "google_iam_deny_policy" "default" {
     content {
       description = rule.value.description
       deny_rule {
-        denied_principals = rule.value.denied_principals
+        denied_principals = [
+          for p in rule.value.denied_principals : lookup(local.ctx.iam_principals, p, p)
+        ]
         dynamic "denial_condition" {
           for_each = rule.value.denial_condition == null ? [] : [""]
           content {
@@ -21,8 +41,10 @@ resource "google_iam_deny_policy" "default" {
             location    = rule.value.denial_condition.location
           }
         }
-        denied_permissions    = rule.value.denied_permissions
-        exception_principals  = rule.value.exception_principals
+        denied_permissions = rule.value.denied_permissions
+        exception_principals = [
+          for p in rule.value.exception_principals : lookup(local.ctx.iam_principals, p, p)
+        ]
         exception_permissions = rule.value.exception_permissions
       }
     }

--- a/modules/project/deny-policies.tf
+++ b/modules/project/deny-policies.tf
@@ -11,17 +11,17 @@ resource "google_iam_deny_policy" "default" {
       deny_rule {
         denied_principals = rule.value.denied_principals
         dynamic "denial_condition" {
-          for_each = try(rule.value.denial_condition, null) == null ? [] : [""]
+          for_each = rule.value.denial_condition == null ? [] : [""]
           content {
-            title       = try(rule.value.denial_condition.title, null)
-            expression  = rule.value.denial_condition.expression
-            description = try(rule.value.denial_condition.description, null)
-            location    = try(rule.value.denial_condition.location, null)
+            title       = rule.value.denial_condition.title
+            expression  = templatestring(rule.value.denial_condition.expression, var.context.condition_vars)
+            description = rule.value.denial_condition.description
+            location    = rule.value.denial_condition.location
           }
         }
         denied_permissions    = rule.value.denied_permissions
-        exception_principals  = try(rule.value.exception_principals, [])
-        exception_permissions = try(rule.value.exception_permissions, [])
+        exception_principals  = rule.value.exception_principals
+        exception_permissions = rule.value.exception_permissions
       }
     }
   }

--- a/modules/project/deny-policies.tf
+++ b/modules/project/deny-policies.tf
@@ -13,8 +13,10 @@ resource "google_iam_deny_policy" "default" {
         dynamic "denial_condition" {
           for_each = rule.value.denial_condition == null ? [] : [""]
           content {
-            title       = rule.value.denial_condition.title
-            expression  = templatestring(rule.value.denial_condition.expression, var.context.condition_vars)
+            title = rule.value.denial_condition.title
+            expression = templatestring(
+              rule.value.denial_condition.expression, var.context.condition_vars
+            )
             description = rule.value.denial_condition.description
             location    = rule.value.denial_condition.location
           }

--- a/modules/project/deny-policies.tf
+++ b/modules/project/deny-policies.tf
@@ -1,5 +1,5 @@
 resource "google_iam_deny_policy" "default" {
-  for_each     = var.iam_deny_policies == null ? {} : var.iam_deny_policies
+  for_each     = var.iam_deny_policies
   parent       = urlencode("cloudresourcemanager.googleapis.com/projects/${local.project.project_id}")
   name         = each.key
   display_name = each.value.display_name

--- a/modules/project/variables-iam.tf
+++ b/modules/project/variables-iam.tf
@@ -113,5 +113,6 @@ variable "iam_deny_policies" {
       exception_permissions = optional(list(string), [])
     }))
   }))
-  default = null
+  default  = {}
+  nullable = false
 }

--- a/modules/project/variables-iam.tf
+++ b/modules/project/variables-iam.tf
@@ -115,4 +115,18 @@ variable "iam_deny_policies" {
   }))
   default  = {}
   nullable = false
+  validation {
+    # Ensure denied_principals and denied_permissions are explicitly not null
+    # (to prevent HCL evaluation errors in loops) and contain at least one
+    # element (required by the GCP API).
+    condition = alltrue(flatten([
+      for k, v in var.iam_deny_policies : [
+        for r in v.rules : (
+          try(length(r.denied_principals) > 0, false) &&
+          try(length(r.denied_permissions) > 0, false)
+        )
+      ]
+    ]))
+    error_message = "Each rule in iam_deny_policies must have at least one denied principal and one denied permission."
+  }
 }

--- a/modules/project/variables-iam.tf
+++ b/modules/project/variables-iam.tf
@@ -94,3 +94,24 @@ variable "iam_by_principals_conditional" {
     error_message = "IAM bindings with the same condition title must have identical expressions and descriptions."
   }
 }
+
+variable "iam_deny_policies" {
+  description = "IAM Deny policies to be applied to the project."
+  type = map(object({
+    display_name = optional(string)
+    rules = list(object({
+      description        = optional(string)
+      denied_principals  = list(string)
+      denied_permissions = list(string)
+      denial_condition = optional(object({
+        expression  = string
+        title       = optional(string)
+        description = optional(string)
+        location    = optional(string)
+      }))
+      exception_principals  = optional(list(string), [])
+      exception_permissions = optional(list(string), [])
+    }))
+  }))
+  default = null
+}

--- a/tests/modules/folder/context.tfvars
+++ b/tests/modules/folder/context.tfvars
@@ -137,3 +137,21 @@ tag_bindings = {
   baz = "$tag_values:test/one"
   foo = "$${projects[\"test-00\"].test}/cc-123"
 }
+
+iam_deny_policies = {
+  test-policy = {
+    display_name = "Test Deny Policy"
+    rules = [
+      {
+        description          = "Test Rule"
+        denied_principals    = ["$iam_principals:myuser"]
+        denied_permissions   = ["compute.googleapis.com/instances.create"]
+        exception_principals = ["$iam_principals:mygroup"]
+        denial_condition = {
+          title      = "Test Condition"
+          expression = "resource.matchTag('$${organization.id}/environment', 'development')"
+        }
+      }
+    ]
+  }
+}

--- a/tests/modules/folder/context.yaml
+++ b/tests/modules/folder/context.yaml
@@ -31,7 +31,6 @@ values:
     - ALL
     timeouts: null
   google_folder.folder[0]:
-    deletion_policy: DELETE
     deletion_protection: false
     display_name: Test Context
     parent: organizations/1234567890
@@ -120,7 +119,6 @@ values:
     kms_key_name: projects/test-kms-0/locations/europe-west8/keyRings/test/cryptoKeys/test
     timeouts: null
   google_logging_folder_sink.sink["test-pubsub"]:
-    deletion_policy: DELETE
     description: test-pubsub (Terraform-managed).
     destination: pubsub.googleapis.com/projects/test-prod-audit-logs-0/topics/audit-logs
     disabled: false

--- a/tests/modules/folder/context.yaml
+++ b/tests/modules/folder/context.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,6 +31,7 @@ values:
     - ALL
     timeouts: null
   google_folder.folder[0]:
+    deletion_policy: DELETE
     deletion_protection: false
     display_name: Test Context
     parent: organizations/1234567890
@@ -96,10 +97,30 @@ values:
     condition: []
     member: user:test-user@example.com
     role: organizations/366118655033/roles/myRoleTwo
+  google_iam_deny_policy.default["test-policy"]:
+    display_name: Test Deny Policy
+    name: test-policy
+    rules:
+    - deny_rule:
+      - denial_condition:
+        - description: null
+          expression: resource.matchTag('1234567890/environment', 'development')
+          location: null
+          title: Test Condition
+        denied_permissions:
+        - compute.googleapis.com/instances.create
+        denied_principals:
+        - user:test-user@example.com
+        exception_permissions: []
+        exception_principals:
+        - group:test-group@example.com
+      description: Test Rule
+    timeouts: null
   google_logging_folder_settings.default[0]:
     kms_key_name: projects/test-kms-0/locations/europe-west8/keyRings/test/cryptoKeys/test
     timeouts: null
   google_logging_folder_sink.sink["test-pubsub"]:
+    deletion_policy: DELETE
     description: test-pubsub (Terraform-managed).
     destination: pubsub.googleapis.com/projects/test-prod-audit-logs-0/topics/audit-logs
     disabled: false
@@ -162,10 +183,22 @@ counts:
   google_folder_iam_audit_config: 1
   google_folder_iam_binding: 7
   google_folder_iam_member: 1
+  google_iam_deny_policy: 1
   google_logging_folder_settings: 1
   google_logging_folder_sink: 1
   google_privileged_access_manager_entitlement: 1
   google_pubsub_topic_iam_member: 1
   google_tags_tag_binding: 3
   modules: 0
-  resources: 19
+  resources: 20
+
+outputs:
+  asset_search_results: {}
+  assured_workload: null
+  folder: __missing__
+  id: __missing__
+  name: Test Context
+  organization_policies_ids: {}
+  scc_custom_sha_modules_ids: {}
+  service_agents: {}
+  sink_writer_identities: __missing__

--- a/tests/modules/folder/examples/iam-deny-policies.yaml
+++ b/tests/modules/folder/examples/iam-deny-policies.yaml
@@ -1,0 +1,50 @@
+
+values:
+  module.folder.google_folder.folder[0]:
+    deletion_protection: false
+    display_name: Folder name
+    parent: folders/1122334455
+    tags: null
+    timeouts: null
+  module.folder.google_iam_deny_policy.default["conditional-delete-deny"]:
+    display_name: Conditional instance deletion deny
+    name: conditional-delete-deny
+    rules:
+    - deny_rule:
+      - denial_condition:
+        - description: Prevent deletion of instances tagged as production.
+          expression: resource.matchTag('123456789012/environment', 'prod')
+          location: null
+          title: prevent_prod_deletion
+        denied_permissions:
+        - compute.googleapis.com/instances.delete
+        denied_principals:
+        - principalSet://goog/public:all
+        exception_permissions: []
+        exception_principals: []
+      description: Deny deletion of compute instances based on resource tags.
+    timeouts: null
+  module.folder.google_iam_deny_policy.default["prevent-key-creation"]:
+    display_name: Prevent SA key creation
+    name: prevent-key-creation
+    rules:
+    - deny_rule:
+      - denial_condition: []
+        denied_permissions:
+        - iam.googleapis.com/serviceAccountKeys.create
+        denied_principals:
+        - principalSet://goog/public:all
+        exception_permissions: []
+        exception_principals:
+        - principalSet://goog/group/gcp-folder-admins@example.com
+      description: Deny service account key creation to all except the folder admin
+        group.
+    timeouts: null
+
+counts:
+  google_folder: 1
+  google_iam_deny_policy: 2
+  modules: 1
+  resources: 3
+
+outputs: {}

--- a/tests/modules/folder/examples/iam-deny-policies.yaml
+++ b/tests/modules/folder/examples/iam-deny-policies.yaml
@@ -1,3 +1,16 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 values:
   module.folder.google_folder.folder[0]:

--- a/tests/modules/organization/context.tfvars
+++ b/tests/modules/organization/context.tfvars
@@ -208,3 +208,21 @@ tags = {
     }
   }
 }
+
+iam_deny_policies = {
+  test-policy = {
+    display_name = "Test Deny Policy"
+    rules = [
+      {
+        description          = "Test Rule"
+        denied_principals    = ["$iam_principals:myuser"]
+        denied_permissions   = ["compute.googleapis.com/instances.create"]
+        exception_principals = ["$iam_principals:mygroup"]
+        denial_condition = {
+          title      = "Test Condition"
+          expression = "resource.matchTag('$${organization.id}/environment', 'development')"
+        }
+      }
+    ]
+  }
+}

--- a/tests/modules/organization/context.yaml
+++ b/tests/modules/organization/context.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,7 +28,7 @@ values:
     feed_output_config:
     - pubsub_destination:
       - topic: projects/test-prod-audit-logs-0/topics/audit-logs
-    org_id: "1234567890"
+    org_id: '1234567890'
     timeouts: null
   google_essential_contacts_contact.contact["$email_addresses:default"]:
     email: foo@example.com
@@ -36,6 +36,26 @@ values:
     notification_category_subscriptions:
     - ALL
     parent: organizations/1234567890
+    timeouts: null
+  google_iam_deny_policy.default["test-policy"]:
+    display_name: Test Deny Policy
+    name: test-policy
+    parent: cloudresourcemanager.googleapis.com%2Forganizations%2F1234567890
+    rules:
+    - deny_rule:
+      - denial_condition:
+        - description: null
+          expression: resource.matchTag('1234567890/environment', 'development')
+          location: null
+          title: Test Condition
+        denied_permissions:
+        - compute.googleapis.com/instances.create
+        denied_principals:
+        - user:test-user@example.com
+        exception_permissions: []
+        exception_principals:
+        - group:test-group@example.com
+      description: Test Rule
     timeouts: null
   google_logging_organization_settings.default[0]:
     kms_key_name: projects/test-kms-0/locations/europe-west8/keyRings/test/cryptoKeys/test
@@ -45,6 +65,7 @@ values:
   google_logging_organization_sink.sink["test-bq"]:
     bigquery_options:
     - use_partitioned_tables: false
+    deletion_policy: DELETE
     description: test-bq (Terraform-managed).
     destination: bigquery.googleapis.com/projects/test-prod-audit-logs-0/datasets/logs
     disabled: false
@@ -55,6 +76,7 @@ values:
     name: test-bq
     org_id: '1234567890'
   google_logging_organization_sink.sink["test-logging"]:
+    deletion_policy: DELETE
     description: test-logging (Terraform-managed).
     destination: logging.googleapis.com/projects/test-prod-audit-logs-0/locations/europe-west8/buckets/audit-logs
     disabled: false
@@ -65,6 +87,7 @@ values:
     name: test-logging
     org_id: '1234567890'
   google_logging_organization_sink.sink["test-project"]:
+    deletion_policy: DELETE
     description: test-project (Terraform-managed).
     destination: logging.googleapis.com/projects/test-prod-audit-logs-0
     disabled: false
@@ -75,6 +98,7 @@ values:
     name: test-project
     org_id: '1234567890'
   google_logging_organization_sink.sink["test-pubsub"]:
+    deletion_policy: DELETE
     description: test-pubsub (Terraform-managed).
     destination: pubsub.googleapis.com/projects/test-prod-audit-logs-0/topics/audit-logs
     disabled: false
@@ -85,6 +109,7 @@ values:
     name: test-pubsub
     org_id: '1234567890'
   google_logging_organization_sink.sink["test-storage"]:
+    deletion_policy: DELETE
     description: test-storage (Terraform-managed).
     destination: storage.googleapis.com/test-prod-logs-audit-0
     disabled: false
@@ -266,6 +291,7 @@ counts:
   google_bigquery_dataset_iam_member: 1
   google_cloud_asset_organization_feed: 1
   google_essential_contacts_contact: 1
+  google_iam_deny_policy: 1
   google_logging_organization_settings: 1
   google_logging_organization_sink: 5
   google_organization_iam_audit_config: 1
@@ -281,4 +307,27 @@ counts:
   google_tags_tag_value_iam_binding: 2
   google_tags_tag_value_iam_member: 1
   modules: 0
-  resources: 30
+  resources: 31
+
+outputs:
+  asset_search_results: {}
+  custom_constraint_ids: {}
+  custom_role_id: {}
+  custom_roles: {}
+  id: organizations/1234567890
+  logging_identities: __missing__
+  logging_sinks: __missing__
+  network_tag_keys: {}
+  network_tag_values: {}
+  organization_id: organizations/1234567890
+  organization_policies_ids: {}
+  scc_custom_sha_modules_ids: {}
+  scc_mute_configs: {}
+  scim_tenants: {}
+  service_agents: {}
+  sink_writer_identities: __missing__
+  tag_keys: {}
+  tag_values: {}
+  workforce_identity_pool_ids: {}
+  workforce_identity_provider_names: {}
+  workforce_identity_providers: {}

--- a/tests/modules/organization/context.yaml
+++ b/tests/modules/organization/context.yaml
@@ -65,7 +65,6 @@ values:
   google_logging_organization_sink.sink["test-bq"]:
     bigquery_options:
     - use_partitioned_tables: false
-    deletion_policy: DELETE
     description: test-bq (Terraform-managed).
     destination: bigquery.googleapis.com/projects/test-prod-audit-logs-0/datasets/logs
     disabled: false
@@ -76,7 +75,6 @@ values:
     name: test-bq
     org_id: '1234567890'
   google_logging_organization_sink.sink["test-logging"]:
-    deletion_policy: DELETE
     description: test-logging (Terraform-managed).
     destination: logging.googleapis.com/projects/test-prod-audit-logs-0/locations/europe-west8/buckets/audit-logs
     disabled: false
@@ -87,7 +85,6 @@ values:
     name: test-logging
     org_id: '1234567890'
   google_logging_organization_sink.sink["test-project"]:
-    deletion_policy: DELETE
     description: test-project (Terraform-managed).
     destination: logging.googleapis.com/projects/test-prod-audit-logs-0
     disabled: false
@@ -98,7 +95,6 @@ values:
     name: test-project
     org_id: '1234567890'
   google_logging_organization_sink.sink["test-pubsub"]:
-    deletion_policy: DELETE
     description: test-pubsub (Terraform-managed).
     destination: pubsub.googleapis.com/projects/test-prod-audit-logs-0/topics/audit-logs
     disabled: false
@@ -109,7 +105,6 @@ values:
     name: test-pubsub
     org_id: '1234567890'
   google_logging_organization_sink.sink["test-storage"]:
-    deletion_policy: DELETE
     description: test-storage (Terraform-managed).
     destination: storage.googleapis.com/test-prod-logs-audit-0
     disabled: false

--- a/tests/modules/organization/examples/iam-deny-policies.yaml
+++ b/tests/modules/organization/examples/iam-deny-policies.yaml
@@ -1,3 +1,16 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 values:
   module.organization.google_iam_deny_policy.default["conditional-key-deny"]:

--- a/tests/modules/organization/examples/iam-deny-policies.yaml
+++ b/tests/modules/organization/examples/iam-deny-policies.yaml
@@ -1,0 +1,45 @@
+
+values:
+  module.organization.google_iam_deny_policy.default["conditional-key-deny"]:
+    display_name: Conditional SA Key Deny
+    name: conditional-key-deny
+    parent: cloudresourcemanager.googleapis.com%2Forganizations%2F1122334455
+    rules:
+    - deny_rule:
+      - denial_condition:
+        - description: Restrict access to specific IP ranges
+          expression: '!inIpRange(request.auth.access_levels, ''accessPolicies/123456789/accessLevels/trusted_ips'')'
+          location: null
+          title: ip-restriction
+        denied_permissions:
+        - iam.serviceAccountKeys.create
+        denied_principals:
+        - principalSet://goog/public:all
+        exception_permissions: []
+        exception_principals: []
+      description: Deny key creation outside of authorized IPs using a condition.
+    timeouts: null
+  module.organization.google_iam_deny_policy.default["prevent-sa-token-creation"]:
+    display_name: Prevent SA token creation
+    name: prevent-sa-token-creation
+    parent: cloudresourcemanager.googleapis.com%2Forganizations%2F1122334455
+    rules:
+    - deny_rule:
+      - denial_condition: []
+        denied_permissions:
+        - iam.serviceAccounts.getAccessToken
+        denied_principals:
+        - principalSet://goog/public:all
+        exception_permissions: []
+        exception_principals:
+        - principalSet://goog/group/gcp-admins@example.com
+      description: Deny service account token creation to all except the central admin
+        group.
+    timeouts: null
+
+counts:
+  google_iam_deny_policy: 2
+  modules: 1
+  resources: 2
+
+outputs: {}

--- a/tests/modules/project/context.tfvars
+++ b/tests/modules/project/context.tfvars
@@ -254,3 +254,21 @@ tags = {
 vpc_sc = {
   perimeter_name = "$vpc_sc_perimeters:default"
 }
+
+iam_deny_policies = {
+  test-policy = {
+    display_name = "Test Deny Policy"
+    rules = [
+      {
+        description          = "Test Rule"
+        denied_principals    = ["$iam_principals:myuser"]
+        denied_permissions   = ["compute.googleapis.com/instances.create"]
+        exception_principals = ["$iam_principals:mygroup"]
+        denial_condition = {
+          title      = "Test Condition"
+          expression = "resource.matchTag('$${organization.id}/environment', 'development')"
+        }
+      }
+    ]
+  }
+}

--- a/tests/modules/project/context.yaml
+++ b/tests/modules/project/context.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,6 +22,7 @@ values:
     billing_project: test-project
     condition: []
     content_type: null
+    deletion_policy: DELETE
     feed_id: test
     feed_output_config:
     - pubsub_destination:
@@ -40,6 +41,26 @@ values:
     - ALL
     parent: projects/my-project
     timeouts: null
+  google_iam_deny_policy.default["test-policy"]:
+    display_name: Test Deny Policy
+    name: test-policy
+    parent: cloudresourcemanager.googleapis.com%2Fprojects%2Fmy-project
+    rules:
+    - deny_rule:
+      - denial_condition:
+        - description: null
+          expression: resource.matchTag('1234567890/environment', 'development')
+          location: null
+          title: Test Condition
+        denied_permissions:
+        - compute.googleapis.com/instances.create
+        denied_principals:
+        - user:test-user@example.com
+        exception_permissions: []
+        exception_principals:
+        - group:test-group@example.com
+      description: Test Rule
+    timeouts: null
   google_kms_crypto_key_iam_member.service_agent_cmek["key-0.compute-system"]:
     condition: []
     crypto_key_id: projects/kms-central-prj/locations/europe-west1/keyRings/my-keyring/cryptoKeys/ew1-compute
@@ -47,6 +68,7 @@ values:
   google_logging_metric.metrics["test-metric"]:
     bucket_name: logging.googleapis.com/projects/my-project/locations/global/buckets/audit-bucket
     bucket_options: []
+    deletion_policy: DELETE
     description: null
     disabled: null
     filter: resource.type="gce_instance"
@@ -57,6 +79,7 @@ values:
     value_extractor: null
   google_logging_project_sink.sink["test-pubsub"]:
     custom_writer_identity: null
+    deletion_policy: DELETE
     description: test-pubsub (Terraform-managed).
     destination: pubsub.googleapis.com/projects/test-prod-audit-logs-0/topics/audit-logs
     disabled: false
@@ -86,6 +109,7 @@ values:
         threshold_value: null
         trigger: []
       display_name: test-condition
+    deletion_policy: DELETE
     display_name: Test Alert
     documentation: []
     enabled: true
@@ -96,6 +120,7 @@ values:
     timeouts: null
     user_labels: null
   google_monitoring_notification_channel.channels["new-email"]:
+    deletion_policy: DELETE
     description: null
     display_name: null
     enabled: true
@@ -108,6 +133,7 @@ values:
     type: email
     user_labels: null
   google_monitoring_notification_channel.channels["new-pubsub"]:
+    deletion_policy: DELETE
     description: null
     display_name: null
     enabled: true
@@ -264,6 +290,7 @@ values:
     project: test-vpc-host
     role: roles/compute.networkUser
   google_project_service.project_services["compute.googleapis.com"]:
+    deletion_policy: DELETE
     disable_dependent_services: false
     disable_on_destroy: false
     project: my-project
@@ -323,6 +350,7 @@ counts:
   google_cloud_asset_project_feed: 1
   google_compute_shared_vpc_service_project: 1
   google_essential_contacts_contact: 1
+  google_iam_deny_policy: 1
   google_kms_crypto_key_iam_member: 1
   google_logging_metric: 1
   google_logging_project_sink: 1
@@ -341,4 +369,36 @@ counts:
   google_tags_tag_value_iam_binding: 2
   google_tags_tag_value_iam_member: 1
   modules: 0
-  resources: 38
+  resources: 39
+
+outputs:
+  alert_ids: __missing__
+  asset_search_results: {}
+  bigquery_reservations:
+    assignments: {}
+    reservations: {}
+  custom_role_id: {}
+  custom_roles: {}
+  default_service_accounts: __missing__
+  id: my-project
+  kms_autokeys: {}
+  name: my-project
+  network_tag_keys: {}
+  network_tag_values: {}
+  notification_channel_names: __missing__
+  notification_channels: __missing__
+  number: __missing__
+  organization_policies_ids: {}
+  project_id: my-project
+  quota_configs: {}
+  quotas: {}
+  scc_custom_sha_modules_ids: {}
+  service_agents: __missing__
+  services:
+  - compute.googleapis.com
+  sink_writer_identities: __missing__
+  tag_keys: {}
+  tag_values: {}
+  workload_identity_pool_ids: {}
+  workload_identity_provider_ids: {}
+  workload_identity_providers: {}

--- a/tests/modules/project/context.yaml
+++ b/tests/modules/project/context.yaml
@@ -22,7 +22,6 @@ values:
     billing_project: test-project
     condition: []
     content_type: null
-    deletion_policy: DELETE
     feed_id: test
     feed_output_config:
     - pubsub_destination:
@@ -30,7 +29,6 @@ values:
     project: my-project
     timeouts: null
   google_compute_shared_vpc_service_project.shared_vpc_service[0]:
-    deletion_policy: null
     host_project: test-vpc-host
     service_project: my-project
     timeouts: null
@@ -68,7 +66,6 @@ values:
   google_logging_metric.metrics["test-metric"]:
     bucket_name: logging.googleapis.com/projects/my-project/locations/global/buckets/audit-bucket
     bucket_options: []
-    deletion_policy: DELETE
     description: null
     disabled: null
     filter: resource.type="gce_instance"
@@ -79,7 +76,6 @@ values:
     value_extractor: null
   google_logging_project_sink.sink["test-pubsub"]:
     custom_writer_identity: null
-    deletion_policy: DELETE
     description: test-pubsub (Terraform-managed).
     destination: pubsub.googleapis.com/projects/test-prod-audit-logs-0/topics/audit-logs
     disabled: false
@@ -109,7 +105,6 @@ values:
         threshold_value: null
         trigger: []
       display_name: test-condition
-    deletion_policy: DELETE
     display_name: Test Alert
     documentation: []
     enabled: true
@@ -120,7 +115,6 @@ values:
     timeouts: null
     user_labels: null
   google_monitoring_notification_channel.channels["new-email"]:
-    deletion_policy: DELETE
     description: null
     display_name: null
     enabled: true
@@ -133,7 +127,6 @@ values:
     type: email
     user_labels: null
   google_monitoring_notification_channel.channels["new-pubsub"]:
-    deletion_policy: DELETE
     description: null
     display_name: null
     enabled: true
@@ -182,7 +175,6 @@ values:
   google_project.project[0]:
     auto_create_network: false
     billing_account: null
-    deletion_policy: DELETE
     effective_labels:
       goog-terraform-provisioned: 'true'
     folder_id: '6789012345'
@@ -290,7 +282,6 @@ values:
     project: test-vpc-host
     role: roles/compute.networkUser
   google_project_service.project_services["compute.googleapis.com"]:
-    deletion_policy: DELETE
     disable_dependent_services: false
     disable_on_destroy: false
     project: my-project

--- a/tests/modules/project/examples/iam-deny-policies.yaml
+++ b/tests/modules/project/examples/iam-deny-policies.yaml
@@ -1,0 +1,59 @@
+values:
+  module.project.google_iam_deny_policy.default["prevent-core-bucket-deletion"]:
+    display_name: Prevent core bucket deletion
+    name: prevent-core-bucket-deletion
+    parent: cloudresourcemanager.googleapis.com%2Fprojects%2Fmy-project
+    rules:
+    - deny_rule:
+      - denial_condition:
+        - description: Applies only to buckets starting with 'core-'.
+          expression: resource.name.startsWith("projects/-/buckets/core-")
+          location: null
+          title: core_buckets_only
+        denied_permissions:
+        - storage.googleapis.com/buckets.delete
+        denied_principals:
+        - principalSet://goog/public:all
+        exception_permissions: []
+        exception_principals: []
+      description: Deny deletion of any Cloud Storage bucket with the 'core-' prefix.
+    timeouts: null
+  module.project.google_iam_deny_policy.default["prevent-kms-destruction"]:
+    display_name: Prevent KMS Key destruction
+    name: prevent-kms-destruction
+    parent: cloudresourcemanager.googleapis.com%2Fprojects%2Fmy-project
+    rules:
+    - deny_rule:
+      - denial_condition: []
+        denied_permissions:
+        - cloudkms.googleapis.com/cryptoKeyVersions.destroy
+        denied_principals:
+        - principalSet://goog/public:all
+        exception_permissions: []
+        exception_principals:
+        - principalSet://goog/group/gcp-kms-admins@example.com
+      description: Deny destroying KMS key versions to all except the key admins group.
+    timeouts: null
+  module.project.google_project.project[0]:
+    auto_create_network: false
+    billing_account: 123456-123456-123456
+    deletion_policy: DELETE
+    effective_labels:
+      goog-terraform-provisioned: 'true'
+    folder_id: '1122334455'
+    labels: null
+    name: my-project
+    org_id: null
+    project_id: my-project
+    tags: null
+    terraform_labels:
+      goog-terraform-provisioned: 'true'
+    timeouts: null
+
+counts:
+  google_iam_deny_policy: 2
+  google_project: 1
+  modules: 1
+  resources: 3
+
+outputs: {}

--- a/tests/modules/project/examples/iam-deny-policies.yaml
+++ b/tests/modules/project/examples/iam-deny-policies.yaml
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 values:
   module.project.google_iam_deny_policy.default["prevent-core-bucket-deletion"]:
     display_name: Prevent core bucket deletion


### PR DESCRIPTION
<!-- Put a description of what this PR is for here -->
Add support IAM deny policies to `project`, `folder`, `organization` modules.
---
This PR introduces native support for IAM Deny policies to the organization, folder, and project modules. IAM Deny is a critical security primitive for a cloud environment, enabling teams to set centralized, preventative guardrails that strictly override any 'Allow' permissions. Integrating this feature directly into the hierarchy modules allows users to manage their Deny rules alongside standard IAM and Organization Policies in a consistent, DRY manner, all while maintaining backward compatibility, for those that do not need operational security features.

**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
