### PR TITLE
Enable Merge Queue and Remove Fast-Dev Branch

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -18,11 +18,12 @@ on:
   pull_request:
     branches:
       - master
-      - fast-dev
   push:
     branches:
       - master
-      - fast-dev
+  merge_group:
+    branches:
+      - master
 
 permissions:
   contents: read

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,11 +18,12 @@ on:
   push:
     branches:
       - master
-      - fast-dev
   pull_request:
     branches:
       - master
-      - fast-dev
+  merge_group:
+    branches:
+      - master
   workflow_dispatch:
     inputs:
       terraform_version:


### PR DESCRIPTION
This PR adds the `merge_group` trigger to tests and linting workflows to support GitHub Merge Queues, and removes the unused `fast-dev` branch from the triggers.