### PR TITLE
Add support for context aware access to the org module and FAST stage 0

### DIFF
--- a/adrs/20260703-context-aware-access.md
+++ b/adrs/20260703-context-aware-access.md
@@ -1,0 +1,87 @@
+# Support for Context-Aware Access (`context_aware_access_bindings`) in `modules/organization`
+
+**authors:** [ludomagno](https://github.com/ludomagno)  
+**date:** Jul 3, 2026  
+
+## Status
+
+Proposed
+
+## Context
+
+Google Cloud Context-Aware Access ([securing GCP Console and APIs](https://cloud.google.com/access-context-manager/docs/securing-console-and-apis)) enforces identity- and context-based access controls for Google Cloud Console and CLI/APIs by binding Google Workspace / Cloud Identity user groups to Access Context Manager access levels using `google_access_context_manager_gcp_user_access_binding` resources.
+
+Access levels specify context conditions (e.g., corporate IP subnets, device posture, geographic regions) and can be referenced via symbolic context keys (`$access_levels:<key>`) or literal access level IDs (`accessPolicies/<id>/accessLevels/<name>`).
+
+## Decision
+
+### 1. Module Scope & Ownership Rationale
+The `google_access_context_manager_gcp_user_access_binding` resources will be implemented in `modules/organization`.
+
+*Rationale:* This follows the universal Fabric pattern where support for a feature or policy is added to the module that owns the resource to which the policy is applied. Since GCP User Access Bindings apply at the Organization resource boundary, `modules/organization` is the correct module owner.
+
+### 2. Context Resolution Pattern
+The standard Fabric context replacement pattern is applied so that `access_levels` attributes in bindings can be specified either:
+- As explicit, fully-qualified Access Level IDs (e.g., `accessPolicies/12345/accessLevels/corp_device`), or
+- Via `$access_levels:<key>` context replacements.
+
+The `$access_levels:` context namespace in `modules/organization` is populated by merging:
+- Static context passed in via `var.context.access_levels`
+- Internal context populated via `var.access_levels`
+- Internal context populated via an `access_levels` factory (`factories_config.access_levels`)
+
+### 3. Feature and Variable Naming
+To strictly align with Fabric naming rules and avoid creating new names for existing components:
+- Binding variable: `context_aware_access_bindings`
+- Access levels variable: `access_levels` (matching the exact name used in `modules/vpc-sc`)
+- Factory configuration key: `factories_config.access_levels` (for access levels only; no factory for bindings)
+
+### 4. Access Level Factory Schema
+The `access_levels` factory schema in `modules/organization` will be identical to the one implemented in `modules/vpc-sc` (`modules/vpc-sc/schemas/access-level.schema.json`).
+
+No additional schema fields are required. The JSON schema will be copied to `modules/organization/schemas/access-level.schema.json` and tracked in `tools/duplicate-diff.py`.
+
+## Interface Specifications
+
+### Variable Interface (`variables.tf`)
+
+```hcl
+variable "access_levels" {
+  description = "Access levels map for internal context resolution (key => access_level_id)."
+  type        = map(string)
+  default     = {}
+  nullable    = false
+}
+
+variable "context_aware_access_bindings" {
+  description = "GCP User Access Bindings for securing Console and APIs."
+  type = map(object({
+    group_key     = string
+    access_levels = list(string)
+    scoped_access_settings = optional(list(object({
+      active_settings = optional(object({
+        access_levels = optional(list(string))
+      }))
+      dry_run_settings = optional(object({
+        access_levels = optional(list(string))
+      }))
+    })), [])
+  }))
+  default  = {}
+  nullable = false
+}
+```
+
+## FAST Support (`fast/stages/0-org-setup`)
+
+To support Context-Aware Access in Fabric FAST environments:
+
+1. **Defaults Context Support**: Add support for the new `$access_levels:` context namespace to the `0-org-setup` defaults dataset and variables.
+2. **Access Level Factory**: Add support for the `access_levels` factory in `0-org-setup` to enable defining org-level access levels alongside org policy and IAM factories.
+3. **Schema Copy & Tracking**: Copy `access-level.schema.json` to `fast/stages/0-org-setup/schemas/access-level.schema.json` and register the triple (`modules/vpc-sc`, `modules/organization`, `fast/stages/0-org-setup`) in `tools/duplicate-diff.py`.
+
+## Consequences
+
+- Enforces Fabric resource ownership principles by placing org-level bindings in `modules/organization`.
+- Allows callers to use explicit access level IDs or `$access_levels:` context replacements.
+- Integrates cleanly into FAST Stage 0 with full schema validation and duplicate checking via `tools/duplicate-diff.py`.

--- a/fast/stages/0-org-setup/README.md
+++ b/fast/stages/0-org-setup/README.md
@@ -914,8 +914,8 @@ Define values for the `var.environments` variable in a tfvars file.
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
 | [context](variables.tf#L17) | Context-specific interpolations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [factories_config](variables.tf#L45) | Configuration for the resource factories or external data. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [org_policies_imports](variables.tf#L65) | List of org policies to import. These need to also be defined in data files. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
+| [factories_config](variables.tf#L46) | Configuration for the resource factories or external data. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [org_policies_imports](variables.tf#L66) | List of org policies to import. These need to also be defined in data files. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
 
 ## Outputs
 

--- a/fast/stages/0-org-setup/organization.tf
+++ b/fast/stages/0-org-setup/organization.tf
@@ -60,6 +60,9 @@ locals {
     gcp-security-admins     = "group:gcp-security-admins@${local.organization.domain}"
     gcp-support             = "group:gcp-support@${local.organization.domain}"
   }
+  org_access_levels = {
+    for k, v in module.organization[0].access_levels : k => v.id
+  }
   org_logging_identities = merge(
     module.organization[0].logging_identities.kms == null ? {} : {
       "organization/logging/kms" = module.organization[0].logging_identities.kms
@@ -84,6 +87,7 @@ module "organization" {
   source           = "../../../modules/organization"
   count            = local.organization_id != null ? 1 : 0
   organization_id  = "organizations/${local.organization_id}"
+  access_policy    = try(local.organization.access_policy, null)
   logging_settings = lookup(local.organization, "logging", null)
   context = {
     condition_vars = {
@@ -97,6 +101,7 @@ module "organization" {
   contacts              = lookup(local.organization, "contacts", {})
   service_agents_config = lookup(local.organization, "service_agents_config", {})
   factories_config = {
+    access_levels          = "${local.paths.organization}/access-levels"
     custom_roles           = "${local.paths.organization}/custom-roles"
     tags                   = "${local.paths.organization}/tags"
     scc_sha_custom_modules = "${local.paths.organization}/scc-sha-custom-modules"
@@ -115,6 +120,10 @@ module "organization-iam" {
   organization_id = module.organization[0].id
   asset_feeds     = lookup(local.organization, "asset_feeds", {})
   context = merge(local.ctx, {
+    access_levels = merge(
+      try(local.ctx.access_levels, {}),
+      local.org_access_levels
+    )
     condition_vars = merge(
       local.ctx_condition_vars,
       { folder_ids = module.factory.folder_ids },
@@ -180,6 +189,9 @@ module "organization-iam" {
   logging_data_access = try(local.organization.data_access_logs, {})
   logging_sinks       = try(local.organization.logging.sinks, {})
   pam_entitlements    = try(local.organization.pam_entitlements, {})
+  context_aware_access_bindings = lookup(
+    local.organization, "context_aware_access_bindings", {}
+  )
   tags_config = {
     force_context_ids = true
   }

--- a/fast/stages/0-org-setup/schemas/access-level.schema.json
+++ b/fast/stages/0-org-setup/schemas/access-level.schema.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "VPC-SC access level",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "combining_function": {
+      "type": "string"
+    },
+    "conditions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "device_policy": {
+            "type": "object",
+            "required": [
+              "require_admin_approval",
+              "require_corp_owned"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "allowed_device_management_levels": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "allowed_encryption_statuses": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "require_admin_approval": {
+                "type": "boolean"
+              },
+              "require_corp_owned": {
+                "type": "boolean"
+              },
+              "require_screen_lock": {
+                "type": "boolean"
+              },
+              "os_constraints": {
+                "type": "array",
+                "required": [
+                  "os_type"
+                ],
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "os_type": {
+                      "type": "string"
+                    },
+                    "minimum_version": {
+                      "type": "string"
+                    },
+                    "require_verified_chrome_os": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "ip_subnetworks": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "members": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "negate": {
+            "type": "boolean"
+          },
+          "regions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "required_access_levels": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "vpc_subnets": {
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+              "^//compute.googleapis.com/projects/[^/]+/global/networks/[^/]+$": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/fast/stages/0-org-setup/schemas/access-level.schema.md
+++ b/fast/stages/0-org-setup/schemas/access-level.schema.md
@@ -1,0 +1,42 @@
+# VPC-SC access level
+
+<!-- markdownlint-disable MD036 -->
+
+## Properties
+
+*additional properties: false*
+
+- **combining_function**: *string*
+- **conditions**: *array*
+  - items: *object*
+    <br>*additional properties: false*
+    - **device_policy**: *object*
+      <br>*additional properties: false*
+      - **allowed_device_management_levels**: *array*
+        - items: *string*
+      - **allowed_encryption_statuses**: *array*
+        - items: *string*
+      - ⁺**require_admin_approval**: *boolean*
+      - ⁺**require_corp_owned**: *boolean*
+      - **require_screen_lock**: *boolean*
+      - **os_constraints**: *array*
+        - items: *object*
+          <br>*additional properties: false*
+          - **os_type**: *string*
+          - **minimum_version**: *string*
+          - **require_verified_chrome_os**: *boolean*
+    - **ip_subnetworks**: *array*
+      - items: *string*
+    - **members**: *array*
+      - items: *string*
+    - **negate**: *boolean*
+    - **regions**: *array*
+      - items: *string*
+    - **required_access_levels**: *array*
+      - items: *string*
+    - **vpc_subnets**: *object*
+      <br>*additional properties: false*
+      - **`^//compute.googleapis.com/projects/[^/]+/global/networks/[^/]+$`**: *array*
+        - items: *string*
+
+## Definitions

--- a/fast/stages/0-org-setup/schemas/defaults.schema.json
+++ b/fast/stages/0-org-setup/schemas/defaults.schema.json
@@ -674,6 +674,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "access_levels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "cidr_ranges_sets": {
           "type": "object",
           "additionalProperties": {

--- a/fast/stages/0-org-setup/schemas/defaults.schema.md
+++ b/fast/stages/0-org-setup/schemas/defaults.schema.md
@@ -197,6 +197,8 @@
       - **internal_range**: *string*
 - **context**: *object*
   <br>*additional properties: false*
+  - **access_levels**: *object*
+    <br>*additional properties: string*
   - **cidr_ranges_sets**: *object*
     <br>*additional properties: array*
   - **custom_roles**: *object*

--- a/fast/stages/0-org-setup/schemas/organization.schema.json
+++ b/fast/stages/0-org-setup/schemas/organization.schema.json
@@ -4,6 +4,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "access_policy": {
+      "type": "string"
+    },
     "asset_feeds": {
       "type": "object",
       "additionalProperties": false,
@@ -111,6 +114,9 @@
           }
         }
       }
+    },
+    "context_aware_access_bindings": {
+      "$ref": "#/$defs/context_aware_access_bindings"
     },
     "data_access_logs": {
       "type": "object",
@@ -825,6 +831,64 @@
               "items": {
                 "type": "string",
                 "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+              }
+            }
+          }
+        }
+      }
+    },
+    "context_aware_access_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-zA-Z0-9-_.]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "group_key",
+            "access_levels"
+          ],
+          "properties": {
+            "group_key": {
+              "type": "string"
+            },
+            "access_levels": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "scoped_access_settings": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "active_settings": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "access_levels": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  "dry_run_settings": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "access_levels": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
               }
             }
           }

--- a/fast/stages/0-org-setup/schemas/organization.schema.md
+++ b/fast/stages/0-org-setup/schemas/organization.schema.md
@@ -6,6 +6,7 @@
 
 *additional properties: false*
 
+- **access_policy**: *string*
 - **asset_feeds**: *object*
   <br>*additional properties: false*
   - **`^[a-z0-9-]+$`**: *object*
@@ -34,6 +35,7 @@
   - **`^(\S+@\S+\.\S+|\$email_addresses:\S+)$`**: *array*
     - items: *string*
       <br>*enum: ['ALL', 'BILLING', 'LEGAL', 'SECURITY', 'PRODUCT_UPDATES', 'SUSPENSION', 'TECHNICAL']*
+- **context_aware_access_bindings**: *reference([context_aware_access_bindings](#refs-context_aware_access_bindings))*
 - **data_access_logs**: *object*
   <br>*additional properties: false*
   - **`^([a-z][a-z-]+\.googleapis\.com|allServices)$`**: *object*
@@ -222,6 +224,24 @@
     - ⁺**roles**: *array*
       - items: *string*
         <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+- **context_aware_access_bindings**<a name="refs-context_aware_access_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-zA-Z0-9-_.]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**group_key**: *string*
+    - ⁺**access_levels**: *array*
+      - items: *string*
+    - **scoped_access_settings**: *array*
+      - items: *object*
+        <br>*additional properties: false*
+        - **active_settings**: *object*
+          <br>*additional properties: false*
+          - **access_levels**: *array*
+            - items: *string*
+        - **dry_run_settings**: *object*
+          <br>*additional properties: false*
+          - **access_levels**: *array*
+            - items: *string*
 - **pam_entitlements**<a name="refs-pam_entitlements"></a>: *object*
   <br>*additional properties: false*
   - **`^[a-z][a-z0-9-]{0,61}[a-z0-9]$`**: *object*

--- a/fast/stages/0-org-setup/variables.tf
+++ b/fast/stages/0-org-setup/variables.tf
@@ -17,6 +17,7 @@
 variable "context" {
   description = "Context-specific interpolations."
   type = object({
+    access_levels         = optional(map(string), {})
     cidr_ranges_sets      = optional(map(list(string)), {})
     custom_roles          = optional(map(string), {})
     email_addresses       = optional(map(string), {})

--- a/modules/organization/README.md
+++ b/modules/organization/README.md
@@ -41,6 +41,7 @@ To manage organization policies, the `orgpolicy.googleapis.com` service should b
   - [Tags Factory](#tags-factory)
 - [Workforce Identity](#workforce-identity)
 - [IAM Deny Policies](#iam-deny-policies)
+- [Context-Aware Access](#context-aware-access)
 - [Files](#files)
 - [Variables](#variables)
 - [Outputs](#outputs)
@@ -1058,6 +1059,35 @@ module "organization" {
 # tftest modules=1 resources=2 inventory=iam-deny-policies.yaml
 ```
 
+## Context-Aware Access
+
+[Context-Aware Access](https://cloud.google.com/access-context-manager/docs/securing-console-and-apis) allows you to secure access to the Google Cloud Console and Google Cloud APIs by enforcing granular access controls based on user identity and request context (such as IP address range or device posture).
+
+The following example demonstrates how to create an Access Level for trusted IP ranges and bind it to a Google Workspace or Cloud Identity group using `context_aware_access_bindings`:
+
+```hcl
+module "org" {
+  source          = "./fabric/modules/organization"
+  organization_id = var.organization_id
+  access_policy   = "1234567890"
+  access_levels = {
+    trusted_ips = {
+      title = "Trusted Corporate IPs"
+      conditions = [{
+        ip_subnetworks = ["203.0.113.0/24", "198.51.100.0/24"]
+      }]
+    }
+  }
+  context_aware_access_bindings = {
+    developers_binding = {
+      group_key     = "gcp-developers@example.com"
+      access_levels = ["$access_levels:trusted_ips"]
+    }
+  }
+}
+# tftest modules=1 resources=2 inventory=context-aware-access.yaml
+```
+
 <!-- TFDOC OPTS files:1 -->
 <!-- BEGIN TFDOC -->
 ## Files
@@ -1065,6 +1095,7 @@ module "organization" {
 | name | description | resources |
 |---|---|---|
 | [assets.tf](./assets.tf) | None | <code>google_cloud_asset_organization_feed</code> |
+| [context_aware_access.tf](./context_aware_access.tf) | Context-Aware Access resources and factory. | <code>google_access_context_manager_access_level</code> · <code>google_access_context_manager_gcp_user_access_binding</code> |
 | [deny-policies.tf](./deny-policies.tf) | IAM Deny policies. | <code>google_iam_deny_policy</code> |
 | [iam.tf](./iam.tf) | IAM bindings. | <code>google_organization_iam_binding</code> · <code>google_organization_iam_custom_role</code> · <code>google_organization_iam_member</code> |
 | [identity-providers.tf](./identity-providers.tf) | Workforce Identity Federation provider definitions. | <code>google_iam_workforce_pool</code> · <code>google_iam_workforce_pool_provider</code> · <code>google_iam_workforce_pool_provider_scim_tenant</code> |
@@ -1091,14 +1122,17 @@ module "organization" {
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [organization_id](variables.tf#L177) | Organization id in organizations/nnnnnn format. | <code>string</code> | ✓ |  |
-| [asset_feeds](variables.tf#L18) | Cloud Asset Inventory feeds. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [asset_search](variables.tf#L51) | Cloud Asset Inventory search configurations. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [contacts](variables.tf#L61) | List of essential contacts for this resource. Must be in the form EMAIL -> [NOTIFICATION_TYPES]. Valid notification types are ALL, SUSPENSION, SECURITY, TECHNICAL, BILLING, LEGAL, PRODUCT_UPDATES. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [context](variables.tf#L79) | Context-specific interpolations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [custom_roles](variables.tf#L104) | Map of role name => list of permissions to create in this project. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [factories_config](variables.tf#L111) | Paths to data files and folders that enable factory functionality. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [firewall_policy](variables.tf#L126) | Hierarchical firewall policies to associate to the organization. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [organization_id](variables.tf#L254) | Organization id in organizations/nnnnnn format. | <code>string</code> | ✓ |  |
+| [access_levels](variables.tf#L18) | Access level definitions. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [access_policy](variables.tf#L69) | Access Policy name or ID, required if creating access levels. | <code>string</code> |  | <code>null</code> |
+| [asset_feeds](variables.tf#L75) | Cloud Asset Inventory feeds. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [asset_search](variables.tf#L108) | Cloud Asset Inventory search configurations. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [contacts](variables.tf#L118) | List of essential contacts for this resource. Must be in the form EMAIL -> [NOTIFICATION_TYPES]. Valid notification types are ALL, SUSPENSION, SECURITY, TECHNICAL, BILLING, LEGAL, PRODUCT_UPDATES. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [context](variables.tf#L136) | Context-specific interpolations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [context_aware_access_bindings](variables.tf#L162) | GCP User Access Bindings for securing Console and APIs. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [custom_roles](variables.tf#L180) | Map of role name => list of permissions to create in this project. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [factories_config](variables.tf#L187) | Paths to data files and folders that enable factory functionality. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [firewall_policy](variables.tf#L203) | Hierarchical firewall policies to associate to the organization. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
 | [iam](variables-iam.tf#L17) | Authoritative IAM bindings in {ROLE => [MEMBERS]} format. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_bindings](variables-iam.tf#L24) | Authoritative IAM bindings in {KEY => {role = ROLE, members = [], condition = {}}}. Keys are arbitrary. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_bindings_additive](variables-iam.tf#L39) | Individual additive IAM bindings. Keys are arbitrary. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
@@ -1111,12 +1145,12 @@ module "organization" {
 | [logging_settings](variables-logging.tf#L35) | Default settings for logging resources. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
 | [logging_sinks](variables-logging.tf#L45) | Logging sinks to create for the organization. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [network_tags](variables-tags.tf#L17) | Network tags by key name. If `id` is provided, key creation is skipped. The `iam` attribute behaves like the similarly named one at module level. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [org_policies](variables.tf#L135) | Organization policies applied to this organization keyed by policy name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [org_policy_custom_constraints](variables.tf#L163) | Organization policy custom constraints keyed by constraint name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [org_policies](variables.tf#L212) | Organization policies applied to this organization keyed by policy name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [org_policy_custom_constraints](variables.tf#L240) | Organization policy custom constraints keyed by constraint name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [pam_entitlements](variables-pam.tf#L17) | Privileged Access Manager entitlements for this resource, keyed by entitlement ID. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [scc_mute_configs](variables-scc.tf#L17) | SCC mute configurations keyed by name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [scc_sha_custom_modules](variables-scc.tf#L28) | SCC custom modules keyed by module name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [service_agents_config](variables.tf#L186) | Service agents configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [service_agents_config](variables.tf#L263) | Service agents configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [tag_bindings](variables-tags.tf#L89) | Tag bindings for this organization, in key => tag value id format. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
 | [tags](variables-tags.tf#L96) | Tags by key name. If `id` is provided, key or value creation is skipped. The `iam` attribute behaves like the similarly named one at module level. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [tags_config](variables-tags.tf#L171) | Fine-grained control on tag resource and IAM creation. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
@@ -1126,25 +1160,27 @@ module "organization" {
 
 | name | description | sensitive |
 |---|---|:---:|
-| [asset_search_results](outputs.tf#L17) | Cloud Asset Inventory search results. |  |
-| [custom_constraint_ids](outputs.tf#L24) | Map of CUSTOM_CONSTRAINTS => ID in the organization. |  |
-| [custom_role_id](outputs.tf#L29) | Map of custom role IDs created in the organization. |  |
-| [custom_roles](outputs.tf#L34) | Map of custom roles resources created in the organization. |  |
-| [id](outputs.tf#L39) | Fully qualified organization id. |  |
-| [logging_identities](outputs.tf#L57) | Principals used for logging sinks. |  |
-| [logging_sinks](outputs.tf#L69) | Logging sink resources. |  |
-| [network_tag_keys](outputs.tf#L77) | Tag key resources. |  |
-| [network_tag_values](outputs.tf#L86) | Tag value resources. |  |
-| [organization_id](outputs.tf#L96) | Organization id dependent on module resources. |  |
-| [organization_policies_ids](outputs.tf#L113) | Map of ORGANIZATION_POLICIES => ID in the organization. |  |
-| [scc_custom_sha_modules_ids](outputs.tf#L118) | Map of SCC CUSTOM SHA MODULES => ID in the organization. |  |
-| [scc_mute_configs](outputs.tf#L123) | SCC mute configurations. |  |
-| [scim_tenants](outputs.tf#L128) | Workforce Identity provider SCIM tenants. |  |
-| [service_agents](outputs.tf#L142) | Identities of all organization-level service agents. |  |
-| [sink_writer_identities](outputs.tf#L150) | Writer identities created for each sink. |  |
-| [tag_keys](outputs.tf#L158) | Tag key resources. |  |
-| [tag_values](outputs.tf#L167) | Tag value resources. |  |
-| [workforce_identity_pool_ids](outputs.tf#L175) | Workforce identity pool ids. |  |
-| [workforce_identity_provider_names](outputs.tf#L182) | Workforce Identity provider names. |  |
-| [workforce_identity_providers](outputs.tf#L189) | Workforce Identity provider attributes. |  |
+| [access_levels](outputs.tf#L17) | Access level resources. |  |
+| [asset_search_results](outputs.tf#L22) | Cloud Asset Inventory search results. |  |
+| [context_aware_access_bindings](outputs.tf#L29) | GCP User Access Bindings for securing Console and APIs. |  |
+| [custom_constraint_ids](outputs.tf#L37) | Map of CUSTOM_CONSTRAINTS => ID in the organization. |  |
+| [custom_role_id](outputs.tf#L42) | Map of custom role IDs created in the organization. |  |
+| [custom_roles](outputs.tf#L47) | Map of custom roles resources created in the organization. |  |
+| [id](outputs.tf#L52) | Fully qualified organization id. |  |
+| [logging_identities](outputs.tf#L70) | Principals used for logging sinks. |  |
+| [logging_sinks](outputs.tf#L82) | Logging sink resources. |  |
+| [network_tag_keys](outputs.tf#L90) | Tag key resources. |  |
+| [network_tag_values](outputs.tf#L99) | Tag value resources. |  |
+| [organization_id](outputs.tf#L109) | Organization id dependent on module resources. |  |
+| [organization_policies_ids](outputs.tf#L126) | Map of ORGANIZATION_POLICIES => ID in the organization. |  |
+| [scc_custom_sha_modules_ids](outputs.tf#L131) | Map of SCC CUSTOM SHA MODULES => ID in the organization. |  |
+| [scc_mute_configs](outputs.tf#L136) | SCC mute configurations. |  |
+| [scim_tenants](outputs.tf#L141) | Workforce Identity provider SCIM tenants. |  |
+| [service_agents](outputs.tf#L155) | Identities of all organization-level service agents. |  |
+| [sink_writer_identities](outputs.tf#L163) | Writer identities created for each sink. |  |
+| [tag_keys](outputs.tf#L171) | Tag key resources. |  |
+| [tag_values](outputs.tf#L180) | Tag value resources. |  |
+| [workforce_identity_pool_ids](outputs.tf#L188) | Workforce identity pool ids. |  |
+| [workforce_identity_provider_names](outputs.tf#L195) | Workforce Identity provider names. |  |
+| [workforce_identity_providers](outputs.tf#L202) | Workforce Identity provider attributes. |  |
 <!-- END TFDOC -->

--- a/modules/organization/README.md
+++ b/modules/organization/README.md
@@ -1122,17 +1122,17 @@ module "org" {
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [organization_id](variables.tf#L254) | Organization id in organizations/nnnnnn format. | <code>string</code> | ✓ |  |
+| [organization_id](variables.tf#L303) | Organization id in organizations/nnnnnn format. | <code>string</code> | ✓ |  |
 | [access_levels](variables.tf#L18) | Access level definitions. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [access_policy](variables.tf#L69) | Access Policy name or ID, required if creating access levels. | <code>string</code> |  | <code>null</code> |
-| [asset_feeds](variables.tf#L75) | Cloud Asset Inventory feeds. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [asset_search](variables.tf#L108) | Cloud Asset Inventory search configurations. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [contacts](variables.tf#L118) | List of essential contacts for this resource. Must be in the form EMAIL -> [NOTIFICATION_TYPES]. Valid notification types are ALL, SUSPENSION, SECURITY, TECHNICAL, BILLING, LEGAL, PRODUCT_UPDATES. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [context](variables.tf#L136) | Context-specific interpolations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [context_aware_access_bindings](variables.tf#L162) | GCP User Access Bindings for securing Console and APIs. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [custom_roles](variables.tf#L180) | Map of role name => list of permissions to create in this project. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [factories_config](variables.tf#L187) | Paths to data files and folders that enable factory functionality. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [firewall_policy](variables.tf#L203) | Hierarchical firewall policies to associate to the organization. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [access_policy](variables.tf#L118) | Access Policy name or ID, required if creating access levels. | <code>string</code> |  | <code>null</code> |
+| [asset_feeds](variables.tf#L124) | Cloud Asset Inventory feeds. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [asset_search](variables.tf#L157) | Cloud Asset Inventory search configurations. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [contacts](variables.tf#L167) | List of essential contacts for this resource. Must be in the form EMAIL -> [NOTIFICATION_TYPES]. Valid notification types are ALL, SUSPENSION, SECURITY, TECHNICAL, BILLING, LEGAL, PRODUCT_UPDATES. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [context](variables.tf#L185) | Context-specific interpolations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [context_aware_access_bindings](variables.tf#L211) | GCP User Access Bindings for securing Console and APIs. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [custom_roles](variables.tf#L229) | Map of role name => list of permissions to create in this project. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [factories_config](variables.tf#L236) | Paths to data files and folders that enable factory functionality. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [firewall_policy](variables.tf#L252) | Hierarchical firewall policies to associate to the organization. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
 | [iam](variables-iam.tf#L17) | Authoritative IAM bindings in {ROLE => [MEMBERS]} format. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_bindings](variables-iam.tf#L24) | Authoritative IAM bindings in {KEY => {role = ROLE, members = [], condition = {}}}. Keys are arbitrary. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_bindings_additive](variables-iam.tf#L39) | Individual additive IAM bindings. Keys are arbitrary. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
@@ -1145,12 +1145,12 @@ module "org" {
 | [logging_settings](variables-logging.tf#L35) | Default settings for logging resources. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
 | [logging_sinks](variables-logging.tf#L45) | Logging sinks to create for the organization. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [network_tags](variables-tags.tf#L17) | Network tags by key name. If `id` is provided, key creation is skipped. The `iam` attribute behaves like the similarly named one at module level. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [org_policies](variables.tf#L212) | Organization policies applied to this organization keyed by policy name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [org_policy_custom_constraints](variables.tf#L240) | Organization policy custom constraints keyed by constraint name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [org_policies](variables.tf#L261) | Organization policies applied to this organization keyed by policy name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [org_policy_custom_constraints](variables.tf#L289) | Organization policy custom constraints keyed by constraint name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [pam_entitlements](variables-pam.tf#L17) | Privileged Access Manager entitlements for this resource, keyed by entitlement ID. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [scc_mute_configs](variables-scc.tf#L17) | SCC mute configurations keyed by name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [scc_sha_custom_modules](variables-scc.tf#L28) | SCC custom modules keyed by module name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [service_agents_config](variables.tf#L263) | Service agents configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [service_agents_config](variables.tf#L312) | Service agents configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [tag_bindings](variables-tags.tf#L89) | Tag bindings for this organization, in key => tag value id format. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
 | [tags](variables-tags.tf#L96) | Tags by key name. If `id` is provided, key or value creation is skipped. The `iam` attribute behaves like the similarly named one at module level. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [tags_config](variables-tags.tf#L171) | Fine-grained control on tag resource and IAM creation. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |

--- a/modules/organization/context_aware_access.tf
+++ b/modules/organization/context_aware_access.tf
@@ -1,0 +1,158 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# tfdoc:file:description Context-Aware Access resources and factory.
+
+locals {
+  _access_levels_factory_path = pathexpand(
+    coalesce(var.factories_config.access_levels, "-")
+  )
+  _access_levels_factory_data_raw = merge([
+    for f in try(fileset(local._access_levels_factory_path, "*.yaml"), []) :
+    yamldecode(file("${local._access_levels_factory_path}/${f}"))
+  ]...)
+  _access_levels_factory_data = {
+    for k, v in local._access_levels_factory_data_raw : k => {
+      combining_function = try(v.combining_function, null)
+      conditions = [
+        for c in try(v.conditions, []) : merge({
+          device_policy          = null
+          ip_subnetworks         = []
+          members                = []
+          negate                 = null
+          regions                = []
+          required_access_levels = []
+          vpc_subnets            = {}
+        }, c)
+      ]
+      description = try(v.description, null)
+      title       = try(v.title, null)
+    }
+  }
+  access_levels = merge(
+    local._access_levels_factory_data,
+    var.access_levels
+  )
+  ctx_access_levels = merge(local.ctx.access_levels, {
+    for k, v in google_access_context_manager_access_level.basic :
+    "$access_levels:${k}" => v.id
+  })
+}
+
+resource "google_access_context_manager_access_level" "basic" {
+  for_each    = local.access_levels
+  parent      = "accessPolicies/${var.access_policy}"
+  name        = "accessPolicies/${var.access_policy}/accessLevels/${each.key}"
+  title       = coalesce(each.value.title, each.key)
+  description = each.value.description
+  basic {
+    combining_function = each.value.combining_function
+    dynamic "conditions" {
+      for_each = toset(each.value.conditions)
+      iterator = c
+      content {
+        ip_subnetworks = c.value.ip_subnetworks
+        members = [
+          for i in c.value.members : lookup(local.ctx.iam_principals, i, i)
+        ]
+        negate                 = c.value.negate
+        regions                = c.value.regions
+        required_access_levels = coalesce(c.value.required_access_levels, [])
+        dynamic "device_policy" {
+          for_each = c.value.device_policy == null ? [] : [c.value.device_policy]
+          iterator = dp
+          content {
+            allowed_device_management_levels = (
+              dp.value.allowed_device_management_levels
+            )
+            allowed_encryption_statuses = (
+              dp.value.allowed_encryption_statuses
+            )
+            require_admin_approval = dp.value.require_admin_approval
+            require_corp_owned     = dp.value.require_corp_owned
+            require_screen_lock    = dp.value.require_screen_lock
+            dynamic "os_constraints" {
+              for_each = toset(
+                dp.value.os_constraints == null
+                ? []
+                : dp.value.os_constraints
+              )
+              iterator = oc
+              content {
+                minimum_version            = oc.value.minimum_version
+                os_type                    = oc.value.os_type
+                require_verified_chrome_os = oc.value.require_verified_chrome_os
+              }
+            }
+
+          }
+        }
+        dynamic "vpc_network_sources" {
+          for_each = c.value.vpc_subnets
+          iterator = vpc
+          content {
+            vpc_subnetwork {
+              network            = vpc.key
+              vpc_ip_subnetworks = vpc.value
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "google_access_context_manager_gcp_user_access_binding" "binding" {
+  for_each        = var.context_aware_access_bindings
+  organization_id = local.organization_id_numeric
+  group_key = lookup(
+    local.ctx.email_addresses, each.value.group_key, each.value.group_key
+  )
+  access_levels = [
+    for al in each.value.access_levels :
+    lookup(local.ctx_access_levels, al, al)
+  ]
+  dynamic "scoped_access_settings" {
+    for_each = each.value.scoped_access_settings
+    iterator = s
+    content {
+      dynamic "active_settings" {
+        for_each = (
+          s.value.active_settings == null ? [] : [s.value.active_settings]
+        )
+        iterator = as
+        content {
+          access_levels = as.value.access_levels == null ? null : [
+            for al in as.value.access_levels :
+            lookup(local.ctx_access_levels, al, al)
+          ]
+        }
+      }
+      dynamic "dry_run_settings" {
+        for_each = (
+          s.value.dry_run_settings == null ? [] : [s.value.dry_run_settings]
+        )
+        iterator = ds
+        content {
+          access_levels = ds.value.access_levels == null ? null : [
+            for al in ds.value.access_levels :
+            lookup(local.ctx_access_levels, al, al)
+          ]
+        }
+      }
+    }
+  }
+}

--- a/modules/organization/context_aware_access.tf
+++ b/modules/organization/context_aware_access.tf
@@ -61,7 +61,7 @@ resource "google_access_context_manager_access_level" "basic" {
   basic {
     combining_function = each.value.combining_function
     dynamic "conditions" {
-      for_each = toset(each.value.conditions)
+      for_each = each.value.conditions
       iterator = c
       content {
         ip_subnetworks = c.value.ip_subnetworks
@@ -85,7 +85,7 @@ resource "google_access_context_manager_access_level" "basic" {
             require_corp_owned     = dp.value.require_corp_owned
             require_screen_lock    = dp.value.require_screen_lock
             dynamic "os_constraints" {
-              for_each = toset(
+              for_each = (
                 dp.value.os_constraints == null
                 ? []
                 : dp.value.os_constraints

--- a/modules/organization/outputs.tf
+++ b/modules/organization/outputs.tf
@@ -14,11 +14,24 @@
  * limitations under the License.
  */
 
+output "access_levels" {
+  description = "Access level resources."
+  value       = google_access_context_manager_access_level.basic
+}
+
 output "asset_search_results" {
   description = "Cloud Asset Inventory search results."
   value = {
     for k, v in data.google_cloud_asset_search_all_resources.default : k => v.results
   }
+}
+
+output "context_aware_access_bindings" {
+  description = "GCP User Access Bindings for securing Console and APIs."
+  value       = google_access_context_manager_gcp_user_access_binding.binding
+  depends_on = [
+    google_access_context_manager_access_level.basic
+  ]
 }
 
 output "custom_constraint_ids" {

--- a/modules/organization/schemas/access-level.schema.json
+++ b/modules/organization/schemas/access-level.schema.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "VPC-SC access level",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "combining_function": {
+      "type": "string"
+    },
+    "conditions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "device_policy": {
+            "type": "object",
+            "required": [
+              "require_admin_approval",
+              "require_corp_owned"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "allowed_device_management_levels": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "allowed_encryption_statuses": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "require_admin_approval": {
+                "type": "boolean"
+              },
+              "require_corp_owned": {
+                "type": "boolean"
+              },
+              "require_screen_lock": {
+                "type": "boolean"
+              },
+              "os_constraints": {
+                "type": "array",
+                "required": [
+                  "os_type"
+                ],
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "os_type": {
+                      "type": "string"
+                    },
+                    "minimum_version": {
+                      "type": "string"
+                    },
+                    "require_verified_chrome_os": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "ip_subnetworks": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "members": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "negate": {
+            "type": "boolean"
+          },
+          "regions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "required_access_levels": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "vpc_subnets": {
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+              "^//compute.googleapis.com/projects/[^/]+/global/networks/[^/]+$": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/modules/organization/schemas/access-level.schema.md
+++ b/modules/organization/schemas/access-level.schema.md
@@ -1,0 +1,42 @@
+# VPC-SC access level
+
+<!-- markdownlint-disable MD036 -->
+
+## Properties
+
+*additional properties: false*
+
+- **combining_function**: *string*
+- **conditions**: *array*
+  - items: *object*
+    <br>*additional properties: false*
+    - **device_policy**: *object*
+      <br>*additional properties: false*
+      - **allowed_device_management_levels**: *array*
+        - items: *string*
+      - **allowed_encryption_statuses**: *array*
+        - items: *string*
+      - ⁺**require_admin_approval**: *boolean*
+      - ⁺**require_corp_owned**: *boolean*
+      - **require_screen_lock**: *boolean*
+      - **os_constraints**: *array*
+        - items: *object*
+          <br>*additional properties: false*
+          - **os_type**: *string*
+          - **minimum_version**: *string*
+          - **require_verified_chrome_os**: *boolean*
+    - **ip_subnetworks**: *array*
+      - items: *string*
+    - **members**: *array*
+      - items: *string*
+    - **negate**: *boolean*
+    - **regions**: *array*
+      - items: *string*
+    - **required_access_levels**: *array*
+      - items: *string*
+    - **vpc_subnets**: *object*
+      <br>*additional properties: false*
+      - **`^//compute.googleapis.com/projects/[^/]+/global/networks/[^/]+$`**: *array*
+        - items: *string*
+
+## Definitions

--- a/modules/organization/variables.tf
+++ b/modules/organization/variables.tf
@@ -15,6 +15,63 @@
  */
 
 
+variable "access_levels" {
+  description = "Access level definitions."
+  type = map(object({
+    combining_function = optional(string)
+    conditions = optional(list(object({
+      device_policy = optional(object({
+        allowed_device_management_levels = optional(list(string))
+        allowed_encryption_statuses      = optional(list(string))
+        require_admin_approval           = bool
+        require_corp_owned               = bool
+        require_screen_lock              = optional(bool)
+        os_constraints = optional(list(object({
+          os_type                    = string
+          minimum_version            = optional(string)
+          require_verified_chrome_os = optional(bool)
+        })))
+      }))
+      ip_subnetworks         = optional(list(string), [])
+      members                = optional(list(string), [])
+      negate                 = optional(bool)
+      regions                = optional(list(string), [])
+      required_access_levels = optional(list(string), [])
+      vpc_subnets            = optional(map(list(string)), {})
+    })), [])
+    description = optional(string)
+    title       = optional(string)
+  }))
+  default  = {}
+  nullable = false
+  validation {
+    condition = alltrue([
+      for k, v in var.access_levels : (
+        v.combining_function == null ||
+        v.combining_function == "AND" ||
+        v.combining_function == "OR"
+      )
+    ])
+    error_message = "Invalid `combining_function` value (null, \"AND\", \"OR\" accepted)."
+  }
+  validation {
+    condition = alltrue([
+      for k, v in var.access_levels : alltrue([
+        for condition in v.conditions : alltrue([
+          for member in condition.members : can(regex("^(?:serviceAccount:|user:)", member))
+        ])
+      ])
+    ])
+    error_message = "Invalid `conditions[].members`. It needs to start with on of the prefixes: 'serviceAccount:' or 'user:'."
+  }
+}
+
+variable "access_policy" {
+  description = "Access Policy name or ID, required if creating access levels."
+  type        = string
+  default     = null
+}
+
 variable "asset_feeds" {
   description = "Cloud Asset Inventory feeds."
   type = map(object({
@@ -79,6 +136,7 @@ variable "contacts" {
 variable "context" {
   description = "Context-specific interpolations."
   type = object({
+    access_levels     = optional(map(string), {})
     bigquery_datasets = optional(map(string), {})
     condition_vars    = optional(map(map(string)), {})
     custom_roles      = optional(map(string), {})
@@ -101,6 +159,24 @@ variable "context" {
   default  = {}
 }
 
+variable "context_aware_access_bindings" {
+  description = "GCP User Access Bindings for securing Console and APIs."
+  type = map(object({
+    group_key     = string
+    access_levels = list(string)
+    scoped_access_settings = optional(list(object({
+      active_settings = optional(object({
+        access_levels = optional(list(string))
+      }))
+      dry_run_settings = optional(object({
+        access_levels = optional(list(string))
+      }))
+    })), [])
+  }))
+  default  = {}
+  nullable = false
+}
+
 variable "custom_roles" {
   description = "Map of role name => list of permissions to create in this project."
   type        = map(list(string))
@@ -111,6 +187,7 @@ variable "custom_roles" {
 variable "factories_config" {
   description = "Paths to data files and folders that enable factory functionality."
   type = object({
+    access_levels                 = optional(string)
     custom_roles                  = optional(string)
     org_policies                  = optional(string)
     org_policy_custom_constraints = optional(string)

--- a/modules/organization/variables.tf
+++ b/modules/organization/variables.tf
@@ -64,6 +64,55 @@ variable "access_levels" {
     ])
     error_message = "Invalid `conditions[].members`. It needs to start with on of the prefixes: 'serviceAccount:' or 'user:'."
   }
+  validation {
+    condition = alltrue([
+      for k, v in var.access_levels : alltrue([
+        for condition in v.conditions : (
+          try(
+            condition.device_policy.allowed_encryption_statuses, null
+          ) == null
+          ? true
+          : alltrue([
+            for status in(
+              condition.device_policy.allowed_encryption_statuses
+            ) :
+            contains([
+              "ENCRYPTION_UNSPECIFIED",
+              "ENCRYPTION_UNSUPPORTED",
+              "UNENCRYPTED",
+              "ENCRYPTED"
+            ], status)
+          ])
+        )
+      ])
+    ])
+    error_message = "Invalid `allowed_encryption_statuses` value."
+  }
+  validation {
+    condition = alltrue([
+      for k, v in var.access_levels : alltrue([
+        for condition in v.conditions : (
+          try(
+            condition.device_policy.allowed_device_management_levels, null
+          ) == null
+          ? true
+          : alltrue([
+            for level in(
+              condition.device_policy.allowed_device_management_levels
+            ) :
+            contains([
+              "MANAGEMENT_UNSPECIFIED",
+              "NONE",
+              "BASIC",
+              "COMPLETE",
+              "CHROME_ENTERPRISE"
+            ], level)
+          ])
+        )
+      ])
+    ])
+    error_message = "Invalid `allowed_device_management_levels` value."
+  }
 }
 
 variable "access_policy" {

--- a/modules/vpc-sc/README.md
+++ b/modules/vpc-sc/README.md
@@ -402,18 +402,18 @@ to:
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [access_policy](variables.tf#L68) | Access Policy name, set to null if creating one. | <code>string</code> | ✓ |  |
+| [access_policy](variables.tf#L117) | Access Policy name, set to null if creating one. | <code>string</code> | ✓ |  |
 | [access_levels](variables.tf#L17) | Access level definitions. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [access_policy_create](variables.tf#L73) | Access Policy configuration, fill in to create. Parent is in 'organizations/123456' format, scopes are in 'folders/456789' or 'projects/project_id' format. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [context](variables.tf#L83) | External context used in replacements. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [egress_policies](variables.tf#L98) | Egress policy definitions that can be referenced in perimeters. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [factories_config](variables.tf#L141) | Paths to folders that enable factory functionality. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [iam](variables.tf#L153) | IAM bindings in {ROLE => [MEMBERS]} format. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [iam_bindings](variables.tf#L159) | Authoritative IAM bindings in {KEY => {role = ROLE, members = [], condition = {}}}. Keys are arbitrary. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [iam_bindings_additive](variables.tf#L174) | Individual additive IAM bindings. Keys are arbitrary. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [ingress_policies](variables.tf#L189) | Ingress policy definitions that can be referenced in perimeters. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [perimeters](variables.tf#L231) | Regular service perimeters. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [project_id_search_scope](variables.tf#L265) | Set this to an organization or folder ID to use Cloud Asset Inventory to automatically translate project ids to numbers. | <code>string</code> |  | <code>null</code> |
+| [access_policy_create](variables.tf#L122) | Access Policy configuration, fill in to create. Parent is in 'organizations/123456' format, scopes are in 'folders/456789' or 'projects/project_id' format. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [context](variables.tf#L132) | External context used in replacements. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [egress_policies](variables.tf#L147) | Egress policy definitions that can be referenced in perimeters. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [factories_config](variables.tf#L190) | Paths to folders that enable factory functionality. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [iam](variables.tf#L202) | IAM bindings in {ROLE => [MEMBERS]} format. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [iam_bindings](variables.tf#L208) | Authoritative IAM bindings in {KEY => {role = ROLE, members = [], condition = {}}}. Keys are arbitrary. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [iam_bindings_additive](variables.tf#L223) | Individual additive IAM bindings. Keys are arbitrary. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [ingress_policies](variables.tf#L238) | Ingress policy definitions that can be referenced in perimeters. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [perimeters](variables.tf#L280) | Regular service perimeters. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [project_id_search_scope](variables.tf#L314) | Set this to an organization or folder ID to use Cloud Asset Inventory to automatically translate project ids to numbers. | <code>string</code> |  | <code>null</code> |
 
 ## Outputs
 

--- a/modules/vpc-sc/variables.tf
+++ b/modules/vpc-sc/variables.tf
@@ -63,6 +63,55 @@ variable "access_levels" {
     ])
     error_message = "Invalid `conditions[].members`. It needs to start with on of the prefixes: 'serviceAccount:' or 'user:'."
   }
+  validation {
+    condition = alltrue([
+      for k, v in var.access_levels : alltrue([
+        for condition in v.conditions : (
+          try(
+            condition.device_policy.allowed_encryption_statuses, null
+          ) == null
+          ? true
+          : alltrue([
+            for status in(
+              condition.device_policy.allowed_encryption_statuses
+            ) :
+            contains([
+              "ENCRYPTION_UNSPECIFIED",
+              "ENCRYPTION_UNSUPPORTED",
+              "UNENCRYPTED",
+              "ENCRYPTED"
+            ], status)
+          ])
+        )
+      ])
+    ])
+    error_message = "Invalid `allowed_encryption_statuses` value."
+  }
+  validation {
+    condition = alltrue([
+      for k, v in var.access_levels : alltrue([
+        for condition in v.conditions : (
+          try(
+            condition.device_policy.allowed_device_management_levels, null
+          ) == null
+          ? true
+          : alltrue([
+            for level in(
+              condition.device_policy.allowed_device_management_levels
+            ) :
+            contains([
+              "MANAGEMENT_UNSPECIFIED",
+              "NONE",
+              "BASIC",
+              "COMPLETE",
+              "CHROME_ENTERPRISE"
+            ], level)
+          ])
+        )
+      ])
+    ])
+    error_message = "Invalid `allowed_device_management_levels` value."
+  }
 }
 
 variable "access_policy" {

--- a/tests/fast/stages/s0_org_setup/caa.tfvars
+++ b/tests/fast/stages/s0_org_setup/caa.tfvars
@@ -1,0 +1,21 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+factories_config = {
+  dataset = "datasets/starter-gcd"
+  paths = {
+    defaults     = "./data-caa/defaults.yaml"
+    organization = "./data-caa/organization"
+  }
+}

--- a/tests/fast/stages/s0_org_setup/caa.yaml
+++ b/tests/fast/stages/s0_org_setup/caa.yaml
@@ -1,0 +1,1384 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values:
+  google_storage_bucket_object.providers["0-org-setup"]:
+    bucket: ft0-prod-iac-core-0-iac-outputs
+    cache_control: null
+    content: "/**\n * Copyright 2022 Google LLC\n *\n * Licensed under the Apache\
+      \ License, Version 2.0 (the \"License\");\n * you may not use this file except\
+      \ in compliance with the License.\n * You may obtain a copy of the License at\n\
+      \ *\n *      http://www.apache.org/licenses/LICENSE-2.0\n *\n * Unless required\
+      \ by applicable law or agreed to in writing, software\n * distributed under\
+      \ the License is distributed on an \"AS IS\" BASIS,\n * WITHOUT WARRANTIES OR\
+      \ CONDITIONS OF ANY KIND, either express or implied.\n * See the License for\
+      \ the specific language governing permissions and\n * limitations under the\
+      \ License.\n */\n\nterraform {\n  backend \"gcs\" {\n    bucket            \
+      \          = \"ft0-prod-iac-core-0-iac-org-state\"\n    impersonate_service_account\
+      \ = \"iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\n  }\n}\nprovider\
+      \ \"google\" {\n  impersonate_service_account = \"iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\
+      \n}\nprovider \"google-beta\" {\n  impersonate_service_account = \"iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\
+      \n}\n"
+    content_disposition: null
+    content_encoding: null
+    content_language: null
+    contexts: []
+    customer_encryption: []
+    deletion_policy: DELETE
+    detect_md5hash: null
+    event_based_hold: null
+    force_empty_content_type: null
+    metadata: null
+    name: providers/0-org-setup-providers.tf
+    retention: []
+    source: null
+    temporary_hold: null
+    timeouts: null
+  google_storage_bucket_object.tfvars["globals"]:
+    bucket: ft0-prod-iac-core-0-iac-outputs
+    cache_control: null
+    content: '{"billing_account":{"id":"012345-012345-012345"},"groups":{"domain":"domain:example.org","gcp-billing-admins":"group:gcp-billing-admins@example.org","gcp-devops":"group:gcp-devops@example.org","gcp-network-admins":"group:gcp-network-admins@example.org","gcp-organization-admins":"group:fabric-fast-owners@google.com","gcp-secops-admins":"group:gcp-secops-admins@example.org","gcp-security-admins":"group:gcp-security-admins@example.org","gcp-support":"group:gcp-support@example.org"},"organization":{"customer_id":"abcd123456","domain":"example.org","id":"1234567890"},"prefix":"ft0","universe":null}'
+    content_disposition: null
+    content_encoding: null
+    content_language: null
+    contexts: []
+    customer_encryption: []
+    deletion_policy: DELETE
+    detect_md5hash: null
+    event_based_hold: null
+    force_empty_content_type: null
+    metadata: null
+    name: tfvars/0-globals.auto.tfvars.json
+    retention: []
+    source: null
+    temporary_hold: null
+    timeouts: null
+  google_storage_bucket_object.tfvars["org-setup"]:
+    bucket: ft0-prod-iac-core-0-iac-outputs
+    cache_control: null
+    content_disposition: null
+    content_encoding: null
+    content_language: null
+    contexts: []
+    customer_encryption: []
+    deletion_policy: DELETE
+    detect_md5hash: null
+    event_based_hold: null
+    force_empty_content_type: null
+    metadata: null
+    name: tfvars/0-org-setup.auto.tfvars.json
+    retention: []
+    source: null
+    temporary_hold: null
+    timeouts: null
+  google_storage_bucket_object.version[0]:
+    bucket: ft0-prod-iac-core-0-iac-outputs
+    cache_control: null
+    content_disposition: null
+    content_encoding: null
+    content_language: null
+    contexts: []
+    customer_encryption: []
+    deletion_policy: DELETE
+    detect_md5hash: null
+    event_based_hold: null
+    force_empty_content_type: null
+    metadata: null
+    name: versions/0-org-setup-version.txt
+    retention: []
+    source: fast_version.txt
+    temporary_hold: null
+    timeouts: null
+  local_file.providers["0-org-setup"]:
+    content: "/**\n * Copyright 2022 Google LLC\n *\n * Licensed under the Apache\
+      \ License, Version 2.0 (the \"License\");\n * you may not use this file except\
+      \ in compliance with the License.\n * You may obtain a copy of the License at\n\
+      \ *\n *      http://www.apache.org/licenses/LICENSE-2.0\n *\n * Unless required\
+      \ by applicable law or agreed to in writing, software\n * distributed under\
+      \ the License is distributed on an \"AS IS\" BASIS,\n * WITHOUT WARRANTIES OR\
+      \ CONDITIONS OF ANY KIND, either express or implied.\n * See the License for\
+      \ the specific language governing permissions and\n * limitations under the\
+      \ License.\n */\n\nterraform {\n  backend \"gcs\" {\n    bucket            \
+      \          = \"ft0-prod-iac-core-0-iac-org-state\"\n    impersonate_service_account\
+      \ = \"iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\n  }\n}\nprovider\
+      \ \"google\" {\n  impersonate_service_account = \"iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\
+      \n}\nprovider \"google-beta\" {\n  impersonate_service_account = \"iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com\"\
+      \n}\n"
+    content_base64: null
+    directory_permission: '0777'
+    file_permission: '0644'
+    sensitive_content: null
+    source: null
+  local_file.tfvars["globals"]:
+    content: '{"billing_account":{"id":"012345-012345-012345"},"groups":{"domain":"domain:example.org","gcp-billing-admins":"group:gcp-billing-admins@example.org","gcp-devops":"group:gcp-devops@example.org","gcp-network-admins":"group:gcp-network-admins@example.org","gcp-organization-admins":"group:fabric-fast-owners@google.com","gcp-secops-admins":"group:gcp-secops-admins@example.org","gcp-security-admins":"group:gcp-security-admins@example.org","gcp-support":"group:gcp-support@example.org"},"organization":{"customer_id":"abcd123456","domain":"example.org","id":"1234567890"},"prefix":"ft0","universe":null}'
+    content_base64: null
+    directory_permission: '0777'
+    file_permission: '0644'
+    sensitive_content: null
+    source: null
+  local_file.tfvars["org-setup"]:
+    content_base64: null
+    directory_permission: '0777'
+    file_permission: '0644'
+    sensitive_content: null
+    source: null
+  module.factory.module.bigquery-datasets["iac-0/billing_export"].google_bigquery_dataset.default:
+    dataset_id: billing_export
+    default_encryption_configuration: []
+    default_partition_expiration_ms: null
+    default_table_expiration_ms: null
+    delete_contents_on_destroy: false
+    deletion_policy: DELETE
+    description: Terraform managed.
+    effective_labels:
+      goog-terraform-provisioned: 'true'
+    external_catalog_dataset_options: []
+    external_dataset_reference: []
+    friendly_name: Billing export
+    labels: null
+    location: europe-west1
+    max_time_travel_hours: '168'
+    project: ft0-prod-iac-core-0
+    resource_tags: null
+    terraform_labels:
+      goog-terraform-provisioned: 'true'
+    timeouts: null
+  module.factory.module.buckets["iac-0/iac-org-state"].google_storage_bucket.bucket[0]:
+    autoclass: []
+    cors: []
+    custom_placement_config: []
+    default_event_based_hold: null
+    deletion_policy: DELETE
+    effective_labels:
+      goog-terraform-provisioned: 'true'
+    enable_object_retention: null
+    encryption: []
+    force_destroy: false
+    hierarchical_namespace: []
+    ip_filter: []
+    labels: null
+    lifecycle_rule: []
+    location: EUROPE-WEST1
+    logging: []
+    name: ft0-prod-iac-core-0-iac-org-state
+    project: ft0-prod-iac-core-0
+    requester_pays: null
+    retention_policy: []
+    storage_class: STANDARD
+    terraform_labels:
+      goog-terraform-provisioned: 'true'
+    timeouts: null
+    uniform_bucket_level_access: true
+    versioning:
+    - enabled: true
+  ? module.factory.module.buckets["iac-0/iac-org-state"].google_storage_bucket_iam_binding.authoritative["roles/storage.admin"]
+  : bucket: ft0-prod-iac-core-0-iac-org-state
+    condition: []
+    role: roles/storage.admin
+    timeouts: null
+  module.factory.module.buckets["iac-0/iac-outputs"].google_storage_bucket.bucket[0]:
+    autoclass: []
+    cors: []
+    custom_placement_config: []
+    default_event_based_hold: null
+    deletion_policy: DELETE
+    effective_labels:
+      goog-terraform-provisioned: 'true'
+    enable_object_retention: null
+    encryption: []
+    force_destroy: false
+    hierarchical_namespace: []
+    ip_filter: []
+    labels: null
+    lifecycle_rule: []
+    location: EUROPE-WEST1
+    logging: []
+    name: ft0-prod-iac-core-0-iac-outputs
+    project: ft0-prod-iac-core-0
+    requester_pays: null
+    retention_policy: []
+    storage_class: STANDARD
+    terraform_labels:
+      goog-terraform-provisioned: 'true'
+    timeouts: null
+    uniform_bucket_level_access: true
+    versioning:
+    - enabled: true
+  module.factory.module.buckets["iac-0/iac-outputs"].google_storage_bucket_iam_binding.authoritative["roles/storage.admin"]:
+    bucket: ft0-prod-iac-core-0-iac-outputs
+    condition: []
+    role: roles/storage.admin
+    timeouts: null
+  module.factory.module.folder-1-iam["dev"].google_tags_tag_binding.binding["environment"]:
+    tag_value: $tag_values:environment/development
+    timeouts: null
+  module.factory.module.folder-1-iam["prod"].google_tags_tag_binding.binding["environment"]:
+    tag_value: $tag_values:environment/production
+    timeouts: null
+  module.factory.module.folder-1["dev"].google_folder.folder[0]:
+    deletion_policy: DELETE
+    deletion_protection: false
+    display_name: Development
+    parent: organizations/1234567890
+    tags: null
+    timeouts: null
+  module.factory.module.folder-1["prod"].google_folder.folder[0]:
+    deletion_policy: DELETE
+    deletion_protection: false
+    display_name: Production
+    parent: organizations/1234567890
+    tags: null
+    timeouts: null
+  module.factory.module.log-buckets["iac-0/audit-logs"].google_logging_project_bucket_config.bucket[0]:
+    bucket_id: audit-logs
+    cmek_settings: []
+    enable_analytics: true
+    index_configs: []
+    location: europe-west1
+    locked: null
+    project: ft0-prod-iac-core-0
+    retention_days: 31
+  module.factory.module.projects-iam["dev-app-0"].google_compute_shared_vpc_service_project.shared_vpc_service[0]:
+    deletion_policy: null
+    host_project: ft0-dev-net-shared-0
+    service_project: ft0-dev-app-example-0
+    timeouts: null
+  module.factory.module.projects-iam["dev-net-0"].google_compute_shared_vpc_host_project.shared_vpc_host[0]:
+    deletion_policy: DELETE
+    project: ft0-dev-net-shared-0
+    timeouts: null
+  module.factory.module.projects-iam["iac-0"].google_project_iam_binding.authoritative["roles/cloudbuild.builds.editor"]:
+    condition: []
+    project: ft0-prod-iac-core-0
+    role: roles/cloudbuild.builds.editor
+  module.factory.module.projects-iam["iac-0"].google_project_iam_binding.authoritative["roles/iam.serviceAccountAdmin"]:
+    condition: []
+    project: ft0-prod-iac-core-0
+    role: roles/iam.serviceAccountAdmin
+  ? module.factory.module.projects-iam["iac-0"].google_project_iam_binding.authoritative["roles/iam.serviceAccountTokenCreator"]
+  : condition: []
+    project: ft0-prod-iac-core-0
+    role: roles/iam.serviceAccountTokenCreator
+  ? module.factory.module.projects-iam["iac-0"].google_project_iam_binding.authoritative["roles/iam.workloadIdentityPoolAdmin"]
+  : condition: []
+    project: ft0-prod-iac-core-0
+    role: roles/iam.workloadIdentityPoolAdmin
+  module.factory.module.projects-iam["iac-0"].google_project_iam_binding.authoritative["roles/owner"]:
+    condition: []
+    project: ft0-prod-iac-core-0
+    role: roles/owner
+  module.factory.module.projects-iam["iac-0"].google_project_iam_binding.authoritative["roles/storage.admin"]:
+    condition: []
+    project: ft0-prod-iac-core-0
+    role: roles/storage.admin
+  module.factory.module.projects-iam["prod-app-0"].google_compute_shared_vpc_service_project.shared_vpc_service[0]:
+    deletion_policy: null
+    host_project: ft0-prod-net-shared-0
+    service_project: ft0-prod-app-example-0
+    timeouts: null
+  module.factory.module.projects-iam["prod-net-0"].google_compute_shared_vpc_host_project.shared_vpc_host[0]:
+    deletion_policy: DELETE
+    project: ft0-prod-net-shared-0
+    timeouts: null
+  module.factory.module.projects["dev-app-0"].data.google_bigquery_default_service_account.bq_sa[0]:
+    project: ft0-dev-app-example-0
+  module.factory.module.projects["dev-app-0"].data.google_logging_project_settings.logging_sa[0]:
+    project: ft0-dev-app-example-0
+  module.factory.module.projects["dev-app-0"].data.google_storage_project_service_account.gcs_sa[0]:
+    project: ft0-dev-app-example-0
+    user_project: null
+  module.factory.module.projects["dev-app-0"].google_project.project[0]:
+    auto_create_network: false
+    billing_account: 012345-012345-012345
+    deletion_policy: DELETE
+    effective_labels:
+      goog-terraform-provisioned: 'true'
+    labels: null
+    name: ft0-dev-app-example-0
+    org_id: null
+    project_id: ft0-dev-app-example-0
+    tags: null
+    terraform_labels:
+      goog-terraform-provisioned: 'true'
+    timeouts: null
+  module.factory.module.projects["dev-app-0"].google_project_iam_member.service_agents["compute-system"]:
+    condition: []
+    project: ft0-dev-app-example-0
+    role: roles/compute.serviceAgent
+  module.factory.module.projects["dev-app-0"].google_project_iam_member.service_agents["monitoring-notification"]:
+    condition: []
+    project: ft0-dev-app-example-0
+    role: roles/monitoring.notificationServiceAgent
+  module.factory.module.projects["dev-app-0"].google_project_service.project_services["bigquery.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-dev-app-example-0
+    service: bigquery.googleapis.com
+    timeouts: null
+  module.factory.module.projects["dev-app-0"].google_project_service.project_services["compute.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-dev-app-example-0
+    service: compute.googleapis.com
+    timeouts: null
+  module.factory.module.projects["dev-app-0"].google_project_service.project_services["logging.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-dev-app-example-0
+    service: logging.googleapis.com
+    timeouts: null
+  module.factory.module.projects["dev-app-0"].google_project_service.project_services["monitoring.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-dev-app-example-0
+    service: monitoring.googleapis.com
+    timeouts: null
+  module.factory.module.projects["dev-app-0"].google_project_service.project_services["storage.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-dev-app-example-0
+    service: storage.googleapis.com
+    timeouts: null
+  module.factory.module.projects["dev-app-0"].google_project_service_identity.default["monitoring.googleapis.com"]:
+    project: ft0-dev-app-example-0
+    service: monitoring.googleapis.com
+    timeouts: null
+  module.factory.module.projects["dev-net-0"].data.google_logging_project_settings.logging_sa[0]:
+    project: ft0-dev-net-shared-0
+  module.factory.module.projects["dev-net-0"].google_project.project[0]:
+    auto_create_network: false
+    billing_account: 012345-012345-012345
+    deletion_policy: DELETE
+    effective_labels:
+      goog-terraform-provisioned: 'true'
+    labels: null
+    name: ft0-dev-net-shared-0
+    org_id: null
+    project_id: ft0-dev-net-shared-0
+    tags: null
+    terraform_labels:
+      goog-terraform-provisioned: 'true'
+    timeouts: null
+  module.factory.module.projects["dev-net-0"].google_project_iam_member.service_agents["compute-system"]:
+    condition: []
+    project: ft0-dev-net-shared-0
+    role: roles/compute.serviceAgent
+  module.factory.module.projects["dev-net-0"].google_project_iam_member.service_agents["container-engine-robot"]:
+    condition: []
+    project: ft0-dev-net-shared-0
+    role: roles/container.serviceAgent
+  module.factory.module.projects["dev-net-0"].google_project_iam_member.service_agents["dns"]:
+    condition: []
+    project: ft0-dev-net-shared-0
+    role: roles/dns.serviceAgent
+  module.factory.module.projects["dev-net-0"].google_project_iam_member.service_agents["gkenode"]:
+    condition: []
+    project: ft0-dev-net-shared-0
+    role: roles/container.defaultNodeServiceAgent
+  module.factory.module.projects["dev-net-0"].google_project_iam_member.service_agents["monitoring-notification"]:
+    condition: []
+    project: ft0-dev-net-shared-0
+    role: roles/monitoring.notificationServiceAgent
+  module.factory.module.projects["dev-net-0"].google_project_service.project_services["compute.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-dev-net-shared-0
+    service: compute.googleapis.com
+    timeouts: null
+  module.factory.module.projects["dev-net-0"].google_project_service.project_services["container.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-dev-net-shared-0
+    service: container.googleapis.com
+    timeouts: null
+  module.factory.module.projects["dev-net-0"].google_project_service.project_services["dns.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-dev-net-shared-0
+    service: dns.googleapis.com
+    timeouts: null
+  module.factory.module.projects["dev-net-0"].google_project_service.project_services["iap.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-dev-net-shared-0
+    service: iap.googleapis.com
+    timeouts: null
+  module.factory.module.projects["dev-net-0"].google_project_service.project_services["logging.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-dev-net-shared-0
+    service: logging.googleapis.com
+    timeouts: null
+  module.factory.module.projects["dev-net-0"].google_project_service.project_services["monitoring.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-dev-net-shared-0
+    service: monitoring.googleapis.com
+    timeouts: null
+  module.factory.module.projects["dev-net-0"].google_project_service_identity.default["container.googleapis.com"]:
+    project: ft0-dev-net-shared-0
+    service: container.googleapis.com
+    timeouts: null
+  module.factory.module.projects["dev-net-0"].google_project_service_identity.default["dns.googleapis.com"]:
+    project: ft0-dev-net-shared-0
+    service: dns.googleapis.com
+    timeouts: null
+  module.factory.module.projects["dev-net-0"].google_project_service_identity.default["iap.googleapis.com"]:
+    project: ft0-dev-net-shared-0
+    service: iap.googleapis.com
+    timeouts: null
+  module.factory.module.projects["dev-net-0"].google_project_service_identity.default["monitoring.googleapis.com"]:
+    project: ft0-dev-net-shared-0
+    service: monitoring.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].data.google_bigquery_default_service_account.bq_sa[0]:
+    project: ft0-prod-iac-core-0
+  module.factory.module.projects["iac-0"].data.google_logging_project_settings.logging_sa[0]:
+    project: ft0-prod-iac-core-0
+  module.factory.module.projects["iac-0"].data.google_storage_project_service_account.gcs_sa[0]:
+    project: ft0-prod-iac-core-0
+    user_project: null
+  module.factory.module.projects["iac-0"].google_project.project[0]:
+    auto_create_network: false
+    billing_account: 012345-012345-012345
+    deletion_policy: DELETE
+    effective_labels:
+      goog-terraform-provisioned: 'true'
+    folder_id: null
+    labels: null
+    name: ft0-prod-iac-core-0
+    org_id: '1234567890'
+    project_id: ft0-prod-iac-core-0
+    tags: null
+    terraform_labels:
+      goog-terraform-provisioned: 'true'
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_iam_member.service_agents["cloudkms"]:
+    condition: []
+    project: ft0-prod-iac-core-0
+    role: roles/cloudkms.serviceAgent
+  module.factory.module.projects["iac-0"].google_project_iam_member.service_agents["compute-system"]:
+    condition: []
+    project: ft0-prod-iac-core-0
+    role: roles/compute.serviceAgent
+  module.factory.module.projects["iac-0"].google_project_iam_member.service_agents["container-engine-robot"]:
+    condition: []
+    project: ft0-prod-iac-core-0
+    role: roles/container.serviceAgent
+  module.factory.module.projects["iac-0"].google_project_iam_member.service_agents["gkenode"]:
+    condition: []
+    project: ft0-prod-iac-core-0
+    role: roles/container.defaultNodeServiceAgent
+  module.factory.module.projects["iac-0"].google_project_iam_member.service_agents["monitoring-notification"]:
+    condition: []
+    project: ft0-prod-iac-core-0
+    role: roles/monitoring.notificationServiceAgent
+  module.factory.module.projects["iac-0"].google_project_iam_member.service_agents["pubsub"]:
+    condition: []
+    project: ft0-prod-iac-core-0
+    role: roles/pubsub.serviceAgent
+  module.factory.module.projects["iac-0"].google_project_service.org_policy_service[0]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: orgpolicy.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["accesscontextmanager.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: accesscontextmanager.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["bigquery.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: bigquery.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["bigquerystorage.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: bigquerystorage.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["cloudbilling.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: cloudbilling.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["cloudkms.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: cloudkms.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["cloudresourcemanager.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: cloudresourcemanager.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["compute.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: compute.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["container.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: container.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["essentialcontacts.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: essentialcontacts.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["iam.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: iam.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["iamcredentials.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: iamcredentials.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["logging.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: logging.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["monitoring.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: monitoring.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["pubsub.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: pubsub.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["serviceusage.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: serviceusage.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["storage-component.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: storage-component.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["storage.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: storage.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service.project_services["sts.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-iac-core-0
+    service: sts.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service_identity.default["cloudkms.googleapis.com"]:
+    project: ft0-prod-iac-core-0
+    service: cloudkms.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service_identity.default["container.googleapis.com"]:
+    project: ft0-prod-iac-core-0
+    service: container.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service_identity.default["monitoring.googleapis.com"]:
+    project: ft0-prod-iac-core-0
+    service: monitoring.googleapis.com
+    timeouts: null
+  module.factory.module.projects["iac-0"].google_project_service_identity.default["pubsub.googleapis.com"]:
+    project: ft0-prod-iac-core-0
+    service: pubsub.googleapis.com
+    timeouts: null
+  module.factory.module.projects["prod-app-0"].data.google_bigquery_default_service_account.bq_sa[0]:
+    project: ft0-prod-app-example-0
+  module.factory.module.projects["prod-app-0"].data.google_logging_project_settings.logging_sa[0]:
+    project: ft0-prod-app-example-0
+  module.factory.module.projects["prod-app-0"].data.google_storage_project_service_account.gcs_sa[0]:
+    project: ft0-prod-app-example-0
+    user_project: null
+  module.factory.module.projects["prod-app-0"].google_project.project[0]:
+    auto_create_network: false
+    billing_account: 012345-012345-012345
+    deletion_policy: DELETE
+    effective_labels:
+      goog-terraform-provisioned: 'true'
+    labels: null
+    name: ft0-prod-app-example-0
+    org_id: null
+    project_id: ft0-prod-app-example-0
+    tags: null
+    terraform_labels:
+      goog-terraform-provisioned: 'true'
+    timeouts: null
+  module.factory.module.projects["prod-app-0"].google_project_iam_member.service_agents["compute-system"]:
+    condition: []
+    project: ft0-prod-app-example-0
+    role: roles/compute.serviceAgent
+  module.factory.module.projects["prod-app-0"].google_project_iam_member.service_agents["monitoring-notification"]:
+    condition: []
+    project: ft0-prod-app-example-0
+    role: roles/monitoring.notificationServiceAgent
+  module.factory.module.projects["prod-app-0"].google_project_service.project_services["bigquery.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-app-example-0
+    service: bigquery.googleapis.com
+    timeouts: null
+  module.factory.module.projects["prod-app-0"].google_project_service.project_services["compute.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-app-example-0
+    service: compute.googleapis.com
+    timeouts: null
+  module.factory.module.projects["prod-app-0"].google_project_service.project_services["logging.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-app-example-0
+    service: logging.googleapis.com
+    timeouts: null
+  module.factory.module.projects["prod-app-0"].google_project_service.project_services["monitoring.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-app-example-0
+    service: monitoring.googleapis.com
+    timeouts: null
+  module.factory.module.projects["prod-app-0"].google_project_service.project_services["storage.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-app-example-0
+    service: storage.googleapis.com
+    timeouts: null
+  module.factory.module.projects["prod-app-0"].google_project_service_identity.default["monitoring.googleapis.com"]:
+    project: ft0-prod-app-example-0
+    service: monitoring.googleapis.com
+    timeouts: null
+  module.factory.module.projects["prod-net-0"].data.google_logging_project_settings.logging_sa[0]:
+    project: ft0-prod-net-shared-0
+  module.factory.module.projects["prod-net-0"].google_project.project[0]:
+    auto_create_network: false
+    billing_account: 012345-012345-012345
+    deletion_policy: DELETE
+    effective_labels:
+      goog-terraform-provisioned: 'true'
+    labels: null
+    name: ft0-prod-net-shared-0
+    org_id: null
+    project_id: ft0-prod-net-shared-0
+    tags: null
+    terraform_labels:
+      goog-terraform-provisioned: 'true'
+    timeouts: null
+  module.factory.module.projects["prod-net-0"].google_project_iam_member.service_agents["compute-system"]:
+    condition: []
+    project: ft0-prod-net-shared-0
+    role: roles/compute.serviceAgent
+  module.factory.module.projects["prod-net-0"].google_project_iam_member.service_agents["container-engine-robot"]:
+    condition: []
+    project: ft0-prod-net-shared-0
+    role: roles/container.serviceAgent
+  module.factory.module.projects["prod-net-0"].google_project_iam_member.service_agents["dns"]:
+    condition: []
+    project: ft0-prod-net-shared-0
+    role: roles/dns.serviceAgent
+  module.factory.module.projects["prod-net-0"].google_project_iam_member.service_agents["gkenode"]:
+    condition: []
+    project: ft0-prod-net-shared-0
+    role: roles/container.defaultNodeServiceAgent
+  module.factory.module.projects["prod-net-0"].google_project_iam_member.service_agents["monitoring-notification"]:
+    condition: []
+    project: ft0-prod-net-shared-0
+    role: roles/monitoring.notificationServiceAgent
+  module.factory.module.projects["prod-net-0"].google_project_service.project_services["compute.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-net-shared-0
+    service: compute.googleapis.com
+    timeouts: null
+  module.factory.module.projects["prod-net-0"].google_project_service.project_services["container.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-net-shared-0
+    service: container.googleapis.com
+    timeouts: null
+  module.factory.module.projects["prod-net-0"].google_project_service.project_services["dns.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-net-shared-0
+    service: dns.googleapis.com
+    timeouts: null
+  module.factory.module.projects["prod-net-0"].google_project_service.project_services["iap.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-net-shared-0
+    service: iap.googleapis.com
+    timeouts: null
+  module.factory.module.projects["prod-net-0"].google_project_service.project_services["logging.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-net-shared-0
+    service: logging.googleapis.com
+    timeouts: null
+  module.factory.module.projects["prod-net-0"].google_project_service.project_services["monitoring.googleapis.com"]:
+    deletion_policy: DELETE
+    disable_dependent_services: false
+    disable_on_destroy: false
+    project: ft0-prod-net-shared-0
+    service: monitoring.googleapis.com
+    timeouts: null
+  module.factory.module.projects["prod-net-0"].google_project_service_identity.default["container.googleapis.com"]:
+    project: ft0-prod-net-shared-0
+    service: container.googleapis.com
+    timeouts: null
+  module.factory.module.projects["prod-net-0"].google_project_service_identity.default["dns.googleapis.com"]:
+    project: ft0-prod-net-shared-0
+    service: dns.googleapis.com
+    timeouts: null
+  module.factory.module.projects["prod-net-0"].google_project_service_identity.default["iap.googleapis.com"]:
+    project: ft0-prod-net-shared-0
+    service: iap.googleapis.com
+    timeouts: null
+  module.factory.module.projects["prod-net-0"].google_project_service_identity.default["monitoring.googleapis.com"]:
+    project: ft0-prod-net-shared-0
+    service: monitoring.googleapis.com
+    timeouts: null
+  module.factory.module.service-accounts["iac-0/iac-org-rw"].google_service_account.service_account[0]:
+    account_id: iac-org-rw
+    create_ignore_already_exists: null
+    deletion_policy: DELETE
+    description: null
+    disabled: false
+    display_name: IaC service account for org setup (read-write).
+    email: iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    member: serviceAccount:iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    project: ft0-prod-iac-core-0
+    timeouts: null
+  module.factory.terraform_data.defaults_preconditions:
+    input: null
+    output: null
+    triggers_replace: null
+  module.factory.terraform_data.project_preconditions:
+    input: null
+    output: null
+    triggers_replace: null
+  module.organization-iam[0].google_access_context_manager_gcp_user_access_binding.binding["test_binding"]:
+    group_key: gcp-organization-admins
+    organization_id: '1234567890'
+    scoped_access_settings: []
+    session_settings: []
+    timeouts: null
+  module.organization-iam[0].google_logging_organization_sink.sink["audit-logs"]:
+    deletion_policy: DELETE
+    description: audit-logs (Terraform-managed).
+    disabled: false
+    exclusions: []
+    filter: 'log_id("cloudaudit.googleapis.com/activity") OR
+
+      log_id("cloudaudit.googleapis.com/system_event") OR
+
+      log_id("cloudaudit.googleapis.com/policy") OR
+
+      log_id("cloudaudit.googleapis.com/access_transparency")
+
+      '
+    include_children: true
+    intercept_children: false
+    name: audit-logs
+    org_id: '1234567890'
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/accesscontextmanager.policyAdmin"]:
+    condition: []
+    members:
+    - serviceAccount:iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/accesscontextmanager.policyAdmin
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/billing.creator"]:
+    condition: []
+    members: null
+    org_id: '1234567890'
+    role: roles/billing.creator
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/cloudasset.owner"]:
+    condition: []
+    members:
+    - group:fabric-fast-owners@google.com
+    org_id: '1234567890'
+    role: roles/cloudasset.owner
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/cloudasset.viewer"]:
+    condition: []
+    members:
+    - serviceAccount:iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/cloudasset.viewer
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/cloudsupport.admin"]:
+    condition: []
+    members:
+    - group:fabric-fast-owners@google.com
+    org_id: '1234567890'
+    role: roles/cloudsupport.admin
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/cloudsupport.techSupportEditor"]:
+    condition: []
+    members:
+    - group:fabric-fast-owners@google.com
+    org_id: '1234567890'
+    role: roles/cloudsupport.techSupportEditor
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/compute.osAdminLogin"]:
+    condition: []
+    members:
+    - group:fabric-fast-owners@google.com
+    org_id: '1234567890'
+    role: roles/compute.osAdminLogin
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/compute.osLoginExternalUser"]:
+    condition: []
+    members:
+    - group:fabric-fast-owners@google.com
+    org_id: '1234567890'
+    role: roles/compute.osLoginExternalUser
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/compute.xpnAdmin"]:
+    condition: []
+    members:
+    - group:fabric-fast-owners@google.com
+    org_id: '1234567890'
+    role: roles/compute.xpnAdmin
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/essentialcontacts.admin"]:
+    condition: []
+    members:
+    - serviceAccount:iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/essentialcontacts.admin
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/iam.organizationRoleAdmin"]:
+    condition: []
+    members:
+    - serviceAccount:iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/iam.organizationRoleAdmin
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/iam.workforcePoolAdmin"]:
+    condition: []
+    members:
+    - group:fabric-fast-owners@google.com
+    - serviceAccount:iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/iam.workforcePoolAdmin
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/logging.admin"]:
+    condition: []
+    members:
+    - serviceAccount:iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/logging.admin
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/orgpolicy.policyAdmin"]:
+    condition: []
+    members:
+    - group:fabric-fast-owners@google.com
+    - serviceAccount:iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/orgpolicy.policyAdmin
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/owner"]:
+    condition: []
+    members:
+    - group:fabric-fast-owners@google.com
+    org_id: '1234567890'
+    role: roles/owner
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/privilegedaccessmanager.admin"]:
+    condition: []
+    members:
+    - serviceAccount:iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/privilegedaccessmanager.admin
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/resourcemanager.folderAdmin"]:
+    condition: []
+    members:
+    - group:fabric-fast-owners@google.com
+    - serviceAccount:iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/resourcemanager.folderAdmin
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/resourcemanager.organizationAdmin"]:
+    condition: []
+    members:
+    - group:fabric-fast-owners@google.com
+    - serviceAccount:iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/resourcemanager.organizationAdmin
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/resourcemanager.projectCreator"]:
+    condition: []
+    members:
+    - group:fabric-fast-owners@google.com
+    - serviceAccount:iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/resourcemanager.projectCreator
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/resourcemanager.projectMover"]:
+    condition: []
+    members:
+    - serviceAccount:iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/resourcemanager.projectMover
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/resourcemanager.tagAdmin"]:
+    condition: []
+    members:
+    - group:fabric-fast-owners@google.com
+    - serviceAccount:iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/resourcemanager.tagAdmin
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/resourcemanager.tagUser"]:
+    condition: []
+    members:
+    - serviceAccount:iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/resourcemanager.tagUser
+  module.organization-iam[0].google_organization_iam_binding.authoritative["roles/viewer"]:
+    condition: []
+    members:
+    - serviceAccount:service-org-1234567890@gcp-sa-pam.iam.gserviceaccount.com
+    org_id: '1234567890'
+    role: roles/viewer
+  module.organization-iam[0].google_project_iam_member.bucket_sinks_binding["audit-logs"]:
+    condition:
+    - title: audit-logs bucket writer
+    role: roles/logging.bucketWriter
+  module.organization[0].google_access_context_manager_access_level.basic["factory_level"]:
+    basic:
+    - combining_function: AND
+      conditions:
+      - device_policy: []
+        ip_subnetworks:
+        - 10.0.0.0/24
+        members:
+        - $iam_principals:gcp-organization-admins
+        negate: null
+        regions: []
+        required_access_levels: []
+        vpc_network_sources: []
+    custom: []
+    description: null
+    name: accessPolicies/1234567890/accessLevels/factory_level
+    parent: accessPolicies/1234567890
+    timeouts: null
+    title: factory_level
+  module.organization[0].google_logging_organization_settings.default[0]:
+    organization: '1234567890'
+    timeouts: null
+  module.organization[0].google_organization_service_identity.default["pam"]:
+    organization: '1234567890'
+    service: privilegedaccessmanager.googleapis.com
+    timeouts: null
+  module.vpcs.module.firewall["dev"].google_compute_firewall.custom_rules["ingress-default-allow-healthchecks"]:
+    allow:
+    - ports: []
+      protocol: all
+    deletion_policy: DELETE
+    deny: []
+    description: Allow GCP Healthcheck Ranges.
+    direction: INGRESS
+    disabled: false
+    log_config: []
+    name: ingress-default-allow-healthchecks
+    network: dev-shared-0
+    params: []
+    priority: 1000
+    project: ft0-dev-net-shared-0
+    source_ranges:
+    - 130.211.0.0/22
+    - 209.85.152.0/22
+    - 209.85.204.0/22
+    - 35.191.0.0/16
+    source_service_accounts: null
+    source_tags: null
+    target_service_accounts: null
+    target_tags: null
+    timeouts: null
+  module.vpcs.module.firewall["dev"].google_compute_firewall.custom_rules["ingress-default-allow-iap"]:
+    allow:
+    - ports: []
+      protocol: all
+    deletion_policy: DELETE
+    deny: []
+    description: Allow IAP.
+    direction: INGRESS
+    disabled: false
+    log_config: []
+    name: ingress-default-allow-iap
+    network: dev-shared-0
+    params: []
+    priority: 1000
+    project: ft0-dev-net-shared-0
+    source_ranges:
+    - 35.235.240.0/20
+    source_service_accounts: null
+    source_tags: null
+    target_service_accounts: null
+    target_tags: null
+    timeouts: null
+  module.vpcs.module.firewall["dev"].google_compute_firewall.custom_rules["ingress-default-allow-icmp"]:
+    allow:
+    - ports: []
+      protocol: icmp
+    deletion_policy: DELETE
+    deny: []
+    description: Allow ICMP.
+    direction: INGRESS
+    disabled: false
+    log_config: []
+    name: ingress-default-allow-icmp
+    network: dev-shared-0
+    params: []
+    priority: 1000
+    project: ft0-dev-net-shared-0
+    source_ranges:
+    - 0.0.0.0/0
+    source_service_accounts: null
+    source_tags: null
+    target_service_accounts: null
+    target_tags: null
+    timeouts: null
+  module.vpcs.module.firewall["prod"].google_compute_firewall.custom_rules["ingress-default-allow-healthchecks"]:
+    allow:
+    - ports: []
+      protocol: all
+    deletion_policy: DELETE
+    deny: []
+    description: Allow GCP Healthcheck Ranges.
+    direction: INGRESS
+    disabled: false
+    log_config: []
+    name: ingress-default-allow-healthchecks
+    network: prod-shared-0
+    params: []
+    priority: 1000
+    project: ft0-prod-net-shared-0
+    source_ranges:
+    - 130.211.0.0/22
+    - 209.85.152.0/22
+    - 209.85.204.0/22
+    - 35.191.0.0/16
+    source_service_accounts: null
+    source_tags: null
+    target_service_accounts: null
+    target_tags: null
+    timeouts: null
+  module.vpcs.module.firewall["prod"].google_compute_firewall.custom_rules["ingress-default-allow-iap"]:
+    allow:
+    - ports: []
+      protocol: all
+    deletion_policy: DELETE
+    deny: []
+    description: Allow IAP.
+    direction: INGRESS
+    disabled: false
+    log_config: []
+    name: ingress-default-allow-iap
+    network: prod-shared-0
+    params: []
+    priority: 1000
+    project: ft0-prod-net-shared-0
+    source_ranges:
+    - 35.235.240.0/20
+    source_service_accounts: null
+    source_tags: null
+    target_service_accounts: null
+    target_tags: null
+    timeouts: null
+  module.vpcs.module.firewall["prod"].google_compute_firewall.custom_rules["ingress-default-allow-icmp"]:
+    allow:
+    - ports: []
+      protocol: icmp
+    deletion_policy: DELETE
+    deny: []
+    description: Allow ICMP.
+    direction: INGRESS
+    disabled: false
+    log_config: []
+    name: ingress-default-allow-icmp
+    network: prod-shared-0
+    params: []
+    priority: 1000
+    project: ft0-prod-net-shared-0
+    source_ranges:
+    - 0.0.0.0/0
+    source_service_accounts: null
+    source_tags: null
+    target_service_accounts: null
+    target_tags: null
+    timeouts: null
+  module.vpcs.module.vpcs["dev"].google_compute_network.network[0]:
+    auto_create_subnetworks: false
+    delete_bgp_always_compare_med: false
+    delete_default_routes_on_create: true
+    deletion_policy: DELETE
+    description: Terraform managed
+    enable_ula_internal_ipv6: null
+    mtu: 1500
+    name: dev-shared-0
+    network_firewall_policy_enforcement_order: AFTER_CLASSIC_FIREWALL
+    network_profile: null
+    params: []
+    project: ft0-dev-net-shared-0
+    routing_mode: GLOBAL
+    timeouts: null
+  module.vpcs.module.vpcs["dev"].google_compute_route.gateway["directpath-googleapis"]:
+    deletion_policy: DELETE
+    description: Terraform-managed.
+    dest_range: 34.126.0.0/18
+    name: dev-shared-0-directpath-googleapis
+    network: dev-shared-0
+    next_hop_gateway: default-internet-gateway
+    next_hop_ilb: null
+    next_hop_instance: null
+    next_hop_vpn_tunnel: null
+    params: []
+    priority: 1000
+    project: ft0-dev-net-shared-0
+    tags: null
+    timeouts: null
+  module.vpcs.module.vpcs["dev"].google_compute_route.gateway["private-googleapis"]:
+    deletion_policy: DELETE
+    description: Terraform-managed.
+    dest_range: 199.36.153.8/30
+    name: dev-shared-0-private-googleapis
+    network: dev-shared-0
+    next_hop_gateway: default-internet-gateway
+    next_hop_ilb: null
+    next_hop_instance: null
+    next_hop_vpn_tunnel: null
+    params: []
+    priority: 1000
+    project: ft0-dev-net-shared-0
+    tags: null
+    timeouts: null
+  module.vpcs.module.vpcs["dev"].google_compute_route.gateway["restricted-googleapis"]:
+    deletion_policy: DELETE
+    description: Terraform-managed.
+    dest_range: 199.36.153.4/30
+    name: dev-shared-0-restricted-googleapis
+    network: dev-shared-0
+    next_hop_gateway: default-internet-gateway
+    next_hop_ilb: null
+    next_hop_instance: null
+    next_hop_vpn_tunnel: null
+    params: []
+    priority: 1000
+    project: ft0-dev-net-shared-0
+    tags: null
+    timeouts: null
+  module.vpcs.module.vpcs["dev"].google_compute_subnetwork.subnetwork["europe-west1/default"]:
+    deletion_policy: DELETE
+    description: Default primary-region subnet for dev
+    ip_cidr_range: 10.0.0.0/24
+    ip_collection: null
+    ipv6_access_type: null
+    log_config: []
+    name: default
+    network: dev-shared-0
+    params: []
+    private_ip_google_access: true
+    project: ft0-dev-net-shared-0
+    region: europe-west1
+    reserved_internal_range: null
+    resolve_subnet_mask: null
+    role: null
+    send_secondary_ip_range_if_empty: true
+    timeouts: null
+  module.vpcs.module.vpcs["prod"].google_compute_network.network[0]:
+    auto_create_subnetworks: false
+    delete_bgp_always_compare_med: false
+    delete_default_routes_on_create: true
+    deletion_policy: DELETE
+    description: Terraform managed
+    enable_ula_internal_ipv6: null
+    mtu: 1500
+    name: prod-shared-0
+    network_firewall_policy_enforcement_order: AFTER_CLASSIC_FIREWALL
+    network_profile: null
+    params: []
+    project: ft0-prod-net-shared-0
+    routing_mode: GLOBAL
+    timeouts: null
+  module.vpcs.module.vpcs["prod"].google_compute_route.gateway["directpath-googleapis"]:
+    deletion_policy: DELETE
+    description: Terraform-managed.
+    dest_range: 34.126.0.0/18
+    name: prod-shared-0-directpath-googleapis
+    network: prod-shared-0
+    next_hop_gateway: default-internet-gateway
+    next_hop_ilb: null
+    next_hop_instance: null
+    next_hop_vpn_tunnel: null
+    params: []
+    priority: 1000
+    project: ft0-prod-net-shared-0
+    tags: null
+    timeouts: null
+  module.vpcs.module.vpcs["prod"].google_compute_route.gateway["private-googleapis"]:
+    deletion_policy: DELETE
+    description: Terraform-managed.
+    dest_range: 199.36.153.8/30
+    name: prod-shared-0-private-googleapis
+    network: prod-shared-0
+    next_hop_gateway: default-internet-gateway
+    next_hop_ilb: null
+    next_hop_instance: null
+    next_hop_vpn_tunnel: null
+    params: []
+    priority: 1000
+    project: ft0-prod-net-shared-0
+    tags: null
+    timeouts: null
+  module.vpcs.module.vpcs["prod"].google_compute_route.gateway["restricted-googleapis"]:
+    deletion_policy: DELETE
+    description: Terraform-managed.
+    dest_range: 199.36.153.4/30
+    name: prod-shared-0-restricted-googleapis
+    network: prod-shared-0
+    next_hop_gateway: default-internet-gateway
+    next_hop_ilb: null
+    next_hop_instance: null
+    next_hop_vpn_tunnel: null
+    params: []
+    priority: 1000
+    project: ft0-prod-net-shared-0
+    tags: null
+    timeouts: null
+  module.vpcs.module.vpcs["prod"].google_compute_subnetwork.subnetwork["europe-west1/default"]:
+    deletion_policy: DELETE
+    description: Default primary-region subnet for prod
+    ip_cidr_range: 10.0.0.0/24
+    ip_collection: null
+    ipv6_access_type: null
+    log_config: []
+    name: default
+    network: prod-shared-0
+    params: []
+    private_ip_google_access: true
+    project: ft0-prod-net-shared-0
+    region: europe-west1
+    reserved_internal_range: null
+    resolve_subnet_mask: null
+    role: null
+    send_secondary_ip_range_if_empty: true
+    timeouts: null
+  terraform_data.precondition:
+    input: null
+    output: null
+    triggers_replace: null
+  terraform_data.precondition_cicd:
+    input: null
+    output: null
+    triggers_replace: null
+
+counts:
+  google_access_context_manager_access_level: 1
+  google_access_context_manager_gcp_user_access_binding: 1
+  google_bigquery_dataset: 1
+  google_bigquery_default_service_account: 3
+  google_compute_firewall: 6
+  google_compute_network: 2
+  google_compute_route: 6
+  google_compute_shared_vpc_host_project: 2
+  google_compute_shared_vpc_service_project: 2
+  google_compute_subnetwork: 2
+  google_folder: 2
+  google_logging_organization_settings: 1
+  google_logging_organization_sink: 1
+  google_logging_project_bucket_config: 1
+  google_logging_project_settings: 5
+  google_organization_iam_binding: 23
+  google_organization_service_identity: 1
+  google_project: 5
+  google_project_iam_binding: 6
+  google_project_iam_member: 21
+  google_project_service: 41
+  google_project_service_identity: 14
+  google_service_account: 1
+  google_storage_bucket: 2
+  google_storage_bucket_iam_binding: 2
+  google_storage_bucket_object: 4
+  google_storage_project_service_account: 3
+  google_tags_tag_binding: 2
+  local_file: 3
+  modules: 27
+  resources: 168
+  terraform_data: 4
+
+outputs:
+  iam_principals:
+    domain: domain:example.org
+    gcp-billing-admins: group:gcp-billing-admins@example.org
+    gcp-devops: group:gcp-devops@example.org
+    gcp-network-admins: group:gcp-network-admins@example.org
+    gcp-organization-admins: group:fabric-fast-owners@google.com
+    gcp-secops-admins: group:gcp-secops-admins@example.org
+    gcp-security-admins: group:gcp-security-admins@example.org
+    gcp-support: group:gcp-support@example.org
+  projects: __missing__
+  subnet_ips:
+    dev:
+      europe-west1/default: 10.0.0.0/24
+    prod:
+      europe-west1/default: 10.0.0.0/24
+  subnet_self_links: __missing__
+  tfvars: __missing__
+  vpc_self_links: __missing__

--- a/tests/fast/stages/s0_org_setup/data-caa/defaults.yaml
+++ b/tests/fast/stages/s0_org_setup/data-caa/defaults.yaml
@@ -1,0 +1,46 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# yaml-language-server: $schema=../../../../../fast/stages/0-org-setup/schemas/defaults.schema.json
+
+global:
+  billing_account: 012345-012345-012345
+  organization:
+    domain: example.org
+    id: 1234567890
+    customer_id: abcd123456
+projects:
+  defaults:
+    prefix: ft0
+    locations:
+      bigquery: $locations:primary
+      logging: $locations:primary
+      storage: $locations:primary
+  overrides: {}
+output_files:
+  local_path: /tmp/fast-config
+  storage_bucket: $storage_buckets:iac-0/iac-outputs
+  providers:
+    0-org-setup:
+      bucket: $storage_buckets:iac-0/iac-org-state
+      service_account: $iam_principals:service_accounts/iac-0/iac-org-rw
+context:
+  access_levels:
+    test_default: accessPolicies/1234567890/accessLevels/test_default
+  iam_principals:
+    gcp-organization-admins: group:fabric-fast-owners@google.com
+  locations:
+    primary: europe-west1
+  workload_identity_providers:
+    iac-0/default/github-default: projects/1234567890/locations/global/workloadIdentityPools/default

--- a/tests/fast/stages/s0_org_setup/data-caa/organization/.config.yaml
+++ b/tests/fast/stages/s0_org_setup/data-caa/organization/.config.yaml
@@ -1,0 +1,72 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# yaml-language-server: $schema=../../../schemas/organization.schema.json
+
+access_policy: "1234567890"
+id: $defaults:organization/id
+service_agents_config:
+  services:
+    - privilegedaccessmanager.googleapis.com
+
+context_aware_access_bindings:
+  test_binding:
+    group_key: gcp-organization-admins
+    access_levels:
+      - $access_levels:test_default
+      - $access_levels:factory_level
+
+iam_by_principals:
+  $iam_principals:gcp-organization-admins:
+    - roles/cloudasset.owner
+    - roles/cloudsupport.admin
+    - roles/cloudsupport.techSupportEditor
+    - roles/compute.osAdminLogin
+    - roles/compute.osLoginExternalUser
+    - roles/compute.xpnAdmin
+    - roles/orgpolicy.policyAdmin
+    - roles/owner
+    - roles/resourcemanager.folderAdmin
+    - roles/resourcemanager.organizationAdmin
+    - roles/resourcemanager.projectCreator
+    - roles/resourcemanager.tagAdmin
+    - roles/iam.workforcePoolAdmin
+  $iam_principals:service_accounts/iac-0/iac-org-rw:
+    - roles/accesscontextmanager.policyAdmin
+    - roles/cloudasset.viewer
+    - roles/essentialcontacts.admin
+    - roles/iam.organizationRoleAdmin
+    - roles/iam.workforcePoolAdmin
+    - roles/logging.admin
+    - roles/orgpolicy.policyAdmin
+    - roles/privilegedaccessmanager.admin
+    - roles/resourcemanager.folderAdmin
+    - roles/resourcemanager.organizationAdmin
+    - roles/resourcemanager.projectCreator
+    - roles/resourcemanager.projectMover
+    - roles/resourcemanager.tagAdmin
+    - roles/resourcemanager.tagUser
+  "$iam_principals:service_agents/pam":
+    - roles/viewer
+logging:
+  sinks:
+    audit-logs:
+      destination: $log_buckets:iac-0/audit-logs
+      filter: |
+        log_id("cloudaudit.googleapis.com/activity") OR
+        log_id("cloudaudit.googleapis.com/system_event") OR
+        log_id("cloudaudit.googleapis.com/policy") OR
+        log_id("cloudaudit.googleapis.com/access_transparency")
+iam:
+  roles/billing.creator: []

--- a/tests/fast/stages/s0_org_setup/data-caa/organization/access-levels/level.yaml
+++ b/tests/fast/stages/s0_org_setup/data-caa/organization/access-levels/level.yaml
@@ -1,0 +1,20 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+factory_level:
+  conditions:
+    - ip_subnetworks:
+        - "10.0.0.0/24"
+      members:
+        - "$iam_principals:gcp-organization-admins"

--- a/tests/fast/stages/s0_org_setup/tftest.yaml
+++ b/tests/fast/stages/s0_org_setup/tftest.yaml
@@ -35,3 +35,8 @@ tests:
       - customizations.yaml
     extra_dirs:
       - ../../../tests/fast/stages/s0_org_setup/data-customizations
+  caa:
+    inventory:
+      - caa.yaml
+    extra_dirs:
+      - ../../../tests/fast/stages/s0_org_setup/data-caa

--- a/tests/modules/organization/context.tfvars
+++ b/tests/modules/organization/context.tfvars
@@ -243,7 +243,7 @@ access_levels = {
 
 context_aware_access_bindings = {
   my_binding = {
-    group_key     = "$email_addresses:default"
+    group_key = "$email_addresses:default"
     access_levels = [
       "$access_levels:test",
       "$access_levels:my_level",

--- a/tests/modules/organization/context.tfvars
+++ b/tests/modules/organization/context.tfvars
@@ -1,4 +1,7 @@
 context = {
+  access_levels = {
+    test = "accessPolicies/1234567890/accessLevels/test"
+  }
   bigquery_datasets = {
     test = "projects/test-prod-audit-logs-0/datasets/logs"
   }
@@ -225,4 +228,30 @@ iam_deny_policies = {
       }
     ]
   }
+}
+
+access_policy = "1234567890"
+
+access_levels = {
+  my_level = {
+    conditions = [{
+      ip_subnetworks = ["10.0.0.0/24"]
+      members        = ["user:test-user@example.com"]
+    }]
+  }
+}
+
+context_aware_access_bindings = {
+  my_binding = {
+    group_key     = "$email_addresses:default"
+    access_levels = [
+      "$access_levels:test",
+      "$access_levels:my_level",
+      "$access_levels:factory_level"
+    ]
+  }
+}
+
+factories_config = {
+  access_levels = "factory-caa/access_levels"
 }

--- a/tests/modules/organization/context.yaml
+++ b/tests/modules/organization/context.yaml
@@ -13,6 +13,50 @@
 # limitations under the License.
 
 values:
+  google_access_context_manager_access_level.basic["factory_level"]:
+    basic:
+    - combining_function: AND
+      conditions:
+      - device_policy: []
+        ip_subnetworks:
+        - 192.168.0.0/24
+        members:
+        - group:test-group@example.com
+        negate: null
+        regions: []
+        required_access_levels: []
+        vpc_network_sources: []
+    custom: []
+    description: null
+    name: accessPolicies/1234567890/accessLevels/factory_level
+    parent: accessPolicies/1234567890
+    timeouts: null
+    title: factory_level
+  google_access_context_manager_access_level.basic["my_level"]:
+    basic:
+    - combining_function: AND
+      conditions:
+      - device_policy: []
+        ip_subnetworks:
+        - 10.0.0.0/24
+        members:
+        - user:test-user@example.com
+        negate: null
+        regions: []
+        required_access_levels: []
+        vpc_network_sources: []
+    custom: []
+    description: null
+    name: accessPolicies/1234567890/accessLevels/my_level
+    parent: accessPolicies/1234567890
+    timeouts: null
+    title: my_level
+  google_access_context_manager_gcp_user_access_binding.binding["my_binding"]:
+    group_key: foo@example.com
+    organization_id: '1234567890'
+    scoped_access_settings: []
+    session_settings: []
+    timeouts: null
   google_bigquery_dataset_iam_member.bq_sinks_binding["test-bq"]:
     condition: []
     dataset_id: logs
@@ -65,6 +109,7 @@ values:
   google_logging_organization_sink.sink["test-bq"]:
     bigquery_options:
     - use_partitioned_tables: false
+    deletion_policy: DELETE
     description: test-bq (Terraform-managed).
     destination: bigquery.googleapis.com/projects/test-prod-audit-logs-0/datasets/logs
     disabled: false
@@ -75,6 +120,7 @@ values:
     name: test-bq
     org_id: '1234567890'
   google_logging_organization_sink.sink["test-logging"]:
+    deletion_policy: DELETE
     description: test-logging (Terraform-managed).
     destination: logging.googleapis.com/projects/test-prod-audit-logs-0/locations/europe-west8/buckets/audit-logs
     disabled: false
@@ -85,6 +131,7 @@ values:
     name: test-logging
     org_id: '1234567890'
   google_logging_organization_sink.sink["test-project"]:
+    deletion_policy: DELETE
     description: test-project (Terraform-managed).
     destination: logging.googleapis.com/projects/test-prod-audit-logs-0
     disabled: false
@@ -95,6 +142,7 @@ values:
     name: test-project
     org_id: '1234567890'
   google_logging_organization_sink.sink["test-pubsub"]:
+    deletion_policy: DELETE
     description: test-pubsub (Terraform-managed).
     destination: pubsub.googleapis.com/projects/test-prod-audit-logs-0/topics/audit-logs
     disabled: false
@@ -105,6 +153,7 @@ values:
     name: test-pubsub
     org_id: '1234567890'
   google_logging_organization_sink.sink["test-storage"]:
+    deletion_policy: DELETE
     description: test-storage (Terraform-managed).
     destination: storage.googleapis.com/test-prod-logs-audit-0
     disabled: false
@@ -283,6 +332,8 @@ values:
     tag_value: tagValues/1234567890
 
 counts:
+  google_access_context_manager_access_level: 2
+  google_access_context_manager_gcp_user_access_binding: 1
   google_bigquery_dataset_iam_member: 1
   google_cloud_asset_organization_feed: 1
   google_essential_contacts_contact: 1
@@ -302,10 +353,12 @@ counts:
   google_tags_tag_value_iam_binding: 2
   google_tags_tag_value_iam_member: 1
   modules: 0
-  resources: 31
+  resources: 34
 
 outputs:
+  access_levels: __missing__
   asset_search_results: {}
+  context_aware_access_bindings: __missing__
   custom_constraint_ids: {}
   custom_role_id: {}
   custom_roles: {}

--- a/tests/modules/organization/examples/context-aware-access.yaml
+++ b/tests/modules/organization/examples/context-aware-access.yaml
@@ -1,0 +1,48 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values:
+  module.org.google_access_context_manager_access_level.basic["trusted_ips"]:
+    basic:
+    - combining_function: AND
+      conditions:
+      - device_policy: []
+        ip_subnetworks:
+        - 203.0.113.0/24
+        - 198.51.100.0/24
+        members: []
+        negate: null
+        regions: []
+        required_access_levels: []
+        vpc_network_sources: []
+    custom: []
+    description: null
+    name: accessPolicies/1234567890/accessLevels/trusted_ips
+    parent: accessPolicies/1234567890
+    timeouts: null
+    title: Trusted Corporate IPs
+  module.org.google_access_context_manager_gcp_user_access_binding.binding["developers_binding"]:
+    group_key: gcp-developers@example.com
+    organization_id: '1122334455'
+    scoped_access_settings: []
+    session_settings: []
+    timeouts: null
+
+counts:
+  google_access_context_manager_access_level: 1
+  google_access_context_manager_gcp_user_access_binding: 1
+  modules: 1
+  resources: 2
+
+outputs: {}

--- a/tests/modules/organization/factory-caa/access_levels/factory_level.yaml
+++ b/tests/modules/organization/factory-caa/access_levels/factory_level.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,23 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-module: modules/organization
-
-common_tfvars:
-  - common.tfvars
-
-tests:
-  context:
-    extra_dirs:
-      - ../../tests/modules/organization/factory-caa
-  iam_by_principals_additive:
-  iam_by_principals_conditional:
-  org_policies:
-  org_policies_factory:
-    inventory:
-      - org_policies.yaml
-    extra_dirs:
-      - ../../tests/modules/organization/factory
-  tags:
-  tags_force_context:
-  tags_skip_iam:
+factory_level:
+  conditions:
+    - ip_subnetworks:
+        - "192.168.0.0/24"
+      members:
+        - "$iam_principals:mygroup"

--- a/tools/duplicate-diff.py
+++ b/tools/duplicate-diff.py
@@ -31,6 +31,7 @@ duplicates = [
     [
         "fast/stages/1-vpcsc/schemas/access-level.schema.json",
         "modules/vpc-sc/schemas/access-level.schema.json",
+        "modules/organization/schemas/access-level.schema.json",
     ],
     [
         "modules/dataplex-aspect-types/schemas/aspect-type.schema.json",

--- a/tools/duplicate-diff.py
+++ b/tools/duplicate-diff.py
@@ -32,6 +32,7 @@ duplicates = [
         "fast/stages/1-vpcsc/schemas/access-level.schema.json",
         "modules/vpc-sc/schemas/access-level.schema.json",
         "modules/organization/schemas/access-level.schema.json",
+        "fast/stages/0-org-setup/schemas/access-level.schema.json",
     ],
     [
         "modules/dataplex-aspect-types/schemas/aspect-type.schema.json",

--- a/tools/schema_docs.py
+++ b/tools/schema_docs.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+# /// script
+# dependencies = [
+#   "click",
+# ]
+# ///
 
 # Copyright 2025 Google LLC
 #


### PR DESCRIPTION
ADR has the full rationale and implementation approach.

## Module (`modules/organization`)

* **Variables and Outputs**: Added `access_levels`, `access_policy`, and `context_aware_access_bindings` variables and corresponding outputs to manage access levels and user access bindings.
* **Resource Implementation (`context_aware_access.tf`)**: Implemented `google_access_context_manager_access_level` and `google_access_context_manager_gcp_user_access_binding` resources. Integrated symbolic context resolution (`$access_levels:<key>`, `$iam_principals:<key>`, and `$email_addresses:<key>`) and YAML factory loading (`factories_config.access_levels`).
* **Schemas**: Copied `access-level.schema.json` from `modules/vpc-sc` and generated `access-level.schema.md`.
* **Testing and Documentation**: Added test coverage in `tftest.yaml` and `context.tfvars`. Added a dedicated Context-Aware Access section and example test to `README.md`.

## FAST Stage 0 (`fast/stages/0-org-setup`)

* **Schema Expansion**: Updated `organization.schema.json` and `defaults.schema.json` to support `access_policy`, `access_levels` in context, and `context_aware_access_bindings`.
* **Module Wiring (`organization.tf`)**: Wired `factories_config.access_levels` to `module "organization"`, extracted generated access level IDs (`local.org_access_levels`), and injected them into the context passed to `module "organization-iam"`. Configured `module "organization-iam"` to consume `context_aware_access_bindings` from the parsed `.config.yaml` dataset.
* **Stage Testing**: Added test case `caa` to `tftest.yaml` with supporting dataset (`data-caa/`) and inventory (`caa.yaml`).

## Tooling

* **Duplicate Schema Tracking**: Updated `tools/duplicate-diff.py` to enforce schema consistency across `modules/vpc-sc/schemas/access-level.schema.json`, `modules/organization/schemas/access-level.schema.json`, and `fast/stages/0-org-setup/schemas/access-level.schema.json`.
