### PR TITLE
Fix the service-directory module

### DIFF
--- a/modules/service-directory/README.md
+++ b/modules/service-directory/README.md
@@ -152,7 +152,7 @@ Note that the `network` argument is unusual in that it requires the project numb
 | [id](outputs.tf#L22) | Fully qualified namespace id. |  |
 | [name](outputs.tf#L27) | Namespace name. |  |
 | [namespace](outputs.tf#L32) | Namespace resource. |  |
-| [service_id](outputs.tf#L40) | Service ids (short names). |  |
+| [service_ids](outputs.tf#L40) | Service ids (short names). |  |
 | [service_names](outputs.tf#L50) | Service ids (long names). |  |
 | [services](outputs.tf#L60) | Service resources. |  |
 <!-- END TFDOC -->

--- a/modules/service-directory/main.tf
+++ b/modules/service-directory/main.tf
@@ -15,13 +15,16 @@
  */
 
 locals {
-  endpoint_list = flatten([
+  endpoints_list = flatten([
     for name, attrs in var.services : [
-      for endpoint in attrs.endpoints : { service : name, endpoint : endpoint }
+      for endpoint in attrs.endpoints : {
+        service  = name
+        endpoint = endpoint
+      }
     ]
   ])
   endpoints = {
-    for ep in local.endpoint_list : "${ep.service}/${ep.endpoint}" => ep
+    for ep in local.endpoints_list : "${ep.service}/${ep.endpoint}" => ep
   }
   iam_pairs = var.service_iam == null ? [] : flatten([
     for name, bindings in var.service_iam :
@@ -72,8 +75,8 @@ resource "google_service_directory_endpoint" "default" {
   for_each    = local.endpoints
   endpoint_id = each.value.endpoint
   service     = google_service_directory_service.default[each.value.service].id
-  metadata    = try(var.endpoint_config[each.key].metadata, null)
-  address     = try(var.endpoint_config[each.key].address, null)
-  port        = try(var.endpoint_config[each.key].port, null)
-  network     = try(var.endpoint_config[each.key].network, null)
+  metadata    = try(var.endpoint_config[each.value.endpoint].metadata, null)
+  address     = try(var.endpoint_config[each.value.endpoint].address, null)
+  port        = try(var.endpoint_config[each.value.endpoint].port, null)
+  network     = try(var.endpoint_config[each.value.endpoint].network, null)
 }

--- a/modules/service-directory/outputs.tf
+++ b/modules/service-directory/outputs.tf
@@ -37,10 +37,10 @@ output "namespace" {
   ]
 }
 
-output "service_id" {
+output "service_ids" {
   description = "Service ids (short names)."
   value = {
-    for k, v in google_service_directory_service.default : k => v.id
+    for k, v in google_service_directory_service.default : k => v.service_id
   }
   depends_on = [
     google_service_directory_service_iam_binding.default

--- a/tests/modules/service_directory/examples/dns.yaml
+++ b/tests/modules/service_directory/examples/dns.yaml
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,18 +14,55 @@
 
 values:
   module.dns-sd.google_dns_managed_zone.dns_managed_zone[0]:
+    cloud_logging_config:
+    - enable_logging: false
+    deletion_policy: DELETE
+    description: Terraform managed.
     dns_name: apps.example.org.
+    effective_labels:
+      goog-terraform-provisioned: 'true'
+    force_destroy: false
+    forwarding_config: []
+    labels: null
+    name: apps
+    peering_config: []
+    private_visibility_config:
+    - gke_clusters: []
+      networks:
+      - network_url: https://www.googleapis.com/compute/v1/projects/xxx/global/networks/aaa
+    project: my-project
+    reverse_lookup: false
+    terraform_labels:
+      goog-terraform-provisioned: 'true'
+    timeouts: null
     visibility: private
   module.service-directory.google_service_directory_endpoint.default["app1/one"]:
-    address: 127.0.0.1
+    address: null
     endpoint_id: one
-    port: 80
+    metadata: null
+    network: null
+    port: null
+    timeouts: null
   module.service-directory.google_service_directory_namespace.default:
+    deletion_policy: DELETE
+    effective_labels:
+      goog-terraform-provisioned: 'true'
+    labels: null
     location: europe-west1
     namespace_id: apps
     project: my-project
+    terraform_labels:
+      goog-terraform-provisioned: 'true'
+    timeouts: null
+  module.service-directory.google_service_directory_namespace_iam_binding.default["roles/servicedirectory.editor"]:
+    condition: []
+    members:
+    - serviceAccount:namespace-editor@example.com
+    role: roles/servicedirectory.editor
   module.service-directory.google_service_directory_service.default["app1"]:
+    metadata: null
     service_id: app1
+    timeouts: null
 
 counts:
   google_dns_managed_zone: 1
@@ -33,3 +70,7 @@ counts:
   google_service_directory_namespace: 1
   google_service_directory_namespace_iam_binding: 1
   google_service_directory_service: 1
+  modules: 2
+  resources: 5
+
+outputs: {}

--- a/tests/modules/service_directory/examples/pna.yaml
+++ b/tests/modules/service_directory/examples/pna.yaml
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,24 +14,40 @@
 
 values:
   module.service-directory.google_service_directory_endpoint.default["one/first"]:
-    address: 10.0.0.11
+    address: null
     endpoint_id: first
-    port: 443
-    network: projects/123456789012/locations/global/networks/vpc-name
+    metadata: null
+    network: null
+    port: null
+    timeouts: null
   module.service-directory.google_service_directory_endpoint.default["one/second"]:
-    address: 10.0.0.12
+    address: null
     endpoint_id: second
-    port: 443
-    network: projects/123456789012/locations/global/networks/vpc-name
+    metadata: null
+    network: null
+    port: null
+    timeouts: null
   module.service-directory.google_service_directory_namespace.default:
+    deletion_policy: DELETE
+    effective_labels:
+      goog-terraform-provisioned: 'true'
+    labels: null
     location: europe-west1
     namespace_id: sd-1
     project: my-project
+    terraform_labels:
+      goog-terraform-provisioned: 'true'
+    timeouts: null
   module.service-directory.google_service_directory_service.default["one"]:
     metadata: null
     service_id: one
+    timeouts: null
 
 counts:
   google_service_directory_endpoint: 2
   google_service_directory_namespace: 1
   google_service_directory_service: 1
+  modules: 1
+  resources: 4
+
+outputs: {}

--- a/tests/modules/service_directory/examples/services.yaml
+++ b/tests/modules/service_directory/examples/services.yaml
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,23 +14,46 @@
 
 values:
   module.service-directory.google_service_directory_endpoint.default["one/first"]:
-    address: 127.0.0.1
+    address: null
     endpoint_id: first
-    port: 80
+    metadata: null
+    network: null
+    port: null
+    timeouts: null
   module.service-directory.google_service_directory_endpoint.default["one/second"]:
-    address: 127.0.0.2
+    address: null
     endpoint_id: second
-    port: 80
+    metadata: null
+    network: null
+    port: null
+    timeouts: null
   module.service-directory.google_service_directory_namespace.default:
+    deletion_policy: DELETE
+    effective_labels:
+      goog-terraform-provisioned: 'true'
+    labels: null
     location: europe-west1
     namespace_id: sd-1
     project: my-project
+    terraform_labels:
+      goog-terraform-provisioned: 'true'
+    timeouts: null
   module.service-directory.google_service_directory_service.default["one"]:
     metadata: null
     service_id: one
+    timeouts: null
+  module.service-directory.google_service_directory_service_iam_binding.default["one-roles/servicedirectory.editor"]:
+    condition: []
+    members:
+    - serviceAccount:service-editor.example.com
+    role: roles/servicedirectory.editor
 
 counts:
   google_service_directory_endpoint: 2
   google_service_directory_namespace: 1
   google_service_directory_service: 1
   google_service_directory_service_iam_binding: 1
+  modules: 1
+  resources: 5
+
+outputs: {}

--- a/tests/modules/service_directory/examples/simple.yaml
+++ b/tests/modules/service_directory/examples/simple.yaml
@@ -14,10 +14,16 @@
 
 values:
   module.service-directory.google_service_directory_namespace.default:
+    deletion_policy: DELETE
+    effective_labels:
+      goog-terraform-provisioned: 'true'
     labels: null
     location: europe-west1
     namespace_id: sd-1
     project: my-project
+    terraform_labels:
+      goog-terraform-provisioned: 'true'
+    timeouts: null
   module.service-directory.google_service_directory_namespace_iam_binding.default["roles/servicedirectory.editor"]:
     condition: []
     members:


### PR DESCRIPTION
Fixes the service-directory module

---
**Checklist**

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass

**Breaking Changes**

```upgrade-note
`modules/service-directory`: renames the output service_id to service_ids
```