### PR TITLE
Fix E2E Test for Cloud SQL PSC Auto Connections

### DIFF
--- a/modules/cloudsql-instance/README.md
+++ b/modules/cloudsql-instance/README.md
@@ -272,7 +272,7 @@ module "db" {
   source     = "./fabric/modules/cloudsql-instance"
   project_id = var.project_id
   context = {
-    networks = { myvpc = "https://www.googleapis.com/compute/v1/projects/xxx/global/networks/aaa" }
+    networks = { myvpc = var.vpc.self_link }
   }
   network_config = {
     connectivity = {


### PR DESCRIPTION
The E2E test for the `cloudsql-instance` module was failing on the "Instance with PSC auto connections" example. The example used a hardcoded dummy VPC network URL (`https://www.googleapis.com/compute/v1/projects/xxx/global/networks/aaa`) which does not exist, causing the Cloud SQL API to return a `400 Invalid Request` during the E2E apply phase.

This PR fixes the issue by:
*   Updating the example in `modules/cloudsql-instance/README.md` to use `var.vpc.self_link` instead of the hardcoded string.
*   This allows the E2E test runner to inject the real VPC created during the test setup, while local plan tests continue to use the default dummy VPC defined in `tests/examples/variables.tf` (ensuring the plan inventory remains unchanged).
