### PR TITLE
network passthrough load balancer traffic policy

### DIFF
--- a/modules/net-lb-int/README.md
+++ b/modules/net-lb-int/README.md
@@ -3,22 +3,24 @@
 This module allows managing a GCE Internal Load Balancer and integrates the forwarding rule, regional backend, and optional health check resources. It's designed to be a simple match for the [`compute-vm`](../compute-vm) module, which can be used to manage instance templates and instance groups.
 
 <!-- BEGIN TOC -->
-- [Examples](#examples)
-  - [Referencing existing MIGs](#referencing-existing-migs)
-  - [Externally managed instances](#externally-managed-instances)
-  - [Passing multiple protocols through the load balancers](#passing-multiple-protocols-through-the-load-balancers)
-  - [Multiple forwarding rules](#multiple-forwarding-rules)
-  - [Dual stack (IPv4 and IPv6)](#dual-stack-ipv4-and-ipv6)
-  - [PSC service attachments](#psc-service-attachments)
-  - [Regional health check](#regional-health-check)
-  - [End to end example](#end-to-end-example)
-  - [Context](#context)
-- [Deploying changes to load balancer configurations](#deploying-changes-to-load-balancer-configurations)
-- [Issues](#issues)
-- [Recipes](#recipes)
-- [Recipes](#recipes)
-- [Variables](#variables)
-- [Outputs](#outputs)
+- [Internal Passthrough Network Load Balancer Module](#internal-passthrough-network-load-balancer-module)
+  - [Examples](#examples)
+    - [Referencing existing MIGs](#referencing-existing-migs)
+    - [Externally managed instances](#externally-managed-instances)
+    - [Passing multiple protocols through the load balancers](#passing-multiple-protocols-through-the-load-balancers)
+    - [Multiple forwarding rules](#multiple-forwarding-rules)
+    - [Dual stack (IPv4 and IPv6)](#dual-stack-ipv4-and-ipv6)
+    - [PSC service attachments](#psc-service-attachments)
+    - [Zonal affinity traffic policy](#zonal-affinity-traffic-policy)
+    - [Regional health check](#regional-health-check)
+    - [End to end example](#end-to-end-example)
+    - [Context](#context)
+  - [Deploying changes to load balancer configurations](#deploying-changes-to-load-balancer-configurations)
+  - [Issues](#issues)
+  - [Recipes](#recipes)
+  - [Recipes](#recipes-1)
+  - [Variables](#variables)
+  - [Outputs](#outputs)
 <!-- END TOC -->
 
 ## Examples
@@ -282,6 +284,45 @@ module "ilb" {
 # tftest modules=1 resources=7
 ```
 
+### Zonal affinity traffic policy
+
+The `backend_service_config.network_pass_through_lb_traffic_policy` block allows tuning the backend service behavior for network passthrough load balancers, including zonal affinity spillover settings.
+
+```hcl
+module "ilb" {
+  source        = "./fabric/modules/net-lb-int"
+  project_id    = var.project_id
+  region        = "europe-west1"
+  name          = "ilb-test"
+  service_label = "ilb-test"
+  vpc_config = {
+    network    = var.vpc.self_link
+    subnetwork = var.subnet.self_link
+  }
+  backend_service_config = {
+    network_pass_through_lb_traffic_policy = {
+      zonal_affinity = {
+        spillover       = "ZONAL_AFFINITY_SPILL_CROSS_ZONE"
+        spillover_ratio = 0.5
+      }
+    }
+  }
+  group_configs = {
+    my-group = {
+      zone = "europe-west1-b"
+      instances = [
+        "instance-1-self-link",
+        "instance-2-self-link"
+      ]
+    }
+  }
+  backends = [{
+    group = module.ilb.groups.my-group.self_link
+  }]
+}
+# tftest modules=1 resources=4
+```
+
 ### Regional health check
 
 The `is_regional` flag in the `health_check_config` block allows creating a regional health check instead of a global one.
@@ -457,39 +498,39 @@ One other issue is a `Provider produced inconsistent final plan` error which is 
 
 ## Variables
 
-| name | description | type | required | default |
-|---|---|:---:|:---:|:---:|
-| [name](variables.tf#L208) | Name used for all resources. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L213) | Project id where resources will be created. | <code>string</code> | ✓ |  |
-| [region](variables.tf#L218) | GCP region. | <code>string</code> | ✓ |  |
-| [vpc_config](variables.tf#L244) | VPC-level configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
-| [backend_service_config](variables.tf#L17) | Backend service level configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [backends](variables.tf#L58) | Load balancer backends. | <code>list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
-| [context](variables.tf#L69) | Context-specific interpolations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [description](variables.tf#L82) | Optional description used for resources. | <code>string</code> |  | <code>&#34;Terraform managed.&#34;</code> |
-| [forwarding_rules_config](variables.tf#L88) | The optional forwarding rules configuration. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#8230;&#125;</code> |
-| [group_configs](variables.tf#L104) | Optional unmanaged groups to create. Can be referenced in backends via outputs. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [health_check](variables.tf#L117) | Name of existing health check to use, disables auto-created health check. Also set `health_check_config = null` when cross-referencing an health check from another load balancer module to avoid a Terraform error. | <code>string</code> |  | <code>null</code> |
-| [health_check_config](variables.tf#L123) | Optional auto-created health check configuration, use the output self-link to set it in the auto healing policy. Refer to examples for usage. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#8230;&#125;</code> |
-| [labels](variables.tf#L202) | Labels set on resources. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
-| [service_attachments](variables.tf#L223) | PSC service attachments, keyed by forwarding rule. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>null</code> |
-| [service_label](variables.tf#L238) | Optional prefix of the fully qualified forwarding rule name. | <code>string</code> |  | <code>null</code> |
+| name                                        | description                                                                                                                                                                                                          |                              type                              | required |                  default                  |
+| ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------: | :------: | :---------------------------------------: |
+| [name](variables.tf#L208)                   | Name used for all resources.                                                                                                                                                                                         |                      <code>string</code>                       |    ✓     |                                           |
+| [project_id](variables.tf#L213)             | Project id where resources will be created.                                                                                                                                                                          |                      <code>string</code>                       |    ✓     |                                           |
+| [region](variables.tf#L218)                 | GCP region.                                                                                                                                                                                                          |                      <code>string</code>                       |    ✓     |                                           |
+| [vpc_config](variables.tf#L244)             | VPC-level configuration.                                                                                                                                                                                             |        <code>object&#40;&#123;&#8230;&#125;&#41;</code>        |    ✓     |                                           |
+| [backend_service_config](variables.tf#L17)  | Backend service level configuration.                                                                                                                                                                                 |        <code>object&#40;&#123;&#8230;&#125;&#41;</code>        |          |         <code>&#123;&#125;</code>         |
+| [backends](variables.tf#L58)                | Load balancer backends.                                                                                                                                                                                              | <code>list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |          |          <code>&#91;&#93;</code>          |
+| [context](variables.tf#L69)                 | Context-specific interpolations.                                                                                                                                                                                     |        <code>object&#40;&#123;&#8230;&#125;&#41;</code>        |          |         <code>&#123;&#125;</code>         |
+| [description](variables.tf#L82)             | Optional description used for resources.                                                                                                                                                                             |                      <code>string</code>                       |          | <code>&#34;Terraform managed.&#34;</code> |
+| [forwarding_rules_config](variables.tf#L88) | The optional forwarding rules configuration.                                                                                                                                                                         | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code>  |          |     <code>&#123;&#8230;&#125;</code>      |
+| [group_configs](variables.tf#L104)          | Optional unmanaged groups to create. Can be referenced in backends via outputs.                                                                                                                                      | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code>  |          |         <code>&#123;&#125;</code>         |
+| [health_check](variables.tf#L117)           | Name of existing health check to use, disables auto-created health check. Also set `health_check_config = null` when cross-referencing an health check from another load balancer module to avoid a Terraform error. |                      <code>string</code>                       |          |             <code>null</code>             |
+| [health_check_config](variables.tf#L123)    | Optional auto-created health check configuration, use the output self-link to set it in the auto healing policy. Refer to examples for usage.                                                                        |        <code>object&#40;&#123;&#8230;&#125;&#41;</code>        |          |     <code>&#123;&#8230;&#125;</code>      |
+| [labels](variables.tf#L202)                 | Labels set on resources.                                                                                                                                                                                             |                <code>map&#40;string&#41;</code>                |          |         <code>&#123;&#125;</code>         |
+| [service_attachments](variables.tf#L223)    | PSC service attachments, keyed by forwarding rule.                                                                                                                                                                   | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code>  |          |             <code>null</code>             |
+| [service_label](variables.tf#L238)          | Optional prefix of the fully qualified forwarding rule name.                                                                                                                                                         |                      <code>string</code>                       |          |             <code>null</code>             |
 
 ## Outputs
 
-| name | description | sensitive |
-|---|---|:---:|
-| [backend_service](outputs.tf#L17) | Backend resource. | ✓ |
-| [backend_service_id](outputs.tf#L23) | Backend id. |  |
-| [backend_service_self_link](outputs.tf#L28) | Backend self link. |  |
-| [forwarding_rule_addresses](outputs.tf#L33) | Forwarding rule address. |  |
-| [forwarding_rule_self_links](outputs.tf#L41) | Forwarding rule self links. |  |
-| [forwarding_rules](outputs.tf#L49) | Forwarding rule resources. |  |
-| [group_self_links](outputs.tf#L57) | Optional unmanaged instance group self links. |  |
-| [groups](outputs.tf#L64) | Optional unmanaged instance group resources. |  |
-| [health_check](outputs.tf#L69) | Auto-created health-check resource. |  |
-| [health_check_id](outputs.tf#L78) | Auto-created health-check id. |  |
-| [health_check_self_link](outputs.tf#L87) | Auto-created health-check self link. |  |
-| [id](outputs.tf#L96) | Fully qualified forwarding rule ids. |  |
-| [service_attachment_ids](outputs.tf#L104) | Service attachment ids. |  |
+| name                                         | description                                   | sensitive |
+| -------------------------------------------- | --------------------------------------------- | :-------: |
+| [backend_service](outputs.tf#L17)            | Backend resource.                             |     ✓     |
+| [backend_service_id](outputs.tf#L23)         | Backend id.                                   |           |
+| [backend_service_self_link](outputs.tf#L28)  | Backend self link.                            |           |
+| [forwarding_rule_addresses](outputs.tf#L33)  | Forwarding rule address.                      |           |
+| [forwarding_rule_self_links](outputs.tf#L41) | Forwarding rule self links.                   |           |
+| [forwarding_rules](outputs.tf#L49)           | Forwarding rule resources.                    |           |
+| [group_self_links](outputs.tf#L57)           | Optional unmanaged instance group self links. |           |
+| [groups](outputs.tf#L64)                     | Optional unmanaged instance group resources.  |           |
+| [health_check](outputs.tf#L69)               | Auto-created health-check resource.           |           |
+| [health_check_id](outputs.tf#L78)            | Auto-created health-check id.                 |           |
+| [health_check_self_link](outputs.tf#L87)     | Auto-created health-check self link.          |           |
+| [id](outputs.tf#L96)                         | Fully qualified forwarding rule ids.          |           |
+| [service_attachment_ids](outputs.tf#L104)    | Service attachment ids.                       |           |
 <!-- END TFDOC -->

--- a/modules/net-lb-int/main.tf
+++ b/modules/net-lb-int/main.tf
@@ -21,6 +21,7 @@ locals {
   )
   bs_conntrack = var.backend_service_config.connection_tracking
   bs_failover  = var.backend_service_config.failover_config
+  bs_nptlb     = var.backend_service_config.network_pass_through_lb_traffic_policy
   forwarding_rule_names = {
     for k, v in var.forwarding_rules_config :
     k => k == "" ? var.name : "${var.name}-${k}"
@@ -150,6 +151,18 @@ resource "google_compute_region_backend_service" "default" {
     }
   }
 
+  dynamic "network_pass_through_lb_traffic_policy" {
+    for_each = local.bs_nptlb == null ? [""] : []
+    content {
+      dynamic "zonal_affinity" {
+        for_each = local.bs_nptlb.zonal_affinity == null ? [""] : []
+        content {
+          spillover       = local.bs_nptlb.zonal_affinity.spillover
+          spillover_ratio = local.bs_nptlb.zonal_affinity.spillover_ratio
+        }
+      }
+    }
+  }
 }
 
 resource "google_compute_service_attachment" "default" {

--- a/modules/net-lb-int/variables.tf
+++ b/modules/net-lb-int/variables.tf
@@ -35,6 +35,12 @@ variable "backend_service_config" {
       optional_mode   = optional(string)
       optional_fields = optional(list(string))
     }))
+    network_pass_through_lb_traffic_policy = optional(object({
+      zonal_affinity = optional(object({
+        spillover       = optional(string, "ZONAL_AFFINITY_DISABLED")
+        spillover_ratio = optional(number)
+      }))
+    }))
     name             = optional(string)
     description      = optional(string, "Terraform managed.")
     protocol         = optional(string, "UNSPECIFIED")
@@ -52,6 +58,26 @@ variable "backend_service_config" {
       coalesce(var.backend_service_config.session_affinity, "NONE")
     )
     error_message = "Invalid session affinity value."
+  }
+  validation {
+    condition = (
+      try(var.backend_service_config.network_pass_through_lb_traffic_policy.zonal_affinity.spillover, null) == null ||
+      contains(
+        ["ZONAL_AFFINITY_DISABLED", "ZONAL_AFFINITY_SPILL_CROSS_ZONE", "ZONAL_AFFINITY_STAY_WITHIN_ZONE"],
+        var.backend_service_config.network_pass_through_lb_traffic_policy.zonal_affinity.spillover
+      )
+    )
+    error_message = "network_pass_through_lb_traffic_policy.zonal_affinity.spillover must be one of ZONAL_AFFINITY_DISABLED, ZONAL_AFFINITY_SPILL_CROSS_ZONE, or ZONAL_AFFINITY_STAY_WITHIN_ZONE."
+  }
+  validation {
+    condition = (
+      try(var.backend_service_config.network_pass_through_lb_traffic_policy.zonal_affinity.spillover_ratio, null) == null
+      || (
+        var.backend_service_config.network_pass_through_lb_traffic_policy.zonal_affinity.spillover_ratio >= 0 &&
+        var.backend_service_config.network_pass_through_lb_traffic_policy.zonal_affinity.spillover_ratio <= 1
+      )
+    )
+    error_message = "network_pass_through_lb_traffic_policy.zonal_affinity.spillover_ratio must be a number between 0 and 1."
   }
 }
 

--- a/tests/modules/net_lb_int/tftest.yaml
+++ b/tests/modules/net_lb_int/tftest.yaml
@@ -24,3 +24,4 @@ tests:
   health-checks-https:
   health-checks-ssl:
   health-checks-tcp:
+  zonal-affinity:

--- a/tests/modules/net_lb_int/zonal-affinity.tfvars
+++ b/tests/modules/net_lb_int/zonal-affinity.tfvars
@@ -1,0 +1,32 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+project_id = "my-project"
+region     = "europe-west1"
+name       = "ilb-test"
+vpc_config = {
+  network    = "default"
+  subnetwork = "default"
+}
+backends = [{
+  group = "foo"
+}]
+backend_service_config = {
+  network_pass_through_lb_traffic_policy = {
+    zonal_affinity = {
+      spillover       = "ZONAL_AFFINITY_SPILL_CROSS_ZONE"
+      spillover_ratio = 0.5
+    }
+  }
+}

--- a/tests/modules/net_lb_int/zonal-affinity.yaml
+++ b/tests/modules/net_lb_int/zonal-affinity.yaml
@@ -1,0 +1,23 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values:
+  google_compute_region_backend_service.default:
+    network_pass_through_lb_traffic_policy:
+    - zonal_affinity:
+      - spillover: ZONAL_AFFINITY_SPILL_CROSS_ZONE
+        spillover_ratio: 0.5
+
+counts:
+  google_compute_region_backend_service: 1


### PR DESCRIPTION
**Summary**

This PR adds support for configuring network passthrough load balancer traffic policies on the internal passthrough load balancer module.

**What changed**

- Added a new backend_service_config.network_pass_through_lb_traffic_policy option to variables.tf
- Wired the new policy into main.tf so it is rendered in the backend service configuration
- Added a focused example in README.md to demonstrate zonal affinity spillover usage
- Added regression coverage in tftest.yaml with supporting tfvars/yaml fixtures for the new behavior

**Details**

The new configuration supports:

- network_pass_through_lb_traffic_policy.zonal_affinity.spillover
- network_pass_through_lb_traffic_policy.zonal_affinity.spillover_ratio

The implementation validates that spillover uses one of the supported values and that spillover_ratio remains within the allowed range of 0 to 1.

**Why**

This enables users to tune backend-service traffic distribution behavior for internal passthrough load balancers using zonal affinity spillover policies, which was previously not exposed by the module.

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [x] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->