### PR TITLE
Add support for regional firewall policies in 2-networking stage

### DIFF
--- a/fast/stages/2-networking/factory-firewall-policies.tf
+++ b/fast/stages/2-networking/factory-firewall-policies.tf
@@ -46,11 +46,13 @@ module "firewall-policies" {
   attachments   = each.value.attachments
   name          = each.key
   parent_id     = each.value.parent
+  region        = try(each.value.region, null)
   egress_rules  = each.value.egress_rules
   ingress_rules = each.value.ingress_rules
   context = {
     folder_ids       = local.ctx_folders
     cidr_ranges_sets = local.ctx.cidr_ranges_sets
     tag_values       = local.ctx.tag_values
+    locations        = local.ctx.locations
   }
 }

--- a/fast/stages/2-networking/schemas/firewall-policy.schema.json
+++ b/fast/stages/2-networking/schemas/firewall-policy.schema.json
@@ -22,6 +22,10 @@
       "type": "string",
       "description": "The name of the firewall policy."
     },
+    "region": {
+      "type": "string",
+      "description": "The region of the firewall policy. Use 'global' for global network policy, or omit for hierarchical policy."
+    },
     "ingress_rules": {
       "$ref": "#/$defs/rules",
       "description": "A map of ingress firewall rules."

--- a/fast/stages/2-networking/schemas/firewall-policy.schema.md
+++ b/fast/stages/2-networking/schemas/firewall-policy.schema.md
@@ -11,6 +11,7 @@
   <br>*additional properties: false*
   - **`^[a-z0-9-]+$`**: *string*
 - **name**: *string*
+- **region**: *string*
 - **ingress_rules**: *reference([rules](#refs-rules))*
 - **egress_rules**: *reference([rules](#refs-rules))*
 

--- a/tests/fast/stages/s2_networking/data-testregionalfw/defaults.yaml
+++ b/tests/fast/stages/s2_networking/data-testregionalfw/defaults.yaml
@@ -1,0 +1,19 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+context: {}
+projects:
+  defaults:
+    locations:
+      storage: eu

--- a/tests/fast/stages/s2_networking/data-testregionalfw/firewall-policies/policy1.yaml
+++ b/tests/fast/stages/s2_networking/data-testregionalfw/firewall-policies/policy1.yaml
@@ -1,0 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: regional-policy
+parent_id: folders/12345
+region: $locations:region1

--- a/tests/fast/stages/s2_networking/regional_fw.tfvars
+++ b/tests/fast/stages/s2_networking/regional_fw.tfvars
@@ -1,0 +1,29 @@
+automation = {
+  outputs_bucket = "test"
+}
+billing_account = {
+  id = "000000-111111-222222"
+}
+factories_config = {
+  dataset = "data-testregionalfw"
+}
+folder_ids = {
+  "networking" = "folders/12345678"
+}
+organization = {
+  domain      = "fast.example.com"
+  id          = 123456789012
+  customer_id = "C00000000"
+}
+prefix = "fast"
+service_accounts = {
+  "iac-0/iac-pf-rw" = "iac-pf-rw@test.iam.gserviceaccount.com"
+}
+storage_buckets = {
+  "iac-0/iac-outputs" = "test"
+}
+context = {
+  locations = {
+    region1 = "europe-west1"
+  }
+}

--- a/tests/fast/stages/s2_networking/regional_fw.yaml
+++ b/tests/fast/stages/s2_networking/regional_fw.yaml
@@ -1,0 +1,19 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+counts:
+  google_compute_region_network_firewall_policy: 1
+  modules: 2
+  resources: 3
+  terraform_data: 2

--- a/tests/fast/stages/s2_networking/tftest.yaml
+++ b/tests/fast/stages/s2_networking/tftest.yaml
@@ -40,3 +40,8 @@ tests:
       - addresses.yaml
     extra_dirs:
       - ../../../tests/fast/stages/s2_networking/data-testaddresses
+  regional_fw:
+    inventory:
+      - regional_fw.yaml
+    extra_dirs:
+      - ../../../tests/fast/stages/s2_networking/data-testregionalfw


### PR DESCRIPTION
- Fixes #3896 
- Update factory to pass region and locations context to net-firewall-policy module.
- Update schema to include region property.
- Add test case in s2_networking tests to verify regional policy creation.
