### PR TITLE
Add server TLS policy support to net-lb-app-int-cross-region

### DIFF
--- a/modules/net-lb-app-int-cross-region/README.md
+++ b/modules/net-lb-app-int-cross-region/README.md
@@ -870,9 +870,9 @@ When deploying changes to load balancer configuration please refer to [net-lb-ap
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [name](variables.tf#L88) | Load balancer name. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L169) | Project id. | <code>string</code> | ✓ |  |
-| [vpc_config](variables.tf#L211) | VPC-level configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
+| [name](variables.tf#L89) | Load balancer name. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L170) | Project id. | <code>string</code> | ✓ |  |
+| [vpc_config](variables.tf#L212) | VPC-level configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
 | [addresses](variables.tf#L17) | Optional IP address used for the forwarding rule. | <code>map&#40;string&#41;</code> |  | <code>null</code> |
 | [backend_service_configs](variables-backend-service.tf#L19) | Backend service level configuration. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [context](variables.tf#L23) | Context-specific interpolations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
@@ -881,12 +881,12 @@ When deploying changes to load balancer configuration please refer to [net-lb-ap
 | [health_check_configs](variables-health-check.tf#L19) | Optional auto-created health check configurations, use the output self-link to set it in the auto healing policy. Refer to examples for usage. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#8230;&#125;</code> |
 | [http_proxy_config](variables.tf#L57) | HTTP proxy configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [https_proxy_config](variables.tf#L68) | HTTPS proxy configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [labels](variables.tf#L82) | Labels set on resources. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
-| [neg_configs](variables.tf#L93) | Optional network endpoint groups to create. Can be referenced in backends via key or outputs. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [ports](variables.tf#L159) | Optional ports for HTTP load balancer. | <code>list&#40;string&#41;</code> |  | <code>null</code> |
-| [protocol](variables.tf#L174) | Protocol supported by this load balancer. | <code>string</code> |  | <code>&#34;HTTP&#34;</code> |
-| [service_attachment](variables.tf#L187) | PSC service attachments. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [service_directory_registration](variables.tf#L202) | Service directory namespace and service used to register this load balancer. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [labels](variables.tf#L83) | Labels set on resources. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [neg_configs](variables.tf#L94) | Optional network endpoint groups to create. Can be referenced in backends via key or outputs. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [ports](variables.tf#L160) | Optional ports for HTTP load balancer. | <code>list&#40;string&#41;</code> |  | <code>null</code> |
+| [protocol](variables.tf#L175) | Protocol supported by this load balancer. | <code>string</code> |  | <code>&#34;HTTP&#34;</code> |
+| [service_attachment](variables.tf#L188) | PSC service attachments. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [service_directory_registration](variables.tf#L203) | Service directory namespace and service used to register this load balancer. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
 | [urlmap_config](variables-urlmap.tf#L19) | The URL map configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#8230;&#125;</code> |
 
 ## Outputs

--- a/modules/net-lb-app-int-cross-region/README.md
+++ b/modules/net-lb-app-int-cross-region/README.md
@@ -19,6 +19,7 @@ Due to the complexity of the underlying resources, changes to the configuration 
     - [Private Service Connect NEG creation](#private-service-connect-neg-creation)
   - [URL Map](#url-map)
   - [PSC service attachment](#psc-service-attachment)
+  - [mTLS with Server TLS Policy](#mtls-with-server-tls-policy)
   - [Complex example](#complex-example)
 - [Deploying changes to load balancer configurations](#deploying-changes-to-load-balancer-configurations)
 - [Recipes](#recipes)
@@ -634,6 +635,45 @@ module "ilb-l7" {
 # tftest modules=1 resources=9
 ```
 
+
+### mTLS with Server TLS Policy
+
+To enable mutual TLS (mTLS) on a cross-region internal Application Load Balancer,
+attach an existing `ServerTlsPolicy` to the HTTPS proxy via `https_proxy_config.server_tls_policy`.
+The module does not create the trust config or policy; it only attaches an existing one.
+See the [mTLS documentation](https://cloud.google.com/load-balancing/docs/mtls) for details.
+
+```hcl
+module "ilb-l7" {
+  source     = "./fabric/modules/net-lb-app-int-cross-region"
+  name       = "ilb-test"
+  project_id = var.project_id
+  backend_service_configs = {
+    default = {
+      backends = [{
+        group = "projects/myprj/zones/europe-west1-a/instanceGroups/my-ig-ew1"
+        }, {
+        group = "projects/myprj/zones/europe-west4-a/instanceGroups/my-ig-ew4"
+      }]
+    }
+  }
+  protocol = "HTTPS"
+  https_proxy_config = {
+    certificate_manager_certificates = [
+      "projects/myprj/locations/global/certificates/certificate"
+    ]
+    server_tls_policy = "projects/myprj/locations/global/serverTlsPolicies/my-tls-policy"
+  }
+  vpc_config = {
+    network = var.vpc.self_link
+    subnetworks = {
+      europe-west1 = var.subnet1.self_link
+      europe-west4 = var.subnet2.self_link
+    }
+  }
+}
+# tftest modules=1 resources=6
+```
 
 ### Complex example
 

--- a/modules/net-lb-app-int-cross-region/main.tf
+++ b/modules/net-lb-app-int-cross-region/main.tf
@@ -228,6 +228,7 @@ resource "google_compute_target_https_proxy" "default" {
   http_keep_alive_timeout_sec      = var.https_proxy_config.http_keepalive_timeout
   quic_override                    = var.https_proxy_config.quic_override
   ssl_policy                       = var.https_proxy_config.ssl_policy
+  server_tls_policy                = var.https_proxy_config.server_tls_policy
   url_map                          = google_compute_url_map.default.id
 }
 

--- a/modules/net-lb-app-int-cross-region/variables.tf
+++ b/modules/net-lb-app-int-cross-region/variables.tf
@@ -74,6 +74,7 @@ variable "https_proxy_config" {
     http_keepalive_timeout           = optional(string)
     quic_override                    = optional(string)
     ssl_policy                       = optional(string)
+    server_tls_policy                = optional(string)
   })
   default  = {}
   nullable = false


### PR DESCRIPTION
This adds a passthrough for `server_tls_policy` on the cross-region internal Application Load Balancer HTTPS proxy configuration.

The field lets users attach a Network Security `ServerTlsPolicy` to the target HTTPS proxy, which is required for frontend mTLS on cross-region internal Application Load Balancers. The module does not create the trust config or server TLS policy; it only allows an existing policy to be attached.

Google Cloud mTLS docs: https://cloud.google.com/load-balancing/docs/mtls

Checks run:
- `terraform fmt -recursive modules/net-lb-app-int-cross-region`
- `.venv/bin/python tools/tfdoc.py modules/net-lb-app-int-cross-region`
- `.venv/bin/pytest tests/modules/net_lb_app_int_cross_region`