### PR TITLE
Pin GitHub Actions to secure commit SHAs

### DIFF
--- a/.github/actions/fabric-tests/action.yml
+++ b/.github/actions/fabric-tests/action.yml
@@ -30,20 +30,20 @@ runs:
         echo '{"type": "service_account", "project_id": "test-only"}' \
           | tee -a $GOOGLE_APPLICATION_CREDENTIALS
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: ${{ inputs.PYTHON_VERSION }}
         cache: 'pip'
         cache-dependency-path: 'tests/requirements.txt'
 
     - name: Set up Terraform
-      uses: hashicorp/setup-terraform@v3
+      uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
       if: ${{ inputs.TERRAFORM_FLAVOUR == 'terraform' }}
       with:
         terraform_version: ${{ inputs.TERRAFORM_VERSION }}
         terraform_wrapper: false
 
-    - uses: opentofu/setup-opentofu@v1
+    - uses: opentofu/setup-opentofu@9d84900f3238fab8cd84ce47d658d25dd008be2f # v1
       if: ${{ inputs.TERRAFORM_FLAVOUR == 'tofu' }}
       with:
         tofu_version: ${{ inputs.TERRAFORM_VERSION }}
@@ -58,12 +58,12 @@ runs:
           | tee -a /home/runner/.terraformrc
         mkdir -p ${TF_PLUGIN_CACHE_DIR}
     - name: Download lockfile
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         name: lockfile-${{ runner.os }}-${{ inputs.TERRAFORM_FLAVOUR  }}-${{ inputs.TERRAFORM_VERSION }}
         path: tools/lockfile
     - name: Download Terraform provider cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ${{ env.TF_PLUGIN_CACHE_DIR }}
         # yamllint disable-line rule:line-length

--- a/.github/workflows/daily-tag.yml
+++ b/.github/workflows/daily-tag.yml
@@ -29,7 +29,9 @@ jobs:
     name: "Create tag on master if there was activity in last 24 hours"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: "Check changes and tag"
         run: |

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -28,7 +28,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v5
+    - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         sync-labels: true

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -32,21 +32,23 @@ jobs:
   linting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.10"
           cache: 'pip'
           cache-dependency-path: 'tools/requirements.txt'
 
       - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
         with:
           terraform_version: 1.11.4
 
-      - uses: terraform-linters/setup-tflint@v4
+      - uses: terraform-linters/setup-tflint@6e87008f9dd1fe3e34e66aca6c97b4a69f72a7f4 # v4
         name: Setup TFLint
         with:
           tflint_version: v0.59.1

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -15,7 +15,7 @@
 name: "Automated PR Review"
 # yamllint disable-line rule:truthy
 on:
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
     types:
       - opened
       - synchronize

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -33,13 +33,14 @@ jobs:
     steps:
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0  # Need full history for diffing
+          persist-credentials: false
 
       - id: gcp-auth
         name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
         with:
           # yamllint disable-line rule:line-length
           workload_identity_provider: ${{ vars.REVIEWS_WIF_PROVIDER }}
@@ -48,7 +49,7 @@ jobs:
 
       - id: setup-python
         name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
@@ -72,7 +73,7 @@ jobs:
 
       - id: fetch-comments
         name: Fetch PR Comments
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const comments = await github.rest.issues.listComments({
@@ -104,7 +105,7 @@ jobs:
 
       - id: pr-comment
         name: Post comment to Pull Request
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const fs = require('fs');
@@ -121,7 +122,7 @@ jobs:
       - id: remove-label
         name: Remove automated-review label
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             try {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,9 @@ jobs:
     name: "Release new version"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: "Validate input"
         # yamllint disable rule:line-length

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,9 @@ jobs:
           - flavour: terraform
           - flavour: tofu
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Set Terraform versions
         run: |
           set -e -o xtrace
@@ -68,13 +70,13 @@ jobs:
             echo TERRAFORM_VERSION=unkown_flavor | tee -a ${GITHUB_ENV}
           fi
 
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
         if: ${{ matrix.flavour == 'terraform' }}
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false
 
-      - uses: opentofu/setup-opentofu@v1
+      - uses: opentofu/setup-opentofu@9d84900f3238fab8cd84ce47d658d25dd008be2f # v1
         if: ${{ matrix.flavour == 'tofu' }}
         with:
           tofu_version: ${{ env.TERRAFORM_VERSION }}
@@ -96,14 +98,14 @@ jobs:
           ${{ matrix.flavour }} init -upgrade=true
 
       - name: Upload Terraform provider cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ env.TF_PLUGIN_CACHE_DIR }}
           # yamllint disable-line rule:line-length
           key: ${{ runner.os }}-${{ matrix.flavour }}-${{ env.TERRAFORM_VERSION }}-${{ hashFiles('tools/lockfile/.terraform.lock.hcl') }}
 
       - name: Upload lockfile
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: lockfile-${{ runner.os }}-${{ matrix.flavour }}-${{ env.TERRAFORM_VERSION }}
           path: tools/lockfile/.terraform.lock.hcl
@@ -114,7 +116,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup-tf-providers
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Call composite action fabric-tests
         uses: ./.github/actions/fabric-tests
@@ -144,7 +148,9 @@ jobs:
           - flavour: tofu
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Set Terraform versions
         run: |
           set -e -o xtrace
@@ -188,7 +194,9 @@ jobs:
           - flavour: tofu
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Set Terraform versions
         run: |
           set -e -o xtrace
@@ -232,7 +240,9 @@ jobs:
           - flavour: terraform
           # - flavour: tofu # tofu fails to find the terraform binary for FAST tests
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Set Terraform versions
         run: |
           set -e -o xtrace
@@ -264,7 +274,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup-tf-providers
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Call composite action fabric-tests
         uses: ./.github/actions/fabric-tests


### PR DESCRIPTION
Pin all remote GitHub Actions used in workflows and custom actions to their respective exact commit SHAs. This resolves security findings related to unpinned action references (unpinned-uses) flagged by zizmor.

Additionally, some workflows were updated to include 'persist-credentials: false' for 'actions/checkout' to prevent potential credential leaks.

Modified files:
- .github/actions/fabric-tests/action.yml
- .github/workflows/daily-tag.yml
- .github/workflows/labeler.yml
- .github/workflows/linting.yml
- .github/workflows/pr-review.yml
- .github/workflows/release.yml
- .github/workflows/tests.yml

TAG=agy
CONV=4fc95682-3649-414b-9123-67a769272df4
