### PR TITLE
Consistent types for_each net-vpc-firewall in custom_rules dynamic blocks

### DIFF
--- a/modules/net-vpc-firewall/README.md
+++ b/modules/net-vpc-firewall/README.md
@@ -194,7 +194,7 @@ module "firewall" {
   }
   default_rules_config = { disabled = true }
 }
-# tftest modules=1 resources=3 files=lbs,cidrs inventory=factory.yaml
+# tftest modules=1 resources=4 files=lbs,cidrs inventory=factory.yaml
 ```
 
 ```yaml
@@ -220,6 +220,16 @@ ingress:
         ports:
           - 80
           - 443
+  allow-admin-mixed:
+    description: Allow ICMP plus SSH/RDP from the admin range (mixed protocols).
+    source_ranges:
+      - 10.0.0.0/8
+    rules:
+      - protocol: icmp
+      - protocol: tcp
+        ports:
+          - 22
+          - 3389
 egress:
   block-telnet:
     description: block outbound telnet
@@ -262,7 +272,7 @@ module "firewall" {
     ]
   }
 }
-# tftest modules=1 resources=3 files=lbs inventory=factory.yaml
+# tftest modules=1 resources=4 files=lbs inventory=factory.yaml
 ```
 <!-- BEGIN TFDOC -->
 ## Variables

--- a/modules/net-vpc-firewall/main.tf
+++ b/modules/net-vpc-firewall/main.tf
@@ -178,7 +178,7 @@ resource "google_compute_firewall" "custom_rules" {
   }
 
   dynamic "deny" {
-    for_each = each.value.action == "DENY" ? each.value.rules : {}
+    for_each = { for k, v in each.value.rules : k => v if each.value.action == "DENY" }
     iterator = rule
     content {
       protocol = rule.value.protocol
@@ -187,7 +187,7 @@ resource "google_compute_firewall" "custom_rules" {
   }
 
   dynamic "allow" {
-    for_each = each.value.action == "ALLOW" ? each.value.rules : {}
+    for_each = { for k, v in each.value.rules : k => v if each.value.action == "ALLOW" }
     iterator = rule
     content {
       protocol = rule.value.protocol

--- a/tests/modules/net_vpc_firewall/examples/factory.yaml
+++ b/tests/modules/net_vpc_firewall/examples/factory.yaml
@@ -13,6 +13,29 @@
 # limitations under the License.
 
 values:
+  module.firewall.google_compute_firewall.custom_rules["allow-admin-mixed"]:
+    allow:
+    - ports:
+      - '22'
+      - '3389'
+      protocol: tcp
+    - ports: []
+      protocol: icmp
+    deny: []
+    description: Allow ICMP plus SSH/RDP from the admin range (mixed protocols).
+    direction: INGRESS
+    disabled: false
+    log_config: []
+    name: allow-admin-mixed
+    network: vpc-name
+    priority: 1000
+    project: project-id
+    source_ranges:
+    - 10.0.0.0/8
+    source_service_accounts: null
+    source_tags: null
+    target_service_accounts: null
+    target_tags: null
   module.firewall.google_compute_firewall.custom_rules["allow-healthchecks"]:
     allow:
     - ports:
@@ -82,4 +105,4 @@ values:
     target_tags: null
 
 counts:
-  google_compute_firewall: 3
+  google_compute_firewall: 4


### PR DESCRIPTION
  The allow/deny dynamic blocks used
  `for_each = each.value.action == "X" ? each.value.rules : {}`. The branches have
  inconsistent types (a populated object vs the empty object `{}`), so a plan fails
  with "Inconsistent conditional result types" when each.value.rules is
  heterogeneous — i.e. some rule entries set `ports` and some don't. The typed
  ingress_rules/egress_rules path coerces entries to one type and hides it; factory
  rules (yamldecode, untyped) don't, so it surfaces there. It's plan-time, so
  `validate` misses it.

  Use a filtered for-expression instead — always a map of consistent type, identical
  output:
    for_each = { for k, v in each.value.rules : k => v if each.value.action == "X" }

  Adds a factory example with a mixed icmp/tcp rule that reproduces it.

<!-- Put a description of what this PR is for here -->

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [x] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
