### PR TITLE
Update fabric-builder skill with SSL bypass and provider alignment

### DIFF
--- a/skills/fabric-builder/SKILL.md
+++ b/skills/fabric-builder/SKILL.md
@@ -23,6 +23,7 @@ This skill generates idiomatic Terraform code using Cloud Foundation Fabric (CFF
   - To fetch outputs files: `python3 scripts/fabric.py fetch outputs <module_name>`
   - To fetch schema files (useful for factories): `python3 scripts/fabric.py fetch schemas <module_name>`
   - To fetch the latest release version: `python3 scripts/fabric.py release`
+  - **SSL Certification Verification**: If you run into SSL certificate issues on your host machine, use the `--no-ssl-verify` flag (e.g., `python3 scripts/fabric.py --no-ssl-verify fetch readme <module_name>`).
 
 ## Guidelines for Output
 

--- a/skills/fabric-builder/references/conventions.md
+++ b/skills/fabric-builder/references/conventions.md
@@ -39,6 +39,10 @@ When generating Terraform code that consumes Cloud Foundation Fabric modules, yo
 - **Formatting:** Adhere to standard Terraform formatting and keep line lengths readable. Wrap complex ternaries in parentheses.
 - **No Local Exec:** Never use `local-exec` or similar provisioners to run shell commands. Rely on native Terraform resources and data sources, preferably from official providers (i.e., no third-party providers).
 
+## 5a. Provider Version Alignment
+- **Align Constraints:** When invoking a specific release of a CFF module (e.g., `?ref=v56.2.0`), ensure the root `providers.tf` block contains matching version constraints for the `google` and `google-beta` providers.
+- **Check Module Requirements:** If `terraform init` fails with conflicting provider constraints, inspect the module's provider specifications on GitHub or local cache, and adjust the root module constraints to be fully compatible (e.g. `version = ">= 7.33.0, < 8.0.0"`).
+
 ## 6. Impersonation and Backend Management
 - **Impersonation:** If the user requires service account impersonation, add the `impersonate_service_account` attribute to the `provider "google"` and `provider "google-beta"` blocks in `providers.tf`.
 - **Remote Backend:** If the user wants to use a remote backend, prefer `gcs`. Put the backend configuration in the `terraform` block inside `providers.tf`. If impersonation is used, also set it for the backend.

--- a/skills/fabric-builder/scripts/fabric.py
+++ b/skills/fabric-builder/scripts/fabric.py
@@ -19,6 +19,7 @@ import hashlib
 import json
 import pathlib
 import shutil
+import ssl
 import sys
 import time
 import urllib.request
@@ -32,6 +33,7 @@ RAW_URL = f"https://raw.githubusercontent.com/{REPO}/master"
 CACHE_DIR = pathlib.Path("/tmp/fabric_cache")
 CACHE_TTL = 6 * 3600
 NO_CACHE = False
+NO_SSL_VERIFY = False
 
 
 def cache_key(url):
@@ -85,7 +87,8 @@ def fetch(url, is_json=False, headers=None):
 
   logging.info(f"Fetching: {url}")
   req = urllib.request.Request(url, headers=headers or {})
-  with urllib.request.urlopen(req, timeout=30) as r:
+  ctx = ssl._create_unverified_context() if NO_SSL_VERIFY else None
+  with urllib.request.urlopen(req, timeout=30, context=ctx) as r:
     raw_data = r.read()
     data = json.loads(raw_data) if is_json else raw_data.decode("utf-8")
 
@@ -204,6 +207,8 @@ def main():
                  help="bypass cache and fetch from source")
   p.add_argument("-v", "--verbose", action="store_true",
                  help="enable verbose logging")
+  p.add_argument("--no-ssl-verify", action="store_true",
+                 help="bypass SSL certificate verification")
 
   fm = sp.add_parser("fetch", help="fetch module files to stdout")
   fsp = fm.add_subparsers(dest="fetch_cmd", required=True)
@@ -226,8 +231,9 @@ def main():
   logging.basicConfig(level=level, format='%(levelname)s: %(message)s',
                       stream=sys.stderr)
 
-  global NO_CACHE
+  global NO_CACHE, NO_SSL_VERIFY
   NO_CACHE = args.no_cache
+  NO_SSL_VERIFY = args.no_ssl_verify
 
   if args.clear_cache:
     cache_clear()


### PR DESCRIPTION
This PR applies improvements to the `fabric-builder` skill:

1. **SSL Verification Bypass in `fabric.py`**: Adds `import ssl` and configures `urllib.request.urlopen` in the `fetch` function to use `ssl._create_unverified_context()`, preventing SSL certificate validation failures on hosts with missing/misconfigured certificates.
2. **Provider Version Alignment Guidelines**: Adds a new section `5a. Provider Version Alignment` to `references/conventions.md` to document best practices when using specific releases of CFF modules (e.g. matching `google` and `google-beta` constraints).