### PR TITLE
Revert "Add CODEOWNERS with maintainers"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @ludoo @juliocc @sruffilli @wiktorn @LucaPrete


### PR DESCRIPTION
Reverts GoogleCloudPlatform/cloud-foundation-fabric#3994 as we have a different less rigid way of accomplishing the same goal.