### PR TITLE
feat(0-org-setup): make predefined iam_principals groups configurable via var.groups

### DIFF
--- a/fast/stages/0-org-setup/README.md
+++ b/fast/stages/0-org-setup/README.md
@@ -900,7 +900,6 @@ Define values for the `var.environments` variable in a tfvars file.
 | [cicd-workflows-preconditions.tf](./cicd-workflows-preconditions.tf) | None |  | <code>terraform_data</code> |
 | [cicd-workflows.tf](./cicd-workflows.tf) | None | <code>iam-service-account</code> | <code>google_storage_bucket_object</code> · <code>local_file</code> |
 | [factory.tf](./factory.tf) | None | <code>net-vpc-factory</code> · <code>project-factory</code> |  |
-| [identity-providers-defs.tf](./identity-providers-defs.tf) | None |  |  |
 | [imports.tf](./imports.tf) | None |  |  |
 | [main.tf](./main.tf) | Module-level locals and resources. |  | <code>terraform_data</code> |
 | [observability.tf](./observability.tf) | None | <code>project</code> |  |
@@ -915,6 +914,7 @@ Define values for the `var.environments` variable in a tfvars file.
 |---|---|:---:|:---:|:---:|
 | [context](variables.tf#L17) | Context-specific interpolations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [factories_config](variables.tf#L41) | Configuration for the resource factories or external data. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [groups](variables.tf#L68) | Predefined group names used to derive the iam_principals lookup map from the organization domain. Set to a subset (or []) to limit which groups are exposed; defaults to the standard FAST set. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#8230;&#93;</code> |
 | [org_policies_imports](variables.tf#L61) | List of org policies to import. These need to also be defined in data files. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
 
 ## Outputs

--- a/fast/stages/0-org-setup/organization.tf
+++ b/fast/stages/0-org-setup/organization.tf
@@ -50,16 +50,10 @@ locals {
     : local.organization.id
   )
   # build map of predefined groups if organization domain is set
-  org_iam_principals = local.organization.domain == null ? {} : {
-    domain                  = "domain:${local.organization.domain}"
-    gcp-billing-admins      = "group:gcp-billing-admins@${local.organization.domain}"
-    gcp-devops              = "group:gcp-devops@${local.organization.domain}"
-    gcp-network-admins      = "group:gcp-network-admins@${local.organization.domain}"
-    gcp-organization-admins = "group:gcp-organization-admins@${local.organization.domain}"
-    gcp-secops-admins       = "group:gcp-secops-admins@${local.organization.domain}"
-    gcp-security-admins     = "group:gcp-security-admins@${local.organization.domain}"
-    gcp-support             = "group:gcp-support@${local.organization.domain}"
-  }
+  org_iam_principals = local.organization.domain == null ? {} : merge(
+    { domain = "domain:${local.organization.domain}" },
+    { for g in var.groups : g => "group:${g}@${local.organization.domain}" }
+  )
   org_logging_identities = merge(
     module.organization[0].logging_identities.kms == null ? {} : {
       "organization/logging/kms" = module.organization[0].logging_identities.kms

--- a/fast/stages/0-org-setup/variables.tf
+++ b/fast/stages/0-org-setup/variables.tf
@@ -64,3 +64,18 @@ variable "org_policies_imports" {
   nullable    = false
   default     = []
 }
+
+variable "groups" {
+  description = "Predefined group names used to derive the iam_principals lookup map from the organization domain. Set to a subset (or []) to limit which groups are exposed; defaults to the standard FAST set."
+  type        = list(string)
+  nullable    = false
+  default = [
+    "gcp-billing-admins",
+    "gcp-devops",
+    "gcp-network-admins",
+    "gcp-organization-admins",
+    "gcp-secops-admins",
+    "gcp-security-admins",
+    "gcp-support",
+  ]
+}

--- a/tests/fast/stages/s0_org_setup/groups.tfvars
+++ b/tests/fast/stages/s0_org_setup/groups.tfvars
@@ -1,0 +1,9 @@
+factories_config = {
+  paths = {
+    cicd_workflows = "./data-simple/cicd-workflows.yaml"
+    defaults       = "./data-simple/defaults.yaml"
+  }
+}
+
+# trim the predefined iam_principals map to just the bound group
+groups = ["gcp-organization-admins"]

--- a/tests/fast/stages/s0_org_setup/groups.yaml
+++ b/tests/fast/stages/s0_org_setup/groups.yaml
@@ -1,0 +1,2941 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values:
+  google_storage_bucket_object.providers["0-org-setup"]:
+    bucket: ft0-prod-iac-core-0-iac-outputs
+    cache_control: null
+    content: "/**\n * Copyright 2022 Google LLC\n *\n * Licensed under the Apache\
+      \ License, Version 2.0 (the \"License\");\n * you may not use this file except\
+      \ in compliance with the License.\n * You may obtain a copy of the License at\n\
+      \ *\n *      http://www.apache.org/licenses/LICENSE-2.0\n *\n * Unless required\
+      \ by applicable law or agreed to in writing, software\n * distributed under\
+      \ the License is distributed on an \"AS IS\" BASIS,\n * WITHOUT WARRANTIES OR\
+      \ CONDITIONS OF ANY KIND, either express or implied.\n * See the License for\
+      \ the specific language governing permissions and\n * limitations under the\
+      \ License.\n */\n\nterraform {\n  backend \"gcs\" {\n    bucket            \
+      \          = \"ft0-prod-iac-core-0-iac-org-state\"\n    impersonate_service_account\
+      \ = \"iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\n  }\n}\nprovider\
+      \ \"google\" {\n  impersonate_service_account = \"iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\
+      \n}\nprovider \"google-beta\" {\n  impersonate_service_account = \"iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\
+      \n}\n"
+    content_disposition: null
+    content_encoding: null
+    content_language: null
+    contexts: []
+    customer_encryption: []
+    deletion_policy: DELETE
+    detect_md5hash: null
+    event_based_hold: null
+    force_empty_content_type: null
+    metadata: null
+    name: providers/0-org-setup-providers.tf
+    retention: []
+    source: null
+    temporary_hold: null
+    timeouts: null
+  google_storage_bucket_object.providers["0-org-setup-ro"]:
+    bucket: ft0-prod-iac-core-0-iac-outputs
+    cache_control: null
+    content: "/**\n * Copyright 2022 Google LLC\n *\n * Licensed under the Apache\
+      \ License, Version 2.0 (the \"License\");\n * you may not use this file except\
+      \ in compliance with the License.\n * You may obtain a copy of the License at\n\
+      \ *\n *      http://www.apache.org/licenses/LICENSE-2.0\n *\n * Unless required\
+      \ by applicable law or agreed to in writing, software\n * distributed under\
+      \ the License is distributed on an \"AS IS\" BASIS,\n * WITHOUT WARRANTIES OR\
+      \ CONDITIONS OF ANY KIND, either express or implied.\n * See the License for\
+      \ the specific language governing permissions and\n * limitations under the\
+      \ License.\n */\n\nterraform {\n  backend \"gcs\" {\n    bucket            \
+      \          = \"ft0-prod-iac-core-0-iac-org-state\"\n    impersonate_service_account\
+      \ = \"iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\n  }\n}\nprovider\
+      \ \"google\" {\n  impersonate_service_account = \"iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\
+      \n}\nprovider \"google-beta\" {\n  impersonate_service_account = \"iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\
+      \n}\n"
+    content_disposition: null
+    content_encoding: null
+    content_language: null
+    contexts: []
+    customer_encryption: []
+    deletion_policy: DELETE
+    detect_md5hash: null
+    event_based_hold: null
+    force_empty_content_type: null
+    metadata: null
+    name: providers/0-org-setup-ro-providers.tf
+    retention: []
+    source: null
+    temporary_hold: null
+    timeouts: null
+  google_storage_bucket_object.providers["1-vpcsc"]:
+    bucket: ft0-prod-iac-core-0-iac-outputs
+    cache_control: null
+    content: "/**\n * Copyright 2022 Google LLC\n *\n * Licensed under the Apache\
+      \ License, Version 2.0 (the \"License\");\n * you may not use this file except\
+      \ in compliance with the License.\n * You may obtain a copy of the License at\n\
+      \ *\n *      http://www.apache.org/licenses/LICENSE-2.0\n *\n * Unless required\
+      \ by applicable law or agreed to in writing, software\n * distributed under\
+      \ the License is distributed on an \"AS IS\" BASIS,\n * WITHOUT WARRANTIES OR\
+      \ CONDITIONS OF ANY KIND, either express or implied.\n * See the License for\
+      \ the specific language governing permissions and\n * limitations under the\
+      \ License.\n */\n\nterraform {\n  backend \"gcs\" {\n    bucket            \
+      \          = \"ft0-prod-iac-core-0-iac-stage-state\"\n    impersonate_service_account\
+      \ = \"iac-vpcsc-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\n    prefix\
+      \ = \"1-vpcsc\"\n  }\n}\nprovider \"google\" {\n  impersonate_service_account\
+      \ = \"iac-vpcsc-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\n}\nprovider\
+      \ \"google-beta\" {\n  impersonate_service_account = \"iac-vpcsc-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\
+      \n}\n"
+    content_disposition: null
+    content_encoding: null
+    content_language: null
+    contexts: []
+    customer_encryption: []
+    deletion_policy: DELETE
+    detect_md5hash: null
+    event_based_hold: null
+    force_empty_content_type: null
+    metadata: null
+    name: providers/1-vpcsc-providers.tf
+    retention: []
+    source: null
+    temporary_hold: null
+    timeouts: null
+  google_storage_bucket_object.providers["2-networking"]:
+    bucket: ft0-prod-iac-core-0-iac-outputs
+    cache_control: null
+    content: "/**\n * Copyright 2022 Google LLC\n *\n * Licensed under the Apache\
+      \ License, Version 2.0 (the \"License\");\n * you may not use this file except\
+      \ in compliance with the License.\n * You may obtain a copy of the License at\n\
+      \ *\n *      http://www.apache.org/licenses/LICENSE-2.0\n *\n * Unless required\
+      \ by applicable law or agreed to in writing, software\n * distributed under\
+      \ the License is distributed on an \"AS IS\" BASIS,\n * WITHOUT WARRANTIES OR\
+      \ CONDITIONS OF ANY KIND, either express or implied.\n * See the License for\
+      \ the specific language governing permissions and\n * limitations under the\
+      \ License.\n */\n\nterraform {\n  backend \"gcs\" {\n    bucket            \
+      \          = \"ft0-prod-iac-core-0-iac-stage-state\"\n    impersonate_service_account\
+      \ = \"iac-networking-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\n    prefix\
+      \ = \"2-networking\"\n  }\n}\nprovider \"google\" {\n  impersonate_service_account\
+      \ = \"iac-networking-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\n}\nprovider\
+      \ \"google-beta\" {\n  impersonate_service_account = \"iac-networking-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\
+      \n}\n"
+    content_disposition: null
+    content_encoding: null
+    content_language: null
+    contexts: []
+    customer_encryption: []
+    deletion_policy: DELETE
+    detect_md5hash: null
+    event_based_hold: null
+    force_empty_content_type: null
+    metadata: null
+    name: providers/2-networking-providers.tf
+    retention: []
+    source: null
+    temporary_hold: null
+    timeouts: null
+  google_storage_bucket_object.providers["2-project-factory"]:
+    bucket: ft0-prod-iac-core-0-iac-outputs
+    cache_control: null
+    content: "/**\n * Copyright 2022 Google LLC\n *\n * Licensed under the Apache\
+      \ License, Version 2.0 (the \"License\");\n * you may not use this file except\
+      \ in compliance with the License.\n * You may obtain a copy of the License at\n\
+      \ *\n *      http://www.apache.org/licenses/LICENSE-2.0\n *\n * Unless required\
+      \ by applicable law or agreed to in writing, software\n * distributed under\
+      \ the License is distributed on an \"AS IS\" BASIS,\n * WITHOUT WARRANTIES OR\
+      \ CONDITIONS OF ANY KIND, either express or implied.\n * See the License for\
+      \ the specific language governing permissions and\n * limitations under the\
+      \ License.\n */\n\nterraform {\n  backend \"gcs\" {\n    bucket            \
+      \          = \"ft0-prod-iac-core-0-iac-stage-state\"\n    impersonate_service_account\
+      \ = \"iac-pf-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\n    prefix =\
+      \ \"2-project-factory\"\n  }\n}\nprovider \"google\" {\n  impersonate_service_account\
+      \ = \"iac-pf-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\n}\nprovider \"\
+      google-beta\" {\n  impersonate_service_account = \"iac-pf-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\
+      \n}\n"
+    content_disposition: null
+    content_encoding: null
+    content_language: null
+    contexts: []
+    customer_encryption: []
+    deletion_policy: DELETE
+    detect_md5hash: null
+    event_based_hold: null
+    force_empty_content_type: null
+    metadata: null
+    name: providers/2-project-factory-providers.tf
+    retention: []
+    source: null
+    temporary_hold: null
+    timeouts: null
+  google_storage_bucket_object.providers["2-security"]:
+    bucket: ft0-prod-iac-core-0-iac-outputs
+    cache_control: null
+    content: "/**\n * Copyright 2022 Google LLC\n *\n * Licensed under the Apache\
+      \ License, Version 2.0 (the \"License\");\n * you may not use this file except\
+      \ in compliance with the License.\n * You may obtain a copy of the License at\n\
+      \ *\n *      http://www.apache.org/licenses/LICENSE-2.0\n *\n * Unless required\
+      \ by applicable law or agreed to in writing, software\n * distributed under\
+      \ the License is distributed on an \"AS IS\" BASIS,\n * WITHOUT WARRANTIES OR\
+      \ CONDITIONS OF ANY KIND, either express or implied.\n * See the License for\
+      \ the specific language governing permissions and\n * limitations under the\
+      \ License.\n */\n\nterraform {\n  backend \"gcs\" {\n    bucket            \
+      \          = \"ft0-prod-iac-core-0-iac-stage-state\"\n    impersonate_service_account\
+      \ = \"iac-security-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\n    prefix\
+      \ = \"2-security\"\n  }\n}\nprovider \"google\" {\n  impersonate_service_account\
+      \ = \"iac-security-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\n}\nprovider\
+      \ \"google-beta\" {\n  impersonate_service_account = \"iac-security-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\
+      \n}\n"
+    content_disposition: null
+    content_encoding: null
+    content_language: null
+    contexts: []
+    customer_encryption: []
+    deletion_policy: DELETE
+    detect_md5hash: null
+    event_based_hold: null
+    force_empty_content_type: null
+    metadata: null
+    name: providers/2-security-providers.tf
+    retention: []
+    source: null
+    temporary_hold: null
+    timeouts: null
+  google_storage_bucket_object.tfvars["globals"]:
+    bucket: ft0-prod-iac-core-0-iac-outputs
+    cache_control: null
+    content: '{"billing_account":{"id":"012345-012345-012345"},"groups":{"domain":"domain:example.org","gcp-organization-admins":"group:fabric-fast-owners@google.com"},"organization":{"customer_id":"abcd123456","domain":"example.org","id":"1234567890"},"prefix":"ft0","universe":null}'
+    content_disposition: null
+    content_encoding: null
+    content_language: null
+    contexts: []
+    customer_encryption: []
+    deletion_policy: DELETE
+    detect_md5hash: null
+    event_based_hold: null
+    force_empty_content_type: null
+    metadata: null
+    name: tfvars/0-globals.auto.tfvars.json
+    retention: []
+    source: null
+    temporary_hold: null
+    timeouts: null
+  google_storage_bucket_object.tfvars["org-setup"]:
+    bucket: ft0-prod-iac-core-0-iac-outputs
+    cache_control: null
+    content_disposition: null
+    content_encoding: null
+    content_language: null
+    contexts: []
+    customer_encryption: []
+    deletion_policy: DELETE
+    detect_md5hash: null
+    event_based_hold: null
+    force_empty_content_type: null
+    metadata: null
+    name: tfvars/0-org-setup.auto.tfvars.json
+    retention: []
+    source: null
+    temporary_hold: null
+    timeouts: null
+  google_storage_bucket_object.version[0]:
+    bucket: ft0-prod-iac-core-0-iac-outputs
+    cache_control: null
+    content_disposition: null
+    content_encoding: null
+    content_language: null
+    contexts: []
+    customer_encryption: []
+    deletion_policy: DELETE
+    detect_md5hash: null
+    event_based_hold: null
+    force_empty_content_type: null
+    metadata: null
+    name: versions/0-org-setup-version.txt
+    retention: []
+    source: fast_version.txt
+    temporary_hold: null
+    timeouts: null
+  google_storage_bucket_object.workflows["org-setup"]:
+    bucket: ft0-prod-iac-core-0-iac-outputs
+    cache_control: null
+    content: "# Copyright 2025 Google LLC\n#\n# Licensed under the Apache License,\
+      \ Version 2.0 (the \"License\");\n# you may not use this file except in compliance\
+      \ with the License.\n# You may obtain a copy of the License at\n#\n#      http://www.apache.org/licenses/LICENSE-2.0\n\
+      #\n# Unless required by applicable law or agreed to in writing, software\n#\
+      \ distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT\
+      \ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the\
+      \ License for the specific language governing permissions and\n# limitations\
+      \ under the License.\n\nname: \"FAST org-setup stage\"\n\non:\n  pull_request:\n\
+      \    branches:\n      - main\n    types:\n      - closed\n      - opened\n \
+      \     - synchronize\n\nenv:\n  FAST_SERVICE_ACCOUNT: iac-org-cicd-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\n\
+      \  FAST_SERVICE_ACCOUNT_PLAN: iac-org-cicd-ro@ft0-prod-iac-core-0.iam.gserviceaccount.com\n\
+      \  FAST_WIF_PROVIDER: projects/1234567890/locations/global/workloadIdentityPools/default\n\
+      \  SSH_AUTH_SOCK: /tmp/ssh_agent.sock\n  TF_PROVIDERS_FILE: 0-org-setup-providers.tf\n\
+      \  TF_PROVIDERS_FILE_PLAN: 0-org-setup-providers-ro.tf\n  TF_VERSION: 1.12.2\n\
+      \njobs:\n  fast-pr:\n    # Skip PRs which are closed without being merged.\n\
+      \    if: >-\n      github.event.action == 'closed' &&\n      github.event.pull_request.merged\
+      \ == true ||\n      github.event.action == 'opened' ||\n      github.event.action\
+      \ == 'synchronize'\n    permissions:\n      contents: read\n      id-token:\
+      \ write\n      issues: write\n      pull-requests: write\n    runs-on: ubuntu-latest\n\
+      \    steps:\n      - id: checkout\n        name: Checkout repository\n     \
+      \   uses: actions/checkout@v6\n\n      # set up SSH key authentication to the\
+      \ modules repository\n\n      - id: ssh-config\n        name: Configure SSH\
+      \ authentication\n        run: |\n          ssh-agent -a \"$SSH_AUTH_SOCK\"\
+      \ > /dev/null\n          ssh-add - <<< \"${{ secrets.CICD_MODULES_KEY }}\"\n\
+      \n      # set up step variables for plan / apply\n\n      - id: vars-plan\n\
+      \        if: github.event.pull_request.merged != true && success()\n       \
+      \ name: Set up plan variables\n        run: |\n          echo \"plan_opts=-lock=false\"\
+      \ >> \"$GITHUB_ENV\"\n          echo \"provider_file=${{env.TF_PROVIDERS_FILE_PLAN}}\"\
+      \ >> \"$GITHUB_ENV\"\n          echo \"service_account=${{env.FAST_SERVICE_ACCOUNT_PLAN}}\"\
+      \ >> \"$GITHUB_ENV\"\n\n      - id: vars-apply\n        if: github.event.pull_request.merged\
+      \ == true && success()\n        name: Set up apply variables\n        run: |\n\
+      \          echo \"provider_file=${{env.TF_PROVIDERS_FILE}}\" >> \"$GITHUB_ENV\"\
+      \n          echo \"service_account=${{env.FAST_SERVICE_ACCOUNT}}\" >> \"$GITHUB_ENV\"\
+      \n\n      # set up authentication via Workload identity Federation and gcloud\n\
+      \n      - id: gcp-auth\n        name: Authenticate to Google Cloud\n       \
+      \ uses: google-github-actions/auth@v3\n        with:\n          workload_identity_provider:\
+      \ ${{env.FAST_WIF_PROVIDER}}\n          service_account: ${{env.service_account}}\n\
+      \          access_token_lifetime: 900s\n\n      - id: gcp-sdk\n        name:\
+      \ Set up Cloud SDK\n        uses: google-github-actions/setup-gcloud@v3\n  \
+      \      with:\n          install_components: alpha\n\n      # copy provider file\n\
+      \n      - id: tf-config-provider\n        name: Copy Terraform provider file\n\
+      \        run: |\n          gcloud storage cp -r \\\n            \"gs://ft0-prod-iac-core-0-iac-outputs/providers/${{env.provider_file}}\"\
+      \ ./\n          gcloud storage cp -r \\\n            \"gs://ft0-prod-iac-core-0-iac-outputs/tfvars/0-org-setup.auto.tfvars\"\
+      \ ./\n\n      - id: tf-setup\n        name: Set up Terraform\n        uses:\
+      \ hashicorp/setup-terraform@v4\n        with:\n          terraform_version:\
+      \ ${{env.TF_VERSION}}\n\n      # run Terraform init/validate/plan\n\n      -\
+      \ id: tf-init\n        name: Terraform init\n        continue-on-error: true\n\
+      \        run: |\n          terraform init -no-color\n\n      - id: tf-validate\n\
+      \        continue-on-error: true\n        name: Terraform validate\n       \
+      \ run: terraform validate -no-color\n\n      - id: tf-plan\n        name: Terraform\
+      \ plan\n        continue-on-error: true\n        run: |\n          terraform\
+      \ plan -input=false -out ../plan.out -no-color ${{env.plan_opts}}\n\n      -\
+      \ id: tf-apply\n        if: github.event.pull_request.merged == true && success()\n\
+      \        name: Terraform apply\n        continue-on-error: true\n        run:\
+      \ |\n          terraform apply -input=false -auto-approve -no-color ../plan.out\n\
+      \n      # PR comment with Terraform result from previous steps\n      # length\
+      \ is checked and trimmed for length so as to stay within the limit\n\n     \
+      \ - id: pr-comment\n        name: Post comment to Pull Request\n        continue-on-error:\
+      \ true\n        uses: actions/github-script@v9\n        if: github.event_name\
+      \ == 'pull_request'\n        env:\n          PLAN: ${{steps.tf-plan.outputs.stdout}}\\\
+      n${{steps.tf-plan.outputs.stderr}}\n        with:\n          script: |\n   \
+      \         const output = `### Terraform Initialization \\`${{steps.tf-init.outcome}}\\\
+      `\n\n            ### Terraform Validation \\`${{steps.tf-validate.outcome}}\\\
+      `\n\n            <details><summary>Validation Output</summary>\n\n         \
+      \   \\`\\`\\`\\n\n            ${{steps.tf-validate.outputs.stdout}}\n      \
+      \      \\`\\`\\`\n\n            </details>\n\n            ### Terraform Plan\
+      \ \\`${{steps.tf-plan.outcome}}\\`\n\n            <details><summary>Show Plan</summary>\n\
+      \n            \\`\\`\\`\\n\n            ${process.env.PLAN.split('\\n').filter(l\
+      \ => l.match(/^([A-Z\\s].*|)$$/)).join('\\n')}\n            \\`\\`\\`\n\n  \
+      \          </details>\n\n            ### Terraform Apply \\`${{steps.tf-apply.outcome}}\\\
+      `\n\n            *Pusher: @${{github.actor}}, Action: \\`${{github.event_name}}\\\
+      `, Working Directory: \\`${{env.tf_actions_working_dir}}\\`, Workflow: \\`${{github.workflow}}\\\
+      `*`;\n\n            github.rest.issues.createComment({\n              issue_number:\
+      \ context.issue.number,\n              owner: context.repo.owner,\n        \
+      \      repo: context.repo.repo,\n              body: output\n            })\n\
+      \n      - id: pr-short-comment\n        name: Post comment to Pull Request (abbreviated)\n\
+      \        uses: actions/github-script@v9\n        if: github.event_name == 'pull_request'\
+      \ && steps.pr-comment.outcome != 'success'\n        with:\n          script:\
+      \ |\n            const output = `### Terraform Initialization \\`${{steps.tf-init.outcome}}\\\
+      `\n\n            ### Terraform Validation \\`${{steps.tf-validate.outcome}}\\\
+      `\n\n            ### Terraform Plan \\`${{steps.tf-plan.outcome}}\\`\n\n   \
+      \         Plan output is in the action log.\n\n            ### Terraform Apply\
+      \ \\`${{steps.tf-apply.outcome}}\\`\n\n            *Pusher: @${{github.actor}},\
+      \ Action: \\`${{github.event_name}}\\`, Working Directory: \\`${{env.tf_actions_working_dir}}\\\
+      `, Workflow: \\`${{github.workflow}}\\`*`;\n\n            github.rest.issues.createComment({\n\
+      \              issue_number: context.issue.number,\n              owner: context.repo.owner,\n\
+      \              repo: context.repo.repo,\n              body: output\n      \
+      \      })\n\n      # exit on error from previous steps\n\n      - id: check-init\n\
+      \        name: Check init failure\n        if: steps.tf-init.outcome != 'success'\n\
+      \        run: exit 1\n\n      - id: check-validate\n        name: Check validate\
+      \ failure\n        if: steps.tf-validate.outcome != 'success'\n        run:\
+      \ exit 1\n\n      - id: check-plan\n        name: Check plan failure\n     \
+      \   if: steps.tf-plan.outcome != 'success'\n        run: exit 1\n\n      - id:\
+      \ check-apply\n        name: Check apply failure\n        if: github.event.pull_request.merged\
+      \ == true && steps.tf-apply.outcome != 'success'\n        run: exit 1\n"
+    content_disposition: null
+    content_encoding: null
+    content_language: null
+    contexts: []
+    customer_encryption: []
+    deletion_policy: DELETE
+    detect_md5hash: null
+    event_based_hold: null
+    force_empty_content_type: null
+    metadata: null
+    name: workflows/org-setup.yaml
+    retention: []
+    source: null
+    temporary_hold: null
+    timeouts: null
+  local_file.providers["0-org-setup"]:
+    content: "/**\n * Copyright 2022 Google LLC\n *\n * Licensed under the Apache\
+      \ License, Version 2.0 (the \"License\");\n * you may not use this file except\
+      \ in compliance with the License.\n * You may obtain a copy of the License at\n\
+      \ *\n *      http://www.apache.org/licenses/LICENSE-2.0\n *\n * Unless required\
+      \ by applicable law or agreed to in writing, software\n * distributed under\
+      \ the License is distributed on an \"AS IS\" BASIS,\n * WITHOUT WARRANTIES OR\
+      \ CONDITIONS OF ANY KIND, either express or implied.\n * See the License for\
+      \ the specific language governing permissions and\n * limitations under the\
+      \ License.\n */\n\nterraform {\n  backend \"gcs\" {\n    bucket            \
+      \          = \"ft0-prod-iac-core-0-iac-org-state\"\n    impersonate_service_account\
+      \ = \"iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\n  }\n}\nprovider\
+      \ \"google\" {\n  impersonate_service_account = \"iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\
+      \n}\nprovider \"google-beta\" {\n  impersonate_service_account = \"iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\
+      \n}\n"
+    content_base64: null
+    directory_permission: '0777'
+    file_permission: '0644'
+    sensitive_content: null
+    source: null
+  local_file.providers["0-org-setup-ro"]:
+    content: "/**\n * Copyright 2022 Google LLC\n *\n * Licensed under the Apache\
+      \ License, Version 2.0 (the \"License\");\n * you may not use this file except\
+      \ in compliance with the License.\n * You may obtain a copy of the License at\n\
+      \ *\n *      http://www.apache.org/licenses/LICENSE-2.0\n *\n * Unless required\
+      \ by applicable law or agreed to in writing, software\n * distributed under\
+      \ the License is distributed on an \"AS IS\" BASIS,\n * WITHOUT WARRANTIES OR\
+      \ CONDITIONS OF ANY KIND, either express or implied.\n * See the License for\
+      \ the specific language governing permissions and\n * limitations under the\
+      \ License.\n */\n\nterraform {\n  backend \"gcs\" {\n    bucket            \
+      \          = \"ft0-prod-iac-core-0-iac-org-state\"\n    impersonate_service_account\
+      \ = \"iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\n  }\n}\nprovider\
+      \ \"google\" {\n  impersonate_service_account = \"iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\
+      \n}\nprovider \"google-beta\" {\n  impersonate_service_account = \"iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\
+      \n}\n"
+    content_base64: null
+    directory_permission: '0777'
+    file_permission: '0644'
+    sensitive_content: null
+    source: null
+  local_file.providers["1-vpcsc"]:
+    content: "/**\n * Copyright 2022 Google LLC\n *\n * Licensed under the Apache\
+      \ License, Version 2.0 (the \"License\");\n * you may not use this file except\
+      \ in compliance with the License.\n * You may obtain a copy of the License at\n\
+      \ *\n *      http://www.apache.org/licenses/LICENSE-2.0\n *\n * Unless required\
+      \ by applicable law or agreed to in writing, software\n * distributed under\
+      \ the License is distributed on an \"AS IS\" BASIS,\n * WITHOUT WARRANTIES OR\
+      \ CONDITIONS OF ANY KIND, either express or implied.\n * See the License for\
+      \ the specific language governing permissions and\n * limitations under the\
+      \ License.\n */\n\nterraform {\n  backend \"gcs\" {\n    bucket            \
+      \          = \"ft0-prod-iac-core-0-iac-stage-state\"\n    impersonate_service_account\
+      \ = \"iac-vpcsc-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\n    prefix\
+      \ = \"1-vpcsc\"\n  }\n}\nprovider \"google\" {\n  impersonate_service_account\
+      \ = \"iac-vpcsc-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\n}\nprovider\
+      \ \"google-beta\" {\n  impersonate_service_account = \"iac-vpcsc-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\
+      \n}\n"
+    content_base64: null
+    directory_permission: '0777'
+    file_permission: '0644'
+    sensitive_content: null
+    source: null
+  local_file.providers["2-networking"]:
+    content: "/**\n * Copyright 2022 Google LLC\n *\n * Licensed under the Apache\
+      \ License, Version 2.0 (the \"License\");\n * you may not use this file except\
+      \ in compliance with the License.\n * You may obtain a copy of the License at\n\
+      \ *\n *      http://www.apache.org/licenses/LICENSE-2.0\n *\n * Unless required\
+      \ by applicable law or agreed to in writing, software\n * distributed under\
+      \ the License is distributed on an \"AS IS\" BASIS,\n * WITHOUT WARRANTIES OR\
+      \ CONDITIONS OF ANY KIND, either express or implied.\n * See the License for\
+      \ the specific language governing permissions and\n * limitations under the\
+      \ License.\n */\n\nterraform {\n  backend \"gcs\" {\n    bucket            \
+      \          = \"ft0-prod-iac-core-0-iac-stage-state\"\n    impersonate_service_account\
+      \ = \"iac-networking-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\n    prefix\
+      \ = \"2-networking\"\n  }\n}\nprovider \"google\" {\n  impersonate_service_account\
+      \ = \"iac-networking-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\n}\nprovider\
+      \ \"google-beta\" {\n  impersonate_service_account = \"iac-networking-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\
+      \n}\n"
+    content_base64: null
+    directory_permission: '0777'
+    file_permission: '0644'
+    sensitive_content: null
+    source: null
+  local_file.providers["2-project-factory"]:
+    content: "/**\n * Copyright 2022 Google LLC\n *\n * Licensed under the Apache\
+      \ License, Version 2.0 (the \"License\");\n * you may not use this file except\
+      \ in compliance with the License.\n * You may obtain a copy of the License at\n\
+      \ *\n *      http://www.apache.org/licenses/LICENSE-2.0\n *\n * Unless required\
+      \ by applicable law or agreed to in writing, software\n * distributed under\
+      \ the License is distributed on an \"AS IS\" BASIS,\n * WITHOUT WARRANTIES OR\
+      \ CONDITIONS OF ANY KIND, either express or implied.\n * See the License for\
+      \ the specific language governing permissions and\n * limitations under the\
+      \ License.\n */\n\nterraform {\n  backend \"gcs\" {\n    bucket            \
+      \          = \"ft0-prod-iac-core-0-iac-stage-state\"\n    impersonate_service_account\
+      \ = \"iac-pf-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\n    prefix =\
+      \ \"2-project-factory\"\n  }\n}\nprovider \"google\" {\n  impersonate_service_account\
+      \ = \"iac-pf-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\n}\nprovider \"\
+      google-beta\" {\n  impersonate_service_account = \"iac-pf-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\
+      \n}\n"
+    content_base64: null
+    directory_permission: '0777'
+    file_permission: '0644'
+    sensitive_content: null
+    source: null
+  local_file.providers["2-security"]:
+    content: "/**\n * Copyright 2022 Google LLC\n *\n * Licensed under the Apache\
+      \ License, Version 2.0 (the \"License\");\n * you may not use this file except\
+      \ in compliance with the License.\n * You may obtain a copy of the License at\n\
+      \ *\n *      http://www.apache.org/licenses/LICENSE-2.0\n *\n * Unless required\
+      \ by applicable law or agreed to in writing, software\n * distributed under\
+      \ the License is distributed on an \"AS IS\" BASIS,\n * WITHOUT WARRANTIES OR\
+      \ CONDITIONS OF ANY KIND, either express or implied.\n * See the License for\
+      \ the specific language governing permissions and\n * limitations under the\
+      \ License.\n */\n\nterraform {\n  backend \"gcs\" {\n    bucket            \
+      \          = \"ft0-prod-iac-core-0-iac-stage-state\"\n    impersonate_service_account\
+      \ = \"iac-security-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\n    prefix\
+      \ = \"2-security\"\n  }\n}\nprovider \"google\" {\n  impersonate_service_account\
+      \ = \"iac-security-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\n}\nprovider\
+      \ \"google-beta\" {\n  impersonate_service_account = \"iac-security-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\
+      \n}\n"
+    content_base64: null
+    directory_permission: '0777'
+    file_permission: '0644'
+    sensitive_content: null
+    source: null
+  local_file.tfvars["globals"]:
+    content: '{"billing_account":{"id":"012345-012345-012345"},"groups":{"domain":"domain:example.org","gcp-organization-admins":"group:fabric-fast-owners@google.com"},"organization":{"customer_id":"abcd123456","domain":"example.org","id":"1234567890"},"prefix":"ft0","universe":null}'
+    content_base64: null
+    directory_permission: '0777'
+    file_permission: '0644'
+    sensitive_content: null
+    source: null
+  local_file.tfvars["org-setup"]:
+    content_base64: null
+    directory_permission: '0777'
+    file_permission: '0644'
+    sensitive_content: null
+    source: null
+  local_file.workflows["org-setup"]:
+    content: "# Copyright 2025 Google LLC\n#\n# Licensed under the Apache License,\
+      \ Version 2.0 (the \"License\");\n# you may not use this file except in compliance\
+      \ with the License.\n# You may obtain a copy of the License at\n#\n#      http://www.apache.org/licenses/LICENSE-2.0\n\
+      #\n# Unless required by applicable law or agreed to in writing, software\n#\
+      \ distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT\
+      \ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the\
+      \ License for the specific language governing permissions and\n# limitations\
+      \ under the License.\n\nname: \"FAST org-setup stage\"\n\non:\n  pull_request:\n\
+      \    branches:\n      - main\n    types:\n      - closed\n      - opened\n \
+      \     - synchronize\n\nenv:\n  FAST_SERVICE_ACCOUNT: iac-org-cicd-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\n\
+      \  FAST_SERVICE_ACCOUNT_PLAN: iac-org-cicd-ro@ft0-prod-iac-core-0.iam.gserviceaccount.com\n\
+      \  FAST_WIF_PROVIDER: projects/1234567890/locations/global/workloadIdentityPools/default\n\
+      \  SSH_AUTH_SOCK: /tmp/ssh_agent.sock\n  TF_PROVIDERS_FILE: 0-org-setup-providers.tf\n\
+      \  TF_PROVIDERS_FILE_PLAN: 0-org-setup-providers-ro.tf\n  TF_VERSION: 1.12.2\n\
+      \njobs:\n  fast-pr:\n    # Skip PRs which are closed without being merged.\n\
+      \    if: >-\n      github.event.action == 'closed' &&\n      github.event.pull_request.merged\
+      \ == true ||\n      github.event.action == 'opened' ||\n      github.event.action\
+      \ == 'synchronize'\n    permissions:\n      contents: read\n      id-token:\
+      \ write\n      issues: write\n      pull-requests: write\n    runs-on: ubuntu-latest\n\
+      \    steps:\n      - id: checkout\n        name: Checkout repository\n     \
+      \   uses: actions/checkout@v6\n\n      # set up SSH key authentication to the\
+      \ modules repository\n\n      - id: ssh-config\n        name: Configure SSH\
+      \ authentication\n        run: |\n          ssh-agent -a \"$SSH_AUTH_SOCK\"\
+      \ > /dev/null\n          ssh-add - <<< \"${{ secrets.CICD_MODULES_KEY }}\"\n\
+      \n      # set up step variables for plan / apply\n\n      - id: vars-plan\n\
+      \        if: github.event.pull_request.merged != true && success()\n       \
+      \ name: Set up plan variables\n        run: |\n          echo \"plan_opts=-lock=false\"\
+      \ >> \"$GITHUB_ENV\"\n          echo \"provider_file=${{env.TF_PROVIDERS_FILE_PLAN}}\"\
+      \ >> \"$GITHUB_ENV\"\n          echo \"service_account=${{env.FAST_SERVICE_ACCOUNT_PLAN}}\"\
+      \ >> \"$GITHUB_ENV\"\n\n      - id: vars-apply\n        if: github.event.pull_request.merged\
+      \ == true && success()\n        name: Set up apply variables\n        run: |\n\
+      \          echo \"provider_file=${{env.TF_PROVIDERS_FILE}}\" >> \"$GITHUB_ENV\"\
+      \n          echo \"service_account=${{env.FAST_SERVICE_ACCOUNT}}\" >> \"$GITHUB_ENV\"\
+      \n\n      # set up authentication via Workload identity Federation and gcloud\n\
+      \n      - id: gcp-auth\n        name: Authenticate to Google Cloud\n       \
+      \ uses: google-github-actions/auth@v3\n        with:\n          workload_identity_provider:\
+      \ ${{env.FAST_WIF_PROVIDER}}\n          service_account: ${{env.service_account}}\n\
+      \          access_token_lifetime: 900s\n\n      - id: gcp-sdk\n        name:\
+      \ Set up Cloud SDK\n        uses: google-github-actions/setup-gcloud@v3\n  \
+      \      with:\n          install_components: alpha\n\n      # copy provider file\n\
+      \n      - id: tf-config-provider\n        name: Copy Terraform provider file\n\
+      \        run: |\n          gcloud storage cp -r \\\n            \"gs://ft0-prod-iac-core-0-iac-outputs/providers/${{env.provider_file}}\"\
+      \ ./\n          gcloud storage cp -r \\\n            \"gs://ft0-prod-iac-core-0-iac-outputs/tfvars/0-org-setup.auto.tfvars\"\
+      \ ./\n\n      - id: tf-setup\n        name: Set up Terraform\n        uses:\
+      \ hashicorp/setup-terraform@v4\n        with:\n          terraform_version:\
+      \ ${{env.TF_VERSION}}\n\n      # run Terraform init/validate/plan\n\n      -\
+      \ id: tf-init\n        name: Terraform init\n        continue-on-error: true\n\
+      \        run: |\n          terraform init -no-color\n\n      - id: tf-validate\n\
+      \        continue-on-error: true\n        name: Terraform validate\n       \
+      \ run: terraform validate -no-color\n\n      - id: tf-plan\n        name: Terraform\
+      \ plan\n        continue-on-error: true\n        run: |\n          terraform\
+      \ plan -input=false -out ../plan.out -no-color ${{env.plan_opts}}\n\n      -\
+      \ id: tf-apply\n        if: github.event.pull_request.merged == true && success()\n\
+      \        name: Terraform apply\n        continue-on-error: true\n        run:\
+      \ |\n          terraform apply -input=false -auto-approve -no-color ../plan.out\n\
+      \n      # PR comment with Terraform result from previous steps\n      # length\
+      \ is checked and trimmed for length so as to stay within the limit\n\n     \
+      \ - id: pr-comment\n        name: Post comment to Pull Request\n        continue-on-error:\
+      \ true\n        uses: actions/github-script@v9\n        if: github.event_name\
+      \ == 'pull_request'\n        env:\n          PLAN: ${{steps.tf-plan.outputs.stdout}}\\\
+      n${{steps.tf-plan.outputs.stderr}}\n        with:\n          script: |\n   \
+      \         const output = `### Terraform Initialization \\`${{steps.tf-init.outcome}}\\\
+      `\n\n            ### Terraform Validation \\`${{steps.tf-validate.outcome}}\\\
+      `\n\n            <details><summary>Validation Output</summary>\n\n         \
+      \   \\`\\`\\`\\n\n            ${{steps.tf-validate.outputs.stdout}}\n      \
+      \      \\`\\`\\`\n\n            </details>\n\n            ### Terraform Plan\
+      \ \\`${{steps.tf-plan.outcome}}\\`\n\n            <details><summary>Show Plan</summary>\n\
+      \n            \\`\\`\\`\\n\n            ${process.env.PLAN.split('\\n').filter(l\
+      \ => l.match(/^([A-Z\\s].*|)$$/)).join('\\n')}\n            \\`\\`\\`\n\n  \
+      \          </details>\n\n            ### Terraform Apply \\`${{steps.tf-apply.outcome}}\\\
+      `\n\n            *Pusher: @${{github.actor}}, Action: \\`${{github.event_name}}\\\
+      `, Working Directory: \\`${{env.tf_actions_working_dir}}\\`, Workflow: \\`${{github.workflow}}\\\
+      `*`;\n\n            github.rest.issues.createComment({\n              issue_number:\
+      \ context.issue.number,\n              owner: context.repo.owner,\n        \
+      \      repo: context.repo.repo,\n              body: output\n            })\n\
+      \n      - id: pr-short-comment\n        name: Post comment to Pull Request (abbreviated)\n\
+      \        uses: actions/github-script@v9\n        if: github.event_name == 'pull_request'\
+      \ && steps.pr-comment.outcome != 'success'\n        with:\n          script:\
+      \ |\n            const output = `### Terraform Initialization \\`${{steps.tf-init.outcome}}\\\
+      `\n\n            ### Terraform Validation \\`${{steps.tf-validate.outcome}}\\\
+      `\n\n            ### Terraform Plan \\`${{steps.tf-plan.outcome}}\\`\n\n   \
+      \         Plan output is in the action log.\n\n            ### Terraform Apply\
+      \ \\`${{steps.tf-apply.outcome}}\\`\n\n            *Pusher: @${{github.actor}},\
+      \ Action: \\`${{github.event_name}}\\`, Working Directory: \\`${{env.tf_actions_working_dir}}\\\
+      `, Workflow: \\`${{github.workflow}}\\`*`;\n\n            github.rest.issues.createComment({\n\
+      \              issue_number: context.issue.number,\n              owner: context.repo.owner,\n\
+      \              repo: context.repo.repo,\n              body: output\n      \
+      \      })\n\n      # exit on error from previous steps\n\n      - id: check-init\n\
+      \        name: Check init failure\n        if: steps.tf-init.outcome != 'success'\n\
+      \        run: exit 1\n\n      - id: check-validate\n        name: Check validate\
+      \ failure\n        if: steps.tf-validate.outcome != 'success'\n        run:\
+      \ exit 1\n\n      - id: check-plan\n        name: Check plan failure\n     \
+      \   if: steps.tf-plan.outcome != 'success'\n        run: exit 1\n\n      - id:\
+      \ check-apply\n        name: Check apply failure\n        if: github.event.pull_request.merged\
+      \ == true && steps.tf-apply.outcome != 'success'\n        run: exit 1\n"
+    content_base64: null
+    directory_permission: '0777'
+    file_permission: '0644'
+    sensitive_content: null
+    source: null
+  module.billing-accounts["default"].google_billing_account_iam_member.bindings["billing_admin_org_admins"]:
+    billing_account_id: 012345-012345-012345
+    condition: []
+    member: group:fabric-fast-owners@google.com
+    role: roles/billing.admin
+  module.billing-accounts["default"].google_billing_account_iam_member.bindings["billing_admin_org_sa"]:
+    billing_account_id: 012345-012345-012345
+    condition: []
+    member: serviceAccount:iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    role: roles/billing.admin
+  module.billing-accounts["default"].google_billing_account_iam_member.bindings["billing_user_networking_sa"]:
+    billing_account_id: 012345-012345-012345
+    condition: []
+    member: serviceAccount:iac-networking-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    role: roles/billing.user
+  module.billing-accounts["default"].google_billing_account_iam_member.bindings["billing_user_pf_sa"]:
+    billing_account_id: 012345-012345-012345
+    condition: []
+    member: serviceAccount:iac-pf-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    role: roles/billing.user
+  module.billing-accounts["default"].google_billing_account_iam_member.bindings["billing_user_security_sa"]:
+    billing_account_id: 012345-012345-012345
+    condition: []
+    member: serviceAccount:iac-security-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    role: roles/billing.user
+  module.billing-accounts["default"].google_billing_account_iam_member.bindings["billing_viewer_org_ro"]:
+    billing_account_id: 012345-012345-012345
+    condition: []
+    member: serviceAccount:iac-org-ro@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    role: roles/billing.viewer
+  module.cicd-sa-apply["org-setup"].google_service_account_iam_binding.authoritative["roles/iam.workloadIdentityUser"]:
+    condition: []
+    members:
+    - principalSet://iam.googleapis.com/$workload_identity_pools:iac-0/default/attribute.fast_sub/repo:gh-org/gh-repo:ref:refs/heads/fast-dev
+    - principalSet://iam.googleapis.com/$workload_identity_pools:iac-0/default/attribute.fast_sub/repo:gh-org/gh-repo:ref:refs/heads/master
+    role: roles/iam.workloadIdentityUser
+    service_account_id: projects/ft0-prod-iac-core-0/serviceAccounts/iac-org-cicd-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+  module.cicd-sa-plan["org-setup"].google_service_account_iam_binding.authoritative["roles/iam.workloadIdentityUser"]:
+    condition: []
+    members:
+    - principalSet://iam.googleapis.com/$workload_identity_pools:iac-0/default/attribute.repository/gh-org/gh-repo
+    role: roles/iam.workloadIdentityUser
+    service_account_id: projects/ft0-prod-iac-core-0/serviceAccounts/iac-org-cicd-ro@ft0-prod-iac-core-0.iam.gserviceaccount.com
+  module.factory.module.bigquery-datasets["billing-0/billing_export"].google_bigquery_dataset.default:
+    dataset_id: billing_export
+    default_encryption_configuration: []
+    default_partition_expiration_ms: null
+    default_table_expiration_ms: null
+    delete_contents_on_destroy: false
+    deletion_policy: DELETE
+    description: Terraform managed.
+    effective_labels:
+      goog-terraform-provisioned: 'true'
+    external_catalog_dataset_options: []
+    external_dataset_reference: []
+    friendly_name: Billing export
+    labels: null
+    location: europe-west1
+    max_time_travel_hours: '168'
+    project: ft0-prod-billing-exp-0
+    resource_tags: null
+    terraform_labels:
+      goog-terraform-provisioned: 'true'
+    timeouts: null
+  module.factory.module.buckets["iac-0/iac-org-state"].google_storage_bucket.bucket[0]:
+    autoclass: []
+    cors: []
+    custom_placement_config: []
+    default_event_based_hold: null
+    deletion_policy: DELETE
+    effective_labels:
+      goog-terraform-provisioned: 'true'
+    enable_object_retention: null
+    encryption: []
+    force_destroy: false
+    hierarchical_namespace: []
+    ip_filter: []
+    labels: null
+    lifecycle_rule: []
+    location: EUROPE-WEST1
+    logging: []
+    name: ft0-prod-iac-core-0-iac-org-state
+    project: ft0-prod-iac-core-0
+    requester_pays: null
+    retention_policy: []
+    storage_class: STANDARD
+    terraform_labels:
+      goog-terraform-provisioned: 'true'
+    timeouts: null
+    uniform_bucket_level_access: true
+    versioning:
+    - enabled: true
+  ? module.factory.module.buckets["iac-0/iac-org-state"].google_storage_bucket_iam_binding.authoritative["$custom_roles:storage_viewer"]
+  : bucket: ft0-prod-iac-core-0-iac-org-state
+    condition: []
+    role: organizations/1234567890/roles/storageViewer
+    timeouts: null
+  ? module.factory.module.buckets["iac-0/iac-org-state"].google_storage_bucket_iam_binding.authoritative["roles/storage.admin"]
+  : bucket: ft0-prod-iac-core-0-iac-org-state
+    condition: []
+    role: roles/storage.admin
+    timeouts: null
+  module.factory.module.buckets["iac-0/iac-outputs"].google_storage_bucket.bucket[0]:
+    autoclass: []
+    cors: []
+    custom_placement_config: []
+    default_event_based_hold: null
+    deletion_policy: DELETE
+    effective_labels:
+      goog-terraform-provisioned: 'true'
+    enable_object_retention: null
+    encryption: []
+    force_destroy: false
+    hierarchical_namespace: []
+    ip_filter: []
+    labels: null
+    lifecycle_rule: []
+    location: EUROPE-WEST1
+    logging: []
+    name: ft0-prod-iac-core-0-iac-outputs
+    project: ft0-prod-iac-core-0
+    requester_pays: null
+    retention_policy: []
+    storage_class: STANDARD
+    terraform_labels:
+      goog-terraform-provisioned: 'true'
+    timeouts: null
+    uniform_bucket_level_access: true
+    versioning:
+    - enabled: true
+  ? module.factory.module.buckets["iac-0/iac-outputs"].google_storage_bucket_iam_binding.authoritative["$custom_roles:storage_viewer"]
+  : bucket: ft0-prod-iac-core-0-iac-outputs
+    condition: []
+    role: organizations/1234567890/roles/storageViewer
+    timeouts: null
+  module.factory.module.buckets["iac-0/iac-outputs"].google_storage_bucket_iam_binding.authoritative["roles/storage.admin"]:
+    bucket: ft0-prod-iac-core-0-iac-outputs
+    condition: []
+    role: roles/storage.admin
+    timeouts: null
+  module.factory.module.buckets["iac-0/iac-stage-state"].google_storage_bucket.bucket[0]:
+    autoclass: []
+    cors: []
+    custom_placement_config: []
+    default_event_based_hold: null
+    deletion_policy: DELETE
+    effective_labels:
+      goog-terraform-provisioned: 'true'
+    enable_object_retention: null
+    encryption: []
+    force_destroy: false
+    hierarchical_namespace: []
+    ip_filter: []
+    labels: null
+    lifecycle_rule: []
+    location: EUROPE-WEST1
+    logging: []
+    name: ft0-prod-iac-core-0-iac-stage-state
+    project: ft0-prod-iac-core-0
+    requester_pays: null
+    retention_policy: []
+    storage_class: STANDARD
+    terraform_labels:
+      goog-terraform-provisioned: 'true'
+    timeouts: null
+    uniform_bucket_level_access: true
+    versioning:
+    - enabled: true
+  module.factory.module.buckets["iac-0/iac-stage-state"].google_storage_managed_folder.folder["1-vpcsc/"]:
+    bucket: ft0-prod-iac-core-0-iac-stage-state
+    force_destroy: false
+    name: 1-vpcsc/
+    timeouts: null
+  module.factory.module.buckets["iac-0/iac-stage-state"].google_storage_managed_folder.folder["2-networking/"]:
+    bucket: ft0-prod-iac-core-0-iac-stage-state
+    force_destroy: false
+    name: 2-networking/
+    timeouts: null
+  module.factory.module.buckets["iac-0/iac-stage-state"].google_storage_managed_folder.folder["2-project-factory/"]:
+    bucket: ft0-prod-iac-core-0-iac-stage-state
+    force_destroy: false
+    name: 2-project-factory/
+    timeouts: null
+  module.factory.module.buckets["iac-0/iac-stage-state"].google_storage_managed_folder.folder["2-security/"]:
+    bucket: ft0-prod-iac-core-0-iac-stage-state
+    force_destroy: false
+    name: 2-security/
+    timeouts: null
+  ? module.factory.module.buckets["iac-0/iac-stage-state"].google_storage_managed_folder_iam_binding.authoritative["1-vpcsc/$custom_roles:storage_viewer"]
+  : bucket: ft0-prod-iac-core-0-iac-stage-state
+    condition: []
+    managed_folder: 1-vpcsc/
+    role: organizations/1234567890/roles/storageViewer
+  ? module.factory.module.buckets["iac-0/iac-stage-state"].google_storage_managed_folder_iam_binding.authoritative["1-vpcsc/roles/storage.admin"]
+  : bucket: ft0-prod-iac-core-0-iac-stage-state
+    condition: []
+    managed_folder: 1-vpcsc/
+    role: roles/storage.admin
+  ? module.factory.module.buckets["iac-0/iac-stage-state"].google_storage_managed_folder_iam_binding.authoritative["2-networking/$custom_roles:storage_viewer"]
+  : bucket: ft0-prod-iac-core-0-iac-stage-state
+    condition: []
+    managed_folder: 2-networking/
+    role: organizations/1234567890/roles/storageViewer
+  ? module.factory.module.buckets["iac-0/iac-stage-state"].google_storage_managed_folder_iam_binding.authoritative["2-networking/roles/storage.admin"]
+  : bucket: ft0-prod-iac-core-0-iac-stage-state
+    condition: []
+    managed_folder: 2-networking/
+    role: roles/storage.admin
+  ? module.factory.module.buckets["iac-0/iac-stage-state"].google_storage_managed_folder_iam_binding.authoritative["2-project-factory/$custom_roles:storage_viewer"]
+  : bucket: ft0-prod-iac-core-0-iac-stage-state
+    condition: []
+    managed_folder: 2-project-factory/
+    role: organizations/1234567890/roles/storageViewer
+  ? module.factory.module.buckets["iac-0/iac-stage-state"].google_storage_managed_folder_iam_binding.authoritative["2-project-factory/roles/storage.admin"]
+  : bucket: ft0-prod-iac-core-0-iac-stage-state
+    condition: []
+    managed_folder: 2-project-factory/
+    role: roles/storage.admin
+  ? module.factory.module.buckets["iac-0/iac-stage-state"].google_storage_managed_folder_iam_binding.authoritative["2-security/$custom_roles:storage_viewer"]
+  : bucket: ft0-prod-iac-core-0-iac-stage-state
+    condition: []
+    managed_folder: 2-security/
+    role: organizations/1234567890/roles/storageViewer
+  ? module.factory.module.buckets["iac-0/iac-stage-state"].google_storage_managed_folder_iam_binding.authoritative["2-security/roles/storage.admin"]
+  : bucket: ft0-prod-iac-core-0-iac-stage-state
+    condition: []
+    managed_folder: 2-security/
+    role: roles/storage.admin
+  ? module.factory.module.folder-1-iam["networking"].google_folder_iam_binding.authoritative["$custom_roles:project_iam_viewer"]
+  : condition: []
+    role: organizations/1234567890/roles/projectIamViewer
+  ? module.factory.module.folder-1-iam["networking"].google_folder_iam_binding.authoritative["$custom_roles:service_project_network_admin"]
+  : condition: []
+    role: organizations/1234567890/roles/serviceProjectNetworkAdmin
+  module.factory.module.folder-1-iam["networking"].google_folder_iam_binding.authoritative["roles/compute.viewer"]:
+    condition: []
+    role: roles/compute.viewer
+  module.factory.module.folder-1-iam["networking"].google_folder_iam_binding.authoritative["roles/compute.xpnAdmin"]:
+    condition: []
+    role: roles/compute.xpnAdmin
+  module.factory.module.folder-1-iam["networking"].google_folder_iam_binding.authoritative["roles/logging.admin"]:
+    condition: []
+    role: roles/logging.admin
+  module.factory.module.folder-1-iam["networking"].google_folder_iam_binding.authoritative["roles/owner"]:
+    condition: []
+    role: roles/owner
+  ? module.factory.module.folder-1-iam["networking"].google_folder_iam_binding.authoritative["roles/resourcemanager.folderAdmin"]
+  : condition: []
+    role: roles/resourcemanager.folderAdmin
+  ? module.factory.module.folder-1-iam["networking"].google_folder_iam_binding.authoritative["roles/resourcemanager.folderViewer"]
+  : condition: []
+    role: roles/resourcemanager.folderViewer
+  ? module.factory.module.folder-1-iam["networking"].google_folder_iam_binding.authoritative["roles/resourcemanager.projectCreator"]
+  : condition: []
+    role: roles/resourcemanager.projectCreator
+  module.factory.module.folder-1-iam["networking"].google_folder_iam_binding.authoritative["roles/resourcemanager.tagUser"]:
+    condition: []
+    role: roles/resourcemanager.tagUser
+  ? module.factory.module.folder-1-iam["networking"].google_folder_iam_binding.authoritative["roles/resourcemanager.tagViewer"]
+  : condition: []
+    role: roles/resourcemanager.tagViewer
+  module.factory.module.folder-1-iam["networking"].google_folder_iam_binding.authoritative["roles/viewer"]:
+    condition: []
+    role: roles/viewer
+  module.factory.module.folder-1-iam["networking"].google_folder_iam_binding.bindings["project_factory"]:
+    condition:
+    - description: null
+      expression: "api.getAttribute('iam.googleapis.com/modifiedGrantsByRole', []).hasOnly([\n\
+        \  'roles/compute.networkUser', 'roles/composer.sharedVpcAgent',\n  'roles/container.hostServiceAgentUser',\
+        \ 'roles/vpcaccess.user'\n])\n"
+      title: Project factory delegated IAM grant.
+    role: roles/resourcemanager.projectIamAdmin
+  module.factory.module.folder-1-iam["security"].google_folder_iam_binding.authoritative["$custom_roles:project_iam_viewer"]:
+    condition: []
+    role: organizations/1234567890/roles/projectIamViewer
+  ? module.factory.module.folder-1-iam["security"].google_folder_iam_binding.authoritative["roles/cloudkms.cryptoKeyEncrypterDecrypter"]
+  : condition: []
+    role: roles/cloudkms.cryptoKeyEncrypterDecrypter
+  module.factory.module.folder-1-iam["security"].google_folder_iam_binding.authoritative["roles/cloudkms.viewer"]:
+    condition: []
+    role: roles/cloudkms.viewer
+  module.factory.module.folder-1-iam["security"].google_folder_iam_binding.authoritative["roles/logging.admin"]:
+    condition: []
+    role: roles/logging.admin
+  module.factory.module.folder-1-iam["security"].google_folder_iam_binding.authoritative["roles/owner"]:
+    condition: []
+    role: roles/owner
+  ? module.factory.module.folder-1-iam["security"].google_folder_iam_binding.authoritative["roles/resourcemanager.folderAdmin"]
+  : condition: []
+    role: roles/resourcemanager.folderAdmin
+  ? module.factory.module.folder-1-iam["security"].google_folder_iam_binding.authoritative["roles/resourcemanager.folderViewer"]
+  : condition: []
+    role: roles/resourcemanager.folderViewer
+  ? module.factory.module.folder-1-iam["security"].google_folder_iam_binding.authoritative["roles/resourcemanager.projectCreator"]
+  : condition: []
+    role: roles/resourcemanager.projectCreator
+  module.factory.module.folder-1-iam["security"].google_folder_iam_binding.authoritative["roles/resourcemanager.tagUser"]:
+    condition: []
+    role: roles/resourcemanager.tagUser
+  module.factory.module.folder-1-iam["security"].google_folder_iam_binding.authoritative["roles/resourcemanager.tagViewer"]:
+    condition: []
+    role: roles/resourcemanager.tagViewer
+  module.factory.module.folder-1-iam["security"].google_folder_iam_binding.authoritative["roles/viewer"]:
+    condition: []
+    role: roles/viewer
+  module.factory.module.folder-1-iam["security"].google_folder_iam_binding.bindings["project_factory"]:
+    condition:
+    - description: null
+      expression: "api.getAttribute('iam.googleapis.com/modifiedGrantsByRole', []).hasOnly([\n\
+        \  'roles/cloudkms.cryptoKeyEncrypterDecrypter'\n])\n"
+      title: Project factory delegated IAM grant.
+    role: roles/resourcemanager.projectIamAdmin
+  ? module.factory.module.folder-1-iam["teams"].google_folder_iam_binding.authoritative["$custom_roles:service_project_network_admin"]
+  : condition: []
+    role: organizations/1234567890/roles/serviceProjectNetworkAdmin
+  module.factory.module.folder-1-iam["teams"].google_folder_iam_binding.authoritative["roles/owner"]:
+    condition: []
+    role: roles/owner
+  module.factory.module.folder-1-iam["teams"].google_folder_iam_binding.authoritative["roles/resourcemanager.folderAdmin"]:
+    condition: []
+    role: roles/resourcemanager.folderAdmin
+  module.factory.module.folder-1-iam["teams"].google_folder_iam_binding.authoritative["roles/resourcemanager.folderViewer"]:
+    condition: []
+    role: roles/resourcemanager.folderViewer
+  ? module.factory.module.folder-1-iam["teams"].google_folder_iam_binding.authoritative["roles/resourcemanager.projectCreator"]
+  : condition: []
+    role: roles/resourcemanager.projectCreator
+  module.factory.module.folder-1-iam["teams"].google_folder_iam_binding.authoritative["roles/resourcemanager.tagUser"]:
+    condition: []
+    role: roles/resourcemanager.tagUser
+  module.factory.module.folder-1-iam["teams"].google_folder_iam_binding.authoritative["roles/resourcemanager.tagViewer"]:
+    condition: []
+    role: roles/resourcemanager.tagViewer
+  module.factory.module.folder-1-iam["teams"].google_folder_iam_binding.authoritative["roles/viewer"]:
+    condition: []
+    role: roles/viewer
+  module.factory.module.folder-1-iam["teams"].google_tags_tag_binding.binding["context"]:
+    timeouts: null
+  module.factory.module.folder-1["networking"].google_folder.folder[0]:
+    deletion_policy: DELETE
+    deletion_protection: false
+    display_name: Networking
+    parent: organizations/1234567890
+    tags: null
+    timeouts: null
+  module.factory.module.folder-1["security"].google_folder.folder[0]:
+    deletion_policy: DELETE
+    deletion_protection: false
+    display_name: Security
+    parent: organizations/1234567890
+    tags: null
+    timeouts: null
+  module.factory.module.folder-1["teams"].google_folder.folder[0]:
+    deletion_policy: DELETE
+    deletion_protection: false
+    display_name: Teams
+    parent: organizations/1234567890
+    tags: null
+    timeouts: null
+  module.factory.module.folder-2-iam["networking/dev"].google_tags_tag_binding.binding["environment"]:
+    timeouts: null
+  module.factory.module.folder-2-iam["networking/prod"].google_tags_tag_binding.binding["environment"]:
+    timeouts: null
+  module.factory.module.folder-2-iam["security/dev"].google_tags_tag_binding.binding["environment"]:
+    timeouts: null
+  module.factory.module.folder-2-iam["security/prod"].google_tags_tag_binding.binding["environment"]:
+    timeouts: null
+  module.factory.module.folder-2["networking/dev"].google_folder.folder[0]:
+    deletion_policy: DELETE
+    deletion_protection: false
+    display_name: Development
+    tags: null
+    timeouts: null
+  module.factory.module.folder-2["networking/prod"].google_folder.folder[0]:
+    deletion_policy: DELETE
+    deletion_protection: false
+    display_name: Production
+    tags: null
+    timeouts: null
+  module.factory.module.folder-2["security/dev"].google_folder.folder[0]:
+    deletion_policy: DELETE
+    deletion_protection: false
+    display_name: Development
+    tags: null
+    timeouts: null
+  module.factory.module.folder-2["security/prod"].google_folder.folder[0]:
+    deletion_policy: DELETE
+    deletion_protection: false
+    display_name: Production
+    tags: null
+    timeouts: null
+  module.factory.module.log-buckets["log-0/audit-logs"].google_logging_project_bucket_config.bucket[0]:
+    bucket_id: audit-logs
+    cmek_settings: []
+    enable_analytics: false
+    index_configs: []
+    location: europe-west1
+    locked: null
+    project: ft0-prod-audit-logs-0
+    retention_days: 30
+  module.factory.module.log-buckets["log-0/iam"].google_logging_project_bucket_config.bucket[0]:
+    bucket_id: iam
+    cmek_settings: []
+    enable_analytics: false
+    index_configs: []
+    location: europe-west1
+    locked: null
+    project: ft0-prod-audit-logs-0
+    retention_days: 30
+  module.factory.module.log-buckets["log-0/vpc-sc"].google_logging_project_bucket_config.bucket[0]:
+    bucket_id: vpc-sc
+    cmek_settings: []
+    enable_analytics: true
+    index_configs: []
+    location: europe-west1
+    locked: null
+    project: ft0-prod-audit-logs-0
+    retention_days: 31
+  module.factory.module.projects-iam["billing-0"].google_project_iam_binding.authoritative["roles/owner"]:
+    condition: []
+    project: ft0-prod-billing-exp-0
+    role: roles/owner
+  module.factory.module.projects-iam["billing-0"].google_project_iam_binding.authoritative["roles/viewer"]:
+    condition: []
+    project: ft0-prod-billing-exp-0
+    role: roles/viewer
+  module.factory.module.projects-iam["iac-0"].google_org_policy_policy.default["iam.workloadIdentityPoolProviders"]:
+    dry_run_spec: []
+    name: projects/ft0-prod-iac-core-0/policies/iam.workloadIdentityPoolProviders
+    parent: projects/ft0-prod-iac-core-0
+    spec:
+    - inherit_from_parent: null
+      reset: null
+      rules:
+      - allow_all: null
+        condition: []
+        deny_all: null
+        enforce: null
+        parameters: null
+        values:
+        - allowed_values:
+          - https://token.actions.githubusercontent.com
+          - https://gitlab.com
+          - https://app.terraform.io
+          denied_values: null
+    timeouts: null
+  module.factory.module.projects-iam["iac-0"].google_project_iam_audit_config.default["iam.googleapis.com"]:
+    audit_log_config:
+    - exempted_members: []
+      log_type: DATA_READ
+    - exempted_members: []
+      log_type: DATA_WRITE
+    project: ft0-prod-iac-core-0
+    service: iam.googleapis.com
+  module.factory.module.projects-iam["iac-0"].google_project_iam_audit_config.default["storage.googleapis.com"]:
+    audit_log_config:
+    - exempted_members: []
+      log_type: DATA_READ
+    - exempted_members: []
+      log_type: DATA_WRITE
+    project: ft0-prod-iac-core-0
+    service: storage.googleapis.com
+  module.factory.module.projects-iam["iac-0"].google_project_iam_audit_config.default["sts.googleapis.com"]:
+    audit_log_config:
+    - exempted_members: []
+      log_type: DATA_READ
+    - exempted_members: []
+      log_type: DATA_WRITE
+    project: ft0-prod-iac-core-0
+    service: sts.googleapis.com
+  module.factory.module.projects-iam["iac-0"].google_project_iam_binding.authoritative["$custom_roles:storage_viewer"]:
+    condition: []
+    project: ft0-prod-iac-core-0
+    role: organizations/1234567890/roles/storageViewer
+  module.factory.module.projects-iam["iac-0"].google_project_iam_binding.authoritative["roles/browser"]:
+    condition: []
+    project: ft0-prod-iac-core-0
+    role: roles/browser
+  module.factory.module.projects-iam["iac-0"].google_project_iam_binding.authoritative["roles/cloudbuild.builds.editor"]:
+    condition: []
+    project: ft0-prod-iac-core-0
+    role: roles/cloudbuild.builds.editor
+  module.factory.module.projects-iam["iac-0"].google_project_iam_binding.authoritative["roles/cloudbuild.builds.viewer"]:
+    condition: []
+    project: ft0-prod-iac-core-0
+    role: roles/cloudbuild.builds.viewer
+  module.factory.module.projects-iam["iac-0"].google_project_iam_binding.authoritative["roles/iam.serviceAccountAdmin"]:
+    condition: []
+    project: ft0-prod-iac-core-0
+    role: roles/iam.serviceAccountAdmin
+  ? module.factory.module.projects-iam["iac-0"].google_project_iam_binding.authoritative["roles/iam.serviceAccountTokenCreator"]
+  : condition: []
+    project: ft0-prod-iac-core-0
+    role: roles/iam.serviceAccountTokenCreator
+  module.factory.module.projects-iam["iac-0"].google_project_iam_binding.authoritative["roles/iam.serviceAccountViewer"]:
+    condition: []
+    project: ft0-prod-iac-core-0
+    role: roles/iam.serviceAccountViewer
+  ? module.factory.module.projects-iam["iac-0"].google_project_iam_binding.authoritative["roles/iam.workloadIdentityPoolAdmin"]
+  : condition: []
+    project: ft0-prod-iac-core-0
+    role: roles/iam.workloadIdentityPoolAdmin
+  ? module.factory.module.projects-iam["iac-0"].google_project_iam_binding.authoritative["roles/iam.workloadIdentityPoolViewer"]
+  : condition: []
+    project: ft0-prod-iac-core-0
+    role: roles/iam.workloadIdentityPoolViewer
+  module.factory.module.projects-iam["iac-0"].google_project_iam_binding.authoritative["roles/owner"]:
+    condition: []
+    project: ft0-prod-iac-core-0
+    role: roles/owner
+  ? module.factory.module.projects-iam["iac-0"].google_project_iam_binding.authoritative["roles/serviceusage.serviceUsageConsumer"]
+  : condition: []
+    project: ft0-prod-iac-core-0
+    role: roles/serviceusage.serviceUsageConsumer
+  module.factory.module.projects-iam["iac-0"].google_project_iam_binding.authoritative["roles/storage.admin"]:
+    condition: []
+    project: ft0-prod-iac-core-0
+    role: roles/storage.admin
+  module.factory.module.projects-iam["iac-0"].google_project_iam_binding.authoritative["roles/viewer"]:
+    condition: []
+    project: ft0-prod-iac-core-0
+    role: roles/viewer
+  module.factory.module.projects-iam["log-0"].google_project_iam_binding.authoritative["roles/owner"]:
+    condition: []
+    project: ft0-prod-audit-logs-0
+    role: roles/owner
+  module.factory.module.projects-iam["log-0"].google_project_iam_binding.authoritative["roles/viewer"]:
+    condition: []
+    project: ft0-prod-audit-logs-0
+    role: roles/viewer
+  module.factory.module.projects["billing-0"].data.google_bigquery_default_service_account.bq_sa[0]:
+    project: ft0-prod-billing-exp-0
+  module.factory.module.projects["billing-0"].data.google_storage_project_service_account.gcs_sa[0]:
+    project: ft0-prod-billing-exp-0
+    user_project: null
+  module.factory.module.projects["billing-0"].google_project.project[0]:
+    auto_create_network: false
+    billing_account: 012345-012345-012345
+    deletion_policy: DELETE
+    effective_labels:
+      goog-terraform-provisioned: 'true'
+    folder_id: null
+    labels: null
+    name: ft0-prod-billing-exp-0
+    org_id: '1234567890'
+    project_id: ft0-prod-billing-exp-0
+    tags: null
+    terraform_labels:
+      goog-terraform-provisioned: 'true'
+    timeouts: null
+  module.factory.module.projects["billing-0"].google_project_iam_member.service_agents["bigquerydatatransfer"]:
+    condition: []
+    project: ft0-prod-billing-exp-0
+    role: roles/bigquerydatatransfer.serviceAgent
+  module.factory.module.projects["billing-0"].google_project_service.project_services["bigquery.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-billing-exp-0
+    service: bigquery.googleapis.com
+    timeouts: null
+  module.factory.module.projects["billing-0"].google_project_service.project_services["bigquerydatatransfer.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-billing-exp-0
+    service: bigquerydatatransfer.googleapis.com
+    timeouts: null
+  module.factory.module.projects["billing-0"].google_project_service.project_services["storage.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-billing-exp-0
+    service: storage.googleapis.com
+    timeouts: null
+  module.factory.module.projects["billing-0"].google_project_service_identity.default["bigquerydatatransfer.googleapis.com"]:
+    project: ft0-prod-billing-exp-0
+    service: bigquerydatatransfer.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].data.google_bigquery_default_service_account.bq_sa[0]:
+    project: ft0-prod-iac-core-0
+  module.factory.module.projects["iac-0"].data.google_logging_project_settings.logging_sa[0]:
+    project: ft0-prod-iac-core-0
+  module.factory.module.projects["iac-0"].data.google_storage_project_service_account.gcs_sa[0]:
+    project: ft0-prod-iac-core-0
+    user_project: null
+  module.factory.module.projects["iac-0"].google_project.project[0]:
+    auto_create_network: false
+    billing_account: 012345-012345-012345
+    deletion_policy: DELETE
+    effective_labels:
+      goog-terraform-provisioned: 'true'
+    folder_id: null
+    labels: null
+    name: ft0-prod-iac-core-0
+    org_id: '1234567890'
+    project_id: ft0-prod-iac-core-0
+    tags: null
+    terraform_labels:
+      goog-terraform-provisioned: 'true'
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_iam_member.service_agents["cloudasset"]:
+    condition: []
+    project: ft0-prod-iac-core-0
+    role: roles/cloudasset.serviceAgent
+  module.factory.module.projects["iac-0"].google_project_iam_member.service_agents["cloudbuild"]:
+    condition: []
+    project: ft0-prod-iac-core-0
+    role: roles/cloudbuild.serviceAgent
+  module.factory.module.projects["iac-0"].google_project_iam_member.service_agents["cloudbuild-sa"]:
+    condition: []
+    project: ft0-prod-iac-core-0
+    role: roles/cloudbuild.builds.builder
+  module.factory.module.projects["iac-0"].google_project_iam_member.service_agents["cloudkms"]:
+    condition: []
+    project: ft0-prod-iac-core-0
+    role: roles/cloudkms.serviceAgent
+  module.factory.module.projects["iac-0"].google_project_iam_member.service_agents["compute-system"]:
+    condition: []
+    project: ft0-prod-iac-core-0
+    role: roles/compute.serviceAgent
+  module.factory.module.projects["iac-0"].google_project_iam_member.service_agents["container-engine-robot"]:
+    condition: []
+    project: ft0-prod-iac-core-0
+    role: roles/container.serviceAgent
+  module.factory.module.projects["iac-0"].google_project_iam_member.service_agents["gkenode"]:
+    condition: []
+    project: ft0-prod-iac-core-0
+    role: roles/container.defaultNodeServiceAgent
+  module.factory.module.projects["iac-0"].google_project_iam_member.service_agents["monitoring-notification"]:
+    condition: []
+    project: ft0-prod-iac-core-0
+    role: roles/monitoring.notificationServiceAgent
+  module.factory.module.projects["iac-0"].google_project_iam_member.service_agents["pubsub"]:
+    condition: []
+    project: ft0-prod-iac-core-0
+    role: roles/pubsub.serviceAgent
+  module.factory.module.projects["iac-0"].google_project_iam_member.service_agents["service-networking"]:
+    condition: []
+    project: ft0-prod-iac-core-0
+    role: roles/servicenetworking.serviceAgent
+  module.factory.module.projects["iac-0"].google_project_service.org_policy_service[0]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: orgpolicy.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["accesscontextmanager.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: accesscontextmanager.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["bigquery.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: bigquery.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["bigqueryreservation.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: bigqueryreservation.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["bigquerystorage.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: bigquerystorage.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["billingbudgets.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: billingbudgets.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["cloudasset.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: cloudasset.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["cloudbilling.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: cloudbilling.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["cloudbuild.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: cloudbuild.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["cloudkms.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: cloudkms.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["cloudquotas.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: cloudquotas.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["cloudresourcemanager.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: cloudresourcemanager.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["compute.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: compute.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["container.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: container.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["datacatalog.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: datacatalog.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["essentialcontacts.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: essentialcontacts.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["iam.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: iam.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["iamcredentials.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: iamcredentials.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["logging.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: logging.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["monitoring.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: monitoring.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["networksecurity.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: networksecurity.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["pubsub.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: pubsub.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["servicenetworking.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: servicenetworking.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["serviceusage.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: serviceusage.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["storage-component.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: storage-component.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["storage.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: storage.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["sts.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: sts.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service_identity.default["cloudasset.googleapis.com"]:
+    project: ft0-prod-iac-core-0
+    service: cloudasset.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service_identity.default["cloudkms.googleapis.com"]:
+    project: ft0-prod-iac-core-0
+    service: cloudkms.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service_identity.default["container.googleapis.com"]:
+    project: ft0-prod-iac-core-0
+    service: container.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service_identity.default["monitoring.googleapis.com"]:
+    project: ft0-prod-iac-core-0
+    service: monitoring.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service_identity.default["networksecurity.googleapis.com"]:
+    project: ft0-prod-iac-core-0
+    service: networksecurity.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service_identity.default["pubsub.googleapis.com"]:
+    project: ft0-prod-iac-core-0
+    service: pubsub.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service_identity.default["servicenetworking.googleapis.com"]:
+    project: ft0-prod-iac-core-0
+    service: servicenetworking.googleapis.com
+    timeouts: null
+  module.factory.module.projects["log-0"].data.google_logging_project_settings.logging_sa[0]:
+    project: ft0-prod-audit-logs-0
+  module.factory.module.projects["log-0"].data.google_storage_project_service_account.gcs_sa[0]:
+    project: ft0-prod-audit-logs-0
+    user_project: null
+  module.factory.module.projects["log-0"].google_project.project[0]:
+    auto_create_network: false
+    billing_account: 012345-012345-012345
+    deletion_policy: DELETE
+    effective_labels:
+      goog-terraform-provisioned: 'true'
+    folder_id: null
+    labels: null
+    name: ft0-prod-audit-logs-0
+    org_id: '1234567890'
+    project_id: ft0-prod-audit-logs-0
+    tags: null
+    terraform_labels:
+      goog-terraform-provisioned: 'true'
+    timeouts: null
+  module.factory.module.projects["log-0"].google_project_iam_member.service_agents["pubsub"]:
+    condition: []
+    project: ft0-prod-audit-logs-0
+    role: roles/pubsub.serviceAgent
+  module.factory.module.projects["log-0"].google_project_service.project_services["logging.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-audit-logs-0
+    service: logging.googleapis.com
+    timeouts: null
+  module.factory.module.projects["log-0"].google_project_service.project_services["pubsub.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-audit-logs-0
+    service: pubsub.googleapis.com
+    timeouts: null
+  module.factory.module.projects["log-0"].google_project_service.project_services["storage.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-audit-logs-0
+    service: storage.googleapis.com
+    timeouts: null
+  module.factory.module.projects["log-0"].google_project_service_identity.default["pubsub.googleapis.com"]:
+    project: ft0-prod-audit-logs-0
+    service: pubsub.googleapis.com
+    timeouts: null
+  ? module.factory.module.service-accounts-iam["iac-0/iac-org-cicd-ro"].google_service_account_iam_member.additive["$service_account_ids:iac-0/iac-org-ro-roles/iam.serviceAccountTokenCreator"]
+  : condition: []
+    role: roles/iam.serviceAccountTokenCreator
+    service_account_id: projects/ft0-prod-iac-core-0/serviceAccounts/iac-org-ro@ft0-prod-iac-core-0.iam.gserviceaccount.com
+  ? module.factory.module.service-accounts-iam["iac-0/iac-org-cicd-ro"].google_service_account_iam_member.additive["$service_account_ids:iac-0/iac-org-ro-roles/iam.workloadIdentityUser"]
+  : condition: []
+    role: roles/iam.workloadIdentityUser
+    service_account_id: projects/ft0-prod-iac-core-0/serviceAccounts/iac-org-ro@ft0-prod-iac-core-0.iam.gserviceaccount.com
+  ? module.factory.module.service-accounts-iam["iac-0/iac-org-cicd-rw"].google_service_account_iam_member.additive["$service_account_ids:iac-0/iac-org-rw-roles/iam.serviceAccountTokenCreator"]
+  : condition: []
+    role: roles/iam.serviceAccountTokenCreator
+    service_account_id: projects/ft0-prod-iac-core-0/serviceAccounts/iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+  ? module.factory.module.service-accounts-iam["iac-0/iac-org-cicd-rw"].google_service_account_iam_member.additive["$service_account_ids:iac-0/iac-org-rw-roles/iam.workloadIdentityUser"]
+  : condition: []
+    role: roles/iam.workloadIdentityUser
+    service_account_id: projects/ft0-prod-iac-core-0/serviceAccounts/iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+  module.factory.module.service-accounts["iac-0/iac-networking-ro"].google_service_account.service_account[0]:
+    account_id: iac-networking-ro
+    create_ignore_already_exists: null
+    deletion_policy: DELETE
+    description: null
+    disabled: false
+    display_name: IaC service account for networking (read-only).
+    email: iac-networking-ro@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    member: serviceAccount:iac-networking-ro@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    project: ft0-prod-iac-core-0
+    timeouts: null
+  module.factory.module.service-accounts["iac-0/iac-networking-rw"].google_service_account.service_account[0]:
+    account_id: iac-networking-rw
+    create_ignore_already_exists: null
+    deletion_policy: DELETE
+    description: null
+    disabled: false
+    display_name: IaC service account for networking (read-write).
+    email: iac-networking-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    member: serviceAccount:iac-networking-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    project: ft0-prod-iac-core-0
+    timeouts: null
+  module.factory.module.service-accounts["iac-0/iac-org-cicd-ro"].google_service_account.service_account[0]:
+    account_id: iac-org-cicd-ro
+    create_ignore_already_exists: null
+    deletion_policy: DELETE
+    description: null
+    disabled: false
+    display_name: IaC service account for org setup CI/CD (read-only).
+    email: iac-org-cicd-ro@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    member: serviceAccount:iac-org-cicd-ro@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    project: ft0-prod-iac-core-0
+    timeouts: null
+  module.factory.module.service-accounts["iac-0/iac-org-cicd-rw"].google_service_account.service_account[0]:
+    account_id: iac-org-cicd-rw
+    create_ignore_already_exists: null
+    deletion_policy: DELETE
+    description: null
+    disabled: false
+    display_name: IaC service account for org setup CI/CD (read-write).
+    email: iac-org-cicd-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    member: serviceAccount:iac-org-cicd-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    project: ft0-prod-iac-core-0
+    timeouts: null
+  module.factory.module.service-accounts["iac-0/iac-org-ro"].google_service_account.service_account[0]:
+    account_id: iac-org-ro
+    create_ignore_already_exists: null
+    deletion_policy: DELETE
+    description: null
+    disabled: false
+    display_name: IaC service account for org setup (read-only).
+    email: iac-org-ro@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    member: serviceAccount:iac-org-ro@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    project: ft0-prod-iac-core-0
+    timeouts: null
+  module.factory.module.service-accounts["iac-0/iac-org-rw"].google_service_account.service_account[0]:
+    account_id: iac-org-rw
+    create_ignore_already_exists: null
+    deletion_policy: DELETE
+    description: null
+    disabled: false
+    display_name: IaC service account for org setup (read-write).
+    email: iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    member: serviceAccount:iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    project: ft0-prod-iac-core-0
+    timeouts: null
+  module.factory.module.service-accounts["iac-0/iac-pf-ro"].google_service_account.service_account[0]:
+    account_id: iac-pf-ro
+    create_ignore_already_exists: null
+    deletion_policy: DELETE
+    description: null
+    disabled: false
+    display_name: IaC service account for project factory (read-only).
+    email: iac-pf-ro@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    member: serviceAccount:iac-pf-ro@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    project: ft0-prod-iac-core-0
+    timeouts: null
+  module.factory.module.service-accounts["iac-0/iac-pf-rw"].google_service_account.service_account[0]:
+    account_id: iac-pf-rw
+    create_ignore_already_exists: null
+    deletion_policy: DELETE
+    description: null
+    disabled: false
+    display_name: IaC service account for project factory (read-write).
+    email: iac-pf-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    member: serviceAccount:iac-pf-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    project: ft0-prod-iac-core-0
+    timeouts: null
+  module.factory.module.service-accounts["iac-0/iac-security-ro"].google_service_account.service_account[0]:
+    account_id: iac-security-ro
+    create_ignore_already_exists: null
+    deletion_policy: DELETE
+    description: null
+    disabled: false
+    display_name: IaC service account for security (read-only).
+    email: iac-security-ro@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    member: serviceAccount:iac-security-ro@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    project: ft0-prod-iac-core-0
+    timeouts: null
+  module.factory.module.service-accounts["iac-0/iac-security-rw"].google_service_account.service_account[0]:
+    account_id: iac-security-rw
+    create_ignore_already_exists: null
+    deletion_policy: DELETE
+    description: null
+    disabled: false
+    display_name: IaC service account for security (read-write).
+    email: iac-security-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    member: serviceAccount:iac-security-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    project: ft0-prod-iac-core-0
+    timeouts: null
+  module.factory.module.service-accounts["iac-0/iac-vpcsc-ro"].google_service_account.service_account[0]:
+    account_id: iac-vpcsc-ro
+    create_ignore_already_exists: null
+    deletion_policy: DELETE
+    description: null
+    disabled: false
+    display_name: IaC service account for VPC service controls (read-only).
+    email: iac-vpcsc-ro@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    member: serviceAccount:iac-vpcsc-ro@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    project: ft0-prod-iac-core-0
+    timeouts: null
+  module.factory.module.service-accounts["iac-0/iac-vpcsc-rw"].google_service_account.service_account[0]:
+    account_id: iac-vpcsc-rw
+    create_ignore_already_exists: null
+    deletion_policy: DELETE
+    description: null
+    disabled: false
+    display_name: IaC service account for VPC service controls (read-write).
+    email: iac-vpcsc-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    member: serviceAccount:iac-vpcsc-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    project: ft0-prod-iac-core-0
+    timeouts: null
+  module.factory.terraform_data.defaults_preconditions:
+    input: null
+    output: null
+    triggers_replace: null
+  module.factory.terraform_data.project_preconditions:
+    input: null
+    output: null
+    triggers_replace: null
+  module.organization-iam[0].google_logging_organization_sink.sink["audit-logs"]:
+    deletion_policy: DELETE
+    description: audit-logs (Terraform-managed).
+    disabled: false
+    exclusions: []
+    filter: 'log_id("cloudaudit.googleapis.com/activity") OR
+
+      log_id("cloudaudit.googleapis.com/system_event") OR
+
+      log_id("cloudaudit.googleapis.com/policy") OR
+
+      log_id("cloudaudit.googleapis.com/access_transparency")
+
+      '
+    include_children: true
+    intercept_children: false
+    name: audit-logs
+    org_id: '1234567890'
+  module.organization-iam[0].google_logging_organization_sink.sink["iam"]:
+    deletion_policy: DELETE
+    description: iam (Terraform-managed).
+    disabled: false
+    exclusions: []
+    filter: 'protoPayload.serviceName="iamcredentials.googleapis.com" OR
+
+      protoPayload.serviceName="iam.googleapis.com" OR
+
+      protoPayload.serviceName="sts.googleapis.com"
+
+      '
+    include_children: true
+    intercept_children: false
+    name: iam
+    org_id: '1234567890'
+  module.organization-iam[0].google_logging_organization_sink.sink["vpc-sc"]:
+    deletion_policy: DELETE
+    description: vpc-sc (Terraform-managed).
+    disabled: false
+    exclusions: []
+    filter: 'protoPayload.metadata.@type="type.googleapis.com/google.cloud.audit.VpcServiceControlAuditMetadata"
+
+      '
+    include_children: true
+    intercept_children: false
+    name: vpc-sc
+    org_id: '1234567890'
+  module.organization-iam[0].google_org_policy_custom_constraint.constraint["custom.denyBridgePerimeters"]:
+    action_type: DENY
+    condition: resource.perimeterType == 'PERIMETER_TYPE_BRIDGE'
+    description: Disables the use of perimeter bridges. Instead, use ingress and egress
+      rules.
+    display_name: Disable perimeter bridges
+    method_types:
+    - CREATE
+    - UPDATE
+    name: custom.denyBridgePerimeters
+    parent: organizations/1234567890
+    resource_types:
+    - accesscontextmanager.googleapis.com/ServicePerimeter
+    timeouts: null
+  module.organization-iam[0].google_org_policy_policy.default["cloudbuild.disableCreateDefaultServiceAccount"]:
+    dry_run_spec: []
+    name: organizations/1234567890/policies/cloudbuild.disableCreateDefaultServiceAccount
+    parent: organizations/1234567890
+    spec:
+    - inherit_from_parent: null
+      reset: null
+      rules:
+      - allow_all: null
+        condition: []
+        deny_all: null
+        enforce: 'TRUE'
+        parameters: null
+        values: []
+    timeouts: null
+  module.organization-iam[0].google_org_policy_policy.default["cloudbuild.useBuildServiceAccount"]:
+    dry_run_spec: []
+    name: organizations/1234567890/policies/cloudbuild.useBuildServiceAccount
+    parent: organizations/1234567890
+    spec:
+    - inherit_from_parent: null
+      reset: null
+      rules:
+      - allow_all: null
+        condition: []
+        deny_all: null
+        enforce: 'TRUE'
+        parameters: null
+        values: []
+    timeouts: null
+  module.organization-iam[0].google_org_policy_policy.default["cloudbuild.useComputeServiceAccount"]:
+    dry_run_spec: []
+    name: organizations/1234567890/policies/cloudbuild.useComputeServiceAccount
+    parent: organizations/1234567890
+    spec:
+    - inherit_from_parent: null
+      reset: null
+      rules:
+      - allow_all: null
+        condition: []
+        deny_all: null
+        enforce: 'TRUE'
+        parameters: null
+        values: []
+    timeouts: null
+  module.organization-iam[0].google_org_policy_policy.default["compute.disableGuestAttributesAccess"]:
+    dry_run_spec: []
+    name: organizations/1234567890/policies/compute.disableGuestAttributesAccess
+    parent: organizations/1234567890
+    spec:
+    - inherit_from_parent: null
+      reset: null
+      rules:
+      - allow_all: null
+        condition: []
+        deny_all: null
+        enforce: 'TRUE'
+        parameters: null
+        values: []
+    timeouts: null
+  module.organization-iam[0].google_org_policy_policy.default["compute.disableInternetNetworkEndpointGroup"]:
+    dry_run_spec: []
+    name: organizations/1234567890/policies/compute.disableInternetNetworkEndpointGroup
+    parent: organizations/1234567890
+    spec:
+    - inherit_from_parent: null
+      reset: null
+      rules:
+      - allow_all: null
+        condition: []
+        deny_all: null
+        enforce: 'TRUE'
+        parameters: null
+        values: []
+    timeouts: null
+  module.organization-iam[0].google_org_policy_policy.default["compute.disableNestedVirtualization"]:
+    dry_run_spec: []
+    name: organizations/1234567890/policies/compute.disableNestedVirtualization
+    parent: organizations/1234567890
+    spec:
+    - inherit_from_parent: null
+      reset: null
+      rules:
+      - allow_all: null
+        condition: []
+        deny_all: null
+        enforce: 'TRUE'
+        parameters: null
+        values: []
+    timeouts: null
+  module.organization-iam[0].google_org_policy_policy.default["compute.disableSerialPortAccess"]:
+    dry_run_spec: []
+    name: organizations/1234567890/policies/compute.disableSerialPortAccess
+    parent: organizations/1234567890
+    spec:
+    - inherit_from_parent: null
+      reset: null
+      rules:
+      - allow_all: null
+        condition: []
+        deny_all: null
+        enforce: 'TRUE'
+        parameters: null
+        values: []
+    timeouts: null
+  module.organization-iam[0].google_org_policy_policy.default["compute.disableVpcExternalIpv6"]:
+    dry_run_spec: []
+    name: organizations/1234567890/policies/compute.disableVpcExternalIpv6
+    parent: organizations/1234567890
+    spec:
+    - inherit_from_parent: null
+      reset: null
+      rules:
+      - allow_all: null
+        condition: []
+        deny_all: null
+        enforce: 'TRUE'
+        parameters: null
+        values: []
+    timeouts: null
+  module.organization-iam[0].google_org_policy_policy.default["compute.requireOsLogin"]:
+    dry_run_spec: []
+    name: organizations/1234567890/policies/compute.requireOsLogin
+    parent: organizations/1234567890
+    spec:
+    - inherit_from_parent: null
+      reset: null
+      rules:
+      - allow_all: null
+        condition: []
+        deny_all: null
+        enforce: 'TRUE'
+        parameters: null
+        values: []
+    timeouts: null
+  module.organization-iam[0].google_org_policy_policy.default["compute.restrictLoadBalancerCreationForTypes"]:
+    dry_run_spec: []
+    name: organizations/1234567890/policies/compute.restrictLoadBalancerCreationForTypes
+    parent: organizations/1234567890
+    spec:
+    - inherit_from_parent: null
+      reset: null
+      rules:
+      - allow_all: null
+        condition: []
+        deny_all: null
+        enforce: null
+        parameters: null
+        values:
+        - allowed_values:
+          - in:INTERNAL
+          denied_values: null
+    timeouts: null
+  module.organization-iam[0].google_org_policy_policy.default["compute.restrictProtocolForwardingCreationForTypes"]:
+    dry_run_spec: []
+    name: organizations/1234567890/policies/compute.restrictProtocolForwardingCreationForTypes
+    parent: organizations/1234567890
+    spec:
+    - inherit_from_parent: null
+      reset: null
+      rules:
+      - allow_all: null
+        condition: []
+        deny_all: null
+        enforce: null
+        parameters: null
+        values:
+        - allowed_values:
+          - is:INTERNAL
+          denied_values: null
+    timeouts: null
+  module.organization-iam[0].google_org_policy_policy.default["compute.setNewProjectDefaultToZonalDNSOnly"]:
+    dry_run_spec: []
+    name: organizations/1234567890/policies/compute.setNewProjectDefaultToZonalDNSOnly
+    parent: organizations/1234567890
+    spec:
+    - inherit_from_parent: null
+      reset: null
+      rules:
+      - allow_all: null
+        condition: []
+        deny_all: null
+        enforce: 'TRUE'
+        parameters: null
+        values: []
+    timeouts: null
+  module.organization-iam[0].google_org_policy_policy.default["compute.skipDefaultNetworkCreation"]:
+    dry_run_spec: []
+    name: organizations/1234567890/policies/compute.skipDefaultNetworkCreation
+    parent: organizations/1234567890
+    spec:
+    - inherit_from_parent: null
+      reset: null
+      rules:
+      - allow_all: null
+        condition: []
+        deny_all: null
+        enforce: 'TRUE'
+        parameters: null
+        values: []
+    timeouts: null
+  module.organization-iam[0].google_org_policy_policy.default["compute.trustedImageProjects"]:
+    dry_run_spec: []
+    name: organizations/1234567890/policies/compute.trustedImageProjects
+    parent: organizations/1234567890
+    spec:
+    - inherit_from_parent: null
+      reset: null
+      rules:
+      - allow_all: null
+        condition: []
+        deny_all: null
+        enforce: null
+        parameters: null
+        values:
+        - allowed_values:
+          - is:projects/centos-cloud
+          - is:projects/cos-cloud
+          - is:projects/debian-cloud
+          - is:projects/fedora-cloud
+          - is:projects/fedora-coreos-cloud
+          - is:projects/opensuse-cloud
+          - is:projects/rhel-cloud
+          - is:projects/rhel-sap-cloud
+          - is:projects/rocky-linux-cloud
+          - is:projects/suse-cloud
+          - is:projects/suse-sap-cloud
+          - is:projects/ubuntu-os-cloud
+          - is:projects/ubuntu-os-pro-cloud
+          - is:projects/windows-cloud
+          - is:projects/windows-sql-cloud
+          - is:projects/confidential-vm-images
+          - is:projects/confidential-space-images
+          - is:projects/backupdr-images
+          - is:projects/deeplearning-platform-release
+          - is:projects/serverless-vpc-access-images
+          - is:projects/gke-node-images
+          - is:projects/gke-windows-node-images
+          - is:projects/ubuntu-os-gke-cloud
+          - is:projects/rocky-linux-accelerator-cloud
+          - is:projects/ubuntu-os-accelerator-images
+          denied_values: null
+    timeouts: null
+  module.organization-iam[0].google_org_policy_policy.default["compute.vmExternalIpAccess"]:
+    dry_run_spec: []
+    name: organizations/1234567890/policies/compute.vmExternalIpAccess
+    parent: organizations/1234567890
+    spec:
+    - inherit_from_parent: null
+      reset: null
+      rules:
+      - allow_all: null
+        condition: []
+        deny_all: 'TRUE'
+        enforce: null
+        parameters: null
+        values: []
+    timeouts: null
+  module.organization-iam[0].google_org_policy_policy.default["container.managed.enablePrivateNodes"]:
+    dry_run_spec: []
+    name: organizations/1234567890/policies/container.managed.enablePrivateNodes
+    parent: organizations/1234567890
+    spec:
+    - inherit_from_parent: null
+      reset: null
+      rules:
+      - allow_all: null
+        condition: []
+        deny_all: null
+        enforce: 'TRUE'
+        parameters: null
+        values: []
+    timeouts: null
+  module.organization-iam[0].google_org_policy_policy.default["custom.denyBridgePerimeters"]:
+    dry_run_spec: []
+    name: organizations/1234567890/policies/custom.denyBridgePerimeters
+    parent: organizations/1234567890
+    spec:
+    - inherit_from_parent: null
+      reset: null
+      rules:
+      - allow_all: null
+        condition: []
+        deny_all: null
+        enforce: 'TRUE'
+        parameters: null
+        values: []
+    timeouts: null
+  module.organization-iam[0].google_org_policy_policy.default["essentialcontacts.allowedContactDomains"]:
+    dry_run_spec: []
+    name: organizations/1234567890/policies/essentialcontacts.allowedContactDomains
+    parent: organizations/1234567890
+    spec:
+    - inherit_from_parent: null
+      reset: null
+      rules:
+      - allow_all: null
+        condition:
+        - description: null
+          expression: '!resource.matchTag(''1234567890/org-policies'', ''allowed-essential-contacts-domains-all'')
+
+            '
+          location: null
+          title: Restrict essential contacts domains
+        deny_all: null
+        enforce: null
+        parameters: null
+        values:
+        - allowed_values:
+          - '@example.org'
+          denied_values: null
+      - allow_all: 'TRUE'
+        condition:
+        - description: null
+          expression: 'resource.matchTag(''1234567890/org-policies'', ''allowed-essential-contacts-domains-all'')
+
+            '
+          location: null
+          title: Allow essential contacts from any domain
+        deny_all: null
+        enforce: null
+        parameters: null
+        values: []
+    timeouts: null
+  module.organization-iam[0].google_org_policy_policy.default["gcp.resourceLocations"]:
+    dry_run_spec: []
+    name: organizations/1234567890/policies/gcp.resourceLocations
+    parent: organizations/1234567890
+    spec:
+    - inherit_from_parent: null
+      reset: null
+      rules:
+      - allow_all: 'TRUE'
+        condition: []
+        deny_all: null
+        enforce: null
+        parameters: null
+        values: []
+    timeouts: null
+  module.organization-iam[0].google_org_policy_policy.default["iam.allowedPolicyMemberDomains"]:
+    dry_run_spec: []
+    name: organizations/1234567890/policies/iam.allowedPolicyMemberDomains
+    parent: organizations/1234567890
+    spec:
+    - inherit_from_parent: null
+      reset: null
+      rules:
+      - allow_all: null
+        condition:
+        - description: null
+          expression: '!resource.matchTag(''1234567890/org-policies'', ''allowed-policy-member-domains-all'')
+
+            '
+          location: null
+          title: Restrict member domains
+        deny_all: null
+        enforce: null
+        parameters: null
+        values:
+        - allowed_values:
+          - is:abcd123456
+          denied_values: null
+      - allow_all: 'TRUE'
+        condition:
+        - description: null
+          expression: 'resource.matchTag(''1234567890/org-policies'', ''allowed-policy-member-domains-all'')
+
+            '
+          location: null
+          title: Allow any member domain
+        deny_all: null
+        enforce: null
+        parameters: null
+        values: []
+    timeouts: null
+  module.organization-iam[0].google_org_policy_policy.default["iam.automaticIamGrantsForDefaultServiceAccounts"]:
+    dry_run_spec: []
+    name: organizations/1234567890/policies/iam.automaticIamGrantsForDefaultServiceAccounts
+    parent: organizations/1234567890
+    spec:
+    - inherit_from_parent: null
+      reset: null
+      rules:
+      - allow_all: null
+        condition: []
+        deny_all: null
+        enforce: 'TRUE'
+        parameters: null
+        values: []
+    timeouts: null
+  module.organization-iam[0].google_org_policy_policy.default["iam.disableAuditLoggingExemption"]:
+    dry_run_spec: []
+    name: organizations/1234567890/policies/iam.disableAuditLoggingExemption
+    parent: organizations/1234567890
+    spec:
+    - inherit_from_parent: null
+      reset: null
+      rules:
+      - allow_all: null
+        condition: []
+        deny_all: null
+        enforce: 'TRUE'
+        parameters: null
+        values: []
+    timeouts: null
+  module.organization-iam[0].google_org_policy_policy.default["iam.disableServiceAccountKeyCreation"]:
+    dry_run_spec: []
+    name: organizations/1234567890/policies/iam.disableServiceAccountKeyCreation
+    parent: organizations/1234567890
+    spec:
+    - inherit_from_parent: null
+      reset: null
+      rules:
+      - allow_all: null
+        condition: []
+        deny_all: null
+        enforce: 'TRUE'
+        parameters: null
+        values: []
+    timeouts: null
+  module.organization-iam[0].google_org_policy_policy.default["iam.disableServiceAccountKeyUpload"]:
+    dry_run_spec: []
+    name: organizations/1234567890/policies/iam.disableServiceAccountKeyUpload
+    parent: organizations/1234567890
+    spec:
+    - inherit_from_parent: null
+      reset: null
+      rules:
+      - allow_all: null
+        condition: []
+        deny_all: null
+        enforce: 'TRUE'
+        parameters: null
+        values: []
+    timeouts: null
+  module.organization-iam[0].google_org_policy_policy.default["iam.managed.disableServiceAccountApiKeyCreation"]:
+    dry_run_spec: []
+    name: organizations/1234567890/policies/iam.managed.disableServiceAccountApiKeyCreation
+    parent: organizations/1234567890
+    spec:
+    - inherit_from_parent: null
+      reset: null
+      rules:
+      - allow_all: null
+        condition: []
+        deny_all: null
+        enforce: 'TRUE'
+        parameters: null
+        values: []
+    timeouts: null
+  module.organization-iam[0].google_org_policy_policy.default["iam.serviceAccountKeyExposureResponse"]:
+    dry_run_spec: []
+    name: organizations/1234567890/policies/iam.serviceAccountKeyExposureResponse
+    parent: organizations/1234567890
+    spec:
+    - inherit_from_parent: null
+      reset: null
+      rules:
+      - allow_all: null
+        condition: []
+        deny_all: null
+        enforce: null
+        parameters: null
+        values:
+        - allowed_values:
+          - is:DISABLE_KEY
+          denied_values: null
+    timeouts: null
+  module.organization-iam[0].google_org_policy_policy.default["iam.workloadIdentityPoolAwsAccounts"]:
+    dry_run_spec: []
+    name: organizations/1234567890/policies/iam.workloadIdentityPoolAwsAccounts
+    parent: organizations/1234567890
+    spec:
+    - inherit_from_parent: null
+      reset: null
+      rules:
+      - allow_all: null
+        condition: []
+        deny_all: 'TRUE'
+        enforce: null
+        parameters: null
+        values: []
+    timeouts: null
+  module.organization-iam[0].google_org_policy_policy.default["iam.workloadIdentityPoolProviders"]:
+    dry_run_spec: []
+    name: organizations/1234567890/policies/iam.workloadIdentityPoolProviders
+    parent: organizations/1234567890
+    spec:
+    - inherit_from_parent: null
+      reset: null
+      rules:
+      - allow_all: null
+        condition: []
+        deny_all: 'TRUE'
+        enforce: null
+        parameters: null
+        values: []
+    timeouts: null
+  module.organization-iam[0].google_org_policy_policy.default["run.allowedIngress"]:
+    dry_run_spec: []
+    name: organizations/1234567890/policies/run.allowedIngress
+    parent: organizations/1234567890
+    spec:
+    - inherit_from_parent: null
+      reset: null
+      rules:
+      - allow_all: null
+        condition: []
+        deny_all: null
+        enforce: null
+        parameters: null
+        values:
+        - allowed_values:
+          - is:internal-and-cloud-load-balancing
+          denied_values: null
+    timeouts: null
+  module.organization-iam[0].google_org_policy_policy.default["run.managed.requireInvokerIam"]:
+    dry_run_spec: []
+    name: organizations/1234567890/policies/run.managed.requireInvokerIam
+    parent: organizations/1234567890
+    spec:
+    - inherit_from_parent: null
+      reset: null
+      rules:
+      - allow_all: null
+        condition: []
+        deny_all: null
+        enforce: 'TRUE'
+        parameters: null
+        values: []
+    timeouts: null
+  module.organization-iam[0].google_org_policy_policy.default["sql.restrictAuthorizedNetworks"]:
+    dry_run_spec: []
+    name: organizations/1234567890/policies/sql.restrictAuthorizedNetworks
+    parent: organizations/1234567890
+    spec:
+    - inherit_from_parent: null
+      reset: null
+      rules:
+      - allow_all: null
+        condition: []
+        deny_all: null
+        enforce: 'TRUE'
+        parameters: null
+        values: []
+    timeouts: null
+  module.organization-iam[0].google_org_policy_policy.default["sql.restrictPublicIp"]:
+    dry_run_spec: []
+    name: organizations/1234567890/policies/sql.restrictPublicIp
+    parent: organizations/1234567890
+    spec:
+    - inherit_from_parent: null
+      reset: null
+      rules:
+      - allow_all: null
+        condition: []
+        deny_all: null
+        enforce: 'TRUE'
+        parameters: null
+        values: []
+    timeouts: null
+  module.organization-iam[0].google_org_policy_policy.default["storage.publicAccessPrevention"]:
+    dry_run_spec: []
+    name: organizations/1234567890/policies/storage.publicAccessPrevention
+    parent: organizations/1234567890
+    spec:
+    - inherit_from_parent: null
+      reset: null
+      rules:
+      - allow_all: null
+        condition: []
+        deny_all: null
+        enforce: 'TRUE'
+        parameters: null
+        values: []
+    timeouts: null
+  module.organization-iam[0].google_org_policy_policy.default["storage.restrictAuthTypes"]:
+    dry_run_spec: []
+    name: organizations/1234567890/policies/storage.restrictAuthTypes
+    parent: organizations/1234567890
+    spec:
+    - inherit_from_parent: null
+      reset: null
+      rules:
+      - allow_all: null
+        condition: []
+        deny_all: null
+        enforce: null
+        parameters: null
+        values:
+        - allowed_values: null
+          denied_values:
+          - in:ALL_HMAC_SIGNED_REQUESTS
+    timeouts: null
+  module.organization-iam[0].google_org_policy_policy.default["storage.secureHttpTransport"]:
+    dry_run_spec: []
+    name: organizations/1234567890/policies/storage.secureHttpTransport
+    parent: organizations/1234567890
+    spec:
+    - inherit_from_parent: null
+      reset: null
+      rules:
+      - allow_all: null
+        condition: []
+        deny_all: null
+        enforce: 'TRUE'
+        parameters: null
+        values: []
+    timeouts: null
+  module.organization-iam[0].google_org_policy_policy.default["storage.uniformBucketLevelAccess"]:
+    dry_run_spec: []
+    name: organizations/1234567890/policies/storage.uniformBucketLevelAccess
+    parent: organizations/1234567890
+    spec:
+    - inherit_from_parent: null
+      reset: null
+      rules:
+      - allow_all: null
+        condition: []
+        deny_all: null
+        enforce: 'TRUE'
+        parameters: null
+        values: []
+    timeouts: null
+  module.organization-iam[0].google_organization_iam_audit_config.default["sts.googleapis.com"]:
+    audit_log_config:
+    - exempted_members: []
+      log_type: ADMIN_READ
+    org_id: '1234567890'
+    service: sts.googleapis.com
+  module.organization-iam[0].google_organization_iam_binding.authoritative["$custom_roles:organization_admin_viewer"]:
+    condition: []
+    members:
+    - serviceAccount:iac-org-ro@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: organizations/1234567890/roles/organizationAdminViewer
+  module.organization-iam[0].google_organization_iam_binding.authoritative["$custom_roles:tag_viewer"]:
+    condition: []
+    members:
+    - serviceAccount:iac-org-ro@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: organizations/1234567890/roles/tagViewer
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/accesscontextmanager.policyAdmin"]:
+    condition: []
+    members:
+    - serviceAccount:iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    - serviceAccount:iac-vpcsc-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/accesscontextmanager.policyAdmin
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/accesscontextmanager.policyReader"]:
+    condition: []
+    members:
+    - serviceAccount:iac-vpcsc-ro@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/accesscontextmanager.policyReader
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/billing.creator"]:
+    condition: []
+    members: null
+    org_id: '1234567890'
+    role: roles/billing.creator
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/cloudasset.owner"]:
+    condition: []
+    members:
+    - group:fabric-fast-owners@google.com
+    org_id: '1234567890'
+    role: roles/cloudasset.owner
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/cloudasset.viewer"]:
+    condition: []
+    members:
+    - serviceAccount:iac-org-ro@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    - serviceAccount:iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    - serviceAccount:iac-security-ro@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    - serviceAccount:iac-security-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    - serviceAccount:iac-vpcsc-ro@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    - serviceAccount:iac-vpcsc-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/cloudasset.viewer
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/cloudsupport.admin"]:
+    condition: []
+    members:
+    - group:fabric-fast-owners@google.com
+    org_id: '1234567890'
+    role: roles/cloudsupport.admin
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/cloudsupport.techSupportEditor"]:
+    condition: []
+    members:
+    - group:fabric-fast-owners@google.com
+    org_id: '1234567890'
+    role: roles/cloudsupport.techSupportEditor
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/compute.orgFirewallPolicyAdmin"]:
+    condition: []
+    members:
+    - serviceAccount:iac-networking-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/compute.orgFirewallPolicyAdmin
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/compute.orgFirewallPolicyUser"]:
+    condition: []
+    members:
+    - serviceAccount:iac-networking-ro@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/compute.orgFirewallPolicyUser
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/compute.osAdminLogin"]:
+    condition: []
+    members:
+    - group:fabric-fast-owners@google.com
+    org_id: '1234567890'
+    role: roles/compute.osAdminLogin
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/compute.osLoginExternalUser"]:
+    condition: []
+    members:
+    - group:fabric-fast-owners@google.com
+    org_id: '1234567890'
+    role: roles/compute.osLoginExternalUser
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/compute.viewer"]:
+    condition: []
+    members:
+    - serviceAccount:iac-networking-ro@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/compute.viewer
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/compute.xpnAdmin"]:
+    condition: []
+    members:
+    - group:fabric-fast-owners@google.com
+    - serviceAccount:iac-networking-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/compute.xpnAdmin
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/essentialcontacts.admin"]:
+    condition: []
+    members:
+    - serviceAccount:iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/essentialcontacts.admin
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/essentialcontacts.viewer"]:
+    condition: []
+    members:
+    - serviceAccount:iac-org-ro@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/essentialcontacts.viewer
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/iam.organizationRoleAdmin"]:
+    condition: []
+    members:
+    - serviceAccount:iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/iam.organizationRoleAdmin
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/iam.organizationRoleViewer"]:
+    condition: []
+    members:
+    - serviceAccount:iac-org-ro@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/iam.organizationRoleViewer
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/iam.workforcePoolAdmin"]:
+    condition: []
+    members:
+    - group:fabric-fast-owners@google.com
+    - serviceAccount:iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/iam.workforcePoolAdmin
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/iam.workforcePoolViewer"]:
+    condition: []
+    members:
+    - serviceAccount:iac-org-ro@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/iam.workforcePoolViewer
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/logging.admin"]:
+    condition: []
+    members:
+    - serviceAccount:iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/logging.admin
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/logging.viewer"]:
+    condition: []
+    members:
+    - serviceAccount:iac-org-ro@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/logging.viewer
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/orgpolicy.policyAdmin"]:
+    condition: []
+    members:
+    - group:fabric-fast-owners@google.com
+    - serviceAccount:iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/orgpolicy.policyAdmin
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/orgpolicy.policyViewer"]:
+    condition: []
+    members:
+    - serviceAccount:iac-org-ro@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/orgpolicy.policyViewer
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/owner"]:
+    condition: []
+    members:
+    - group:fabric-fast-owners@google.com
+    org_id: '1234567890'
+    role: roles/owner
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/resourcemanager.folderAdmin"]:
+    condition: []
+    members:
+    - group:fabric-fast-owners@google.com
+    - serviceAccount:iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/resourcemanager.folderAdmin
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/resourcemanager.folderViewer"]:
+    condition: []
+    members:
+    - serviceAccount:iac-org-ro@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/resourcemanager.folderViewer
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/resourcemanager.organizationAdmin"]:
+    condition: []
+    members:
+    - group:fabric-fast-owners@google.com
+    - serviceAccount:iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/resourcemanager.organizationAdmin
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/resourcemanager.projectCreator"]:
+    condition: []
+    members:
+    - group:fabric-fast-owners@google.com
+    - serviceAccount:iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/resourcemanager.projectCreator
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/resourcemanager.projectMover"]:
+    condition: []
+    members:
+    - serviceAccount:iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/resourcemanager.projectMover
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/resourcemanager.tagAdmin"]:
+    condition: []
+    members:
+    - group:fabric-fast-owners@google.com
+    - serviceAccount:iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/resourcemanager.tagAdmin
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/resourcemanager.tagUser"]:
+    condition: []
+    members:
+    - serviceAccount:iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/resourcemanager.tagUser
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/resourcemanager.tagViewer"]:
+    condition: []
+    members:
+    - serviceAccount:iac-org-ro@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/resourcemanager.tagViewer
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/serviceusage.serviceUsageViewer"]:
+    condition: []
+    members:
+    - serviceAccount:iac-org-ro@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/serviceusage.serviceUsageViewer
+  module.organization-iam[0].google_organization_iam_binding.bindings["pf_org_policy_admin"]:
+    condition:
+    - description: null
+      expression: resource.matchTag('1234567890/context', 'project-factory')
+      title: Project factory org policy admin
+    members:
+    - serviceAccount:iac-pf-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/orgpolicy.policyAdmin
+  module.organization-iam[0].google_organization_iam_binding.bindings["pf_org_policy_viewer"]:
+    condition:
+    - description: null
+      expression: resource.matchTag('1234567890/context', 'project-factory')
+      title: Project factory org policy viewer
+    members:
+    - serviceAccount:iac-pf-ro@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/orgpolicy.policyViewer
+  module.organization-iam[0].google_project_iam_member.bucket_sinks_binding["audit-logs"]:
+    condition:
+    - title: audit-logs bucket writer
+    role: roles/logging.bucketWriter
+  module.organization-iam[0].google_project_iam_member.bucket_sinks_binding["iam"]:
+    condition:
+    - title: iam bucket writer
+    role: roles/logging.bucketWriter
+  module.organization-iam[0].google_project_iam_member.bucket_sinks_binding["vpc-sc"]:
+    condition:
+    - title: vpc-sc bucket writer
+    role: roles/logging.bucketWriter
+  ? module.organization-iam[0].google_tags_tag_value_iam_binding.default["environment/development:roles/resourcemanager.tagUser"]
+  : condition: []
+    members:
+    - serviceAccount:iac-networking-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    - serviceAccount:iac-pf-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    - serviceAccount:iac-security-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    role: roles/resourcemanager.tagUser
+  ? module.organization-iam[0].google_tags_tag_value_iam_binding.default["environment/development:roles/resourcemanager.tagViewer"]
+  : condition: []
+    members:
+    - serviceAccount:iac-networking-ro@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    - serviceAccount:iac-pf-ro@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    - serviceAccount:iac-security-ro@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    role: roles/resourcemanager.tagViewer
+  ? module.organization-iam[0].google_tags_tag_value_iam_binding.default["environment/production:roles/resourcemanager.tagUser"]
+  : condition: []
+    members:
+    - serviceAccount:iac-networking-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    - serviceAccount:iac-pf-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    - serviceAccount:iac-security-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    role: roles/resourcemanager.tagUser
+  ? module.organization-iam[0].google_tags_tag_value_iam_binding.default["environment/production:roles/resourcemanager.tagViewer"]
+  : condition: []
+    members:
+    - serviceAccount:iac-networking-ro@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    - serviceAccount:iac-pf-ro@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    - serviceAccount:iac-security-ro@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    role: roles/resourcemanager.tagViewer
+  module.organization[0].google_essential_contacts_contact.contact["$email_addresses:gcp-organization-admins"]:
+    email: $email_addresses:gcp-organization-admins
+    language_tag: en
+    notification_category_subscriptions:
+    - ALL
+    parent: organizations/1234567890
+    timeouts: null
+  module.organization[0].google_logging_organization_settings.default[0]:
+    organization: '1234567890'
+    storage_location: europe-west1
+    timeouts: null
+  module.organization[0].google_organization_iam_custom_role.roles["network_firewall_policies_admin"]:
+    deletion_policy: DELETE
+    description: Terraform-managed.
+    org_id: '1234567890'
+    permissions:
+    - compute.networks.setFirewallPolicy
+    - networksecurity.firewallEndpointAssociations.create
+    - networksecurity.firewallEndpointAssociations.delete
+    - networksecurity.firewallEndpointAssociations.get
+    - networksecurity.firewallEndpointAssociations.list
+    - networksecurity.firewallEndpointAssociations.update
+    role_id: networkFirewallPoliciesAdmin
+    stage: GA
+    title: Custom role networkFirewallPoliciesAdmin
+  module.organization[0].google_organization_iam_custom_role.roles["ngfw_enterprise_admin"]:
+    deletion_policy: DELETE
+    description: Terraform-managed.
+    org_id: '1234567890'
+    permissions:
+    - networksecurity.firewallEndpoints.create
+    - networksecurity.firewallEndpoints.delete
+    - networksecurity.firewallEndpoints.get
+    - networksecurity.firewallEndpoints.list
+    - networksecurity.firewallEndpoints.update
+    - networksecurity.firewallEndpoints.use
+    - networksecurity.locations.get
+    - networksecurity.locations.list
+    - networksecurity.operations.cancel
+    - networksecurity.operations.delete
+    - networksecurity.operations.get
+    - networksecurity.operations.list
+    - networksecurity.securityProfileGroups.create
+    - networksecurity.securityProfileGroups.delete
+    - networksecurity.securityProfileGroups.get
+    - networksecurity.securityProfileGroups.list
+    - networksecurity.securityProfileGroups.update
+    - networksecurity.securityProfileGroups.use
+    - networksecurity.securityProfiles.create
+    - networksecurity.securityProfiles.delete
+    - networksecurity.securityProfiles.get
+    - networksecurity.securityProfiles.list
+    - networksecurity.securityProfiles.update
+    - networksecurity.securityProfiles.use
+    - networksecurity.tlsInspectionPolicies.create
+    - networksecurity.tlsInspectionPolicies.delete
+    - networksecurity.tlsInspectionPolicies.get
+    - networksecurity.tlsInspectionPolicies.list
+    - networksecurity.tlsInspectionPolicies.update
+    - networksecurity.tlsInspectionPolicies.use
+    role_id: ngfwEnterpriseAdmin
+    stage: GA
+    title: Custom role ngfwEnterpriseAdmin
+  module.organization[0].google_organization_iam_custom_role.roles["ngfw_enterprise_viewer"]:
+    deletion_policy: DELETE
+    description: Terraform-managed.
+    org_id: '1234567890'
+    permissions:
+    - networksecurity.firewallEndpoints.get
+    - networksecurity.firewallEndpoints.list
+    - networksecurity.firewallEndpoints.use
+    - networksecurity.locations.get
+    - networksecurity.locations.list
+    - networksecurity.operations.get
+    - networksecurity.operations.list
+    - networksecurity.securityProfileGroups.get
+    - networksecurity.securityProfileGroups.list
+    - networksecurity.securityProfileGroups.use
+    - networksecurity.securityProfiles.get
+    - networksecurity.securityProfiles.list
+    - networksecurity.securityProfiles.use
+    - networksecurity.tlsInspectionPolicies.get
+    - networksecurity.tlsInspectionPolicies.list
+    - networksecurity.tlsInspectionPolicies.use
+    role_id: ngfwEnterpriseViewer
+    stage: GA
+    title: Custom role ngfwEnterpriseViewer
+  module.organization[0].google_organization_iam_custom_role.roles["organization_admin_viewer"]:
+    deletion_policy: DELETE
+    description: Terraform-managed.
+    org_id: '1234567890'
+    permissions:
+    - essentialcontacts.contacts.get
+    - essentialcontacts.contacts.list
+    - logging.settings.get
+    - orgpolicy.constraints.list
+    - orgpolicy.policies.list
+    - orgpolicy.policy.get
+    - resourcemanager.folders.get
+    - resourcemanager.folders.getIamPolicy
+    - resourcemanager.folders.list
+    - resourcemanager.organizations.get
+    - resourcemanager.organizations.getIamPolicy
+    - resourcemanager.projects.get
+    - resourcemanager.projects.getIamPolicy
+    - resourcemanager.projects.list
+    - storage.buckets.getIamPolicy
+    role_id: organizationAdminViewer
+    stage: GA
+    title: Custom role organizationAdminViewer
+  module.organization[0].google_organization_iam_custom_role.roles["organization_iam_admin"]:
+    deletion_policy: DELETE
+    description: Terraform-managed.
+    org_id: '1234567890'
+    permissions:
+    - resourcemanager.organizations.get
+    - resourcemanager.organizations.getIamPolicy
+    - resourcemanager.organizations.setIamPolicy
+    role_id: organizationIamAdmin
+    stage: GA
+    title: Custom role organizationIamAdmin
+  module.organization[0].google_organization_iam_custom_role.roles["project_iam_viewer"]:
+    deletion_policy: DELETE
+    description: Terraform-managed.
+    org_id: '1234567890'
+    permissions:
+    - iam.policybindings.get
+    - iam.policybindings.list
+    - resourcemanager.projects.get
+    - resourcemanager.projects.getIamPolicy
+    - resourcemanager.projects.searchPolicyBindings
+    role_id: projectIamViewer
+    stage: GA
+    title: Custom role projectIamViewer
+  module.organization[0].google_organization_iam_custom_role.roles["service_project_network_admin"]:
+    deletion_policy: DELETE
+    description: Terraform-managed.
+    org_id: '1234567890'
+    permissions:
+    - compute.globalOperations.get
+    - compute.networks.get
+    - compute.networks.updatePeering
+    - compute.organizations.disableXpnResource
+    - compute.organizations.enableXpnResource
+    - compute.projects.get
+    - compute.subnetworks.getIamPolicy
+    - compute.subnetworks.setIamPolicy
+    - dns.networks.bindPrivateDNSZone
+    - resourcemanager.projects.get
+    role_id: serviceProjectNetworkAdmin
+    stage: GA
+    title: Custom role serviceProjectNetworkAdmin
+  module.organization[0].google_organization_iam_custom_role.roles["storage_viewer"]:
+    deletion_policy: DELETE
+    description: Terraform-managed.
+    org_id: '1234567890'
+    permissions:
+    - storage.buckets.get
+    - storage.buckets.getIamPolicy
+    - storage.buckets.getObjectInsights
+    - storage.buckets.list
+    - storage.buckets.listEffectiveTags
+    - storage.buckets.listTagBindings
+    - storage.managedFolders.get
+    - storage.managedFolders.getIamPolicy
+    - storage.managedFolders.list
+    - storage.multipartUploads.list
+    - storage.multipartUploads.listParts
+    - storage.objects.get
+    - storage.objects.getIamPolicy
+    - storage.objects.list
+    role_id: storageViewer
+    stage: GA
+    title: Custom role storageViewer
+  module.organization[0].google_organization_iam_custom_role.roles["tag_viewer"]:
+    deletion_policy: DELETE
+    description: Terraform-managed.
+    org_id: '1234567890'
+    permissions:
+    - resourcemanager.tagHolds.list
+    - resourcemanager.tagKeys.get
+    - resourcemanager.tagKeys.getIamPolicy
+    - resourcemanager.tagKeys.list
+    - resourcemanager.tagValues.get
+    - resourcemanager.tagValues.getIamPolicy
+    - resourcemanager.tagValues.list
+    role_id: tagViewer
+    stage: GA
+    title: Custom role tagViewer
+  module.organization[0].google_tags_tag_key.default["context"]:
+    allowed_values_regex: null
+    description: Organization-level contexts.
+    parent: organizations/1234567890
+    purpose: null
+    purpose_data: null
+    short_name: context
+    timeouts: null
+  module.organization[0].google_tags_tag_key.default["environment"]:
+    allowed_values_regex: null
+    description: Organization-level environments.
+    parent: organizations/1234567890
+    purpose: null
+    purpose_data: null
+    short_name: environment
+    timeouts: null
+  module.organization[0].google_tags_tag_key.default["org-policies"]:
+    allowed_values_regex: null
+    description: Organization policy condition tags.
+    parent: organizations/1234567890
+    purpose: null
+    purpose_data: null
+    short_name: org-policies
+    timeouts: null
+  module.organization[0].google_tags_tag_value.default["context/project-factory"]:
+    description: Project factory.
+    short_name: project-factory
+    timeouts: null
+  module.organization[0].google_tags_tag_value.default["environment/development"]:
+    description: Development.
+    short_name: development
+    timeouts: null
+  module.organization[0].google_tags_tag_value.default["environment/production"]:
+    description: Production.
+    short_name: production
+    timeouts: null
+  module.organization[0].google_tags_tag_value.default["org-policies/allowed-essential-contacts-domains-all"]:
+    description: Allow all domains in essntial contacts org policy.
+    short_name: allowed-essential-contacts-domains-all
+    timeouts: null
+  module.organization[0].google_tags_tag_value.default["org-policies/allowed-policy-member-domains-all"]:
+    description: Allow all domains in DRS org policy.
+    short_name: allowed-policy-member-domains-all
+    timeouts: null
+  terraform_data.precondition:
+    input: null
+    output: null
+    triggers_replace: null
+  terraform_data.precondition_cicd:
+    input: null
+    output: null
+    triggers_replace: null
+
+counts:
+  google_bigquery_dataset: 1
+  google_bigquery_default_service_account: 2
+  google_billing_account_iam_member: 6
+  google_essential_contacts_contact: 1
+  google_folder: 7
+  google_folder_iam_binding: 33
+  google_logging_organization_settings: 1
+  google_logging_organization_sink: 3
+  google_logging_project_bucket_config: 3
+  google_logging_project_settings: 2
+  google_org_policy_custom_constraint: 1
+  google_org_policy_policy: 37
+  google_organization_iam_audit_config: 1
+  google_organization_iam_binding: 37
+  google_organization_iam_custom_role: 9
+  google_project: 3
+  google_project_iam_audit_config: 3
+  google_project_iam_binding: 17
+  google_project_iam_member: 15
+  google_project_service: 33
+  google_project_service_identity: 9
+  google_service_account: 12
+  google_service_account_iam_binding: 2
+  google_service_account_iam_member: 4
+  google_storage_bucket: 3
+  google_storage_bucket_iam_binding: 4
+  google_storage_bucket_object: 10
+  google_storage_managed_folder: 4
+  google_storage_managed_folder_iam_binding: 8
+  google_storage_project_service_account: 3
+  google_tags_tag_binding: 5
+  google_tags_tag_key: 3
+  google_tags_tag_value: 5
+  google_tags_tag_value_iam_binding: 4
+  local_file: 9
+  modules: 47
+  resources: 304
+  terraform_data: 4
+
+outputs:
+  iam_principals:
+    domain: domain:example.org
+    gcp-organization-admins: group:fabric-fast-owners@google.com
+  projects: __missing__
+  subnet_ips: {}
+  subnet_self_links: {}
+  tfvars: __missing__
+  vpc_self_links: {}

--- a/tests/fast/stages/s0_org_setup/tftest.yaml
+++ b/tests/fast/stages/s0_org_setup/tftest.yaml
@@ -35,3 +35,8 @@ tests:
       - customizations.yaml
     extra_dirs:
       - ../../../tests/fast/stages/s0_org_setup/data-customizations
+  groups:
+    inventory:
+      - groups.yaml
+    extra_dirs:
+      - ../../../tests/fast/stages/s0_org_setup/data-simple


### PR DESCRIPTION
**What:** add a groups variable to 0-org-setup controlling which predefined group names are derived into iam_principals from the org domain. Default= the current 7, so fully backward-compatible.

**Why:** consumers that only bind gcp-organization-admins currently carry 6 unused group:…@domain entries in the published iam_principals map / downstream globals. This lets them trim to the groups they actually use (e.g. groups = ["gcp-organization-admins"]).

**Tests:** existing cases pass unchanged (backward-compat); new groups tftest case proves the trim. terraform fmt, tfdoc, and the stage tests pass.