### PR TITLE
fix(fast): grant custom storage_viewer role to iac-pf-ro on Teams folder

### DIFF
--- a/fast/stages/0-org-setup/datasets/classic/folders/teams/.config.yaml
+++ b/fast/stages/0-org-setup/datasets/classic/folders/teams/.config.yaml
@@ -26,5 +26,6 @@ iam_by_principals:
     - roles/viewer
     - roles/resourcemanager.folderViewer
     - roles/resourcemanager.tagViewer
+    - $custom_roles:storage_viewer
 tag_bindings:
   context: $tag_values:context/project-factory


### PR DESCRIPTION
This PR adds the custom storage_viewer role to the read-only project factory service account (iac-pf-ro) on the Teams folder config. This resolves the 403 permission denied error on storage.buckets.getIamPolicy during terraform plan.