### PR TITLE
Supplementing missing IAM sections mapping in project-factory module.

### DIFF
--- a/modules/project-factory/projects-service-accounts.tf
+++ b/modules/project-factory/projects-service-accounts.tf
@@ -31,6 +31,7 @@ locals {
         iam_bindings           = try(opts.iam_bindings, {})
         iam_bindings_additive  = try(opts.iam_bindings_additive, {})
         iam_billing_roles      = try(opts.iam_billing_roles, {})
+        iam_folder_roles       = try(opts.iam_folder_roles, {})
         iam_organization_roles = try(opts.iam_organization_roles, {})
         iam_sa_roles           = try(opts.iam_sa_roles, {})
         iam_project_roles      = try(opts.iam_project_roles, {})
@@ -93,13 +94,17 @@ module "service-accounts" {
     project_ids = local.ctx_project_ids
     tag_values  = local.ctx_tag_values
   })
+  iam_billing_roles      = each.value.iam_billing_roles
+  iam_folder_roles       = each.value.iam_folder_roles
+  iam_organization_roles = each.value.iam_organization_roles
   iam_project_roles = merge(
     each.value.iam_project_roles,
     {
       "$project_ids:${each.value.project_key}" = each.value.iam_self_roles
     }
   )
-  tag_bindings = each.value.tag_bindings
+  iam_storage_roles = each.value.iam_storage_roles
+  tag_bindings      = each.value.tag_bindings
 }
 
 moved {


### PR DESCRIPTION
Adding missing mappings for iam_[billing|folder|organization|storage]_roles sections in project-factory module. 

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
