### PR TITLE
Standardize net-lb family interfaces and features

### DIFF
--- a/adrs/20260615-net-lb-interface-standardization.md
+++ b/adrs/20260615-net-lb-interface-standardization.md
@@ -1,0 +1,198 @@
+# Standardizing Interfaces and Features in the `net-lb` Module Family
+
+**authors:** Antigravity (AI Assistant)
+**date:** June 15, 2026
+
+## Status
+
+Proposed
+
+## Context
+
+The `net-lb` family in Cloud Foundation Fabric (CFF) consists of 8 modules covering different regional, global, and cross-region load balancer types (L4 and L7, internal and external):
+
+| Module | LB Type | Scope | Protocol |
+| :--- | :--- | :--- | :--- |
+| [`net-lb-int`](file:///home/ludomagno/dev/tf-playground/cloud-foundation-fabric/modules/net-lb-int) | Internal Passthrough NLB | Regional | L4 (TCP/UDP) |
+| [`net-lb-ext`](file:///home/ludomagno/dev/tf-playground/cloud-foundation-fabric/modules/net-lb-ext) | External Passthrough NLB | Regional | L4 (TCP/UDP) |
+| [`net-lb-proxy-int`](file:///home/ludomagno/dev/tf-playground/cloud-foundation-fabric/modules/net-lb-proxy-int) | Internal Proxy LB | Regional | L4 (TCP) |
+| [`net-lb-proxy-int-cross-region`](file:///home/ludomagno/dev/tf-playground/cloud-foundation-fabric/modules/net-lb-proxy-int-cross-region) | Internal Proxy LB | Cross-Region | L4 (TCP) |
+| [`net-lb-app-int`](file:///home/ludomagno/dev/tf-playground/cloud-foundation-fabric/modules/net-lb-app-int) | Internal Application LB | Regional | L7 (HTTP/S) |
+| [`net-lb-app-int-cross-region`](file:///home/ludomagno/dev/tf-playground/cloud-foundation-fabric/modules/net-lb-app-int-cross-region) | Internal Application LB | Cross-Region | L7 (HTTP/S) |
+| [`net-lb-app-ext`](file:///home/ludomagno/dev/tf-playground/cloud-foundation-fabric/modules/net-lb-app-ext) | External Application LB | Global | L7 (HTTP/S) |
+| [`net-lb-app-ext-regional`](file:///home/ludomagno/dev/tf-playground/cloud-foundation-fabric/modules/net-lb-app-ext-regional) | External Application LB | Regional | L7 (HTTP/S) |
+
+These modules currently exhibit several interface inconsistencies (e.g. backend naming `group` vs `backend`, different styles for VPC config, missing context support) and, in some cases, implement invalid or unsupported features (e.g. failover and connection tracking in proxy/application load balancers) or have gaps in feature parity (e.g. URL map capabilities).
+
+### Interface Matrix (Current State)
+
+| Module | Forwarding Rules Style | Backends Style | Backend Key Name | Health Check Style | VPC Config Style | Context Support |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| `net-lb-int` | Multi (Map) | External List | `group` | Single (Object) | Regional (Object) | Yes |
+| `net-lb-ext` | Multi (Map) | External List | `group` | Single (Object) | None | No |
+| `net-lb-proxy-int` | Multi (Map) | Nested (Object) | `group` | Single (Object) | Regional (Object) | Yes |
+| `net-lb-proxy-int-cr` | Single (Scalar) | Nested (Object) | `group` | Single (Object) | Cross-Region (Map) | Yes |
+| `net-lb-app-int` | Single (Scalar) | Nested (Map) | `group` | Multi (Map) | Regional (Object) | Yes |
+| `net-lb-app-int-cr` | Single (Scalar) | Nested (Map) | `group` | Multi (Map) | Cross-Region (Map) | No |
+| `net-lb-app-ext` | Multi (Map) | Nested (Map) | `backend` | Multi (Map) | None | Yes |
+| `net-lb-app-ext-reg` | Single (Scalar) | Nested (Map) | `backend` | Multi (Map) | Network (String) | No |
+
+### Resource Relationships and Interface Fit
+
+The mapping of Terraform resources explains some necessary design differences (such as forwarding rule styles) but highlights where standardization is possible:
+
+1.  **Passthrough NLBs (`net-lb-int`, `net-lb-ext`)**: Forwarding Rules -> Backend Service (Direct). No proxy. Multiple rules targeting one service fits a `forwarding_rules_config` map and a flat `backends` list.
+2.  **Proxy LBs (Regional L4) (`net-lb-proxy-int`)**: Forwarding Rules -> Target Proxy -> Backend Service. Multiple rules point to one proxy and one backend service.
+3.  **Proxy LBs (Cross-Region L4) (`net-lb-proxy-int-cross-region`)**: Global Forwarding Rules (per subnet/region) -> Global Target Proxy -> Global Backend Service. Driven by a map of subnetworks (one rule per region).
+4.  **Application LBs (Regional L7) (`net-lb-app-int`, `net-lb-app-ext-regional`)**: Forwarding Rule(s) -> Target Proxy -> URL Map -> Backend Services (Multiple). URL Map routes to multiple backend services, requiring a map-based `backend_service_configs`.
+5.  **Application LBs (Global/Cross-Region L7) (`net-lb-app-ext`, `net-lb-app-int-cross-region`)**: Global Forwarding Rules -> Global Target Proxy -> Global URL Map -> Global Backend Services.
+
+## Decision
+
+To improve consistency, maintainability, and correctness across the module family, we will implement the following changes:
+
+### 1. Standardize Backend Key Name to `group`
+We will standardize on `group` across all modules.
+*   Rename `backend` to `group` in `net-lb-app-ext` and `net-lb-app-ext-regional` variables.
+*   *Reasoning*: While `backend` is a generic term, `group` matches the actual Terraform provider attribute name (`group` inside the `backend` block of `google_compute_backend_service` and `google_compute_region_backend_service` for both IGs and NEGs) and is already used by 6 out of 8 modules.
+
+### 2. Align VPC Config for Regional External ALB
+*   In `net-lb-app-ext-regional`, replace the top-level `vpc` (string) variable with a `vpc_config` object containing only the `network` attribute to match the internal modules' pattern.
+    ```hcl
+    variable "vpc_config" {
+      type = object({
+        network = string
+      })
+    }
+    ```
+
+### 3. Remove Unsupported/Invalid Features
+We will remove configuration blocks and variables for features that are not supported by the underlying GCP load balancer type, despite being supported by the shared Terraform resource type:
+*   **Connection Tracking**: Only supported for Passthrough NLBs. We will remove `connection_tracking` from `net-lb-proxy-int` variables and code (which also contains a syntax typo bug `ar.backend_service_config`).
+*   **Failover Configuration**: Only supported at backend service level for Passthrough NLBs. We will remove failover variables and configurations from `net-lb-proxy-int`, `net-lb-app-int`, `net-lb-app-ext`, and `net-lb-app-ext-regional`.
+
+### 4. Implement Context Support
+We will add `context` support to the three modules currently missing it:
+*   `net-lb-ext`: requires `addresses`, `project_ids`, `subnets` (for IPv6).
+*   `net-lb-app-int-cross-region`: requires `networks`, `subnets`, `project_ids`, `addresses`, `locations`.
+*   `net-lb-app-ext-regional`: requires `networks`, `subnets`, `project_ids`, `addresses`, `locations`.
+
+### 5. Align URL Map Features
+We will align URL map capabilities across all L7 modules, as both global and regional URL map provider resources support top-level routing and header actions:
+*   **Fix Bug**: Implement the missing top-level `header_action` in `net-lb-app-ext-regional`'s `urlmap.tf` (it is currently defined in variables but ignored in code).
+*   **Implement Gaps**: Add top-level `default_route_action` and `header_action` to variables and resource blocks in `net-lb-app-int` and `net-lb-app-int-cross-region`.
+
+### 6. Accept Forwarding Rules Design Differences
+*   We accept that some modules use a Multi-Rule (Map) pattern (using `forwarding_rules_config`) and others use a Single-Rule (Scalar) pattern (using `address`/`ports`). This is an intentional design choice that aligns with the typical deployment patterns and usability of the specific load balancer type (e.g. regional internal ALBs usually only have one forwarding rule per target proxy, whereas passthrough NLBs benefit from multiple rules).
+
+#### Multi-Rule Pattern (Map) Type Definition
+```hcl
+variable "forwarding_rules_config" {
+  type = map(object({
+    address       = optional(string)
+    description   = optional(string)
+    global_access = optional(bool, true)
+    ipv6          = optional(bool, false)
+    name          = optional(string)
+    ports         = optional(list(string), null)
+    protocol      = optional(string, "TCP")
+  }))
+}
+```
+
+#### Single-Rule Pattern (Scalar) Type Definition
+```hcl
+variable "address" {
+  type    = string
+  default = null
+}
+variable "ports" {
+  type    = list(string)
+  default = null
+}
+```
+
+## Consequences
+
+*   **Consistency**: Standardizing backend keys and VPC configuration makes it easier to swap or compare load balancer modules.
+*   **Correctness**: Removing unsupported blocks like failover and connection tracking from proxy/app LBs prevents users from writing invalid Terraform configurations that would fail at apply time or behave unexpectedly.
+*   **Feature Completeness**: Fixes a bug in `net-lb-app-ext-regional` and brings all L7 modules to parity regarding URL map routing capabilities.
+*   **Portability**: Adding `context` support enables consistent symbolic resolution in landing zones (e.g. FAST) for all load balancer types.
+
+## Reasoning
+
+Standardizing on the provider's resource terminology (`group`) is preferred over generic terms (`backend`) to remain close to the provider's API. Removing dead code (unused failover variables) and invalid blocks ensures the modules remain lean and correct. Preserving the forwarding rules difference is a pragmatic decision that prioritizes usability over strict uniformity.
+
+## Implementation
+
+The standardization will be carried out across the following modules:
+1.  `net-lb-ext`: Implement context support.
+2.  `net-lb-proxy-int`: Remove connection tracking and failover.
+3.  `net-lb-app-int`: Remove failover; implement top-level URL map routing/header actions.
+4.  `net-lb-app-int-cross-region`: Implement context support; implement top-level URL map routing/header actions.
+5.  `net-lb-app-ext`: Rename `backend` -> `group` in variables; remove failover variables.
+6.  `net-lb-app-ext-regional`: Rename `backend` -> `group` in variables; replace `vpc` with `vpc_config`; remove failover variables; implement missing URL map `header_action`; implement context support.
+
+---
+
+## Appendix: Interface Examples
+
+### 1. Multi-Rule Pattern with External Backends (`net-lb-int`)
+
+```hcl
+module "nlb" {
+  source     = "./modules/net-lb-int"
+  project_id = "my-project"
+  region     = "europe-west1"
+  name       = "my-nlb"
+
+  vpc_config = {
+    network    = "my-vpc"
+    subnetwork = "my-subnet"
+  }
+
+  forwarding_rules_config = {
+    tcp = {
+      protocol = "TCP"
+      ports    = ["80", "443"]
+    }
+    udp = {
+      protocol = "UDP"
+      ports    = ["53"]
+    }
+  }
+
+  backends = [
+    { group = "instance-group-1" },
+    { group = "instance-group-2" } # Failover removed in this ADR
+  ]
+}
+```
+
+### 2. Single-Rule Pattern with Nested Backends (`net-lb-app-int`)
+
+```hcl
+module "ilb" {
+  source     = "./modules/net-lb-app-int"
+  project_id = "my-project"
+  region     = "europe-west1"
+  name       = "my-ilb"
+
+  vpc_config = {
+    network    = "my-vpc"
+    subnetwork = "my-subnet"
+  }
+
+  protocol = "HTTP"
+  ports    = ["80"]
+
+  backend_service_configs = {
+    default = {
+      backends = [
+        { group = "neg-1" },
+        { group = "neg-2" }
+      ]
+    }
+  }
+}
+```

--- a/adrs/20260615-net-lb-interface-standardization.md
+++ b/adrs/20260615-net-lb-interface-standardization.md
@@ -217,7 +217,38 @@ Each module was tested using specific scenarios defined in `tfvars` files. Below
     }
     ```
 
-#### 3. `net-lb-app-int`
+#### 3. `net-lb-proxy-int-cross-region`
+
+*   **Multi-region MIGs (`test-cr-migs.tfvars`)**
+    ```hcl
+    project_id = "$project_ids:gce"
+    name       = "test-ilb-l4-proxy-cr"
+    vpc_config = {
+      network = "$networks:dev"
+      subnetworks = {
+        europe-west1 = "$subnets:dev/europe-west1/gce"
+        europe-west8 = "$subnets:dev/europe-west8/gce"
+      }
+    }
+    backend_service_config = {
+      backends = [
+        { 
+          group = "projects/gce-project-id/zones/europe-west1-b/instanceGroups/mig-name-ew1"
+          max_connections = {
+            per_group = 100
+          }
+        },
+        { 
+          group = "projects/gce-project-id/zones/europe-west8-b/instanceGroups/mig-name-ew8"
+          max_connections = {
+            per_group = 100
+          }
+        }
+      ]
+    }
+    ```
+
+#### 4. `net-lb-app-int`
 
 *   **MIG with Actions (`test-mig-actions.tfvars`)**
     ```hcl
@@ -249,7 +280,7 @@ Each module was tested using specific scenarios defined in `tfvars` files. Below
     }
     ```
 
-#### 4. `net-lb-app-int-cross-region`
+#### 5. `net-lb-app-int-cross-region`
 
 *   **Multi-region MIGs (`test-cr-migs.tfvars`)**
     ```hcl
@@ -272,7 +303,7 @@ Each module was tested using specific scenarios defined in `tfvars` files. Below
     }
     ```
 
-#### 5. `net-lb-app-ext`
+#### 6. `net-lb-app-ext`
 
 *   **Cloud Run Scenario (`test-run.tfvars`)**
     ```hcl
@@ -303,7 +334,7 @@ Each module was tested using specific scenarios defined in `tfvars` files. Below
     }
     ```
 
-#### 6. `net-lb-app-ext-regional`
+#### 7. `net-lb-app-ext-regional`
 
 *   **MIG Scenario (`test-mig.tfvars`)**
     ```hcl

--- a/adrs/20260615-net-lb-interface-standardization.md
+++ b/adrs/20260615-net-lb-interface-standardization.md
@@ -133,6 +133,196 @@ The standardization will be carried out across the following modules:
 5.  `net-lb-app-ext`: Rename `backend` -> `group` in variables; remove failover variables.
 6.  `net-lb-app-ext-regional`: Rename `backend` -> `group` in variables; replace `vpc` with `vpc_config`; remove failover variables; implement missing URL map `header_action`; implement context support.
 
+## Testing
+
+Live testing was conducted in a playground environment to verify the standardized interfaces and context resolution.
+
+### Context Variables (Anonymized)
+
+The following context configuration was used to resolve symbolic references (e.g. `"$project_ids:gce"`) to concrete resource IDs:
+
+```json
+{
+  "context": {
+    "addresses": {
+      "ew1_ext": "203.0.113.10",
+      "ew1_int": "192.0.2.50",
+      "ew8_int": "198.51.100.2",
+      "global_ext": "198.51.100.10"
+    },
+    "locations": {
+      "ew1": "europe-west1",
+      "ew8": "europe-west8"
+    },
+    "networks": {
+      "dev": "projects/net-project-id/global/networks/vpc-name"
+    },
+    "project_ids": {
+      "gce": "gce-project-id"
+    },
+    "subnets": {
+      "dev/europe-west1/gce": "projects/net-project-id/regions/europe-west1/subnetworks/subnet-name-ew1",
+      "dev/europe-west8/gce": "projects/net-project-id/regions/europe-west8/subnetworks/subnet-name-ew8"
+    }
+  }
+}
+```
+
+### Test Scenarios (tfvars)
+
+Each module was tested using specific scenarios defined in `tfvars` files. Below are the anonymized configurations used:
+
+#### 1. `net-lb-ext`
+
+*   **MIG Scenario (`test-mig.tfvars`)**
+    ```hcl
+    project_id = "$project_ids:gce"
+    region     = "$locations:ew1"
+    name       = "test-nlb-ext-mig"
+    backends = [
+      { group = "projects/gce-project-id/zones/europe-west1-b/instanceGroups/mig-name" }
+    ]
+    ```
+
+*   **Context Scenario (`test-context.tfvars`)**
+    ```hcl
+    project_id = "$project_ids:gce"
+    region     = "$locations:ew1"
+    name       = "test-nlb-ext-context"
+    backends = [
+      { group = "projects/gce-project-id/zones/europe-west1-b/instanceGroups/mig-name" }
+    ]
+    forwarding_rules_config = {
+      "" = {
+        address = "$addresses:ew1_ext"
+      }
+    }
+    ```
+
+#### 2. `net-lb-proxy-int`
+
+*   **MIG Scenario (`test-mig.tfvars`)**
+    ```hcl
+    project_id = "$project_ids:gce"
+    region     = "$locations:ew1"
+    name       = "test-ilb-l4-proxy-mig"
+    vpc_config = {
+      network    = "$networks:dev"
+      subnetwork = "$subnets:dev/europe-west1/gce"
+    }
+    backend_service_config = {
+      backends = [
+        { group = "projects/gce-project-id/zones/europe-west1-b/instanceGroups/mig-name" }
+      ]
+    }
+    ```
+
+#### 3. `net-lb-app-int`
+
+*   **MIG with Actions (`test-mig-actions.tfvars`)**
+    ```hcl
+    project_id = "$project_ids:gce"
+    region     = "$locations:ew1"
+    name       = "test-ilb-l7-mig"
+    global_access = true
+    vpc_config = {
+      network    = "$networks:dev"
+      subnetwork = "$subnets:dev/europe-west1/gce"
+    }
+    backend_service_configs = {
+      default = {
+        backends = [
+          { group = "projects/gce-project-id/zones/europe-west1-b/instanceGroups/mig-name" }
+        ]
+      }
+    }
+    urlmap_config = {
+      default_service = "default"
+      header_action = {
+        response_add = {
+          "x-test-header" = {
+            value   = "CFF-Test-Actions"
+            replace = true
+          }
+        }
+      }
+    }
+    ```
+
+#### 4. `net-lb-app-int-cross-region`
+
+*   **Multi-region MIGs (`test-cr-migs.tfvars`)**
+    ```hcl
+    project_id = "$project_ids:gce"
+    name       = "test-ilb-l7-cr"
+    vpc_config = {
+      network    = "$networks:dev"
+      subnetworks = {
+        europe-west1 = "$subnets:dev/europe-west1/gce"
+        europe-west8 = "$subnets:dev/europe-west8/gce"
+      }
+    }
+    backend_service_configs = {
+      default = {
+        backends = [
+          { group = "projects/gce-project-id/zones/europe-west1-b/instanceGroups/mig-name-ew1" },
+          { group = "projects/gce-project-id/zones/europe-west8-b/instanceGroups/mig-name-ew8" }
+        ]
+      }
+    }
+    ```
+
+#### 5. `net-lb-app-ext`
+
+*   **Cloud Run Scenario (`test-run.tfvars`)**
+    ```hcl
+    project_id = "$project_ids:gce"
+    name       = "test-glb-l7-run"
+    backend_service_configs = {
+      default = {
+        protocol      = "HTTP"
+        health_checks = []
+        backends = [
+          { group = "projects/gce-project-id/regions/europe-west1/networkEndpointGroups/sneg-name" }
+        ]
+      }
+    }
+    ```
+
+*   **MIG Scenario (`test-mig.tfvars`)**
+    ```hcl
+    project_id = "$project_ids:gce"
+    name       = "test-glb-l7-mig"
+    backend_service_configs = {
+      default = {
+        protocol = "HTTP"
+        backends = [
+          { group = "projects/gce-project-id/zones/europe-west1-b/instanceGroups/mig-name" }
+        ]
+      }
+    }
+    ```
+
+#### 6. `net-lb-app-ext-regional`
+
+*   **MIG Scenario (`test-mig.tfvars`)**
+    ```hcl
+    project_id = "$project_ids:gce"
+    region     = "$locations:ew1"
+    name       = "test-rlb-l7-mig"
+    vpc_config = {
+      network = "$networks:dev"
+    }
+    backend_service_configs = {
+      default = {
+        protocol = "HTTP"
+        backends = [
+          { group = "projects/gce-project-id/zones/europe-west1-b/instanceGroups/mig-name" }
+        ]
+      }
+    }
+    ```
+
 ---
 
 ## Appendix: Interface Examples

--- a/modules/api-gateway/recipe-multi-region/main.tf
+++ b/modules/api-gateway/recipe-multi-region/main.tf
@@ -27,7 +27,7 @@ locals {
   }
   backends = [
     for region in var.regions : {
-      backend = google_compute_region_network_endpoint_group.serverless_negs[region].id
+      group = google_compute_region_network_endpoint_group.serverless_negs[region].id
     }
   ]
 }

--- a/modules/apigee/recipe-apigee-swp/main.tf
+++ b/modules/apigee/recipe-apigee-swp/main.tf
@@ -135,7 +135,7 @@ module "ext-lb" {
   use_classic_version = false
   backend_service_configs = {
     default = {
-      backends      = [for k, v in module.apigee.instances : { backend = "neg-${k}" }]
+      backends      = [for k, v in module.apigee.instances : { group = "neg-${k}" }]
       protocol      = "HTTPS"
       health_checks = []
     }

--- a/modules/net-lb-app-ext-regional/README.md
+++ b/modules/net-lb-app-ext-regional/README.md
@@ -42,16 +42,29 @@ An HTTP load balancer with a backend service pointing to a GCE instance group:
 ```hcl
 module "glb-0" {
   source     = "./fabric/modules/net-lb-app-ext-regional"
-  project_id = var.project_id
+  project_id = "$project_ids:my-project"
   name       = "ralb-test-0"
-  vpc        = var.vpc.self_link
-  region     = var.region
+  vpc_config = {
+    network = "$networks:default"
+  }
+  region = "$locations:my-region"
   backend_service_configs = {
     default = {
       backends = [
-        { backend = module.compute-vm-group-b.group.id },
-        { backend = module.compute-vm-group-c.group.id }
+        { group = module.compute-vm-group-b.group.id },
+        { group = module.compute-vm-group-c.group.id }
       ]
+    }
+  }
+  context = {
+    locations = {
+      my-region = var.region
+    }
+    networks = {
+      default = var.vpc.self_link
+    }
+    project_ids = {
+      my-project = var.project_id
     }
   }
 }
@@ -88,13 +101,13 @@ module "ralb-0" {
   source     = "./fabric/modules/net-lb-app-ext-regional"
   project_id = var.project_id
   name       = "ralb-test-0"
-  vpc        = var.vpc.self_link
+  vpc_config = { network = var.vpc.self_link }
   region     = var.region
   backend_service_configs = {
     default = {
       backends = [
-        { backend = module.compute-vm-group-b.group.id },
-        { backend = module.compute-vm-group-c.group.id }
+        { group = module.compute-vm-group-b.group.id },
+        { group = module.compute-vm-group-c.group.id }
       ]
       protocol = "HTTP"
     }
@@ -122,13 +135,13 @@ module "ralb-0" {
   source     = "./fabric/modules/net-lb-app-ext-regional"
   project_id = var.project_id
   name       = "ralb-test-0"
-  vpc        = var.vpc.self_link
+  vpc_config = { network = var.vpc.self_link }
   region     = var.region
   backend_service_configs = {
     default = {
       backends = [
-        { backend = module.compute-vm-group-b.group.id },
-        { backend = module.compute-vm-group-c.group.id }
+        { group = module.compute-vm-group-b.group.id },
+        { group = module.compute-vm-group-c.group.id }
       ]
       protocol = "HTTPS"
     }
@@ -173,7 +186,7 @@ module "ralb-test-0-redirect" {
   source     = "./fabric/modules/net-lb-app-ext-regional"
   project_id = var.project_id
   name       = "ralb-test-0-redirect"
-  vpc        = var.vpc.self_link
+  vpc_config = { network = var.vpc.self_link }
   region     = var.region
   address = (
     module.addresses.external_addresses["ralb-test-0"].id
@@ -192,7 +205,7 @@ module "ralb-test-0" {
   source     = "./fabric/modules/net-lb-app-ext-regional"
   project_id = var.project_id
   name       = "ralb-test-0"
-  vpc        = var.vpc.self_link
+  vpc_config = { network = var.vpc.self_link }
   region     = var.region
   address = (
     module.addresses.external_addresses["ralb-test-0"].id
@@ -200,7 +213,7 @@ module "ralb-test-0" {
   backend_service_configs = {
     default = {
       backends = [
-        { backend = module.compute-vm-group-b.group.id },
+        { group = module.compute-vm-group-b.group.id },
       ]
       protocol = "HTTP"
     }
@@ -228,12 +241,12 @@ module "ralb-0" {
   source     = "./fabric/modules/net-lb-app-ext-regional"
   project_id = var.project_id
   name       = "ralb-test-0"
-  vpc        = var.vpc.self_link
+  vpc_config = { network = var.vpc.self_link }
   region     = var.region
   backend_service_configs = {
     default = {
       backends = [
-        { backend = module.compute-vm-group-b.group.id },
+        { group = module.compute-vm-group-b.group.id },
       ]
       tls_settings = {
         sni               = "backend.example.com"
@@ -258,12 +271,12 @@ module "ralb-0" {
   source     = "./fabric/modules/net-lb-app-ext-regional"
   project_id = var.project_id
   name       = "ralb-test-0"
-  vpc        = var.vpc.self_link
+  vpc_config = { network = var.vpc.self_link }
   region     = var.region
   backend_service_configs = {
     default = {
       backends = [{
-        backend = module.compute-vm-group-b.group.id
+        group = module.compute-vm-group-b.group.id
       }]
       # no need to reference the hc explicitly when using the `default` key
       # health_checks = ["default"]
@@ -285,12 +298,12 @@ module "ralb-0" {
   source     = "./fabric/modules/net-lb-app-ext-regional"
   project_id = var.project_id
   name       = "ralb-test-0"
-  vpc        = var.vpc.self_link
+  vpc_config = { network = var.vpc.self_link }
   region     = var.region
   backend_service_configs = {
     default = {
       backends = [{
-        backend = module.compute-vm-group-b.group.id
+        group = module.compute-vm-group-b.group.id
       }]
       health_checks = ["projects/${var.project_id}/regions/${var.region}/healthChecks/custom"]
     }
@@ -311,12 +324,12 @@ module "ralb-0" {
   source     = "./fabric/modules/net-lb-app-ext-regional"
   project_id = var.project_id
   name       = "ralb-test-0"
-  vpc        = var.vpc.self_link
+  vpc_config = { network = var.vpc.self_link }
   region     = var.region
   backend_service_configs = {
     default = {
       backends = [
-        { backend = "default-b" }
+        { group = "default-b" }
       ]
     }
   }
@@ -388,12 +401,12 @@ module "ralb-0" {
   source     = "./fabric/modules/net-lb-app-ext-regional"
   project_id = var.project_id
   name       = "ralb-test-0"
-  vpc        = var.vpc.self_link
+  vpc_config = { network = var.vpc.self_link }
   region     = var.region
   backend_service_configs = {
     default = {
       backends = [
-        { backend = module.win-mig.group_manager.instance_group }
+        { group = module.win-mig.group_manager.instance_group }
       ]
     }
   }
@@ -412,13 +425,13 @@ module "ralb-0" {
   source     = "./fabric/modules/net-lb-app-ext-regional"
   project_id = var.project_id
   name       = "ralb-test-0"
-  vpc        = var.vpc.self_link
+  vpc_config = { network = var.vpc.self_link }
   region     = var.region
   backend_service_configs = {
     default = {
       backends = [
         {
-          backend        = "neg-0"
+          group          = "neg-0"
           balancing_mode = "RATE"
           max_rate       = { per_endpoint = 10 }
         }
@@ -454,12 +467,12 @@ module "ralb-0" {
   source     = "./fabric/modules/net-lb-app-ext-regional"
   project_id = var.project_id
   name       = "ralb-test-0"
-  vpc        = var.vpc.self_link
+  vpc_config = { network = var.vpc.self_link }
   region     = var.region
   backend_service_configs = {
     default = {
       backends = [{
-        backend = "hybrid-neg"
+        group = "hybrid-neg"
         # Balancing mode must be RATE for Hybrid NEG
         balancing_mode = "RATE"
         max_rate = {
@@ -496,13 +509,13 @@ module "ralb-0" {
   source     = "./fabric/modules/net-lb-app-ext-regional"
   project_id = var.project_id
   name       = "ralb-test-0"
-  vpc        = var.vpc.self_link
+  vpc_config = { network = var.vpc.self_link }
   region     = var.region
   backend_service_configs = {
     default = {
       backends = [
-        { backend = "internet-neg-fqdn" },
-        { backend = "internet-neg-ip" }
+        { group = "internet-neg-fqdn" },
+        { group = "internet-neg-ip" }
       ]
     }
   }
@@ -541,12 +554,12 @@ module "ralb-0" {
   source     = "./fabric/modules/net-lb-app-ext-regional"
   project_id = var.project_id
   name       = "ralb-test-0"
-  vpc        = var.vpc.self_link
+  vpc_config = { network = var.vpc.self_link }
   region     = var.region
   backend_service_configs = {
     default = {
       backends = [
-        { backend = "neg-0" }
+        { group = "neg-0" }
       ]
       health_checks = []
     }
@@ -574,12 +587,12 @@ module "ralb-0" {
   source     = "./fabric/modules/net-lb-app-ext-regional"
   project_id = var.project_id
   name       = "ralb-test-0"
-  vpc        = var.vpc.self_link
+  vpc_config = { network = var.vpc.self_link }
   region     = var.region
   backend_service_configs = {
     default = {
       backends = [
-        { backend = "neg-0" }
+        { group = "neg-0" }
       ]
       health_checks = []
     }
@@ -609,7 +622,7 @@ module "ralb-0" {
   source     = "./fabric/modules/net-lb-app-ext-regional"
   project_id = var.project_id
   name       = "ralb-test-0"
-  vpc        = var.vpc.self_link
+  vpc_config = { network = var.vpc.self_link }
   region     = var.region
 
   backend_service_configs = {
@@ -618,7 +631,7 @@ module "ralb-0" {
 
       backends = [
         {
-          backend = "neg-0"
+          group = "neg-0"
         }
       ]
       health_checks = []
@@ -642,22 +655,30 @@ module "ralb-0" {
   source     = "./fabric/modules/net-lb-app-ext-regional"
   project_id = var.project_id
   name       = "ralb-test-0"
-  vpc        = var.vpc.self_link
+  vpc_config = { network = var.vpc.self_link }
   region     = var.region
   backend_service_configs = {
     default = {
       backends = [{
-        backend = module.compute-vm-group-b.group.id
+        group = module.compute-vm-group-b.group.id
       }]
     }
     other = {
       backends = [{
-        backend = module.compute-vm-group-c.group.id
+        group = module.compute-vm-group-c.group.id
       }]
     }
   }
   urlmap_config = {
     default_service = "default"
+    header_action = {
+      response_add = {
+        strict-transport-security = {
+          value   = "max-age=31536000; includeSubDomains; preload"
+          replace = true
+        }
+      }
+    }
     host_rules = [{
       hosts        = ["*"]
       path_matcher = "pathmap"
@@ -686,26 +707,26 @@ module "ralb-0" {
   source     = "./fabric/modules/net-lb-app-ext-regional"
   project_id = var.project_id
   name       = "ralb-test-0"
-  vpc        = var.vpc.self_link
+  vpc_config = { network = var.vpc.self_link }
   region     = var.region
   backend_service_configs = {
     default = {
       backends = [
-        { backend = "group-zone-b" },
-        { backend = "group-zone-c" },
+        { group = "group-zone-b" },
+        { group = "group-zone-c" },
       ]
     }
     neg-gce-0 = {
       backends = [{
         balancing_mode = "RATE"
-        backend        = "neg-zone-c"
+        group          = "neg-zone-c"
         max_rate       = { per_endpoint = 10 }
       }]
     }
     neg-hybrid-0 = {
       backends = [{
         balancing_mode = "RATE"
-        backend        = "neg-hello"
+        group          = "neg-hello"
         max_rate       = { per_endpoint = 10 }
       }]
       health_checks = ["neg"]
@@ -832,23 +853,24 @@ For deploying changes to load balancer configuration please refer to [net-lb-app
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [name](variables.tf#L73) | Load balancer name. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L199) | Project id. | <code>string</code> | ✓ |  |
-| [region](variables.tf#L217) | Region where the load balancer is created. | <code>string</code> | ✓ |  |
-| [vpc](variables.tf#L237) | VPC-level configuration. | <code>string</code> | ✓ |  |
+| [name](variables.tf#L86) | Load balancer name. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L212) | Project id. | <code>string</code> | ✓ |  |
+| [region](variables.tf#L230) | Region where the load balancer is created. | <code>string</code> | ✓ |  |
+| [vpc_config](variables.tf#L250) | VPC-level configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
 | [address](variables.tf#L17) | Optional IP address used for the forwarding rule. | <code>string</code> |  | <code>null</code> |
 | [backend_service_configs](variables-backend-service.tf#L19) | Backend service level configuration. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [description](variables.tf#L23) | Optional description used for resources. | <code>string</code> |  | <code>&#34;Terraform managed.&#34;</code> |
-| [group_configs](variables.tf#L29) | Optional unmanaged groups to create. Can be referenced in backends via key or outputs. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [context](variables.tf#L23) | Context-specific interpolations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [description](variables.tf#L36) | Optional description used for resources. | <code>string</code> |  | <code>&#34;Terraform managed.&#34;</code> |
+| [group_configs](variables.tf#L42) | Optional unmanaged groups to create. Can be referenced in backends via key or outputs. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [health_check_configs](variables-health-check.tf#L19) | Optional auto-created health check configurations, use the output self-link to set it in the auto healing policy. Refer to examples for usage. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#8230;&#125;</code> |
-| [http_proxy_config](variables.tf#L43) | HTTP proxy configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [https_proxy_config](variables.tf#L53) | HTTPS proxy connfiguration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [labels](variables.tf#L67) | Labels set on resources. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
-| [neg_configs](variables.tf#L78) | Optional network endpoint groups to create. Can be referenced in backends via key or outputs. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [network_tier_standard](variables.tf#L182) | Use standard network tier. | <code>bool</code> |  | <code>true</code> |
-| [ports](variables.tf#L189) | Optional ports for HTTP load balancer. | <code>list&#40;string&#41;</code> |  | <code>null</code> |
-| [protocol](variables.tf#L204) | Protocol supported by this load balancer. | <code>string</code> |  | <code>&#34;HTTP&#34;</code> |
-| [ssl_certificates](variables.tf#L222) | SSL target proxy certificates (only if protocol is HTTPS) for existing, custom, and managed certificates. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [http_proxy_config](variables.tf#L56) | HTTP proxy configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [https_proxy_config](variables.tf#L66) | HTTPS proxy connfiguration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [labels](variables.tf#L80) | Labels set on resources. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [neg_configs](variables.tf#L91) | Optional network endpoint groups to create. Can be referenced in backends via key or outputs. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [network_tier_standard](variables.tf#L195) | Use standard network tier. | <code>bool</code> |  | <code>true</code> |
+| [ports](variables.tf#L202) | Optional ports for HTTP load balancer. | <code>list&#40;string&#41;</code> |  | <code>null</code> |
+| [protocol](variables.tf#L217) | Protocol supported by this load balancer. | <code>string</code> |  | <code>&#34;HTTP&#34;</code> |
+| [ssl_certificates](variables.tf#L235) | SSL target proxy certificates (only if protocol is HTTPS) for existing, custom, and managed certificates. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [urlmap_config](variables-urlmap.tf#L19) | The URL map configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#8230;&#125;</code> |
 
 ## Outputs

--- a/modules/net-lb-app-ext-regional/backend-service.tf
+++ b/modules/net-lb-app-ext-regional/backend-service.tf
@@ -44,11 +44,11 @@ resource "google_compute_region_backend_service" "default" {
   for_each = var.backend_service_configs
   project = (
     each.value.project_id == null
-    ? var.project_id
-    : each.value.project_id
+    ? local.project_id
+    : lookup(local.ctx.project_ids, each.value.project_id, each.value.project_id)
   )
   name                            = coalesce(each.value.name, "${var.name}-${each.key}")
-  region                          = var.region
+  region                          = local.region
   description                     = each.value.description
   affinity_cookie_ttl_sec         = each.value.affinity_cookie_ttl_sec
   connection_draining_timeout_sec = each.value.connection_draining_timeout_sec
@@ -72,7 +72,7 @@ resource "google_compute_region_backend_service" "default" {
   timeout_sec        = each.value.timeout_sec
 
   dynamic "backend" {
-    for_each = { for b in coalesce(each.value.backends, []) : b.backend => b }
+    for_each = { for b in coalesce(each.value.backends, []) : b.group => b }
     content {
       group           = lookup(local.group_ids, backend.key, backend.key)
       balancing_mode  = backend.value.balancing_mode # UTILIZATION, RATE

--- a/modules/net-lb-app-ext-regional/groups.tf
+++ b/modules/net-lb-app-ext-regional/groups.tf
@@ -18,10 +18,10 @@ resource "google_compute_instance_group" "default" {
   for_each = var.group_configs
   project = (
     each.value.project_id == null
-    ? var.project_id
-    : each.value.project_id
+    ? local.project_id
+    : lookup(local.ctx.project_ids, each.value.project_id, each.value.project_id)
   )
-  zone        = each.value.zone
+  zone        = lookup(local.ctx.locations, each.value.zone, each.value.zone)
   name        = coalesce(each.value.name, "${var.name}-${each.key}")
   description = each.value.description
   instances   = each.value.instances

--- a/modules/net-lb-app-ext-regional/health-check.tf
+++ b/modules/net-lb-app-ext-regional/health-check.tf
@@ -21,11 +21,11 @@ resource "google_compute_region_health_check" "default" {
   for_each = var.health_check_configs
   project = (
     each.value.project_id == null
-    ? var.project_id
-    : each.value.project_id
+    ? local.project_id
+    : lookup(local.ctx.project_ids, each.value.project_id, each.value.project_id)
   )
   name                = coalesce(each.value.name, "${var.name}-${each.key}")
-  region              = var.region
+  region              = local.region
   description         = each.value.description
   check_interval_sec  = each.value.check_interval_sec
   healthy_threshold   = each.value.healthy_threshold

--- a/modules/net-lb-app-ext-regional/main.tf
+++ b/modules/net-lb-app-ext-regional/main.tf
@@ -15,6 +15,12 @@
  */
 
 locals {
+  ctx = {
+    for k, v in var.context : k => {
+      for kk, vv in v : "${local.ctx_p}${k}:${kk}" => vv
+    }
+  }
+  ctx_p = "$"
   fwd_rule_ports = (
     var.protocol == "HTTPS" ? [443] : coalesce(var.ports, [80])
   )
@@ -23,33 +29,39 @@ locals {
     ? google_compute_region_target_https_proxy.default[0].id
     : google_compute_region_target_http_proxy.default[0].id
   )
+  project_id = lookup(local.ctx.project_ids, var.project_id, var.project_id)
   proxy_ssl_certificates = concat(
     coalesce(var.ssl_certificates.certificate_ids, []),
     [for k, v in google_compute_region_ssl_certificate.default : v.id],
   )
+  region = lookup(local.ctx.locations, var.region, var.region)
 }
 
 resource "google_compute_forwarding_rule" "default" {
-  provider              = google-beta
-  project               = var.project_id
-  name                  = var.name
-  region                = var.region
-  description           = var.description
-  ip_address            = var.address
+  provider    = google-beta
+  project     = local.project_id
+  name        = var.name
+  region      = local.region
+  description = var.description
+  ip_address = (
+    var.address == null
+    ? null
+    : lookup(local.ctx.addresses, var.address, var.address)
+  )
   ip_protocol           = "TCP"
   load_balancing_scheme = "EXTERNAL_MANAGED"
   port_range            = join(",", local.fwd_rule_ports)
   labels                = var.labels
   target                = local.fwd_rule_target
-  network               = var.vpc
+  network               = lookup(local.ctx.networks, var.vpc_config.network, var.vpc_config.network)
   network_tier          = var.network_tier_standard ? "STANDARD" : "PREMIUM"
 }
 
 resource "google_compute_region_ssl_certificate" "default" {
   for_each    = var.ssl_certificates.create_configs
-  project     = var.project_id
+  project     = local.project_id
   name        = coalesce(each.value.name, "${var.name}-${each.key}")
-  region      = var.region
+  region      = local.region
   certificate = trimspace(each.value.certificate)
   private_key = trimspace(each.value.private_key)
   lifecycle {
@@ -59,8 +71,8 @@ resource "google_compute_region_ssl_certificate" "default" {
 
 resource "google_compute_region_target_http_proxy" "default" {
   count       = var.protocol == "HTTPS" ? 0 : 1
-  project     = var.project_id
-  region      = var.region
+  project     = local.project_id
+  region      = local.region
   name        = coalesce(var.http_proxy_config.name, var.name)
   description = var.http_proxy_config.description
   url_map     = google_compute_region_url_map.default.id
@@ -68,12 +80,13 @@ resource "google_compute_region_target_http_proxy" "default" {
 
 resource "google_compute_region_target_https_proxy" "default" {
   count                            = var.protocol == "HTTPS" ? 1 : 0
-  project                          = var.project_id
+  project                          = local.project_id
   name                             = coalesce(var.https_proxy_config.name, var.name)
-  region                           = var.region
+  region                           = local.region
   description                      = var.https_proxy_config.description
   certificate_manager_certificates = var.https_proxy_config.certificate_manager_certificates
   ssl_certificates                 = length(local.proxy_ssl_certificates) == 0 ? null : local.proxy_ssl_certificates
   ssl_policy                       = var.https_proxy_config.ssl_policy
   url_map                          = google_compute_region_url_map.default.id
 }
+

--- a/modules/net-lb-app-ext-regional/negs.tf
+++ b/modules/net-lb-app-ext-regional/negs.tf
@@ -54,10 +54,10 @@ locals {
     for k, v in var.neg_configs : k => {
       description = v.description
       endpoints   = v.gce != null ? v.gce.endpoints : v.hybrid.endpoints
-      network     = v.gce != null ? v.gce.network : v.hybrid.network
-      subnetwork  = v.gce != null ? v.gce.subnetwork : null
+      network     = v.gce != null ? lookup(local.ctx.networks, v.gce.network, v.gce.network) : lookup(local.ctx.networks, v.hybrid.network, v.hybrid.network)
+      subnetwork  = v.gce != null ? lookup(local.ctx.subnets, v.gce.subnetwork, v.gce.subnetwork) : null
       type        = v.gce != null ? "GCE_VM_IP_PORT" : "NON_GCP_PRIVATE_IP_PORT"
-      zone        = v.gce != null ? v.gce.zone : v.hybrid.zone
+      zone        = v.gce != null ? lookup(local.ctx.locations, v.gce.zone, v.gce.zone) : lookup(local.ctx.locations, v.hybrid.zone, v.hybrid.zone)
     } if v.gce != null || v.hybrid != null
   }
 
@@ -69,7 +69,7 @@ locals {
           id            = "${neg_key}-${endpoint_key}"
           neg_key       = neg_key
           endpoint_key  = endpoint_key
-          region        = neg.internet.region
+          region        = lookup(local.ctx.locations, neg.internet.region, neg.internet.region)
           fqdn          = try(endpoint.fqdn, null)
           ip_address    = try(endpoint.ip_address, null)
           port          = endpoint.port
@@ -82,7 +82,7 @@ locals {
 
 resource "google_compute_network_endpoint_group" "default" {
   for_each = local.neg_zonal
-  project  = var.project_id
+  project  = local.project_id
   zone     = each.value.zone
   name     = "${var.name}-${each.key}"
   # re-enable once provider properly supports this
@@ -113,12 +113,12 @@ resource "google_compute_network_endpoint" "default" {
 
 resource "google_compute_region_network_endpoint_group" "internet" {
   for_each              = local.neg_regional_internet
-  project               = var.project_id
-  region                = each.value.internet.region
+  project               = local.project_id
+  region                = lookup(local.ctx.locations, each.value.internet.region, each.value.internet.region)
   name                  = "${var.name}-${each.key}"
   description           = coalesce(each.value.description, var.description)
   network_endpoint_type = each.value.endpoint_type
-  network               = each.value.internet.network
+  network               = lookup(local.ctx.networks, each.value.internet.network, each.value.internet.network)
 }
 
 resource "google_compute_region_network_endpoint" "internet" {
@@ -130,19 +130,19 @@ resource "google_compute_region_network_endpoint" "internet" {
   # Only set ip_address if endpoint type is IP_PORT
   ip_address = each.value.endpoint_type == "INTERNET_IP_PORT" ? each.value.ip_address : null
   port       = each.value.port
-  project    = var.project_id
+  project    = local.project_id
 }
 
 resource "google_compute_region_network_endpoint_group" "psc" {
   for_each              = local.neg_regional_psc
-  project               = var.project_id
-  region                = each.value.psc.region
+  project               = local.project_id
+  region                = lookup(local.ctx.locations, each.value.psc.region, each.value.psc.region)
   name                  = "${var.name}-${each.key}"
   description           = coalesce(each.value.description, var.description)
   network_endpoint_type = "PRIVATE_SERVICE_CONNECT"
   psc_target_service    = each.value.psc.target_service
-  network               = each.value.psc.network
-  subnetwork            = each.value.psc.subnetwork
+  network               = each.value.psc.network == null ? null : lookup(local.ctx.networks, each.value.psc.network, each.value.psc.network)
+  subnetwork            = each.value.psc.subnetwork == null ? null : lookup(local.ctx.subnets, each.value.psc.subnetwork, each.value.psc.subnetwork)
   lifecycle {
     # ignore until https://github.com/hashicorp/terraform-provider-google/issues/20576 is fixed
     ignore_changes = [psc_data]
@@ -153,11 +153,17 @@ resource "google_compute_region_network_endpoint_group" "serverless" {
   for_each = local.neg_regional_serverless
   project = (
     each.value.project_id == null
-    ? var.project_id
-    : each.value.project_id
+    ? local.project_id
+    : lookup(local.ctx.project_ids, each.value.project_id, each.value.project_id)
   )
-  region = try(
-    each.value.cloudrun.region, each.value.cloudfunction.region, null
+  region = (
+    try(each.value.cloudrun.region, null) != null
+    ? lookup(local.ctx.locations, each.value.cloudrun.region, each.value.cloudrun.region)
+    : (
+      try(each.value.cloudfunction.region, null) != null
+      ? lookup(local.ctx.locations, each.value.cloudfunction.region, each.value.cloudfunction.region)
+      : null
+    )
   )
   name                  = "${var.name}-${each.key}"
   description           = coalesce(each.value.description, var.description)

--- a/modules/net-lb-app-ext-regional/urlmap.tf
+++ b/modules/net-lb-app-ext-regional/urlmap.tf
@@ -24,9 +24,9 @@ locals {
 
 resource "google_compute_region_url_map" "default" {
   provider    = google-beta
-  project     = var.project_id
+  project     = local.project_id
   name        = var.name
-  region      = var.region
+  region      = local.region
   description = var.urlmap_config.description
   default_service = (
     var.urlmap_config.default_service == null ? null : lookup(
@@ -210,6 +210,35 @@ resource "google_compute_region_url_map" "default" {
       prefix_redirect        = r.value.prefix
       redirect_response_code = r.value.response_code
       strip_query            = r.value.strip_query
+    }
+  }
+
+  dynamic "header_action" {
+    for_each = (
+      var.urlmap_config.header_action == null
+      ? []
+      : [var.urlmap_config.header_action]
+    )
+    iterator = h
+    content {
+      request_headers_to_remove  = h.value.request_remove
+      response_headers_to_remove = h.value.response_remove
+      dynamic "request_headers_to_add" {
+        for_each = coalesce(h.value.request_add, {})
+        content {
+          header_name  = request_headers_to_add.key
+          header_value = request_headers_to_add.value.value
+          replace      = request_headers_to_add.value.replace
+        }
+      }
+      dynamic "response_headers_to_add" {
+        for_each = coalesce(h.value.response_add, {})
+        content {
+          header_name  = response_headers_to_add.key
+          header_value = response_headers_to_add.value.value
+          replace      = response_headers_to_add.value.replace
+        }
+      }
     }
   }
 

--- a/modules/net-lb-app-ext-regional/variables-backend-service.tf
+++ b/modules/net-lb-app-ext-regional/variables-backend-service.tf
@@ -39,12 +39,10 @@ variable "backend_service_configs" {
     locality_lb_policy = optional(string)
     timeout_sec        = optional(number)
     backends = list(object({
-      # group renamed to backend
-      backend         = string
+      group           = string
       balancing_mode  = optional(string, "UTILIZATION")
       capacity_scaler = optional(number, 1)
       description     = optional(string, "Terraform managed.")
-      failover        = optional(bool, false)
       max_connections = optional(object({
         per_endpoint = optional(number)
         per_group    = optional(number)

--- a/modules/net-lb-app-ext-regional/variables.tf
+++ b/modules/net-lb-app-ext-regional/variables.tf
@@ -20,6 +20,19 @@ variable "address" {
   default     = null
 }
 
+variable "context" {
+  description = "Context-specific interpolations."
+  type = object({
+    addresses   = optional(map(string), {})
+    locations   = optional(map(string), {})
+    networks    = optional(map(string), {})
+    project_ids = optional(map(string), {})
+    subnets     = optional(map(string), {})
+  })
+  default  = {}
+  nullable = false
+}
+
 variable "description" {
   description = "Optional description used for resources."
   type        = string
@@ -234,8 +247,11 @@ variable "ssl_certificates" {
 }
 
 
-variable "vpc" {
+variable "vpc_config" {
   description = "VPC-level configuration."
-  type        = string
-  nullable    = false
+  type = object({
+    network = string
+  })
+  nullable = false
 }
+

--- a/modules/net-lb-app-ext/README.md
+++ b/modules/net-lb-app-ext/README.md
@@ -53,8 +53,8 @@ module "glb-0" {
   backend_service_configs = {
     default = {
       backends = [
-        { backend = module.compute-vm-group-b.group.id },
-        { backend = module.compute-vm-group-c.group.id },
+        { group = module.compute-vm-group-b.group.id },
+        { group = module.compute-vm-group-c.group.id },
       ]
     }
   }
@@ -76,8 +76,8 @@ module "glb-0" {
   backend_service_configs = {
     default = {
       backends = [
-        { backend = module.compute-vm-group-b.group.id },
-        { backend = module.compute-vm-group-c.group.id },
+        { group = module.compute-vm-group-b.group.id },
+        { group = module.compute-vm-group-c.group.id },
       ]
       protocol = "HTTP"
     }
@@ -106,8 +106,8 @@ module "glb-0" {
   backend_service_configs = {
     default = {
       backends = [
-        { backend = module.compute-vm-group-b.group.id },
-        { backend = module.compute-vm-group-c.group.id },
+        { group = module.compute-vm-group-b.group.id },
+        { group = module.compute-vm-group-c.group.id },
       ]
       protocol = "HTTPS"
     }
@@ -180,7 +180,7 @@ module "glb-test-0" {
   backend_service_configs = {
     default = {
       backends = [
-        { backend = module.compute-vm-group-b.group.id },
+        { group = module.compute-vm-group-b.group.id },
       ]
       protocol = "HTTP"
     }
@@ -211,8 +211,8 @@ module "glb-0" {
   backend_service_configs = {
     default = {
       backends = [
-        { backend = module.compute-vm-group-b.group.id },
-        { backend = module.compute-vm-group-c.group.id },
+        { group = module.compute-vm-group-b.group.id },
+        { group = module.compute-vm-group-c.group.id },
       ]
     }
   }
@@ -236,7 +236,7 @@ module "glb-0" {
   backend_service_configs = {
     default = {
       backends = [{
-        backend = module.compute-vm-group-b.group.id
+        group = module.compute-vm-group-b.group.id
       }]
       # no need to reference the hc explicitly when using the `default` key
       # health_checks = ["default"]
@@ -261,7 +261,7 @@ module "glb-0" {
   backend_service_configs = {
     default = {
       backends = [{
-        backend = module.compute-vm-group-b.group.id
+        group = module.compute-vm-group-b.group.id
       }]
       health_checks = ["projects/${var.project_id}/global/healthChecks/custom"]
     }
@@ -285,7 +285,7 @@ module "glb-0" {
   backend_service_configs = {
     default = {
       backends = [
-        { backend = "default-b" }
+        { group = "default-b" }
       ]
     }
   }
@@ -358,7 +358,7 @@ module "glb-0" {
   backend_service_configs = {
     default = {
       backends = [
-        { backend = module.win-mig.group_manager.instance_group }
+        { group = module.win-mig.group_manager.instance_group }
       ]
     }
   }
@@ -399,7 +399,7 @@ module "glb-0" {
     default = {
       backends = [
         {
-          backend        = "myneg-b"
+          group          = "myneg-b"
           balancing_mode = "RATE"
           max_rate       = { per_endpoint = 10 }
         }
@@ -433,7 +433,7 @@ module "glb-0" {
     default = {
       backends = [
         {
-          backend        = "neg-0"
+          group          = "neg-0"
           balancing_mode = "RATE"
           max_rate       = { per_endpoint = 10 }
         }
@@ -473,7 +473,7 @@ module "glb-0" {
     default = {
       backends = [
         {
-          backend        = "neg-0"
+          group          = "neg-0"
           balancing_mode = "RATE"
           max_rate       = { per_endpoint = 10 }
         }
@@ -510,7 +510,7 @@ module "glb-0" {
   backend_service_configs = {
     default = {
       backends = [
-        { backend = "neg-0" }
+        { group = "neg-0" }
       ]
       health_checks = []
     }
@@ -547,7 +547,7 @@ module "glb-0" {
   backend_service_configs = {
     default = {
       backends = [
-        { backend = "neg-0" }
+        { group = "neg-0" }
       ]
       health_checks = []
     }
@@ -578,7 +578,7 @@ module "glb-0" {
   backend_service_configs = {
     default = {
       backends = [
-        { backend = "neg-0" }
+        { group = "neg-0" }
       ]
       health_checks = []
       port_name     = ""
@@ -610,7 +610,7 @@ module "glb-0" {
   backend_service_configs = {
     default = {
       backends = [
-        { backend = "neg-0" }
+        { group = "neg-0" }
       ]
       health_checks = []
       port_name     = "http"
@@ -656,7 +656,7 @@ module "ralb-0" {
 
       backends = [
         {
-          backend = "neg-0"
+          group = "neg-0"
         }
       ]
       health_checks = []
@@ -683,12 +683,12 @@ module "glb-0" {
   backend_service_configs = {
     default = {
       backends = [{
-        backend = module.compute-vm-group-b.group.id
+        group = module.compute-vm-group-b.group.id
       }]
     }
     other = {
       backends = [{
-        backend = module.compute-vm-group-c.group.id
+        group = module.compute-vm-group-c.group.id
       }]
     }
   }
@@ -746,8 +746,8 @@ module "glb-0" {
   backend_service_configs = {
     default = {
       backends = [
-        { backend = module.compute-vm-group-b.group.id },
-        { backend = module.compute-vm-group-c.group.id },
+        { group = module.compute-vm-group-b.group.id },
+        { group = module.compute-vm-group-c.group.id },
       ]
       protocol = "HTTP"
     }
@@ -778,7 +778,7 @@ module "glb-0" {
   backend_service_configs = {
     default = {
       backends = [
-        { backend = module.compute-vm-group-b.group.id },
+        { group = module.compute-vm-group-b.group.id },
       ]
       tls_settings = {
         sni = "backend.example.com"
@@ -806,26 +806,26 @@ module "glb-0" {
   backend_service_configs = {
     default = {
       backends = [
-        { backend = "projects/my-project/zones/europe-west8-b/instanceGroups/ig-b" },
-        { backend = "ig-c" }
+        { group = "projects/my-project/zones/europe-west8-b/instanceGroups/ig-b" },
+        { group = "ig-c" }
       ]
     }
     neg-cloudrun = {
-      backends      = [{ backend = "neg-cloudrun" }]
+      backends      = [{ group = "neg-cloudrun" }]
       health_checks = []
     }
     neg-gce = {
-      backends       = [{ backend = "neg-gce" }]
+      backends       = [{ group = "neg-gce" }]
       balancing_mode = "RATE"
       max_rate       = { per_endpoint = 10 }
     }
     neg-hybrid = {
-      backends       = [{ backend = "neg-hybrid" }]
+      backends       = [{ group = "neg-hybrid" }]
       balancing_mode = "RATE"
       max_rate       = { per_endpoint = 10 }
     }
     neg-internet = {
-      backends      = [{ backend = "neg-internet" }]
+      backends      = [{ group = "neg-internet" }]
       health_checks = []
     }
   }
@@ -952,21 +952,21 @@ module "glb-0" {
   backend_service_configs = {
     default = {
       backends = [
-        { backend = "group-zone-b" },
-        { backend = "group-zone-c" },
+        { group = "group-zone-b" },
+        { group = "group-zone-c" },
       ]
     }
     neg-gce-0 = {
       backends = [{
         balancing_mode = "RATE"
-        backend        = "neg-zone-c"
+        group          = "neg-zone-c"
         max_rate       = { per_endpoint = 10 }
       }]
     }
     neg-hybrid-0 = {
       backends = [{
         balancing_mode = "RATE"
-        backend        = "neg-hello"
+        group          = "neg-hello"
         max_rate       = { per_endpoint = 10 }
       }]
       health_checks = ["neg"]
@@ -1105,7 +1105,7 @@ module "glb-0" {
   backend_service_configs = {
     default = {
       backends = [
-        { backend = "neg-0" }
+        { group = "neg-0" }
       ]
       health_checks = []
       port_name     = "http"
@@ -1170,7 +1170,7 @@ After applying this change, you can update the backend service to point to the n
   backend_service_configs = {
     default = {
       backends = [
-        { backend = "neg-1" }
+        { group = "neg-1" }
       ]
       health_checks = []
       port_name     = "http"

--- a/modules/net-lb-app-ext/backend-service.tf
+++ b/modules/net-lb-app-ext/backend-service.tf
@@ -75,7 +75,7 @@ resource "google_compute_backend_service" "default" {
   timeout_sec      = each.value.timeout_sec
 
   dynamic "backend" {
-    for_each = { for b in coalesce(each.value.backends, []) : b.backend => b }
+    for_each = { for b in coalesce(each.value.backends, []) : b.group => b }
     content {
       group           = lookup(local.group_ids, backend.key, backend.key)
       preference      = backend.value.preferred ? "PREFERRED" : null

--- a/modules/net-lb-app-ext/main.tf
+++ b/modules/net-lb-app-ext/main.tf
@@ -60,7 +60,7 @@ moved {
 resource "google_compute_global_forwarding_rule" "default" {
   provider    = google-beta
   for_each    = var.forwarding_rules_config
-  project     = var.project_id
+  project     = local.project_id
   name        = coalesce(each.value.name, local.fwd_rule_names[each.key])
   description = each.value.description
   ip_address  = try(local.ctx.addresses[each.value.address], each.value.address)
@@ -80,7 +80,7 @@ resource "google_compute_global_forwarding_rule" "default" {
 
 resource "google_compute_ssl_certificate" "default" {
   for_each    = var.ssl_certificates.create_configs
-  project     = var.project_id
+  project     = local.project_id
   name        = "${var.name}-${each.key}"
   certificate = trimspace(each.value.certificate)
   private_key = trimspace(each.value.private_key)

--- a/modules/net-lb-app-ext/negs.tf
+++ b/modules/net-lb-app-ext/negs.tf
@@ -27,7 +27,10 @@ locals {
   _neg_endpoints_zonal = flatten([
     for k, v in local.neg_zonal : [
       for kk, vv in v.endpoints : merge(vv, {
-        key = "${k}-${kk}", neg = k, zone = v.zone
+        key        = "${k}-${kk}"
+        neg        = k
+        zone       = v.zone
+        ip_address = try(local.ctx.addresses[vv.ip_address], vv.ip_address)
       })
     ]
   ])
@@ -42,8 +45,14 @@ locals {
     k => v if v.internet != null
   }
   neg_regional_psc = {
-    for k, v in var.neg_configs :
-    k => v if v.psc != null
+    for k, v in var.neg_configs : k => merge(v, {
+      psc = {
+        region         = lookup(local.ctx.locations, v.psc.region, v.psc.region)
+        target_service = v.psc.target_service
+        network        = v.psc.network == null ? null : lookup(local.ctx.networks, v.psc.network, v.psc.network)
+        subnetwork     = v.psc.subnetwork == null ? null : lookup(local.ctx.subnets, v.psc.subnetwork, v.psc.subnetwork)
+      }
+    }) if v.psc != null
   }
   neg_regional_serverless = {
     for k, v in var.neg_configs :
@@ -54,10 +63,10 @@ locals {
     for k, v in var.neg_configs : k => {
       description = v.description
       endpoints   = v.gce != null ? v.gce.endpoints : v.hybrid.endpoints
-      network     = v.gce != null ? v.gce.network : v.hybrid.network
-      subnetwork  = v.gce != null ? v.gce.subnetwork : null
+      network     = v.gce != null ? try(local.ctx.networks[v.gce.network], v.gce.network) : try(local.ctx.networks[v.hybrid.network], v.hybrid.network)
+      subnetwork  = v.gce != null ? try(local.ctx.subnets[v.gce.subnetwork], v.gce.subnetwork) : null
       type        = v.gce != null ? "GCE_VM_IP_PORT" : "NON_GCP_PRIVATE_IP_PORT"
-      zone        = v.gce != null ? v.gce.zone : v.hybrid.zone
+      zone        = v.gce != null ? try(local.ctx.locations[v.gce.zone], v.gce.zone) : try(local.ctx.locations[v.hybrid.zone], v.hybrid.zone)
     } if v.gce != null || v.hybrid != null
   }
 }
@@ -144,11 +153,18 @@ resource "google_compute_region_network_endpoint_group" "serverless" {
     ? local.project_id
     : each.value.project_id
   )
-  region = try(
-    each.value.cloudrun.region,
-    each.value.cloudfunction.region,
-    each.value.serverless_deployment.region,
-    null
+  region = (
+    try(each.value.cloudrun.region, null) != null
+    ? lookup(local.ctx.locations, each.value.cloudrun.region, each.value.cloudrun.region)
+    : (
+      try(each.value.cloudfunction.region, null) != null
+      ? lookup(local.ctx.locations, each.value.cloudfunction.region, each.value.cloudfunction.region)
+      : (
+        try(each.value.serverless_deployment.region, null) != null
+        ? lookup(local.ctx.locations, each.value.serverless_deployment.region, each.value.serverless_deployment.region)
+        : null
+      )
+    )
   )
   name                  = "${var.name}-${each.key}"
   description           = coalesce(each.value.description, var.description)

--- a/modules/net-lb-app-ext/recipe-cloud-run-iap/main.tf
+++ b/modules/net-lb-app-ext/recipe-cloud-run-iap/main.tf
@@ -95,7 +95,7 @@ module "glb" {
   backend_service_configs = {
     default = {
       backends = [
-        { backend = "neg-backend" }
+        { group = "neg-backend" }
       ]
       health_checks = []
       iap_config = {

--- a/modules/net-lb-app-ext/variables-backend-service.tf
+++ b/modules/net-lb-app-ext/variables-backend-service.tf
@@ -42,13 +42,11 @@ variable "backend_service_configs" {
     session_affinity = optional(string)
     timeout_sec      = optional(number)
     backends = list(object({
-      # group renamed to backend
-      backend         = string
+      group           = string
       preferred       = optional(bool, false)
       balancing_mode  = optional(string, "UTILIZATION")
       capacity_scaler = optional(number, 1)
       description     = optional(string, "Terraform managed.")
-      failover        = optional(bool, false)
       max_connections = optional(object({
         per_endpoint = optional(number)
         per_group    = optional(number)

--- a/modules/net-lb-app-int-cross-region/README.md
+++ b/modules/net-lb-app-int-cross-region/README.md
@@ -36,7 +36,7 @@ An HTTP ILB with a backend service pointing to a GCE instance group:
 module "ilb-l7" {
   source     = "./fabric/modules/net-lb-app-int-cross-region"
   name       = "ilb-test"
-  project_id = var.project_id
+  project_id = "$project_ids:project"
   backend_service_configs = {
     default = {
       backends = [{
@@ -45,9 +45,20 @@ module "ilb-l7" {
     }
   }
   vpc_config = {
-    network = var.vpc.self_link
+    network = "$networks:vpc"
     subnetworks = {
-      (var.region) = var.subnet.self_link
+      (var.region) = "$subnets:subnet"
+    }
+  }
+  context = {
+    project_ids = {
+      project = var.project_id
+    }
+    networks = {
+      vpc = var.vpc.self_link
+    }
+    subnets = {
+      subnet = var.subnet.self_link
     }
   }
 }
@@ -819,22 +830,23 @@ When deploying changes to load balancer configuration please refer to [net-lb-ap
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [name](variables.tf#L74) | Load balancer name. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L155) | Project id. | <code>string</code> | ✓ |  |
-| [vpc_config](variables.tf#L197) | VPC-level configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
+| [name](variables.tf#L88) | Load balancer name. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L169) | Project id. | <code>string</code> | ✓ |  |
+| [vpc_config](variables.tf#L211) | VPC-level configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
 | [addresses](variables.tf#L17) | Optional IP address used for the forwarding rule. | <code>map&#40;string&#41;</code> |  | <code>null</code> |
 | [backend_service_configs](variables-backend-service.tf#L19) | Backend service level configuration. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [description](variables.tf#L23) | Optional description used for resources. | <code>string</code> |  | <code>&#34;Terraform managed.&#34;</code> |
-| [group_configs](variables.tf#L29) | Optional unmanaged groups to create. Can be referenced in backends via key or outputs. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [context](variables.tf#L23) | Context-specific interpolations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [description](variables.tf#L37) | Optional description used for resources. | <code>string</code> |  | <code>&#34;Terraform managed.&#34;</code> |
+| [group_configs](variables.tf#L43) | Optional unmanaged groups to create. Can be referenced in backends via key or outputs. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [health_check_configs](variables-health-check.tf#L19) | Optional auto-created health check configurations, use the output self-link to set it in the auto healing policy. Refer to examples for usage. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#8230;&#125;</code> |
-| [http_proxy_config](variables.tf#L43) | HTTP proxy configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [https_proxy_config](variables.tf#L54) | HTTPS proxy configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [labels](variables.tf#L68) | Labels set on resources. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
-| [neg_configs](variables.tf#L79) | Optional network endpoint groups to create. Can be referenced in backends via key or outputs. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [ports](variables.tf#L145) | Optional ports for HTTP load balancer. | <code>list&#40;string&#41;</code> |  | <code>null</code> |
-| [protocol](variables.tf#L160) | Protocol supported by this load balancer. | <code>string</code> |  | <code>&#34;HTTP&#34;</code> |
-| [service_attachment](variables.tf#L173) | PSC service attachments. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [service_directory_registration](variables.tf#L188) | Service directory namespace and service used to register this load balancer. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [http_proxy_config](variables.tf#L57) | HTTP proxy configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [https_proxy_config](variables.tf#L68) | HTTPS proxy configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [labels](variables.tf#L82) | Labels set on resources. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [neg_configs](variables.tf#L93) | Optional network endpoint groups to create. Can be referenced in backends via key or outputs. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [ports](variables.tf#L159) | Optional ports for HTTP load balancer. | <code>list&#40;string&#41;</code> |  | <code>null</code> |
+| [protocol](variables.tf#L174) | Protocol supported by this load balancer. | <code>string</code> |  | <code>&#34;HTTP&#34;</code> |
+| [service_attachment](variables.tf#L187) | PSC service attachments. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [service_directory_registration](variables.tf#L202) | Service directory namespace and service used to register this load balancer. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
 | [urlmap_config](variables-urlmap.tf#L19) | The URL map configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#8230;&#125;</code> |
 
 ## Outputs

--- a/modules/net-lb-app-int-cross-region/backend-service.tf
+++ b/modules/net-lb-app-int-cross-region/backend-service.tf
@@ -38,10 +38,10 @@ locals {
 
 resource "google_compute_backend_service" "default" {
   provider = google-beta
-  for_each = var.backend_service_configs
+  for_each = local.backend_service_configs
   project = (
     each.value.project_id == null
-    ? var.project_id
+    ? local.project_id
     : each.value.project_id
   )
   name                            = coalesce(each.value.name, "${var.name}-${each.key}")

--- a/modules/net-lb-app-int-cross-region/groups.tf
+++ b/modules/net-lb-app-int-cross-region/groups.tf
@@ -15,10 +15,10 @@
  */
 
 resource "google_compute_instance_group" "default" {
-  for_each = var.group_configs
+  for_each = local.group_configs
   project = (
     each.value.project_id == null
-    ? var.project_id
+    ? local.project_id
     : each.value.project_id
   )
   zone        = each.value.zone

--- a/modules/net-lb-app-int-cross-region/health-check.tf
+++ b/modules/net-lb-app-int-cross-region/health-check.tf
@@ -18,10 +18,10 @@
 
 resource "google_compute_health_check" "default" {
   provider = google-beta
-  for_each = var.health_check_configs
+  for_each = local.health_check_configs
   project = (
     each.value.project_id == null
-    ? var.project_id
+    ? local.project_id
     : each.value.project_id
   )
   name                = coalesce(each.value.name, "${var.name}-${each.key}")

--- a/modules/net-lb-app-int-cross-region/main.tf
+++ b/modules/net-lb-app-int-cross-region/main.tf
@@ -15,6 +15,124 @@
  */
 
 locals {
+  # Context definition
+  ctx = {
+    for k, v in var.context : k => {
+      for kk, vv in v : "${local.ctx_p}${k}:${kk}" => vv
+    }
+  }
+  ctx_p = "$"
+
+  # Resolved variables
+  project_id = lookup(local.ctx.project_ids, var.project_id, var.project_id)
+
+  vpc_config = {
+    network     = lookup(local.ctx.networks, var.vpc_config.network, var.vpc_config.network)
+    subnetworks = { for k, v in var.vpc_config.subnetworks : k => lookup(local.ctx.subnets, v, v) }
+  }
+
+  addresses = var.addresses == null ? null : {
+    for k, v in var.addresses : k => lookup(local.ctx.addresses, v, v)
+  }
+
+  service_attachment = var.service_attachment == null ? null : merge(var.service_attachment, {
+    nat_subnets = {
+      for k, v in var.service_attachment.nat_subnets : k => [
+        for s in v : lookup(local.ctx.subnets, s, s)
+      ]
+    }
+  })
+
+  _neg_configs = {
+    for k, v in var.neg_configs : k => {
+      project_id = (
+        v.project_id == null
+        ? null
+        : lookup(local.ctx.project_ids, v.project_id, v.project_id)
+      )
+      cloudrun = v.cloudrun
+      gce = (
+        v.gce == null
+        ? null
+        : {
+          endpoints = v.gce.endpoints
+          network = (
+            v.gce.network == null
+            ? null
+            : lookup(local.ctx.networks, v.gce.network, v.gce.network)
+          )
+          subnetwork = (
+            v.gce.subnetwork == null
+            ? null
+            : lookup(local.ctx.subnets, v.gce.subnetwork, v.gce.subnetwork)
+          )
+          zone = v.gce.zone
+        }
+      )
+      hybrid = (
+        v.hybrid == null
+        ? null
+        : {
+          endpoints = v.hybrid.endpoints
+          network = (
+            v.hybrid.network == null
+            ? null
+            : lookup(local.ctx.networks, v.hybrid.network, v.hybrid.network)
+          )
+          zone = v.hybrid.zone
+        }
+      )
+      psc = (
+        v.psc == null
+        ? null
+        : {
+          region         = v.psc.region
+          target_service = v.psc.target_service
+          network = (
+            v.psc.network == null
+            ? null
+            : lookup(local.ctx.networks, v.psc.network, v.psc.network)
+          )
+          subnetwork = (
+            v.psc.subnetwork == null
+            ? null
+            : lookup(local.ctx.subnets, v.psc.subnetwork, v.psc.subnetwork)
+          )
+        }
+      )
+    }
+  }
+
+  backend_service_configs = {
+    for k, v in var.backend_service_configs : k => merge(v, {
+      project_id = (
+        v.project_id == null
+        ? null
+        : lookup(local.ctx.project_ids, v.project_id, v.project_id)
+      )
+    })
+  }
+
+  group_configs = {
+    for k, v in var.group_configs : k => merge(v, {
+      project_id = (
+        v.project_id == null
+        ? null
+        : lookup(local.ctx.project_ids, v.project_id, v.project_id)
+      )
+    })
+  }
+
+  health_check_configs = {
+    for k, v in var.health_check_configs : k => merge(v, {
+      project_id = (
+        v.project_id == null
+        ? null
+        : lookup(local.ctx.project_ids, v.project_id, v.project_id)
+      )
+    })
+  }
+
   # we need keys in the endpoint type to address issue #1055
   _neg_endpoints = flatten([
     for k, v in local.neg_zonal : [
@@ -35,12 +153,12 @@ locals {
     for v in local._neg_endpoints : (v.key) => v
   }
   neg_regional = {
-    for k, v in var.neg_configs :
+    for k, v in local._neg_configs :
     k => merge(v.cloudrun, { project_id = v.project_id }) if v.cloudrun != null
   }
   neg_zonal = {
     # we need to rebuild new objects as we cannot merge different types
-    for k, v in var.neg_configs : k => {
+    for k, v in local._neg_configs : k => {
       endpoints  = v.gce != null ? v.gce.endpoints : v.hybrid.endpoints
       network    = v.gce != null ? v.gce.network : v.hybrid.network
       project_id = v.project_id
@@ -50,23 +168,24 @@ locals {
     } if v.gce != null || v.hybrid != null
   }
   neg_regional_psc = {
-    for k, v in var.neg_configs :
+    for k, v in local._neg_configs :
     k => v if v.psc != null
   }
 }
 
+
 resource "google_compute_global_forwarding_rule" "forwarding_rules" {
-  for_each              = var.vpc_config.subnetworks
+  for_each              = local.vpc_config.subnetworks
   provider              = google-beta
-  project               = var.project_id
+  project               = local.project_id
   name                  = "${var.name}-${each.key}"
   description           = var.description
-  ip_address            = try(var.addresses[each.key], null)
+  ip_address            = try(local.addresses[each.key], null)
   ip_protocol           = "TCP"
   load_balancing_scheme = "INTERNAL_MANAGED"
-  network               = var.vpc_config.network
+  network               = local.vpc_config.network
   port_range            = join(",", local.fwd_rule_ports)
-  subnetwork            = var.vpc_config.subnetworks[each.key]
+  subnetwork            = local.vpc_config.subnetworks[each.key]
   labels                = var.labels
   target                = local.fwd_rule_target
   # during the preview phase you cannot change this attribute on an existing rule
@@ -81,7 +200,7 @@ resource "google_compute_global_forwarding_rule" "forwarding_rules" {
 
 resource "google_compute_target_http_proxy" "default" {
   count                       = var.protocol == "HTTPS" ? 0 : 1
-  project                     = var.project_id
+  project                     = local.project_id
   name                        = coalesce(var.http_proxy_config.name, var.name)
   description                 = var.http_proxy_config.description
   http_keep_alive_timeout_sec = var.http_proxy_config.http_keepalive_timeout
@@ -90,7 +209,7 @@ resource "google_compute_target_http_proxy" "default" {
 
 resource "google_compute_target_https_proxy" "default" {
   count                            = var.protocol == "HTTPS" ? 1 : 0
-  project                          = var.project_id
+  project                          = local.project_id
   name                             = coalesce(var.https_proxy_config.name, var.name)
   description                      = var.https_proxy_config.description
   certificate_manager_certificates = var.https_proxy_config.certificate_manager_certificates
@@ -101,28 +220,28 @@ resource "google_compute_target_https_proxy" "default" {
 }
 
 resource "google_compute_service_attachment" "default" {
-  for_each       = var.service_attachment == null ? {} : google_compute_global_forwarding_rule.forwarding_rules
-  project        = var.project_id
+  for_each       = local.service_attachment == null ? {} : google_compute_global_forwarding_rule.forwarding_rules
+  project        = local.project_id
   region         = each.key
   name           = each.value.name
-  description    = var.service_attachment.description
+  description    = local.service_attachment.description
   target_service = each.value.id
-  nat_subnets    = var.service_attachment.nat_subnets[each.key]
+  nat_subnets    = local.service_attachment.nat_subnets[each.key]
   connection_preference = (
-    var.service_attachment.automatic_connection
+    local.service_attachment.automatic_connection
     ? "ACCEPT_AUTOMATIC"
     : "ACCEPT_MANUAL"
   )
-  consumer_reject_lists = var.service_attachment.consumer_reject_lists
+  consumer_reject_lists = local.service_attachment.consumer_reject_lists
   domain_names = (
-    var.service_attachment.domain_name == null
+    local.service_attachment.domain_name == null
     ? null
-    : [var.service_attachment.domain_name[each.key]]
+    : [local.service_attachment.domain_name[each.key]]
   )
-  enable_proxy_protocol = var.service_attachment.enable_proxy_protocol
-  reconcile_connections = var.service_attachment.reconcile_connections
+  enable_proxy_protocol = local.service_attachment.enable_proxy_protocol
+  reconcile_connections = local.service_attachment.reconcile_connections
   dynamic "consumer_accept_lists" {
-    for_each = var.service_attachment.consumer_accept_lists
+    for_each = local.service_attachment.consumer_accept_lists
     iterator = accept
     content {
       project_id_or_num = accept.key
@@ -135,7 +254,7 @@ resource "google_compute_network_endpoint_group" "default" {
   for_each = local.neg_zonal
   project = (
     each.value.project_id == null
-    ? var.project_id
+    ? local.project_id
     : each.value.project_id
   )
   zone = each.value.zone
@@ -145,12 +264,12 @@ resource "google_compute_network_endpoint_group" "default" {
   description           = var.description
   network_endpoint_type = each.value.type
   network = (
-    each.value.network != null ? each.value.network : var.vpc_config.network
+    each.value.network != null ? each.value.network : local.vpc_config.network
   )
   subnetwork = (
     each.value.type == "NON_GCP_PRIVATE_IP_PORT"
     ? null
-    : coalesce(each.value.subnetwork, var.vpc_config.subnetworks[substr(each.value.zone, 0, length(each.value.zone) - 2)])
+    : coalesce(each.value.subnetwork, local.vpc_config.subnetworks[substr(each.value.zone, 0, length(each.value.zone) - 2)])
   )
 }
 
@@ -172,7 +291,7 @@ resource "google_compute_region_network_endpoint_group" "default" {
   for_each = local.neg_regional
   project = (
     each.value.project_id == null
-    ? var.project_id
+    ? local.project_id
     : each.value.project_id
   )
   region                = each.value.region
@@ -188,7 +307,7 @@ resource "google_compute_region_network_endpoint_group" "default" {
 
 resource "google_compute_region_network_endpoint_group" "psc" {
   for_each = local.neg_regional_psc
-  project  = var.project_id
+  project  = local.project_id
   region   = each.value.psc.region
   name     = "${var.name}-${each.key}"
   //description           = coalesce(each.value.description, var.description)

--- a/modules/net-lb-app-int-cross-region/main.tf
+++ b/modules/net-lb-app-int-cross-region/main.tf
@@ -50,7 +50,15 @@ locals {
         ? null
         : lookup(local.ctx.project_ids, v.project_id, v.project_id)
       )
-      cloudrun = v.cloudrun
+      cloudrun = (
+        v.cloudrun == null
+        ? null
+        : {
+          region         = lookup(local.ctx.locations, v.cloudrun.region, v.cloudrun.region)
+          target_service = v.cloudrun.target_service
+          target_urlmask = v.cloudrun.target_urlmask
+        }
+      )
       gce = (
         v.gce == null
         ? null
@@ -66,7 +74,7 @@ locals {
             ? null
             : lookup(local.ctx.subnets, v.gce.subnetwork, v.gce.subnetwork)
           )
-          zone = v.gce.zone
+          zone = lookup(local.ctx.locations, v.gce.zone, v.gce.zone)
         }
       )
       hybrid = (
@@ -79,14 +87,14 @@ locals {
             ? null
             : lookup(local.ctx.networks, v.hybrid.network, v.hybrid.network)
           )
-          zone = v.hybrid.zone
+          zone = lookup(local.ctx.locations, v.hybrid.zone, v.hybrid.zone)
         }
       )
       psc = (
         v.psc == null
         ? null
         : {
-          region         = v.psc.region
+          region         = lookup(local.ctx.locations, v.psc.region, v.psc.region)
           target_service = v.psc.target_service
           network = (
             v.psc.network == null
@@ -120,6 +128,7 @@ locals {
         ? null
         : lookup(local.ctx.project_ids, v.project_id, v.project_id)
       )
+      zone = lookup(local.ctx.locations, v.zone, v.zone)
     })
   }
 
@@ -137,7 +146,10 @@ locals {
   _neg_endpoints = flatten([
     for k, v in local.neg_zonal : [
       for kk, vv in v.endpoints : merge(vv, {
-        key = "${k}-${kk}", neg = k, zone = v.zone
+        key        = "${k}-${kk}"
+        neg        = k
+        zone       = v.zone
+        ip_address = try(local.ctx.addresses[vv.ip_address], vv.ip_address)
       })
     ]
   ])

--- a/modules/net-lb-app-int-cross-region/urlmap.tf
+++ b/modules/net-lb-app-int-cross-region/urlmap.tf
@@ -24,7 +24,7 @@ locals {
 
 resource "google_compute_url_map" "default" {
   provider    = google-beta
-  project     = var.project_id
+  project     = local.project_id
   name        = var.name
   description = var.urlmap_config.description
   default_service = (
@@ -49,6 +49,195 @@ resource "google_compute_url_map" "default" {
       prefix_redirect        = r.value.prefix
       redirect_response_code = r.value.response_code
       strip_query            = r.value.strip_query
+    }
+  }
+
+  dynamic "default_route_action" {
+    for_each = (
+      var.urlmap_config.default_route_action == null
+      ? []
+      : [var.urlmap_config.default_route_action]
+    )
+    iterator = route_action
+    content {
+      dynamic "cors_policy" {
+        for_each = (
+          route_action.value.cors_policy == null
+          ? []
+          : [route_action.value.cors_policy]
+        )
+        content {
+          allow_credentials    = cors_policy.value.allow_credentials
+          allow_headers        = cors_policy.value.allow_headers
+          allow_methods        = cors_policy.value.allow_methods
+          allow_origin_regexes = cors_policy.value.allow_origin_regexes
+          allow_origins        = cors_policy.value.allow_origins
+          disabled             = cors_policy.value.disabled
+          expose_headers       = cors_policy.value.expose_headers
+          max_age              = cors_policy.value.max_age
+        }
+      }
+      dynamic "fault_injection_policy" {
+        for_each = (
+          route_action.value.fault_injection_policy == null
+          ? []
+          : [route_action.value.fault_injection_policy]
+        )
+        content {
+          dynamic "abort" {
+            for_each = (
+              fault_injection_policy.value.abort == null
+              ? []
+              : [fault_injection_policy.value.abort]
+            )
+            content {
+              http_status = abort.value.status
+              percentage  = abort.value.percentage
+            }
+          }
+          dynamic "delay" {
+            for_each = (
+              fault_injection_policy.value.delay == null
+              ? []
+              : [fault_injection_policy.value.delay]
+            )
+            content {
+              percentage = delay.value.percentage
+              fixed_delay {
+                nanos   = delay.value.fixed.nanos
+                seconds = delay.value.fixed.seconds
+              }
+            }
+          }
+        }
+      }
+      dynamic "request_mirror_policy" {
+        for_each = (
+          route_action.value.request_mirror_backend == null
+          ? []
+          : [""]
+        )
+        content {
+          backend_service = lookup(
+            local.backend_ids,
+            route_action.value.request_mirror_backend,
+            route_action.value.request_mirror_backend
+          )
+        }
+      }
+      dynamic "retry_policy" {
+        for_each = (
+          route_action.value.retry_policy == null
+          ? []
+          : [route_action.value.retry_policy]
+        )
+        content {
+          num_retries      = retry_policy.value.num_retries
+          retry_conditions = retry_policy.value.retry_conditions
+          dynamic "per_try_timeout" {
+            for_each = (
+              retry_policy.value.per_try_timeout == null
+              ? []
+              : [retry_policy.value.per_try_timeout]
+            )
+            content {
+              nanos   = per_try_timeout.value.nanos
+              seconds = per_try_timeout.value.seconds
+            }
+          }
+        }
+      }
+      dynamic "timeout" {
+        for_each = (
+          route_action.value.timeout == null
+          ? []
+          : [route_action.value.timeout]
+        )
+        content {
+          nanos   = timeout.value.nanos
+          seconds = timeout.value.seconds
+        }
+      }
+      dynamic "url_rewrite" {
+        for_each = (
+          route_action.value.url_rewrite == null
+          ? []
+          : [route_action.value.url_rewrite]
+        )
+        content {
+          host_rewrite        = url_rewrite.value.host
+          path_prefix_rewrite = url_rewrite.value.path_prefix
+        }
+      }
+      dynamic "weighted_backend_services" {
+        for_each = coalesce(
+          route_action.value.weighted_backend_services, {}
+        )
+        iterator = service
+        content {
+          backend_service = lookup(
+            local.backend_ids, service.key, service.key
+          )
+          weight = service.value.weight
+          dynamic "header_action" {
+            for_each = (
+              service.value.header_action == null
+              ? []
+              : [service.value.header_action]
+            )
+            iterator = h
+            content {
+              request_headers_to_remove  = h.value.request_remove
+              response_headers_to_remove = h.value.response_remove
+              dynamic "request_headers_to_add" {
+                for_each = coalesce(h.value.request_add, {})
+                content {
+                  header_name  = request_headers_to_add.key
+                  header_value = request_headers_to_add.value.value
+                  replace      = request_headers_to_add.value.replace
+                }
+              }
+              dynamic "response_headers_to_add" {
+                for_each = coalesce(h.value.response_add, {})
+                content {
+                  header_name  = response_headers_to_add.key
+                  header_value = response_headers_to_add.value.value
+                  replace      = response_headers_to_add.value.replace
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  dynamic "header_action" {
+    for_each = (
+      var.urlmap_config.header_action == null
+      ? []
+      : [var.urlmap_config.header_action]
+    )
+    iterator = h
+    content {
+      request_headers_to_remove  = h.value.request_remove
+      response_headers_to_remove = h.value.response_remove
+      dynamic "request_headers_to_add" {
+        for_each = coalesce(h.value.request_add, {})
+        content {
+          header_name  = request_headers_to_add.key
+          header_value = request_headers_to_add.value.value
+          replace      = request_headers_to_add.value.replace
+        }
+      }
+      dynamic "response_headers_to_add" {
+        for_each = coalesce(h.value.response_add, {})
+        content {
+          header_name  = response_headers_to_add.key
+          header_value = response_headers_to_add.value.value
+          replace      = response_headers_to_add.value.replace
+        }
+      }
     }
   }
 

--- a/modules/net-lb-app-int-cross-region/variables-urlmap.tf
+++ b/modules/net-lb-app-int-cross-region/variables-urlmap.tf
@@ -29,6 +29,75 @@ variable "urlmap_config" {
       response_code = optional(string)
       strip_query   = optional(bool)
     }))
+    default_route_action = optional(object({
+      request_mirror_backend = optional(string)
+      cors_policy = optional(object({
+        allow_credentials    = optional(bool)
+        allow_headers        = optional(list(string))
+        allow_methods        = optional(list(string))
+        allow_origin_regexes = optional(list(string))
+        allow_origins        = optional(list(string))
+        disabled             = optional(bool)
+        expose_headers       = optional(list(string))
+        max_age              = optional(string)
+      }))
+      fault_injection_policy = optional(object({
+        abort = optional(object({
+          percentage = number
+          status     = number
+        }))
+        delay = optional(object({
+          fixed = object({
+            seconds = number
+            nanos   = number
+          })
+          percentage = number
+        }))
+      }))
+      retry_policy = optional(object({
+        num_retries      = number
+        retry_conditions = optional(list(string))
+        per_try_timeout = optional(object({
+          seconds = number
+          nanos   = optional(number)
+        }))
+      }))
+      timeout = optional(object({
+        seconds = number
+        nanos   = optional(number)
+      }))
+      url_rewrite = optional(object({
+        host        = optional(string)
+        path_prefix = optional(string)
+      }))
+      weighted_backend_services = optional(map(object({
+        weight = number
+        header_action = optional(object({
+          request_add = optional(map(object({
+            value   = string
+            replace = optional(bool, true)
+          })))
+          request_remove = optional(list(string))
+          response_add = optional(map(object({
+            value   = string
+            replace = optional(bool, true)
+          })))
+          response_remove = optional(list(string))
+        }))
+      })))
+    }))
+    header_action = optional(object({
+      request_add = optional(map(object({
+        value   = string
+        replace = optional(bool, true)
+      })))
+      request_remove = optional(list(string))
+      response_add = optional(map(object({
+        value   = string
+        replace = optional(bool, true)
+      })))
+      response_remove = optional(list(string))
+    }))
     host_rules = optional(list(object({
       hosts        = list(string)
       path_matcher = string

--- a/modules/net-lb-app-int-cross-region/variables.tf
+++ b/modules/net-lb-app-int-cross-region/variables.tf
@@ -20,6 +20,20 @@ variable "addresses" {
   default     = null
 }
 
+variable "context" {
+  description = "Context-specific interpolations."
+  type = object({
+    addresses   = optional(map(string), {})
+    locations   = optional(map(string), {})
+    networks    = optional(map(string), {})
+    project_ids = optional(map(string), {})
+    subnets     = optional(map(string), {})
+  })
+  default  = {}
+  nullable = false
+}
+
+
 variable "description" {
   description = "Optional description used for resources."
   type        = string

--- a/modules/net-lb-app-int/backend-service.tf
+++ b/modules/net-lb-app-int/backend-service.tf
@@ -80,7 +80,6 @@ resource "google_compute_region_backend_service" "default" {
       balancing_mode  = backend.value.balancing_mode
       capacity_scaler = backend.value.capacity_scaler
       description     = backend.value.description
-      failover        = backend.value.failover
       max_connections = try(
         backend.value.max_connections.per_group, null
       )
@@ -150,18 +149,6 @@ resource "google_compute_region_backend_service" "default" {
           }
         }
       }
-    }
-  }
-
-  dynamic "failover_policy" {
-    for_each = (
-      each.value.failover_config == null ? [] : [each.value.failover_config]
-    )
-    iterator = fc
-    content {
-      disable_connection_drain_on_failover = fc.value.disable_conn_drain
-      drop_traffic_if_unhealthy            = fc.value.drop_traffic_if_unhealthy
-      failover_ratio                       = fc.value.ratio
     }
   }
 

--- a/modules/net-lb-app-int/main.tf
+++ b/modules/net-lb-app-int/main.tf
@@ -32,7 +32,10 @@ locals {
   _neg_endpoints = flatten([
     for k, v in local.neg_zonal : [
       for kk, vv in v.endpoints : merge(vv, {
-        key = "${k}-${kk}", neg = k, zone = v.zone
+        key        = "${k}-${kk}"
+        neg        = k
+        zone       = v.zone
+        ip_address = try(local.ctx.addresses[vv.ip_address], vv.ip_address)
       })
     ]
   ])
@@ -49,22 +52,32 @@ locals {
   }
   neg_regional = {
     for k, v in var.neg_configs :
-    k => merge(v.cloudrun, { project_id = v.project_id }) if v.cloudrun != null
+    k => merge(v.cloudrun, {
+      project_id = v.project_id == null ? null : lookup(local.ctx.project_ids, v.project_id, v.project_id)
+      region     = lookup(local.ctx.locations, v.cloudrun.region, v.cloudrun.region)
+    }) if v.cloudrun != null
   }
   neg_zonal = {
     # we need to rebuild new objects as we cannot merge different types
     for k, v in var.neg_configs : k => {
       endpoints  = v.gce != null ? v.gce.endpoints : v.hybrid.endpoints
-      network    = v.gce != null ? v.gce.network : v.hybrid.network
-      project_id = v.project_id
-      subnetwork = v.gce != null ? v.gce.subnetwork : null
+      network    = v.gce != null ? try(local.ctx.networks[v.gce.network], v.gce.network) : try(local.ctx.networks[v.hybrid.network], v.hybrid.network)
+      project_id = v.project_id == null ? null : try(local.ctx.project_ids[v.project_id], v.project_id)
+      subnetwork = v.gce != null ? try(local.ctx.subnets[v.gce.subnetwork], v.gce.subnetwork) : null
       type       = v.gce != null ? "GCE_VM_IP_PORT" : "NON_GCP_PRIVATE_IP_PORT"
-      zone       = v.gce != null ? v.gce.zone : v.hybrid.zone
+      zone       = v.gce != null ? try(local.ctx.locations[v.gce.zone], v.gce.zone) : try(local.ctx.locations[v.hybrid.zone], v.hybrid.zone)
     } if v.gce != null || v.hybrid != null
   }
   neg_regional_psc = {
-    for k, v in var.neg_configs :
-    k => v if v.psc != null
+    for k, v in var.neg_configs : k => merge(v, {
+      project_id = v.project_id == null ? null : lookup(local.ctx.project_ids, v.project_id, v.project_id)
+      psc = {
+        region         = lookup(local.ctx.locations, v.psc.region, v.psc.region)
+        target_service = v.psc.target_service
+        network        = v.psc.network == null ? null : lookup(local.ctx.networks, v.psc.network, v.psc.network)
+        subnetwork     = v.psc.subnetwork == null ? null : lookup(local.ctx.subnets, v.psc.subnetwork, v.psc.subnetwork)
+      }
+    }) if v.psc != null
   }
   proxy_ssl_certificates = concat(
     coalesce(var.ssl_certificates.certificate_ids, []),
@@ -170,30 +183,17 @@ resource "google_compute_service_attachment" "default" {
 }
 
 resource "google_compute_network_endpoint_group" "default" {
-  for_each = local.neg_zonal
-  project = (
-    each.value.project_id == null
-    ? local.project_id
-    : each.value.project_id
-  )
-  zone = each.value.zone
-  name = "${var.name}-${each.key}"
-  # re-enable once provider properly supports this
-  # default_port = each.value.default_port
+  for_each              = local.neg_zonal
+  project               = coalesce(each.value.project_id, local.project_id)
+  zone                  = each.value.zone
+  name                  = "${var.name}-${each.key}"
   description           = var.description
   network_endpoint_type = each.value.type
-  network = (
-    each.value.network != null
-    ? try(local.ctx.networks[each.value.network], each.value.network)
-    : local.network
-  )
+  network               = coalesce(each.value.network, local.network)
   subnetwork = (
     each.value.type == "NON_GCP_PRIVATE_IP_PORT"
     ? null
-    : coalesce(
-      try(local.ctx.subnets[each.value.subnetwork], each.value.subnetwork),
-      local.subnetwork
-    )
+    : coalesce(each.value.subnetwork, local.subnetwork)
   )
 }
 
@@ -212,12 +212,8 @@ resource "google_compute_network_endpoint" "default" {
 }
 
 resource "google_compute_region_network_endpoint_group" "default" {
-  for_each = local.neg_regional
-  project = (
-    each.value.project_id == null
-    ? local.project_id
-    : each.value.project_id
-  )
+  for_each              = local.neg_regional
+  project               = coalesce(each.value.project_id, local.project_id)
   region                = each.value.region
   name                  = "${var.name}-${each.key}"
   description           = var.description
@@ -233,26 +229,14 @@ resource "google_compute_region_network_endpoint_group" "default" {
 
 resource "google_compute_region_network_endpoint_group" "psc" {
   for_each = local.neg_regional_psc
-  project = (
-    each.value.project_id == null
-    ? local.project_id
-    : each.value.project_id
-  )
-  region = each.value.psc.region
-  name   = "${var.name}-${each.key}"
+  project  = coalesce(each.value.project_id, local.project_id)
+  region   = each.value.psc.region
+  name     = "${var.name}-${each.key}"
   //description           = coalesce(each.value.description, var.description)
   network_endpoint_type = "PRIVATE_SERVICE_CONNECT"
   psc_target_service    = each.value.psc.target_service
-  network = (
-    each.value.psc.network == null
-    ? null
-    : try(local.ctx.networks[each.value.psc.network], each.value.psc.network)
-  )
-  subnetwork = (
-    each.value.psc.subnetwork == null
-    ? null
-    : try(local.ctx.subnets[each.value.psc.subnetwork], each.value.psc.subnetwork)
-  )
+  network               = each.value.psc.network
+  subnetwork            = each.value.psc.subnetwork
   lifecycle {
     # ignore until https://github.com/hashicorp/terraform-provider-google/issues/20576 is fixed
     ignore_changes = [psc_data]
@@ -271,18 +255,22 @@ locals {
     for v in local._neg_endpoints_internet : (v.key) => v
   }
   neg_internet = {
-    for k, v in var.neg_configs :
-    k => v if v.internet != null
+    for k, v in var.neg_configs : k => merge(v, {
+      project_id = v.project_id == null ? null : lookup(local.ctx.project_ids, v.project_id, v.project_id)
+      internet = {
+        region    = lookup(local.ctx.locations, v.internet.region, v.internet.region)
+        use_fqdn  = v.internet.use_fqdn
+        endpoints = v.internet.endpoints
+      }
+    }) if v.internet != null
   }
 }
 
 resource "google_compute_region_network_endpoint_group" "internet" {
-  for_each = local.neg_internet
-  project  = local.project_id
-  name     = "${var.name}-${each.key}"
-  region   = each.value.internet.region
-  # re-enable once provider properly supports this
-  # default_port = each.value.default_port
+  for_each    = local.neg_internet
+  project     = coalesce(each.value.project_id, local.project_id)
+  name        = "${var.name}-${each.key}"
+  region      = each.value.internet.region
   description = coalesce(each.value.description, var.description)
   network_endpoint_type = (
     each.value.internet.use_fqdn ? "INTERNET_FQDN_PORT" : "INTERNET_IP_PORT"

--- a/modules/net-lb-app-int/urlmap.tf
+++ b/modules/net-lb-app-int/urlmap.tf
@@ -53,6 +53,195 @@ resource "google_compute_region_url_map" "default" {
     }
   }
 
+  dynamic "default_route_action" {
+    for_each = (
+      var.urlmap_config.default_route_action == null
+      ? []
+      : [var.urlmap_config.default_route_action]
+    )
+    iterator = route_action
+    content {
+      dynamic "cors_policy" {
+        for_each = (
+          route_action.value.cors_policy == null
+          ? []
+          : [route_action.value.cors_policy]
+        )
+        content {
+          allow_credentials    = cors_policy.value.allow_credentials
+          allow_headers        = cors_policy.value.allow_headers
+          allow_methods        = cors_policy.value.allow_methods
+          allow_origin_regexes = cors_policy.value.allow_origin_regexes
+          allow_origins        = cors_policy.value.allow_origins
+          disabled             = cors_policy.value.disabled
+          expose_headers       = cors_policy.value.expose_headers
+          max_age              = cors_policy.value.max_age
+        }
+      }
+      dynamic "fault_injection_policy" {
+        for_each = (
+          route_action.value.fault_injection_policy == null
+          ? []
+          : [route_action.value.fault_injection_policy]
+        )
+        content {
+          dynamic "abort" {
+            for_each = (
+              fault_injection_policy.value.abort == null
+              ? []
+              : [fault_injection_policy.value.abort]
+            )
+            content {
+              http_status = abort.value.status
+              percentage  = abort.value.percentage
+            }
+          }
+          dynamic "delay" {
+            for_each = (
+              fault_injection_policy.value.delay == null
+              ? []
+              : [fault_injection_policy.value.delay]
+            )
+            content {
+              percentage = delay.value.percentage
+              fixed_delay {
+                nanos   = delay.value.fixed.nanos
+                seconds = delay.value.fixed.seconds
+              }
+            }
+          }
+        }
+      }
+      dynamic "request_mirror_policy" {
+        for_each = (
+          route_action.value.request_mirror_backend == null
+          ? []
+          : [""]
+        )
+        content {
+          backend_service = lookup(
+            local.backend_ids,
+            route_action.value.request_mirror_backend,
+            route_action.value.request_mirror_backend
+          )
+        }
+      }
+      dynamic "retry_policy" {
+        for_each = (
+          route_action.value.retry_policy == null
+          ? []
+          : [route_action.value.retry_policy]
+        )
+        content {
+          num_retries      = retry_policy.value.num_retries
+          retry_conditions = retry_policy.value.retry_conditions
+          dynamic "per_try_timeout" {
+            for_each = (
+              retry_policy.value.per_try_timeout == null
+              ? []
+              : [retry_policy.value.per_try_timeout]
+            )
+            content {
+              nanos   = per_try_timeout.value.nanos
+              seconds = per_try_timeout.value.seconds
+            }
+          }
+        }
+      }
+      dynamic "timeout" {
+        for_each = (
+          route_action.value.timeout == null
+          ? []
+          : [route_action.value.timeout]
+        )
+        content {
+          nanos   = timeout.value.nanos
+          seconds = timeout.value.seconds
+        }
+      }
+      dynamic "url_rewrite" {
+        for_each = (
+          route_action.value.url_rewrite == null
+          ? []
+          : [route_action.value.url_rewrite]
+        )
+        content {
+          host_rewrite        = url_rewrite.value.host
+          path_prefix_rewrite = url_rewrite.value.path_prefix
+        }
+      }
+      dynamic "weighted_backend_services" {
+        for_each = coalesce(
+          route_action.value.weighted_backend_services, {}
+        )
+        iterator = service
+        content {
+          backend_service = lookup(
+            local.backend_ids, service.key, service.key
+          )
+          weight = service.value.weight
+          dynamic "header_action" {
+            for_each = (
+              service.value.header_action == null
+              ? []
+              : [service.value.header_action]
+            )
+            iterator = h
+            content {
+              request_headers_to_remove  = h.value.request_remove
+              response_headers_to_remove = h.value.response_remove
+              dynamic "request_headers_to_add" {
+                for_each = coalesce(h.value.request_add, {})
+                content {
+                  header_name  = request_headers_to_add.key
+                  header_value = request_headers_to_add.value.value
+                  replace      = request_headers_to_add.value.replace
+                }
+              }
+              dynamic "response_headers_to_add" {
+                for_each = coalesce(h.value.response_add, {})
+                content {
+                  header_name  = response_headers_to_add.key
+                  header_value = response_headers_to_add.value.value
+                  replace      = response_headers_to_add.value.replace
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  dynamic "header_action" {
+    for_each = (
+      var.urlmap_config.header_action == null
+      ? []
+      : [var.urlmap_config.header_action]
+    )
+    iterator = h
+    content {
+      request_headers_to_remove  = h.value.request_remove
+      response_headers_to_remove = h.value.response_remove
+      dynamic "request_headers_to_add" {
+        for_each = coalesce(h.value.request_add, {})
+        content {
+          header_name  = request_headers_to_add.key
+          header_value = request_headers_to_add.value.value
+          replace      = request_headers_to_add.value.replace
+        }
+      }
+      dynamic "response_headers_to_add" {
+        for_each = coalesce(h.value.response_add, {})
+        content {
+          header_name  = response_headers_to_add.key
+          header_value = response_headers_to_add.value.value
+          replace      = response_headers_to_add.value.replace
+        }
+      }
+    }
+  }
+
   dynamic "host_rule" {
     for_each = coalesce(var.urlmap_config.host_rules, [])
     iterator = r

--- a/modules/net-lb-app-int/variables-backend-service.tf
+++ b/modules/net-lb-app-int/variables-backend-service.tf
@@ -42,7 +42,6 @@ variable "backend_service_configs" {
       balancing_mode  = optional(string, "UTILIZATION")
       capacity_scaler = optional(number, 1)
       description     = optional(string, "Terraform managed.")
-      failover        = optional(bool, false)
       max_rate = optional(object({
         per_endpoint = optional(number)
         per_group    = optional(number)
@@ -74,10 +73,6 @@ variable "backend_service_configs" {
       }))
     }))
     enable_subsetting = optional(bool)
-    failover_config = optional(object({
-      disable_conn_drain        = optional(bool)
-      drop_traffic_if_unhealthy = optional(bool)
-    }))
     iap_config = optional(object({
       oauth2_client_id            = optional(string)
       oauth2_client_secret        = optional(string)

--- a/modules/net-lb-app-int/variables-urlmap.tf
+++ b/modules/net-lb-app-int/variables-urlmap.tf
@@ -29,6 +29,75 @@ variable "urlmap_config" {
       response_code = optional(string)
       strip_query   = optional(bool)
     }))
+    default_route_action = optional(object({
+      request_mirror_backend = optional(string)
+      cors_policy = optional(object({
+        allow_credentials    = optional(bool)
+        allow_headers        = optional(list(string))
+        allow_methods        = optional(list(string))
+        allow_origin_regexes = optional(list(string))
+        allow_origins        = optional(list(string))
+        disabled             = optional(bool)
+        expose_headers       = optional(list(string))
+        max_age              = optional(string)
+      }))
+      fault_injection_policy = optional(object({
+        abort = optional(object({
+          percentage = number
+          status     = number
+        }))
+        delay = optional(object({
+          fixed = object({
+            seconds = number
+            nanos   = number
+          })
+          percentage = number
+        }))
+      }))
+      retry_policy = optional(object({
+        num_retries      = number
+        retry_conditions = optional(list(string))
+        per_try_timeout = optional(object({
+          seconds = number
+          nanos   = optional(number)
+        }))
+      }))
+      timeout = optional(object({
+        seconds = number
+        nanos   = optional(number)
+      }))
+      url_rewrite = optional(object({
+        host        = optional(string)
+        path_prefix = optional(string)
+      }))
+      weighted_backend_services = optional(map(object({
+        weight = number
+        header_action = optional(object({
+          request_add = optional(map(object({
+            value   = string
+            replace = optional(bool, true)
+          })))
+          request_remove = optional(list(string))
+          response_add = optional(map(object({
+            value   = string
+            replace = optional(bool, true)
+          })))
+          response_remove = optional(list(string))
+        }))
+      })))
+    }))
+    header_action = optional(object({
+      request_add = optional(map(object({
+        value   = string
+        replace = optional(bool, true)
+      })))
+      request_remove = optional(list(string))
+      response_add = optional(map(object({
+        value   = string
+        replace = optional(bool, true)
+      })))
+      response_remove = optional(list(string))
+    }))
     host_rules = optional(list(object({
       hosts        = list(string)
       path_matcher = string

--- a/modules/net-lb-ext/README.md
+++ b/modules/net-lb-ext/README.md
@@ -15,8 +15,8 @@ This example shows how to reference existing Managed Infrastructure Groups (MIGs
 ```hcl
 module "nlb" {
   source     = "./fabric/modules/net-lb-ext"
-  project_id = var.project_id
-  region     = var.region
+  project_id = "$project_ids:my-project"
+  region     = "$locations:europe-west1"
   name       = "nlb-test"
   backends = [{
     group = module.compute-mig.group_manager.instance_group
@@ -24,6 +24,14 @@ module "nlb" {
   health_check_config = {
     http = {
       port = 80
+    }
+  }
+  context = {
+    project_ids = {
+      my-project = var.project_id
+    }
+    locations = {
+      europe-west1 = var.region
     }
   }
 }
@@ -205,16 +213,17 @@ For deploying changes to load balancer configuration please refer to [net-lb-app
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [name](variables.tf#L203) | Name used for all resources. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L208) | Project id where resources will be created. | <code>string</code> | ✓ |  |
-| [region](variables.tf#L213) | GCP region. | <code>string</code> | ✓ |  |
+| [name](variables.tf#L215) | Name used for all resources. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L220) | Project id where resources will be created. | <code>string</code> | ✓ |  |
+| [region](variables.tf#L225) | GCP region. | <code>string</code> | ✓ |  |
 | [backend_service_config](variables.tf#L17) | Backend service level configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [backends](variables.tf#L73) | Load balancer backends. | <code>list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
-| [forwarding_rules_config](variables.tf#L84) | The optional forwarding rules configuration. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#8230;&#125;</code> |
-| [group_configs](variables.tf#L100) | Optional unmanaged groups to create. Can be referenced in backends via outputs. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [health_check](variables.tf#L113) | Name of existing health check to use, disables auto-created health check. | <code>string</code> |  | <code>null</code> |
-| [health_check_config](variables.tf#L119) | Optional auto-created health check configuration, use the output self-link to set it in the auto healing policy. Refer to examples for usage. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#8230;&#125;</code> |
-| [labels](variables.tf#L197) | Labels set on resources. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [context](variables.tf#L84) | Context-specific interpolations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [forwarding_rules_config](variables.tf#L96) | The optional forwarding rules configuration. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#8230;&#125;</code> |
+| [group_configs](variables.tf#L112) | Optional unmanaged groups to create. Can be referenced in backends via outputs. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [health_check](variables.tf#L125) | Name of existing health check to use, disables auto-created health check. | <code>string</code> |  | <code>null</code> |
+| [health_check_config](variables.tf#L131) | Optional auto-created health check configuration, use the output self-link to set it in the auto healing policy. Refer to examples for usage. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#8230;&#125;</code> |
+| [labels](variables.tf#L209) | Labels set on resources. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
 
 ## Outputs
 

--- a/modules/net-lb-ext/groups.tf
+++ b/modules/net-lb-ext/groups.tf
@@ -18,7 +18,7 @@
 
 resource "google_compute_instance_group" "default" {
   for_each    = var.group_configs
-  project     = var.project_id
+  project     = local.project_id
   zone        = each.value.zone
   name        = coalesce(each.value.name, "${var.name}-${each.key}")
   description = each.value.description

--- a/modules/net-lb-ext/health-check.tf
+++ b/modules/net-lb-ext/health-check.tf
@@ -31,8 +31,8 @@ locals {
 resource "google_compute_region_health_check" "default" {
   provider            = google-beta
   count               = local.hc != null ? 1 : 0
-  project             = var.project_id
-  region              = var.region
+  project             = local.project_id
+  region              = local.region
   name                = local.hc.name != null ? local.hc.name : var.name
   description         = local.hc.description
   check_interval_sec  = local.hc.check_interval_sec

--- a/modules/net-lb-ext/main.tf
+++ b/modules/net-lb-ext/main.tf
@@ -22,6 +22,14 @@ locals {
     ? var.health_check
     : google_compute_region_health_check.default[0].self_link
   )
+  ctx = {
+    for k, v in var.context : k => {
+      for kk, vv in v : "${local.ctx_p}${k}:${kk}" => vv
+    }
+  }
+  ctx_p      = "$"
+  project_id = lookup(local.ctx.project_ids, var.project_id, var.project_id)
+  region     = lookup(local.ctx.locations, var.region, var.region)
 }
 
 moved {
@@ -32,11 +40,15 @@ moved {
 resource "google_compute_forwarding_rule" "default" {
   for_each    = var.forwarding_rules_config
   provider    = google-beta
-  project     = var.project_id
-  region      = var.region
+  project     = local.project_id
+  region      = local.region
   name        = coalesce(each.value.name, each.key == "" ? var.name : "${var.name}-${each.key}")
   description = each.value.description
-  ip_address  = each.value.address
+  ip_address = (
+    each.value.address == null
+    ? null
+    : lookup(local.ctx.addresses, each.value.address, each.value.address)
+  )
   ip_protocol = each.value.protocol
   ip_version  = each.value.address != null ? null : each.value.ipv6 == true ? "IPV6" : "IPV4" # do not set if address is provided
   backend_service = (
@@ -46,14 +58,18 @@ resource "google_compute_forwarding_rule" "default" {
   ports                 = each.value.ports # "nnnnn" or "nnnnn,nnnnn,nnnnn" max 5
   all_ports             = each.value.ports == null ? true : null
   labels                = var.labels
-  subnetwork            = each.value.subnetwork
+  subnetwork = (
+    each.value.subnetwork == null
+    ? null
+    : lookup(local.ctx.subnets, each.value.subnetwork, each.value.subnetwork)
+  )
   # is_mirroring_collector = false
 }
 
 resource "google_compute_region_backend_service" "default" {
   provider                        = google-beta
-  project                         = var.project_id
-  region                          = var.region
+  project                         = local.project_id
+  region                          = local.region
   name                            = coalesce(var.backend_service_config.name, var.name)
   description                     = var.backend_service_config.description
   load_balancing_scheme           = "EXTERNAL"

--- a/modules/net-lb-ext/variables.tf
+++ b/modules/net-lb-ext/variables.tf
@@ -81,6 +81,18 @@ variable "backends" {
   nullable = false
 }
 
+variable "context" {
+  description = "Context-specific interpolations."
+  type = object({
+    addresses   = optional(map(string), {})
+    locations   = optional(map(string), {})
+    project_ids = optional(map(string), {})
+    subnets     = optional(map(string), {})
+  })
+  default  = {}
+  nullable = false
+}
+
 variable "forwarding_rules_config" {
   description = "The optional forwarding rules configuration."
   type = map(object({

--- a/modules/net-lb-proxy-int/README.md
+++ b/modules/net-lb-proxy-int/README.md
@@ -562,20 +562,20 @@ For deploying changes to load balancer configuration please refer to [net-lb-app
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [name](variables.tf#L224) | Load balancer name. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L288) | Project id. | <code>string</code> | ✓ |  |
-| [region](variables.tf#L293) | The region where to allocate the ILB resources. | <code>string</code> | ✓ |  |
-| [vpc_config](variables.tf#L314) | VPC-level configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
+| [name](variables.tf#L213) | Load balancer name. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L277) | Project id. | <code>string</code> | ✓ |  |
+| [region](variables.tf#L282) | The region where to allocate the ILB resources. | <code>string</code> | ✓ |  |
+| [vpc_config](variables.tf#L303) | VPC-level configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
 | [backend_service_config](variables.tf#L17) | Backend service level configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [context](variables.tf#L76) | Context-specific interpolations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [description](variables.tf#L89) | Optional description used for resources. | <code>string</code> |  | <code>&#34;Terraform managed.&#34;</code> |
-| [forwarding_rules_config](variables.tf#L95) | The optional forwarding rules configuration. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#8230;&#125;</code> |
-| [group_configs](variables.tf#L111) | Optional unmanaged groups to create. Can be referenced in backends via key or outputs. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [health_check](variables.tf#L125) | Name of existing health check to use, disables auto-created health check. | <code>string</code> |  | <code>null</code> |
-| [health_check_config](variables.tf#L131) | Optional auto-created health check configurations, use the output self-link to set it in the auto healing policy. Refer to examples for usage. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#8230;&#125;</code> |
-| [labels](variables.tf#L218) | Labels set on resources. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
-| [neg_configs](variables.tf#L229) | Optional network endpoint groups to create. Can be referenced in backends via key or outputs. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [service_attachment](variables.tf#L298) | PSC service attachment. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [context](variables.tf#L65) | Context-specific interpolations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [description](variables.tf#L78) | Optional description used for resources. | <code>string</code> |  | <code>&#34;Terraform managed.&#34;</code> |
+| [forwarding_rules_config](variables.tf#L84) | The optional forwarding rules configuration. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#8230;&#125;</code> |
+| [group_configs](variables.tf#L100) | Optional unmanaged groups to create. Can be referenced in backends via key or outputs. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [health_check](variables.tf#L114) | Name of existing health check to use, disables auto-created health check. | <code>string</code> |  | <code>null</code> |
+| [health_check_config](variables.tf#L120) | Optional auto-created health check configurations, use the output self-link to set it in the auto healing policy. Refer to examples for usage. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#8230;&#125;</code> |
+| [labels](variables.tf#L207) | Labels set on resources. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [neg_configs](variables.tf#L218) | Optional network endpoint groups to create. Can be referenced in backends via key or outputs. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [service_attachment](variables.tf#L287) | PSC service attachment. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
 
 ## Outputs
 

--- a/modules/net-lb-proxy-int/backend-service.tf
+++ b/modules/net-lb-proxy-int/backend-service.tf
@@ -64,7 +64,6 @@ resource "google_compute_region_backend_service" "default" {
       balancing_mode  = backend.value.balancing_mode
       capacity_scaler = backend.value.capacity_scaler
       description     = backend.value.description
-      failover        = backend.value.failover
       max_connections = try(
         backend.value.max_connections.per_group, null
       )
@@ -75,28 +74,6 @@ resource "google_compute_region_backend_service" "default" {
         backend.value.max_connections.per_instance, null
       )
       max_utilization = backend.value.max_utilization
-    }
-  }
-
-  dynamic "connection_tracking_policy" {
-    for_each = var.backend_service_config.connection_tracking == null ? [] : [""]
-    content {
-      connection_persistence_on_unhealthy_backends = (
-        ar.backend_service_config.connection_tracking.persist_conn_on_unhealthy != null
-        ? ar.backend_service_config.connection_tracking.persist_conn_on_unhealthy
-        : null
-      )
-      idle_timeout_sec = var.backend_service_config.connection_tracking.idle_timeout_sec
-      tracking_mode    = try(local.bs_conntrack.track_per_session ? "PER_SESSION" : "PER_CONNECTION", null)
-    }
-  }
-
-  dynamic "failover_policy" {
-    for_each = var.backend_service_config.failover_config == null ? [] : [""]
-    content {
-      disable_connection_drain_on_failover = var.backend_service_config.failover_config.disable_conn_drain
-      drop_traffic_if_unhealthy            = var.backend_service_config.failover_config.drop_traffic_if_unhealthy
-      failover_ratio                       = var.backend_service_config.failover_config.ratio
     }
   }
 

--- a/modules/net-lb-proxy-int/variables.tf
+++ b/modules/net-lb-proxy-int/variables.tf
@@ -54,7 +54,7 @@ variable "backend_service_config" {
     error_message = "Invalid session affinity value."
   }
   validation {
-    condition = alltrue([
+    condition = var.backend_service_config.backends == null ? true : alltrue([
       for b in var.backend_service_config.backends : contains(
         ["CONNECTION", "UTILIZATION"], coalesce(b.balancing_mode, "CONNECTION")
     )])

--- a/modules/net-lb-proxy-int/variables.tf
+++ b/modules/net-lb-proxy-int/variables.tf
@@ -37,7 +37,6 @@ variable "backend_service_config" {
       balancing_mode  = optional(string, "UTILIZATION")
       capacity_scaler = optional(number, 1)
       description     = optional(string, "Terraform managed.")
-      failover        = optional(bool, false)
       max_connections = optional(object({
         per_endpoint = optional(number)
         per_group    = optional(number)
@@ -45,16 +44,6 @@ variable "backend_service_config" {
       }))
       max_utilization = optional(number)
     })))
-    connection_tracking = optional(object({
-      idle_timeout_sec          = optional(number)
-      persist_conn_on_unhealthy = optional(string)
-      track_per_session         = optional(bool)
-    }))
-    failover_config = optional(object({
-      disable_conn_drain        = optional(bool)
-      drop_traffic_if_unhealthy = optional(bool)
-      ratio                     = optional(number)
-    }))
   })
   default  = {}
   nullable = false

--- a/tests/modules/net_lb_app_ext/examples/context.yaml
+++ b/tests/modules/net_lb_app_ext/examples/context.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,6 +17,7 @@ values:
     bucket_name: my-bucket
     compression_mode: null
     custom_response_headers: null
+    deletion_policy: DELETE
     description: null
     edge_security_policy: null
     enable_cdn: null
@@ -48,6 +49,7 @@ values:
     custom_metrics: []
     custom_request_headers: null
     custom_response_headers: null
+    deletion_policy: DELETE
     description: Terraform managed.
     dynamic_forwarding: []
     edge_security_policy: null
@@ -88,6 +90,7 @@ values:
     custom_metrics: []
     custom_request_headers: null
     custom_response_headers: null
+    deletion_policy: DELETE
     description: Terraform managed.
     dynamic_forwarding: []
     edge_security_policy: null
@@ -129,6 +132,7 @@ values:
     custom_metrics: []
     custom_request_headers: null
     custom_response_headers: null
+    deletion_policy: DELETE
     description: Terraform managed.
     dynamic_forwarding: []
     edge_security_policy: null
@@ -169,6 +173,7 @@ values:
     custom_metrics: []
     custom_request_headers: null
     custom_response_headers: null
+    deletion_policy: DELETE
     description: Terraform managed.
     dynamic_forwarding: []
     edge_security_policy: null
@@ -209,6 +214,7 @@ values:
     custom_metrics: []
     custom_request_headers: null
     custom_response_headers: null
+    deletion_policy: DELETE
     description: Terraform managed.
     dynamic_forwarding: []
     edge_security_policy: null
@@ -236,6 +242,7 @@ values:
     tls_settings: []
   module.glb-0.google_compute_global_forwarding_rule.default[""]:
     allow_psc_global_access: null
+    deletion_policy: DELETE
     description: Terraform managed.
     external_managed_backend_bucket_migration_state: null
     external_managed_backend_bucket_migration_testing_percentage: null
@@ -247,10 +254,11 @@ values:
     name: glb-test-0
     no_automate_dns_zone: null
     port_range: '80'
-    project: $project_ids:test
+    project: my-project
     source_ip_ranges: null
     timeouts: null
   module.glb-0.google_compute_global_network_endpoint.default["neg-internet-e-0"]:
+    deletion_policy: DELETE
     fqdn: hello.example.org
     global_network_endpoint_group: glb-test-0-neg-internet
     ip_address: null
@@ -259,6 +267,7 @@ values:
     timeouts: null
   module.glb-0.google_compute_global_network_endpoint_group.default["neg-internet"]:
     default_port: null
+    deletion_policy: DELETE
     description: Terraform managed.
     name: glb-test-0-neg-internet
     network_endpoint_type: INTERNET_FQDN_PORT
@@ -266,6 +275,7 @@ values:
     timeouts: null
   module.glb-0.google_compute_health_check.default["default"]:
     check_interval_sec: 5
+    deletion_policy: DELETE
     description: Terraform managed.
     grpc_health_check: []
     grpc_tls_health_check: []
@@ -289,6 +299,7 @@ values:
     timeouts: null
     unhealthy_threshold: 2
   module.glb-0.google_compute_instance_group.default["ig-c"]:
+    deletion_policy: DELETE
     description: Terraform managed.
     instances:
     - projects/my-project/zones/europe-west8-c/instances/vm-c
@@ -300,6 +311,7 @@ values:
     timeouts: null
     zone: europe-west8-c
   module.glb-0.google_compute_network_endpoint.default["neg-gce-e-0"]:
+    deletion_policy: DELETE
     instance: nginx-ew8-b
     ip_address: $addresses:test
     network_endpoint_group: glb-test-0-neg-gce
@@ -308,6 +320,7 @@ values:
     timeouts: null
     zone: $locations:ew8-b
   module.glb-0.google_compute_network_endpoint.default["neg-hybrid-e-0"]:
+    deletion_policy: DELETE
     instance: null
     ip_address: $addresses:test-hybrid
     network_endpoint_group: glb-test-0-neg-hybrid
@@ -317,6 +330,7 @@ values:
     zone: $locations:ew8-b
   module.glb-0.google_compute_network_endpoint_group.default["neg-gce"]:
     default_port: null
+    deletion_policy: DELETE
     description: Terraform managed.
     name: glb-test-0-neg-gce
     network: projects/my-project/global/networks/shared-vpc
@@ -327,6 +341,7 @@ values:
     zone: $locations:ew8-b
   module.glb-0.google_compute_network_endpoint_group.default["neg-hybrid"]:
     default_port: null
+    deletion_policy: DELETE
     description: Terraform managed.
     name: glb-test-0-neg-hybrid
     network: projects/my-project/global/networks/shared-vpc
@@ -342,6 +357,7 @@ values:
     - service: hello
       tag: null
       url_mask: null
+    deletion_policy: DELETE
     description: Terraform managed.
     name: glb-test-0-neg-cloudrun
     network_endpoint_type: SERVERLESS
@@ -352,6 +368,7 @@ values:
     subnetwork: null
     timeouts: null
   module.glb-0.google_compute_target_http_proxy.default[0]:
+    deletion_policy: DELETE
     description: Terraform managed.
     http_keep_alive_timeout_sec: null
     name: glb-test-0
@@ -361,6 +378,7 @@ values:
     default_custom_error_response_policy: []
     default_route_action: []
     default_url_redirect: []
+    deletion_policy: DELETE
     description: Terraform managed.
     header_action: []
     host_rule:

--- a/tests/modules/net_lb_app_ext/examples/context.yaml
+++ b/tests/modules/net_lb_app_ext/examples/context.yaml
@@ -313,21 +313,21 @@ values:
   module.glb-0.google_compute_network_endpoint.default["neg-gce-e-0"]:
     deletion_policy: DELETE
     instance: nginx-ew8-b
-    ip_address: $addresses:test
+    ip_address: 10.24.32.25
     network_endpoint_group: glb-test-0-neg-gce
     port: 80
     project: my-project
     timeouts: null
-    zone: $locations:ew8-b
+    zone: europe-west8-b
   module.glb-0.google_compute_network_endpoint.default["neg-hybrid-e-0"]:
     deletion_policy: DELETE
     instance: null
-    ip_address: $addresses:test-hybrid
+    ip_address: 192.168.0.3
     network_endpoint_group: glb-test-0-neg-hybrid
     port: 80
     project: my-project
     timeouts: null
-    zone: $locations:ew8-b
+    zone: europe-west8-b
   module.glb-0.google_compute_network_endpoint_group.default["neg-gce"]:
     default_port: null
     deletion_policy: DELETE
@@ -338,7 +338,7 @@ values:
     project: my-project
     subnetwork: projects/my-project/regions/europe-west8/subnetworks/gce
     timeouts: null
-    zone: $locations:ew8-b
+    zone: europe-west8-b
   module.glb-0.google_compute_network_endpoint_group.default["neg-hybrid"]:
     default_port: null
     deletion_policy: DELETE
@@ -349,7 +349,7 @@ values:
     project: my-project
     subnetwork: null
     timeouts: null
-    zone: $locations:ew8-b
+    zone: europe-west8-b
   module.glb-0.google_compute_region_network_endpoint_group.serverless["neg-cloudrun"]:
     app_engine: []
     cloud_function: []
@@ -363,7 +363,7 @@ values:
     network_endpoint_type: SERVERLESS
     project: my-project
     psc_target_service: null
-    region: $locations:ew8
+    region: europe-west8
     serverless_deployment: []
     subnetwork: null
     timeouts: null

--- a/tests/modules/net_lb_app_ext/test-plan-llp.tfvars
+++ b/tests/modules/net_lb_app_ext/test-plan-llp.tfvars
@@ -4,7 +4,7 @@ project_id = "my-project"
 backend_service_configs = {
   default = {
     backends = [
-      { backend = "ig-b" },
+      { group = "ig-b" },
     ]
     locality_lb_policies = [{
       policy = {

--- a/tests/modules/net_lb_app_ext/test-plan.tfvars
+++ b/tests/modules/net_lb_app_ext/test-plan.tfvars
@@ -8,26 +8,26 @@ backend_buckets_config = {
 backend_service_configs = {
   default = {
     backends = [
-      { backend = "projects/my-project/zones/europe-west8-b/instanceGroups/ig-b" },
-      { backend = "ig-c" }
+      { group = "projects/my-project/zones/europe-west8-b/instanceGroups/ig-b" },
+      { group = "ig-c" }
     ]
   }
   neg-cloudrun = {
-    backends      = [{ backend = "neg-cloudrun" }]
+    backends      = [{ group = "neg-cloudrun" }]
     health_checks = []
   }
   neg-gce = {
-    backends       = [{ backend = "neg-gce" }]
+    backends       = [{ group = "neg-gce" }]
     balancing_mode = "RATE"
     max_rate       = { per_endpoint = 10 }
   }
   neg-hybrid = {
-    backends       = [{ backend = "neg-hybrid" }]
+    backends       = [{ group = "neg-hybrid" }]
     balancing_mode = "RATE"
     max_rate       = { per_endpoint = 10 }
   }
   neg-internet = {
-    backends      = [{ backend = "neg-internet" }]
+    backends      = [{ group = "neg-internet" }]
     health_checks = []
   }
 }

--- a/tests/modules/net_lb_app_ext_regional/context.tfvars
+++ b/tests/modules/net_lb_app_ext_regional/context.tfvars
@@ -1,0 +1,57 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+project_id = "$project_ids:my-project"
+region     = "$locations:my-region"
+name       = "test-lb"
+address    = "$addresses:lb-ip"
+vpc_config = {
+  network = "$networks:default"
+}
+
+context = {
+  addresses = {
+    lb-ip = "10.0.0.1"
+  }
+  locations = {
+    my-region = "europe-west1"
+    my-zone   = "europe-west1-b"
+  }
+  networks = {
+    default = "projects/test-project/global/networks/test-vpc"
+  }
+  project_ids = {
+    my-project = "test-project"
+  }
+  subnets = {
+    my-subnet = "projects/test-project/regions/europe-west1/subnetworks/test-subnet"
+  }
+}
+
+group_configs = {
+  default = {
+    zone = "$locations:my-zone"
+  }
+}
+
+neg_configs = {
+  psc = {
+    psc = {
+      region             = "$locations:my-region"
+      target_service     = "test-service"
+      network            = "$networks:default"
+      subnetwork         = "$subnets:my-subnet"
+    }
+  }
+}

--- a/tests/modules/net_lb_app_ext_regional/context.tfvars
+++ b/tests/modules/net_lb_app_ext_regional/context.tfvars
@@ -48,10 +48,10 @@ group_configs = {
 neg_configs = {
   psc = {
     psc = {
-      region             = "$locations:my-region"
-      target_service     = "test-service"
-      network            = "$networks:default"
-      subnetwork         = "$subnets:my-subnet"
+      region         = "$locations:my-region"
+      target_service = "test-service"
+      network        = "$networks:default"
+      subnetwork     = "$subnets:my-subnet"
     }
   }
 }

--- a/tests/modules/net_lb_app_ext_regional/context.yaml
+++ b/tests/modules/net_lb_app_ext_regional/context.yaml
@@ -13,32 +13,40 @@
 # limitations under the License.
 
 values:
-  module.ilb-l7.google_compute_forwarding_rule.default:
+  google_compute_forwarding_rule.default:
     all_ports: null
     allow_global_access: null
     allow_psc_global_access: null
     backend_service: null
     deletion_policy: DELETE
     description: Terraform managed.
+    ip_address: 10.0.0.1
     ip_collection: null
     ip_protocol: TCP
     is_mirroring_collector: null
     labels: null
-    load_balancing_scheme: INTERNAL_MANAGED
-    name: ilb-test
-    network: https://www.googleapis.com/compute/v1/projects/xxx/global/networks/aaa
-    network_tier: PREMIUM
+    load_balancing_scheme: EXTERNAL_MANAGED
+    name: test-lb
+    network: projects/test-project/global/networks/test-vpc
+    network_tier: STANDARD
     no_automate_dns_zone: null
     port_range: '80'
     ports: null
-    project: project-id
+    project: test-project
     recreate_closed_psc: false
     region: europe-west1
     service_label: null
     source_ip_ranges: null
-    subnetwork: subnet_self_link
     timeouts: null
-  module.ilb-l7.google_compute_health_check.default["default"]:
+  google_compute_instance_group.default["default"]:
+    deletion_policy: DELETE
+    description: Terraform managed.
+    name: test-lb-default
+    named_port: []
+    project: test-project
+    timeouts: null
+    zone: europe-west1-b
+  google_compute_region_health_check.default["default"]:
     check_interval_sec: 5
     deletion_policy: DELETE
     description: Terraform managed.
@@ -55,91 +63,68 @@ values:
       request_path: /
       response: null
     https_health_check: []
-    name: ilb-test-default
-    project: project-id
-    source_regions: null
+    name: test-lb-default
+    project: test-project
+    region: europe-west1
     ssl_health_check: []
     tcp_health_check: []
     timeout_sec: 5
     timeouts: null
     unhealthy_threshold: 2
-  module.ilb-l7.google_compute_region_backend_service.default["default"]:
-    affinity_cookie_ttl_sec: null
-    backend:
-    - balancing_mode: UTILIZATION
-      capacity_scaler: 1
-      custom_metrics: []
-      description: Terraform managed.
-      group: projects/myprj/zones/europe-west1-a/instanceGroups/my-ig
-      max_connections: null
-      max_connections_per_endpoint: null
-      max_connections_per_instance: null
-      max_rate: null
-      max_rate_per_endpoint: null
-      max_rate_per_instance: null
-      max_utilization: null
-      traffic_duration: ''
-    circuit_breakers: []
-    connection_draining_timeout_sec: 300
-    connection_tracking_policy: []
-    consistent_hash: []
-    custom_metrics: []
+  google_compute_region_network_endpoint_group.psc["psc"]:
+    app_engine: []
+    cloud_function: []
+    cloud_run: []
     deletion_policy: DELETE
     description: Terraform managed.
-    dynamic_forwarding: []
-    enable_cdn: null
-    failover_policy: []
-    ha_policy: []
-    ip_address_selection_policy: null
-    load_balancing_scheme: INTERNAL_MANAGED
-    locality_lb_policy: null
-    name: ilb-test-default
-    network: null
-    network_pass_through_lb_traffic_policy: []
-    outlier_detection: []
-    params: []
-    project: project-id
-    protocol: HTTP
+    name: test-lb-psc
+    network: projects/test-project/global/networks/test-vpc
+    network_endpoint_type: PRIVATE_SERVICE_CONNECT
+    project: test-project
+    psc_target_service: test-service
     region: europe-west1
-    security_policy: null
-    strong_session_affinity_cookie: []
-    subsetting: []
+    subnetwork: projects/test-project/regions/europe-west1/subnetworks/test-subnet
     timeouts: null
-    tls_settings:
-    - authentication_config: null
-      sni: backend.example.com
-      subject_alt_names:
-      - dns_name: backend.example.com
-        uniform_resource_identifier: null
-  module.ilb-l7.google_compute_region_target_http_proxy.default[0]:
+  google_compute_region_target_http_proxy.default[0]:
     deletion_policy: DELETE
     description: Terraform managed.
     http_keep_alive_timeout_sec: null
-    name: ilb-test
-    project: project-id
+    name: test-lb
+    project: test-project
     region: europe-west1
     timeouts: null
-  module.ilb-l7.google_compute_region_url_map.default:
+  google_compute_region_url_map.default:
     default_route_action: []
+    default_service: default
     default_url_redirect: []
     deletion_policy: DELETE
     description: Terraform managed.
     header_action: []
     host_rule: []
-    name: ilb-test
+    name: test-lb
     path_matcher: []
-    project: project-id
+    project: test-project
     region: europe-west1
     test: []
     timeouts: null
 
 counts:
   google_compute_forwarding_rule: 1
-  google_compute_health_check: 1
-  google_compute_region_backend_service: 1
+  google_compute_instance_group: 1
+  google_compute_region_health_check: 1
+  google_compute_region_network_endpoint_group: 1
   google_compute_region_target_http_proxy: 1
   google_compute_region_url_map: 1
-  modules: 1
-  resources: 5
+  modules: 0
+  resources: 6
 
-outputs: {}
+outputs:
+  address: 10.0.0.1
+  backend_service_ids: {}
+  backend_service_names: {}
+  forwarding_rule: __missing__
+  group_ids: __missing__
+  health_check_ids: __missing__
+  id: __missing__
+  neg_ids: __missing__
+  url_map_id: __missing__

--- a/tests/modules/net_lb_app_ext_regional/tftest.yaml
+++ b/tests/modules/net_lb_app_ext_regional/tftest.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,16 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-module: modules/net-lb-ext
+module: modules/net-lb-app-ext-regional
 
 tests:
   context:
-  defaults:
-  dual-stack:
-  forwarding-rule:
-  health-checks-grpc:
-  health-checks-http:
-  health-checks-http2:
-  health-checks-https:
-  health-checks-ssl:
-  health-checks-tcp:

--- a/tests/modules/net_lb_app_int/context.yaml
+++ b/tests/modules/net_lb_app_int/context.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,29 +14,136 @@
 
 values:
   google_compute_forwarding_rule.default:
+    all_ports: null
+    allow_global_access: null
+    allow_psc_global_access: null
+    backend_service: null
+    deletion_policy: DELETE
+    description: Terraform managed.
     ip_address: 10.0.0.10
+    ip_collection: null
+    ip_protocol: TCP
+    is_mirroring_collector: null
+    labels: null
     load_balancing_scheme: INTERNAL_MANAGED
     name: ilb-l7-test
     network: projects/foo-dev-net-spoke-0/global/networks/dev-spoke-0
+    network_tier: PREMIUM
+    no_automate_dns_zone: null
+    port_range: '80'
+    ports: null
     project: foo-test-0
+    recreate_closed_psc: false
     region: europe-west8
+    service_label: null
+    source_ip_ranges: null
     subnetwork: projects/foo-dev-net-spoke-0/regions/europe-west8/subnetworks/gce
+    timeouts: null
   google_compute_health_check.default["default"]:
+    check_interval_sec: 5
+    deletion_policy: DELETE
+    description: Terraform managed.
+    grpc_health_check: []
+    grpc_tls_health_check: []
+    healthy_threshold: 2
+    http2_health_check: []
+    http_health_check:
+    - host: null
+      port: null
+      port_name: null
+      port_specification: USE_SERVING_PORT
+      proxy_header: NONE
+      request_path: /
+      response: null
+    https_health_check: []
+    name: ilb-l7-test-default
     project: foo-test-0
+    source_regions: null
+    ssl_health_check: []
+    tcp_health_check: []
+    timeout_sec: 5
+    timeouts: null
+    unhealthy_threshold: 2
   google_compute_region_backend_service.default["default"]:
+    affinity_cookie_ttl_sec: null
+    backend:
+    - balancing_mode: UTILIZATION
+      capacity_scaler: 1
+      custom_metrics: []
+      description: Terraform managed.
+      group: projects/foo-test-0/zones/europe-west8-a/instanceGroups/my-ig
+      max_connections: null
+      max_connections_per_endpoint: null
+      max_connections_per_instance: null
+      max_rate: null
+      max_rate_per_endpoint: null
+      max_rate_per_instance: null
+      max_utilization: null
+      traffic_duration: ''
+    circuit_breakers: []
+    connection_draining_timeout_sec: 300
+    connection_tracking_policy: []
+    consistent_hash: []
+    custom_metrics: []
+    deletion_policy: DELETE
+    description: Terraform managed.
+    dynamic_forwarding: []
+    enable_cdn: null
+    failover_policy: []
+    ha_policy: []
+    ip_address_selection_policy: null
+    load_balancing_scheme: INTERNAL_MANAGED
+    locality_lb_policy: null
+    name: ilb-l7-test-default
+    network: null
+    network_pass_through_lb_traffic_policy: []
+    outlier_detection: []
+    params: []
     project: foo-test-0
+    protocol: HTTP
     region: europe-west8
+    security_policy: null
+    strong_session_affinity_cookie: []
+    subsetting: []
+    timeouts: null
+    tls_settings: []
   google_compute_region_target_http_proxy.default[0]:
+    deletion_policy: DELETE
+    description: Terraform managed.
+    http_keep_alive_timeout_sec: null
+    name: ilb-l7-test
     project: foo-test-0
     region: europe-west8
+    timeouts: null
   google_compute_region_url_map.default:
+    default_route_action: []
+    default_url_redirect: []
+    deletion_policy: DELETE
+    description: Terraform managed.
+    header_action: []
+    host_rule: []
+    name: ilb-l7-test
+    path_matcher: []
     project: foo-test-0
     region: europe-west8
+    test: []
+    timeouts: null
   google_compute_service_attachment.default[0]:
+    connection_preference: ACCEPT_MANUAL
+    consumer_accept_lists: []
+    consumer_reject_lists: null
+    deletion_policy: DELETE
+    description: Terraform managed.
+    domain_names: null
+    enable_proxy_protocol: false
+    name: ilb-l7-test
     nat_subnets:
     - projects/foo-dev-net-spoke-0/regions/europe-west8/subnetworks/test-nat
     project: foo-test-0
     region: europe-west8
+    send_propagated_connection_limit_if_zero: false
+    show_nat_ips: null
+    timeouts: null
 
 counts:
   google_compute_forwarding_rule: 1
@@ -47,3 +154,18 @@ counts:
   google_compute_service_attachment: 1
   modules: 0
   resources: 6
+
+outputs:
+  address: 10.0.0.10
+  backend_service_ids: __missing__
+  backend_service_names:
+    default: ilb-l7-test-default
+  forwarding_rule: __missing__
+  group_ids: {}
+  health_check_ids: __missing__
+  id: __missing__
+  neg_ids: {}
+  psc_neg_ids: {}
+  regional_neg_ids: {}
+  service_attachment_id: __missing__
+  url_map_id: __missing__

--- a/tests/modules/net_lb_app_int/examples/context.yaml
+++ b/tests/modules/net_lb_app_int/examples/context.yaml
@@ -79,21 +79,21 @@ values:
   module.ilb-l7.google_compute_network_endpoint.default["neg-gce-e-0"]:
     deletion_policy: DELETE
     instance: nginx-ew8-b
-    ip_address: $addresses:test
+    ip_address: 10.0.0.10
     network_endpoint_group: ilb-test-0-neg-gce
     port: 80
     project: foo-test-0
     timeouts: null
-    zone: $locations:ew8-b
+    zone: europe-west8-b
   module.ilb-l7.google_compute_network_endpoint.default["neg-hybrid-e-0"]:
     deletion_policy: DELETE
     instance: null
-    ip_address: $addresses:test-hybrid
+    ip_address: 192.168.0.3
     network_endpoint_group: ilb-test-0-neg-hybrid
     port: 80
     project: foo-test-0
     timeouts: null
-    zone: $locations:ew8-b
+    zone: europe-west8-b
   module.ilb-l7.google_compute_network_endpoint_group.default["neg-gce"]:
     default_port: null
     deletion_policy: DELETE
@@ -104,7 +104,7 @@ values:
     project: foo-test-0
     subnetwork: projects/foo-dev-net-spoke-0/regions/europe-west8/subnetworks/gce
     timeouts: null
-    zone: $locations:ew8-b
+    zone: europe-west8-b
   module.ilb-l7.google_compute_network_endpoint_group.default["neg-hybrid"]:
     default_port: null
     deletion_policy: DELETE
@@ -115,7 +115,7 @@ values:
     project: foo-test-0
     subnetwork: null
     timeouts: null
-    zone: $locations:ew8-b
+    zone: europe-west8-b
   module.ilb-l7.google_compute_region_backend_service.default["default"]:
     affinity_cookie_ttl_sec: null
     backend:
@@ -392,7 +392,7 @@ values:
     ip_address: null
     port: 80
     project: foo-test-0
-    region: $locations:ew8
+    region: europe-west8
     region_network_endpoint_group: ilb-test-0-neg-internet
     timeouts: null
   module.ilb-l7.google_compute_region_network_endpoint_group.default["neg-cloudrun"]:
@@ -408,7 +408,7 @@ values:
     network_endpoint_type: SERVERLESS
     project: foo-test-0
     psc_target_service: null
-    region: $locations:ew8
+    region: europe-west8
     subnetwork: null
     timeouts: null
   module.ilb-l7.google_compute_region_network_endpoint_group.internet["neg-internet"]:
@@ -422,7 +422,7 @@ values:
     network_endpoint_type: INTERNET_FQDN_PORT
     project: foo-test-0
     psc_target_service: null
-    region: $locations:ew8
+    region: europe-west8
     subnetwork: null
     timeouts: null
   module.ilb-l7.google_compute_region_network_endpoint_group.psc["neg-psc"]:
@@ -436,7 +436,7 @@ values:
     network_endpoint_type: PRIVATE_SERVICE_CONNECT
     project: foo-test-0
     psc_target_service: projects/foo-test-0/regions/europe-west8/serviceAttachments/sa
-    region: $locations:ew8
+    region: europe-west8
     subnetwork: projects/foo-dev-net-spoke-0/regions/europe-west8/subnetworks/gce
     timeouts: null
   module.ilb-l7.google_compute_region_target_http_proxy.default[0]:

--- a/tests/modules/net_lb_app_int/examples/context.yaml
+++ b/tests/modules/net_lb_app_int/examples/context.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,28 +14,58 @@
 
 values:
   module.ilb-l7.google_compute_forwarding_rule.default:
+    all_ports: null
+    allow_global_access: null
+    allow_psc_global_access: null
+    backend_service: null
+    deletion_policy: DELETE
+    description: Terraform managed.
     ip_address: 10.0.0.10
+    ip_collection: null
     ip_protocol: TCP
+    is_mirroring_collector: null
+    labels: null
     load_balancing_scheme: INTERNAL_MANAGED
     name: ilb-test-0
     network: projects/foo-dev-net-spoke-0/global/networks/dev-spoke-0
     network_tier: PREMIUM
+    no_automate_dns_zone: null
     port_range: '80'
+    ports: null
     project: foo-test-0
+    recreate_closed_psc: false
     region: europe-west8
+    service_label: null
+    source_ip_ranges: null
     subnetwork: projects/foo-dev-net-spoke-0/regions/europe-west8/subnetworks/gce
+    timeouts: null
   module.ilb-l7.google_compute_health_check.default["default"]:
     check_interval_sec: 5
+    deletion_policy: DELETE
     description: Terraform managed.
+    grpc_health_check: []
+    grpc_tls_health_check: []
     healthy_threshold: 2
+    http2_health_check: []
     http_health_check:
     - host: hello.example.org
+      port: null
+      port_name: null
       port_specification: USE_SERVING_PORT
+      proxy_header: NONE
+      request_path: /
+      response: null
+    https_health_check: []
     name: ilb-test-0-default
     project: foo-test-0
+    source_regions: null
+    ssl_health_check: []
+    tcp_health_check: []
     timeout_sec: 5
+    timeouts: null
     unhealthy_threshold: 2
   module.ilb-l7.google_compute_instance_group.default["ig-c"]:
+    deletion_policy: DELETE
     description: Terraform managed.
     instances:
     - projects/foo-test-0/zones/europe-west8-c/instances/vm-c
@@ -44,140 +74,363 @@ values:
     - name: http
       port: 80
     project: foo-test-0
+    timeouts: null
     zone: europe-west8-c
   module.ilb-l7.google_compute_network_endpoint.default["neg-gce-e-0"]:
+    deletion_policy: DELETE
     instance: nginx-ew8-b
     ip_address: $addresses:test
     network_endpoint_group: ilb-test-0-neg-gce
     port: 80
     project: foo-test-0
+    timeouts: null
     zone: $locations:ew8-b
   module.ilb-l7.google_compute_network_endpoint.default["neg-hybrid-e-0"]:
+    deletion_policy: DELETE
+    instance: null
     ip_address: $addresses:test-hybrid
     network_endpoint_group: ilb-test-0-neg-hybrid
     port: 80
     project: foo-test-0
+    timeouts: null
     zone: $locations:ew8-b
   module.ilb-l7.google_compute_network_endpoint_group.default["neg-gce"]:
+    default_port: null
+    deletion_policy: DELETE
     description: Terraform managed.
     name: ilb-test-0-neg-gce
     network: projects/foo-dev-net-spoke-0/global/networks/dev-spoke-0
     network_endpoint_type: GCE_VM_IP_PORT
     project: foo-test-0
     subnetwork: projects/foo-dev-net-spoke-0/regions/europe-west8/subnetworks/gce
+    timeouts: null
     zone: $locations:ew8-b
   module.ilb-l7.google_compute_network_endpoint_group.default["neg-hybrid"]:
+    default_port: null
+    deletion_policy: DELETE
     description: Terraform managed.
     name: ilb-test-0-neg-hybrid
     network: projects/foo-dev-net-spoke-0/global/networks/dev-spoke-0
     network_endpoint_type: NON_GCP_PRIVATE_IP_PORT
     project: foo-test-0
+    subnetwork: null
+    timeouts: null
     zone: $locations:ew8-b
   module.ilb-l7.google_compute_region_backend_service.default["default"]:
+    affinity_cookie_ttl_sec: null
     backend:
     - balancing_mode: UTILIZATION
       capacity_scaler: 1
+      custom_metrics: []
       description: Terraform managed.
-      failover: false
       group: projects/foo-test-0/zones/europe-west8-b/instanceGroups/ig-b
+      max_connections: null
+      max_connections_per_endpoint: null
+      max_connections_per_instance: null
+      max_rate: null
+      max_rate_per_endpoint: null
+      max_rate_per_instance: null
+      max_utilization: null
+      traffic_duration: ''
     - balancing_mode: UTILIZATION
       capacity_scaler: 1
+      custom_metrics: []
       description: Terraform managed.
-      failover: false
+      max_connections: null
+      max_connections_per_endpoint: null
+      max_connections_per_instance: null
+      max_rate: null
+      max_rate_per_endpoint: null
+      max_rate_per_instance: null
+      max_utilization: null
+      traffic_duration: ''
+    circuit_breakers: []
     connection_draining_timeout_sec: 300
+    connection_tracking_policy: []
+    consistent_hash: []
+    custom_metrics: []
+    deletion_policy: DELETE
     description: Terraform managed.
+    dynamic_forwarding: []
+    enable_cdn: null
+    failover_policy: []
+    ha_policy: []
+    ip_address_selection_policy: null
     load_balancing_scheme: INTERNAL_MANAGED
+    locality_lb_policy: null
     name: ilb-test-0-default
+    network: null
+    network_pass_through_lb_traffic_policy: []
+    outlier_detection: []
+    params: []
     project: foo-test-0
     protocol: HTTP
     region: europe-west8
+    security_policy: null
+    strong_session_affinity_cookie: []
+    subsetting: []
+    timeouts: null
+    tls_settings: []
   module.ilb-l7.google_compute_region_backend_service.default["neg-cloudrun"]:
+    affinity_cookie_ttl_sec: null
     backend:
     - balancing_mode: UTILIZATION
       capacity_scaler: 1
+      custom_metrics: []
       description: Terraform managed.
-      failover: false
+      max_connections: null
+      max_connections_per_endpoint: null
+      max_connections_per_instance: null
+      max_rate: null
+      max_rate_per_endpoint: null
+      max_rate_per_instance: null
+      max_utilization: null
+      traffic_duration: ''
+    circuit_breakers: []
     connection_draining_timeout_sec: 300
+    connection_tracking_policy: []
+    consistent_hash: []
+    custom_metrics: []
+    deletion_policy: DELETE
     description: Terraform managed.
+    dynamic_forwarding: []
+    enable_cdn: null
+    failover_policy: []
+    ha_policy: []
+    health_checks: null
+    ip_address_selection_policy: null
     load_balancing_scheme: INTERNAL_MANAGED
+    locality_lb_policy: null
     name: ilb-test-0-neg-cloudrun
+    network: null
+    network_pass_through_lb_traffic_policy: []
+    outlier_detection: []
+    params: []
     project: foo-test-0
     protocol: HTTP
     region: europe-west8
+    security_policy: null
+    strong_session_affinity_cookie: []
+    subsetting: []
+    timeouts: null
+    tls_settings: []
   module.ilb-l7.google_compute_region_backend_service.default["neg-gce"]:
+    affinity_cookie_ttl_sec: null
     backend:
     - balancing_mode: UTILIZATION
       capacity_scaler: 1
+      custom_metrics: []
       description: Terraform managed.
-      failover: false
+      max_connections: null
+      max_connections_per_endpoint: null
+      max_connections_per_instance: null
+      max_rate: null
+      max_rate_per_endpoint: null
+      max_rate_per_instance: null
+      max_utilization: null
+      traffic_duration: ''
+    circuit_breakers: []
     connection_draining_timeout_sec: 300
+    connection_tracking_policy: []
+    consistent_hash: []
+    custom_metrics: []
+    deletion_policy: DELETE
     description: Terraform managed.
+    dynamic_forwarding: []
+    enable_cdn: null
+    failover_policy: []
+    ha_policy: []
+    ip_address_selection_policy: null
     load_balancing_scheme: INTERNAL_MANAGED
+    locality_lb_policy: null
     name: ilb-test-0-neg-gce
+    network: null
+    network_pass_through_lb_traffic_policy: []
+    outlier_detection: []
+    params: []
     project: foo-test-0
     protocol: HTTP
     region: europe-west8
+    security_policy: null
+    strong_session_affinity_cookie: []
+    subsetting: []
+    timeouts: null
+    tls_settings: []
   module.ilb-l7.google_compute_region_backend_service.default["neg-hybrid"]:
+    affinity_cookie_ttl_sec: null
     backend:
     - balancing_mode: UTILIZATION
       capacity_scaler: 1
+      custom_metrics: []
       description: Terraform managed.
-      failover: false
+      max_connections: null
+      max_connections_per_endpoint: null
+      max_connections_per_instance: null
+      max_rate: null
+      max_rate_per_endpoint: null
+      max_rate_per_instance: null
+      max_utilization: null
+      traffic_duration: ''
+    circuit_breakers: []
     connection_draining_timeout_sec: 300
+    connection_tracking_policy: []
+    consistent_hash: []
+    custom_metrics: []
+    deletion_policy: DELETE
     description: Terraform managed.
+    dynamic_forwarding: []
+    enable_cdn: null
+    failover_policy: []
+    ha_policy: []
+    ip_address_selection_policy: null
     load_balancing_scheme: INTERNAL_MANAGED
+    locality_lb_policy: null
     name: ilb-test-0-neg-hybrid
+    network: null
+    network_pass_through_lb_traffic_policy: []
+    outlier_detection: []
+    params: []
     project: foo-test-0
     protocol: HTTP
     region: europe-west8
+    security_policy: null
+    strong_session_affinity_cookie: []
+    subsetting: []
+    timeouts: null
+    tls_settings: []
   module.ilb-l7.google_compute_region_backend_service.default["neg-internet"]:
+    affinity_cookie_ttl_sec: null
     backend:
     - balancing_mode: UTILIZATION
       capacity_scaler: 1
+      custom_metrics: []
       description: Terraform managed.
-      failover: false
+      max_connections: null
+      max_connections_per_endpoint: null
+      max_connections_per_instance: null
+      max_rate: null
+      max_rate_per_endpoint: null
+      max_rate_per_instance: null
+      max_utilization: null
+      traffic_duration: ''
+    circuit_breakers: []
     connection_draining_timeout_sec: 300
+    connection_tracking_policy: []
+    consistent_hash: []
+    custom_metrics: []
+    deletion_policy: DELETE
     description: Terraform managed.
+    dynamic_forwarding: []
+    enable_cdn: null
+    failover_policy: []
+    ha_policy: []
+    health_checks: null
+    ip_address_selection_policy: null
     load_balancing_scheme: INTERNAL_MANAGED
+    locality_lb_policy: null
     name: ilb-test-0-neg-internet
+    network: null
+    network_pass_through_lb_traffic_policy: []
+    outlier_detection: []
+    params: []
     project: foo-test-0
     protocol: HTTP
     region: europe-west8
+    security_policy: null
+    strong_session_affinity_cookie: []
+    subsetting: []
+    timeouts: null
+    tls_settings: []
   module.ilb-l7.google_compute_region_backend_service.default["neg-psc"]:
+    affinity_cookie_ttl_sec: null
     backend:
     - balancing_mode: UTILIZATION
       capacity_scaler: 1
+      custom_metrics: []
       description: Terraform managed.
-      failover: false
+      max_connections: null
+      max_connections_per_endpoint: null
+      max_connections_per_instance: null
+      max_rate: null
+      max_rate_per_endpoint: null
+      max_rate_per_instance: null
+      max_utilization: null
+      traffic_duration: ''
+    circuit_breakers: []
     connection_draining_timeout_sec: 300
+    connection_tracking_policy: []
+    consistent_hash: []
+    custom_metrics: []
+    deletion_policy: DELETE
     description: Terraform managed.
+    dynamic_forwarding: []
+    enable_cdn: null
+    failover_policy: []
+    ha_policy: []
+    health_checks: null
+    ip_address_selection_policy: null
     load_balancing_scheme: INTERNAL_MANAGED
+    locality_lb_policy: null
     name: ilb-test-0-neg-psc
+    network: null
+    network_pass_through_lb_traffic_policy: []
+    outlier_detection: []
+    params: []
     project: foo-test-0
     protocol: HTTP
     region: europe-west8
+    security_policy: null
+    strong_session_affinity_cookie: []
+    subsetting: []
+    timeouts: null
+    tls_settings: []
   module.ilb-l7.google_compute_region_network_endpoint.internet["neg-internet-e-0"]:
+    client_destination_port: null
+    deletion_policy: DELETE
     fqdn: hello.example.org
+    instance: null
+    ip_address: null
     port: 80
     project: foo-test-0
     region: $locations:ew8
     region_network_endpoint_group: ilb-test-0-neg-internet
+    timeouts: null
   module.ilb-l7.google_compute_region_network_endpoint_group.default["neg-cloudrun"]:
+    app_engine: []
+    cloud_function: []
     cloud_run:
     - service: hello
+      tag: null
+      url_mask: null
+    deletion_policy: DELETE
     description: Terraform managed.
     name: ilb-test-0-neg-cloudrun
     network_endpoint_type: SERVERLESS
     project: foo-test-0
+    psc_target_service: null
     region: $locations:ew8
+    subnetwork: null
+    timeouts: null
   module.ilb-l7.google_compute_region_network_endpoint_group.internet["neg-internet"]:
+    app_engine: []
+    cloud_function: []
+    cloud_run: []
+    deletion_policy: DELETE
     description: Terraform managed.
     name: ilb-test-0-neg-internet
     network: projects/foo-dev-net-spoke-0/global/networks/dev-spoke-0
     network_endpoint_type: INTERNET_FQDN_PORT
     project: foo-test-0
+    psc_target_service: null
     region: $locations:ew8
+    subnetwork: null
+    timeouts: null
   module.ilb-l7.google_compute_region_network_endpoint_group.psc["neg-psc"]:
+    app_engine: []
+    cloud_function: []
+    cloud_run: []
+    deletion_policy: DELETE
+    description: null
     name: ilb-test-0-neg-psc
     network: projects/foo-dev-net-spoke-0/global/networks/dev-spoke-0
     network_endpoint_type: PRIVATE_SERVICE_CONNECT
@@ -185,38 +438,64 @@ values:
     psc_target_service: projects/foo-test-0/regions/europe-west8/serviceAttachments/sa
     region: $locations:ew8
     subnetwork: projects/foo-dev-net-spoke-0/regions/europe-west8/subnetworks/gce
+    timeouts: null
   module.ilb-l7.google_compute_region_target_http_proxy.default[0]:
+    deletion_policy: DELETE
     description: Terraform managed.
+    http_keep_alive_timeout_sec: null
     name: ilb-test-0
     project: foo-test-0
     region: europe-west8
+    timeouts: null
   module.ilb-l7.google_compute_region_url_map.default:
+    default_route_action: []
+    default_url_redirect: []
+    deletion_policy: DELETE
     description: Terraform managed.
+    header_action: []
     host_rule:
-    - hosts:
+    - description: ''
+      hosts:
       - '*'
       path_matcher: pathmap
     name: ilb-test-0
     path_matcher:
-    - name: pathmap
+    - default_route_action: []
+      default_url_redirect: []
+      description: null
+      header_action: []
+      name: pathmap
       path_rule:
       - paths:
         - /cloudrun
         - /cloudrun/*
+        route_action: []
+        url_redirect: []
       - paths:
         - /gce
         - /gce/*
+        route_action: []
+        url_redirect: []
       - paths:
         - /hybrid
         - /hybrid/*
+        route_action: []
+        url_redirect: []
       - paths:
         - /internet
         - /internet/*
+        route_action: []
+        url_redirect: []
       - paths:
         - /psc
         - /psc/*
+        route_action: []
+        url_redirect: []
+      route_rules: []
     project: foo-test-0
     region: europe-west8
+    test: []
+    timeouts: null
 
 counts:
   google_compute_forwarding_rule: 1
@@ -231,3 +510,5 @@ counts:
   google_compute_region_url_map: 1
   modules: 1
   resources: 19
+
+outputs: {}

--- a/tests/modules/net_lb_app_int/examples/urlmap.yaml
+++ b/tests/modules/net_lb_app_int/examples/urlmap.yaml
@@ -18,6 +18,7 @@ values:
     allow_global_access: null
     allow_psc_global_access: null
     backend_service: null
+    deletion_policy: DELETE
     description: Terraform managed.
     ip_collection: null
     ip_protocol: TCP
@@ -39,6 +40,7 @@ values:
     timeouts: null
   module.ilb-l7.google_compute_health_check.default["default"]:
     check_interval_sec: 5
+    deletion_policy: DELETE
     description: Terraform managed.
     grpc_health_check: []
     grpc_tls_health_check: []
@@ -68,7 +70,6 @@ values:
       capacity_scaler: 1
       custom_metrics: []
       description: Terraform managed.
-      failover: false
       group: projects/myprj/zones/europe-west1-a/instanceGroups/my-ig-3
       max_connections: null
       max_connections_per_endpoint: null
@@ -83,6 +84,7 @@ values:
     connection_tracking_policy: []
     consistent_hash: []
     custom_metrics: []
+    deletion_policy: DELETE
     description: Terraform managed.
     dynamic_forwarding: []
     enable_cdn: null
@@ -114,7 +116,6 @@ values:
       capacity_scaler: 1
       custom_metrics: []
       description: Terraform managed.
-      failover: false
       group: projects/myprj/zones/europe-west1-a/instanceGroups/my-ig
       max_connections: null
       max_connections_per_endpoint: null
@@ -129,6 +130,7 @@ values:
     connection_tracking_policy: []
     consistent_hash: []
     custom_metrics: []
+    deletion_policy: DELETE
     description: Terraform managed.
     dynamic_forwarding: []
     enable_cdn: null
@@ -157,7 +159,6 @@ values:
       capacity_scaler: 1
       custom_metrics: []
       description: Terraform managed.
-      failover: false
       group: projects/myprj/zones/europe-west1-a/instanceGroups/my-ig-2
       max_connections: null
       max_connections_per_endpoint: null
@@ -172,6 +173,7 @@ values:
     connection_tracking_policy: []
     consistent_hash: []
     custom_metrics: []
+    deletion_policy: DELETE
     description: Terraform managed.
     dynamic_forwarding: []
     enable_cdn: null
@@ -197,6 +199,7 @@ values:
     timeouts: null
     tls_settings: []
   module.ilb-l7.google_compute_region_target_http_proxy.default[0]:
+    deletion_policy: DELETE
     description: Terraform managed.
     http_keep_alive_timeout_sec: null
     name: ilb-test
@@ -206,6 +209,7 @@ values:
   module.ilb-l7.google_compute_region_url_map.default:
     default_route_action: []
     default_url_redirect: []
+    deletion_policy: DELETE
     description: Terraform managed.
     header_action: []
     host_rule:

--- a/tests/modules/net_lb_app_int/urlmaps.tfvars
+++ b/tests/modules/net_lb_app_int/urlmaps.tfvars
@@ -28,6 +28,21 @@ backend_service_configs = {
 }
 urlmap_config = {
   default_service = "default"
+  header_action = {
+    request_remove = ["foo"]
+    request_add = {
+      bar = {
+        value   = "baz"
+        replace = true
+      }
+    }
+  }
+  default_route_action = {
+    timeout = {
+      seconds = 10
+      nanos   = 0
+    }
+  }
   host_rules = [{
     hosts        = ["*"]
     path_matcher = "pathmap"

--- a/tests/modules/net_lb_app_int/urlmaps.yaml
+++ b/tests/modules/net_lb_app_int/urlmaps.yaml
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,9 +12,238 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+values:
+  google_compute_forwarding_rule.default:
+    all_ports: null
+    allow_global_access: null
+    allow_psc_global_access: null
+    backend_service: null
+    deletion_policy: DELETE
+    description: Terraform managed.
+    ip_collection: null
+    ip_protocol: TCP
+    is_mirroring_collector: null
+    labels: null
+    load_balancing_scheme: INTERNAL_MANAGED
+    name: ilb-l7-test
+    network: projects/my-project/global/networks/default
+    network_tier: PREMIUM
+    no_automate_dns_zone: null
+    port_range: '80'
+    ports: null
+    project: my-project
+    recreate_closed_psc: false
+    region: europe-west1
+    service_label: null
+    source_ip_ranges: null
+    subnetwork: projects/my-project/regions/europe-west1/subnetworks/default
+    timeouts: null
+  google_compute_health_check.default["default"]:
+    check_interval_sec: 5
+    deletion_policy: DELETE
+    description: Terraform managed.
+    grpc_health_check: []
+    grpc_tls_health_check: []
+    healthy_threshold: 2
+    http2_health_check: []
+    http_health_check:
+    - host: null
+      port: null
+      port_name: null
+      port_specification: USE_SERVING_PORT
+      proxy_header: NONE
+      request_path: /
+      response: null
+    https_health_check: []
+    name: ilb-l7-test-default
+    project: my-project
+    source_regions: null
+    ssl_health_check: []
+    tcp_health_check: []
+    timeout_sec: 5
+    timeouts: null
+    unhealthy_threshold: 2
+  google_compute_region_backend_service.default["default"]:
+    affinity_cookie_ttl_sec: null
+    backend:
+    - balancing_mode: UTILIZATION
+      capacity_scaler: 1
+      custom_metrics: []
+      description: Terraform managed.
+      group: projects/myprj/zones/europe-west1-a/instanceGroups/my-ig
+      max_connections: null
+      max_connections_per_endpoint: null
+      max_connections_per_instance: null
+      max_rate: null
+      max_rate_per_endpoint: null
+      max_rate_per_instance: null
+      max_utilization: null
+      traffic_duration: ''
+    circuit_breakers: []
+    connection_draining_timeout_sec: 300
+    connection_tracking_policy: []
+    consistent_hash: []
+    custom_metrics: []
+    deletion_policy: DELETE
+    description: Terraform managed.
+    dynamic_forwarding: []
+    enable_cdn: null
+    failover_policy: []
+    ha_policy: []
+    ip_address_selection_policy: null
+    load_balancing_scheme: INTERNAL_MANAGED
+    locality_lb_policy: null
+    name: ilb-l7-test-default
+    network: null
+    network_pass_through_lb_traffic_policy: []
+    outlier_detection: []
+    params: []
+    project: my-project
+    protocol: HTTP
+    region: europe-west1
+    security_policy: null
+    strong_session_affinity_cookie: []
+    subsetting: []
+    timeouts: null
+    tls_settings: []
+  google_compute_region_backend_service.default["video"]:
+    affinity_cookie_ttl_sec: null
+    backend:
+    - balancing_mode: UTILIZATION
+      capacity_scaler: 1
+      custom_metrics: []
+      description: Terraform managed.
+      group: projects/myprj/zones/europe-west1-a/instanceGroups/my-ig-2
+      max_connections: null
+      max_connections_per_endpoint: null
+      max_connections_per_instance: null
+      max_rate: null
+      max_rate_per_endpoint: null
+      max_rate_per_instance: null
+      max_utilization: null
+      traffic_duration: ''
+    circuit_breakers: []
+    connection_draining_timeout_sec: 300
+    connection_tracking_policy: []
+    consistent_hash: []
+    custom_metrics: []
+    deletion_policy: DELETE
+    description: Terraform managed.
+    dynamic_forwarding: []
+    enable_cdn: null
+    failover_policy: []
+    ha_policy: []
+    ip_address_selection_policy: null
+    load_balancing_scheme: INTERNAL_MANAGED
+    locality_lb_policy: null
+    name: ilb-l7-test-video
+    network: null
+    network_pass_through_lb_traffic_policy: []
+    outlier_detection: []
+    params: []
+    project: my-project
+    protocol: HTTP
+    region: europe-west1
+    security_policy: null
+    strong_session_affinity_cookie: []
+    subsetting: []
+    timeouts: null
+    tls_settings: []
+  google_compute_region_target_http_proxy.default[0]:
+    deletion_policy: DELETE
+    description: Terraform managed.
+    http_keep_alive_timeout_sec: null
+    name: ilb-l7-test
+    project: my-project
+    region: europe-west1
+    timeouts: null
+  google_compute_region_url_map.default:
+    default_route_action:
+    - cors_policy: []
+      fault_injection_policy: []
+      request_mirror_policy: []
+      retry_policy: []
+      timeout:
+      - nanos: 0
+        seconds: '10'
+      url_rewrite: []
+      weighted_backend_services: []
+    default_url_redirect: []
+    deletion_policy: DELETE
+    description: Terraform managed.
+    header_action:
+    - request_headers_to_add:
+      - header_name: bar
+        header_value: baz
+        replace: true
+      request_headers_to_remove:
+      - foo
+      response_headers_to_add: []
+      response_headers_to_remove: null
+    host_rule:
+    - description: ''
+      hosts:
+      - '*'
+      path_matcher: pathmap
+    name: ilb-l7-test
+    path_matcher:
+    - default_route_action: []
+      default_url_redirect: []
+      description: null
+      header_action: []
+      name: pathmap
+      path_rule:
+      - paths:
+        - /video
+        - /video/*
+        route_action: []
+        url_redirect: []
+      route_rules:
+      - header_action: []
+        match_rules:
+        - full_path_match: null
+          header_matches: []
+          ignore_case: true
+          metadata_filters: []
+          path_template_match: null
+          prefix_match: null
+          query_parameter_matches: []
+          regex_match: null
+        priority: 1
+        route_action: []
+        url_redirect:
+        - host_redirect: foo.example.org
+          https_redirect: true
+          path_redirect: /foo
+          prefix_redirect: null
+          redirect_response_code: null
+          strip_query: false
+    project: my-project
+    region: europe-west1
+    test: []
+    timeouts: null
+
 counts:
   google_compute_forwarding_rule: 1
   google_compute_health_check: 1
   google_compute_region_backend_service: 2
   google_compute_region_target_http_proxy: 1
   google_compute_region_url_map: 1
+  modules: 0
+  resources: 6
+
+outputs:
+  address: __missing__
+  backend_service_ids: __missing__
+  backend_service_names:
+    default: ilb-l7-test-default
+    video: ilb-l7-test-video
+  forwarding_rule: __missing__
+  group_ids: {}
+  health_check_ids: __missing__
+  id: __missing__
+  neg_ids: {}
+  psc_neg_ids: {}
+  regional_neg_ids: {}
+  service_attachment_id: null
+  url_map_id: __missing__

--- a/tests/modules/net_lb_app_int_cross_region/context.tfvars
+++ b/tests/modules/net_lb_app_int_cross_region/context.tfvars
@@ -34,10 +34,16 @@ service_attachment = {
   }
 }
 
+group_configs = {
+  default = {
+    zone = "$locations:ew1-z"
+  }
+}
+
 neg_configs = {
   psc-neg = {
     psc = {
-      region         = "europe-west1"
+      region         = "$locations:ew1"
       target_service = "projects/resolved-project/regions/europe-west1/serviceAttachments/sa"
       network        = "$networks:bar"
       subnetwork     = "$subnets:psc"
@@ -48,6 +54,11 @@ neg_configs = {
 context = {
   project_ids = {
     foo = "resolved-project"
+  }
+  locations = {
+    ew1   = "europe-west1"
+    ew4   = "europe-west4"
+    ew1-z = "europe-west1-b"
   }
   networks = {
     bar = "resolved-network"

--- a/tests/modules/net_lb_app_int_cross_region/context.tfvars
+++ b/tests/modules/net_lb_app_int_cross_region/context.tfvars
@@ -1,0 +1,63 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name       = "lb-test"
+project_id = "$project_ids:foo"
+
+vpc_config = {
+  network = "$networks:bar"
+  subnetworks = {
+    europe-west1 = "$subnets:ew1"
+    europe-west4 = "$subnets:ew4"
+  }
+}
+
+addresses = {
+  europe-west1 = "$addresses:ip1"
+}
+
+service_attachment = {
+  nat_subnets = {
+    europe-west1 = ["$subnets:ew1"]
+    europe-west4 = ["$subnets:ew4"]
+  }
+}
+
+neg_configs = {
+  psc-neg = {
+    psc = {
+      region         = "europe-west1"
+      target_service = "projects/resolved-project/regions/europe-west1/serviceAttachments/sa"
+      network        = "$networks:bar"
+      subnetwork     = "$subnets:psc"
+    }
+  }
+}
+
+context = {
+  project_ids = {
+    foo = "resolved-project"
+  }
+  networks = {
+    bar = "resolved-network"
+  }
+  subnets = {
+    ew1 = "resolved-subnet-ew1"
+    ew4 = "resolved-subnet-ew4"
+    psc = "resolved-subnet-psc"
+  }
+  addresses = {
+    ip1 = "10.0.0.1"
+  }
+}

--- a/tests/modules/net_lb_app_int_cross_region/context.yaml
+++ b/tests/modules/net_lb_app_int_cross_region/context.yaml
@@ -1,0 +1,38 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values:
+  google_compute_global_forwarding_rule.forwarding_rules["europe-west1"]:
+    project: resolved-project
+    network: resolved-network
+    subnetwork: resolved-subnet-ew1
+    ip_address: 10.0.0.1
+  google_compute_global_forwarding_rule.forwarding_rules["europe-west4"]:
+    project: resolved-project
+    network: resolved-network
+    subnetwork: resolved-subnet-ew4
+  google_compute_url_map.default:
+    project: resolved-project
+  google_compute_region_network_endpoint_group.psc["psc-neg"]:
+    project: resolved-project
+    network: resolved-network
+    subnetwork: resolved-subnet-psc
+  google_compute_service_attachment.default["europe-west1"]:
+    project: resolved-project
+    nat_subnets:
+      - resolved-subnet-ew1
+  google_compute_service_attachment.default["europe-west4"]:
+    project: resolved-project
+    nat_subnets:
+      - resolved-subnet-ew4

--- a/tests/modules/net_lb_app_int_cross_region/context.yaml
+++ b/tests/modules/net_lb_app_int_cross_region/context.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,25 +14,165 @@
 
 values:
   google_compute_global_forwarding_rule.forwarding_rules["europe-west1"]:
-    project: resolved-project
-    network: resolved-network
-    subnetwork: resolved-subnet-ew1
+    allow_psc_global_access: null
+    deletion_policy: DELETE
+    description: Terraform managed.
+    external_managed_backend_bucket_migration_state: null
+    external_managed_backend_bucket_migration_testing_percentage: null
     ip_address: 10.0.0.1
+    ip_protocol: TCP
+    ip_version: null
+    labels: null
+    load_balancing_scheme: INTERNAL_MANAGED
+    metadata_filters: []
+    name: lb-test-europe-west1
+    network: resolved-network
+    no_automate_dns_zone: null
+    port_range: '80'
+    project: resolved-project
+    source_ip_ranges: null
+    subnetwork: resolved-subnet-ew1
+    timeouts: null
   google_compute_global_forwarding_rule.forwarding_rules["europe-west4"]:
-    project: resolved-project
+    allow_psc_global_access: null
+    deletion_policy: DELETE
+    description: Terraform managed.
+    external_managed_backend_bucket_migration_state: null
+    external_managed_backend_bucket_migration_testing_percentage: null
+    ip_protocol: TCP
+    ip_version: null
+    labels: null
+    load_balancing_scheme: INTERNAL_MANAGED
+    metadata_filters: []
+    name: lb-test-europe-west4
     network: resolved-network
+    no_automate_dns_zone: null
+    port_range: '80'
+    project: resolved-project
+    source_ip_ranges: null
     subnetwork: resolved-subnet-ew4
-  google_compute_url_map.default:
+    timeouts: null
+  google_compute_health_check.default["default"]:
+    check_interval_sec: 5
+    deletion_policy: DELETE
+    description: Terraform managed.
+    grpc_health_check: []
+    grpc_tls_health_check: []
+    healthy_threshold: 2
+    http2_health_check: []
+    http_health_check:
+    - host: null
+      port: null
+      port_name: null
+      port_specification: USE_SERVING_PORT
+      proxy_header: NONE
+      request_path: /
+      response: null
+    https_health_check: []
+    name: lb-test-default
     project: resolved-project
+    source_regions: null
+    ssl_health_check: []
+    tcp_health_check: []
+    timeout_sec: 5
+    timeouts: null
+    unhealthy_threshold: 2
+  google_compute_instance_group.default["default"]:
+    deletion_policy: DELETE
+    description: Terraform managed.
+    name: lb-test-default
+    named_port: []
+    project: resolved-project
+    timeouts: null
+    zone: europe-west1-b
   google_compute_region_network_endpoint_group.psc["psc-neg"]:
-    project: resolved-project
+    app_engine: []
+    cloud_function: []
+    cloud_run: []
+    deletion_policy: DELETE
+    description: null
+    name: lb-test-psc-neg
     network: resolved-network
+    network_endpoint_type: PRIVATE_SERVICE_CONNECT
+    project: resolved-project
+    psc_target_service: projects/resolved-project/regions/europe-west1/serviceAttachments/sa
+    region: europe-west1
     subnetwork: resolved-subnet-psc
+    timeouts: null
   google_compute_service_attachment.default["europe-west1"]:
-    project: resolved-project
+    connection_preference: ACCEPT_MANUAL
+    consumer_accept_lists: []
+    consumer_reject_lists: null
+    deletion_policy: DELETE
+    description: null
+    domain_names: null
+    enable_proxy_protocol: false
+    name: lb-test-europe-west1
     nat_subnets:
-      - resolved-subnet-ew1
+    - resolved-subnet-ew1
+    project: resolved-project
+    region: europe-west1
+    send_propagated_connection_limit_if_zero: false
+    show_nat_ips: null
+    timeouts: null
   google_compute_service_attachment.default["europe-west4"]:
-    project: resolved-project
+    connection_preference: ACCEPT_MANUAL
+    consumer_accept_lists: []
+    consumer_reject_lists: null
+    deletion_policy: DELETE
+    description: null
+    domain_names: null
+    enable_proxy_protocol: false
+    name: lb-test-europe-west4
     nat_subnets:
-      - resolved-subnet-ew4
+    - resolved-subnet-ew4
+    project: resolved-project
+    region: europe-west4
+    send_propagated_connection_limit_if_zero: false
+    show_nat_ips: null
+    timeouts: null
+  google_compute_target_http_proxy.default[0]:
+    deletion_policy: DELETE
+    description: Terraform managed.
+    http_keep_alive_timeout_sec: null
+    name: lb-test
+    project: resolved-project
+    timeouts: null
+  google_compute_url_map.default:
+    default_custom_error_response_policy: []
+    default_route_action: []
+    default_service: default
+    default_url_redirect: []
+    deletion_policy: DELETE
+    description: Terraform managed.
+    header_action: []
+    host_rule: []
+    name: lb-test
+    path_matcher: []
+    project: resolved-project
+    test: []
+    timeouts: null
+
+counts:
+  google_compute_global_forwarding_rule: 2
+  google_compute_health_check: 1
+  google_compute_instance_group: 1
+  google_compute_region_network_endpoint_group: 1
+  google_compute_service_attachment: 2
+  google_compute_target_http_proxy: 1
+  google_compute_url_map: 1
+  modules: 0
+  resources: 9
+
+outputs:
+  addresses: __missing__
+  backend_service_ids: {}
+  backend_service_names: {}
+  forwarding_rules: __missing__
+  group_ids: __missing__
+  health_check_ids: __missing__
+  ids: __missing__
+  neg_ids: {}
+  psc_neg_ids: __missing__
+  regional_neg_ids: {}
+  url_map_id: __missing__

--- a/tests/modules/net_lb_app_int_cross_region/tftest.yaml
+++ b/tests/modules/net_lb_app_int_cross_region/tftest.yaml
@@ -20,3 +20,5 @@ tests:
   health-checks-https:
   health-checks-ssl:
   health-checks-tcp:
+  context:
+

--- a/tests/modules/net_lb_ext/context.tfvars
+++ b/tests/modules/net_lb_ext/context.tfvars
@@ -1,0 +1,45 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+project_id = "$project_ids:my-project-ctx"
+region     = "$locations:europe-west1-ctx"
+name       = "nlb-test"
+backends = [{
+  group    = "foo"
+  failover = false
+}]
+
+context = {
+  project_ids = {
+    my-project-ctx = "resolved-project"
+  }
+  locations = {
+    europe-west1-ctx = "resolved-region"
+  }
+  addresses = {
+    my-address = "1.2.3.4"
+  }
+  subnets = {
+    my-subnet = "https://www.googleapis.com/compute/v1/projects/resolved-project/regions/resolved-region/subnetworks/resolved-subnet"
+  }
+}
+
+forwarding_rules_config = {
+  rule1 = {
+    address    = "$addresses:my-address"
+    subnetwork = "$subnets:my-subnet"
+    protocol   = "TCP"
+    ports      = ["80"]
+  }
+}

--- a/tests/modules/net_lb_ext/context.yaml
+++ b/tests/modules/net_lb_ext/context.yaml
@@ -1,0 +1,35 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values:
+  google_compute_forwarding_rule.default["rule1"]:
+    all_ports: null
+    ip_address: 1.2.3.4
+    ip_protocol: TCP
+    labels: null
+    load_balancing_scheme: EXTERNAL
+    name: nlb-test-rule1
+    project: resolved-project
+    region: resolved-region
+    subnetwork: https://www.googleapis.com/compute/v1/projects/resolved-project/regions/resolved-region/subnetworks/resolved-subnet
+  google_compute_region_backend_service.default:
+    load_balancing_scheme: EXTERNAL
+    name: nlb-test
+    project: resolved-project
+    protocol: UNSPECIFIED
+    region: resolved-region
+
+counts:
+  google_compute_forwarding_rule: 1
+  google_compute_region_backend_service: 1

--- a/tests/modules/net_lb_proxy_int/examples/address.yaml
+++ b/tests/modules/net_lb_proxy_int/examples/address.yaml
@@ -64,7 +64,6 @@ values:
       capacity_scaler: 1
       custom_metrics: []
       description: Terraform managed.
-      failover: false
       group: projects/myprj/zones/europe-west1-a/instanceGroups/my-ig
       max_connections: null
       max_connections_per_endpoint: null

--- a/tests/modules/net_lb_proxy_int/examples/context.yaml
+++ b/tests/modules/net_lb_proxy_int/examples/context.yaml
@@ -57,7 +57,6 @@ values:
       capacity_scaler: 1
       custom_metrics: []
       description: Terraform managed.
-      failover: false
       group: projects/myprj/zones/europe-west1-a/instanceGroups/my-ig
       max_connections: null
       max_connections_per_endpoint: null

--- a/tests/modules/net_lb_proxy_int/examples/group-config.yaml
+++ b/tests/modules/net_lb_proxy_int/examples/group-config.yaml
@@ -57,7 +57,6 @@ values:
       capacity_scaler: 1
       custom_metrics: []
       description: Terraform managed.
-      failover: false
       max_connections: null
       max_connections_per_endpoint: null
       max_connections_per_instance: null

--- a/tests/modules/net_lb_proxy_int/examples/health-check-config.yaml
+++ b/tests/modules/net_lb_proxy_int/examples/health-check-config.yaml
@@ -45,7 +45,6 @@ values:
       capacity_scaler: 1
       custom_metrics: []
       description: Terraform managed.
-      failover: false
       group: projects/myprj/zones/europe-west1-a/instanceGroups/my-ig
       max_connections: null
       max_connections_per_endpoint: null

--- a/tests/modules/net_lb_proxy_int/examples/health-check-link.yaml
+++ b/tests/modules/net_lb_proxy_int/examples/health-check-link.yaml
@@ -45,7 +45,6 @@ values:
       capacity_scaler: 1
       custom_metrics: []
       description: Terraform managed.
-      failover: false
       group: projects/myprj/zones/europe-west1-a/instanceGroups/my-ig
       max_connections: null
       max_connections_per_endpoint: null

--- a/tests/modules/net_lb_proxy_int/examples/hybrid-neg.yaml
+++ b/tests/modules/net_lb_proxy_int/examples/hybrid-neg.yaml
@@ -65,7 +65,6 @@ values:
       capacity_scaler: 1
       custom_metrics: []
       description: Terraform managed.
-      failover: false
       max_connections: null
       max_connections_per_endpoint: 10
       max_connections_per_instance: null

--- a/tests/modules/net_lb_proxy_int/examples/internet-neg.yaml
+++ b/tests/modules/net_lb_proxy_int/examples/internet-neg.yaml
@@ -45,7 +45,6 @@ values:
       capacity_scaler: 1
       custom_metrics: []
       description: Terraform managed.
-      failover: false
       max_connections: null
       max_connections_per_endpoint: null
       max_connections_per_instance: null

--- a/tests/modules/net_lb_proxy_int/examples/minimal.yaml
+++ b/tests/modules/net_lb_proxy_int/examples/minimal.yaml
@@ -45,7 +45,6 @@ values:
       capacity_scaler: 1
       custom_metrics: []
       description: Terraform managed.
-      failover: false
       group: projects/myprj/zones/europe-west1-a/instanceGroups/my-ig
       max_connections: null
       max_connections_per_endpoint: null

--- a/tests/modules/net_lb_proxy_int/examples/neg-link.yaml
+++ b/tests/modules/net_lb_proxy_int/examples/neg-link.yaml
@@ -45,7 +45,6 @@ values:
       capacity_scaler: 1
       custom_metrics: []
       description: Terraform managed.
-      failover: false
       group: projects/myprj/zones/europe-west1-a/networkEndpointGroups/my-neg
       max_connections: null
       max_connections_per_endpoint: null

--- a/tests/modules/net_lb_proxy_int/examples/ports.yaml
+++ b/tests/modules/net_lb_proxy_int/examples/ports.yaml
@@ -89,7 +89,6 @@ values:
       capacity_scaler: 1
       custom_metrics: []
       description: Terraform managed.
-      failover: false
       group: projects/myprj/zones/europe-west1-a/instanceGroups/my-ig
       max_connections: null
       max_connections_per_endpoint: null

--- a/tests/modules/net_lb_proxy_int/examples/psc-neg.yaml
+++ b/tests/modules/net_lb_proxy_int/examples/psc-neg.yaml
@@ -177,7 +177,6 @@ values:
       capacity_scaler: 1
       custom_metrics: []
       description: Terraform managed.
-      failover: false
       max_connections: null
       max_connections_per_endpoint: null
       max_connections_per_instance: null

--- a/tests/modules/net_lb_proxy_int/examples/zonal-neg.yaml
+++ b/tests/modules/net_lb_proxy_int/examples/zonal-neg.yaml
@@ -65,7 +65,6 @@ values:
       capacity_scaler: 1
       custom_metrics: []
       description: Terraform managed.
-      failover: false
       max_connections: null
       max_connections_per_endpoint: 10
       max_connections_per_instance: null

--- a/tests/modules/net_lb_proxy_int/health-checks-none.yaml
+++ b/tests/modules/net_lb_proxy_int/health-checks-none.yaml
@@ -45,7 +45,6 @@ values:
       capacity_scaler: 1
       custom_metrics: []
       description: Terraform managed.
-      failover: false
       group: projects/myprj/zones/europe-west4-a/instanceGroups/my-ig
       max_connections: null
       max_connections_per_endpoint: null

--- a/tests/modules/net_lb_proxy_int/health-checks-psc.yaml
+++ b/tests/modules/net_lb_proxy_int/health-checks-psc.yaml
@@ -45,7 +45,6 @@ values:
       capacity_scaler: 1
       custom_metrics: []
       description: Terraform managed.
-      failover: false
       max_connections: null
       max_connections_per_endpoint: null
       max_connections_per_instance: null


### PR DESCRIPTION
This PR completes the implementation of the L7 load balancer interface standardization as per [ADR 20260615](adrs/20260615-net-lb-interface-standardization.md).

Key changes:
- Resolved missing context lookups (zone, region, IP address) in `net-lb-app-ext`, `net-lb-app-int`, and `net-lb-app-int-cross-region` modules for NEGs and instance groups.
- Switched to robust try-based lookups to handle optional null values in configuration schemas without failing.
- Updated test configurations and regenerated inventories for affected module-level tests and README examples.
- Verified all tests pass and ran linting checks (check docs, yaml lint, boilerplate).
- Added a "Testing" section to the ADR detailing the required context variables and tfvars used for validation.
- **Fixed `apigee` and `api-gateway` recipes** to use the standardized `group` key instead of the old `backend` key in `net-lb-app-ext` module calls.

E2E live tests executed (apply/destroy) in playground environment:
- `net-lb-ext`: MIG Scenario, Context Scenario
- `net-lb-proxy-int`: MIG Scenario
- `net-lb-proxy-int-cross-region`: Multi-region MIGs (verified existing context support works with standardized format)
- `net-lb-app-int`: MIG with Actions
- `net-lb-app-int-cross-region`: Multi-region MIGs
- `net-lb-app-ext`: Cloud Run Scenario, MIG Scenario
- `net-lb-app-ext-regional`: MIG Scenario

---
**Breaking Changes**

```upgrade-note
`modules/net-lb-proxy-int`: Removed connection tracking and failover configurations as they are not supported by the underlying resources.
```
```upgrade-note
`modules/net-lb-app-int`: Removed failover configurations.
```
```upgrade-note
`modules/net-lb-app-ext`: Renamed the `backend` key to `group` inside `backend_service_configs` to standardize the backend interface. Removed failover configurations.
```
```upgrade-note
`modules/net-lb-app-ext-regional`: Renamed the `backend` key to `group` inside `backend_service_configs`. Replaced the `vpc` variable with `vpc_config` to match other regional modules. Removed failover configurations.
```
