### PR TITLE
Fix malformed member in automation SA IAM roles

### DIFF
--- a/modules/project-factory/README.md
+++ b/modules/project-factory/README.md
@@ -791,6 +791,9 @@ automation:
   service_accounts:
     rw:
       description: Team B app 0 read/write automation sa.
+      iam_sa_roles:
+        $service_account_ids:dev-tb-app0-0/automation/ro:
+          - roles/iam.serviceAccountTokenCreator
     ro:
       description: Team B app 0 read-only automation sa.
   bucket:

--- a/modules/project-factory/automation.tf
+++ b/modules/project-factory/automation.tf
@@ -177,10 +177,9 @@ module "automation-service-accounts-iam" {
     for k, v in local.automation_sas :
     k => v if lookup(v, "iam_sa_roles", null) != null
   }
-  project_id = (
-    module.automation-service-accounts[each.key].service_account.project
-  )
-  name = module.automation-service-accounts[each.key].name
+  project_id = each.value.automation_project
+  prefix     = each.value.prefix
+  name       = each.value.name
   service_account_reuse = {
     use_data_source = false
   }

--- a/tests/modules/project_factory/examples/example.yaml
+++ b/tests/modules/project_factory/examples/example.yaml
@@ -73,6 +73,11 @@ values:
     - serviceAccount:dev-tb-app0-0-rw@test-pf-teams-iac-0.iam.gserviceaccount.com
     role: roles/storage.objectViewer
     timeouts: null
+  ? module.project-factory.module.automation-service-accounts-iam["dev-tb-app0-0/automation/rw"].google_service_account_iam_member.additive["$service_account_ids:dev-tb-app0-0/automation/ro-roles/iam.serviceAccountTokenCreator"]
+  : condition: []
+    member: serviceAccount:dev-tb-app0-0-rw@test-pf-teams-iac-0.iam.gserviceaccount.com
+    role: roles/iam.serviceAccountTokenCreator
+    service_account_id: projects/test-pf-teams-iac-0/serviceAccounts/dev-tb-app0-0-ro@test-pf-teams-iac-0.iam.gserviceaccount.com
   ? module.project-factory.module.automation-service-accounts["dev-tb-app0-0/automation/ro"].google_service_account.service_account[0]
   : account_id: dev-tb-app0-0-ro
     create_ignore_already_exists: null
@@ -1056,7 +1061,7 @@ counts:
   google_pubsub_topic_iam_binding: 1
   google_service_account: 6
   google_service_account_iam_binding: 2
-  google_service_account_iam_member: 2
+  google_service_account_iam_member: 3
   google_storage_bucket: 3
   google_storage_bucket_iam_binding: 2
   google_storage_project_service_account: 4
@@ -1065,8 +1070,8 @@ counts:
   google_tags_tag_key: 1
   google_tags_tag_value: 2
   google_tags_tag_value_iam_binding: 1
-  modules: 38
-  resources: 120
+  modules: 39
+  resources: 121
   terraform_data: 2
 
 outputs: {}


### PR DESCRIPTION
Fix member formatting for automation service accounts when granting IAM roles on service accounts (`iam_sa_roles`) in `project-factory`.                       
                                                                                                                                                                   
Previously, `modules/project-factory/automation.tf` passed the full resource ID (`module.automation-service-accounts[each.key].name`) as `var.name` into `automation-service-accounts-iam`. This caused `iam-service-account` to construct a malformed principal string (`serviceAccount:projects/PROJECT/serviceAccounts/EMAIL`) for the `member` attribute on `google_service_account_iam_member.additive`.                            
                                                                                                                                                                   
This change updates `automation-service-accounts-iam` to pass `each.value.prefix` and `each.value.name` directly, matching the behavior of regular service accounts in project factory.                                                                                                                                     
                                                                                                                                                                   
Fixes #4035                                                                                                                                                    
