### PR TITLE
Add CODEOWNERS with maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ludoo @juliocc @sruffilli @wiktorn @LucaPrete


### PR DESCRIPTION
Adds a `.github/CODEOWNERS` file listing the five active maintainers as global code owners.

The branch protection rule on `master` already requires code owner reviews (`require_code_owner_reviews: true`), but without a CODEOWNERS file, GitHub fell back to requiring approval from anyone with write access. This meant non-member approvals (which GitHub allows on public repos) could incorrectly appear to satisfy the requirement.

With this change, only reviews from `@ludoo`, `@juliocc`, `@sruffilli`, `@wiktorn`, and `@LucaPrete` will count toward the required review count.

## Context
See #3973 where a non-member (`Jobayer-cloud1`, `author_association: NONE`) was able to submit an approving review that appeared in the PR UI — though it did not actually satisfy the branch protection rule.