### PR TITLE
[Cloud SQL] Allow week5 maintenance update track

### DIFF
--- a/modules/cloudsql-instance/variables.tf
+++ b/modules/cloudsql-instance/variables.tf
@@ -193,10 +193,10 @@ variable "maintenance_config" {
         var.maintenance_config.maintenance_window.hour <= 23 &&
         # Maintenance window update_track validation below
         try(var.maintenance_config.maintenance_window.update_track, null) == null ? true :
-        contains(["canary", "stable"], var.maintenance_config.maintenance_window.update_track)
+        contains(["canary", "stable", "week5"], var.maintenance_config.maintenance_window.update_track)
       )
     )
-    error_message = "Maintenance window day must be between 1 and 7 or null, maintenance window hour must be between 0 and 23 and maintenance window update_track must be 'stable' or 'canary'."
+    error_message = "Maintenance window day must be between 1 and 7 or null, maintenance window hour must be between 0 and 23 and maintenance window update_track must be 'stable', 'canary', or 'week5'."
   }
 }
 


### PR DESCRIPTION
The `google_sql_database_instance` resource supports 3 options for `maintenance_window.update_track`: canary, stable, and week5. The current module blocks the ability to specify "week5" as an argument.

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
