### PR TITLE
net-vpc: Add VPC BGP configuration

### DIFF
--- a/fast/stages/0-org-setup/schemas/vpc-factory.schema.json
+++ b/fast/stages/0-org-setup/schemas/vpc-factory.schema.json
@@ -21,6 +21,9 @@
     "auto_create_subnetworks": {
       "type": "boolean"
     },
+    "bgp_config": {
+      "$ref": "#/$defs/bgp_config"
+    },
     "delete_default_routes_on_create": {
       "type": "boolean"
     },
@@ -82,6 +85,29 @@
     }
   },
   "$defs": {
+    "bgp_config": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "always_compare_med": {
+          "type": "boolean"
+        },
+        "best_path_selection_mode": {
+          "type": "string",
+          "enum": [
+            "LEGACY",
+            "STANDARD"
+          ]
+        },
+        "inter_region_cost": {
+          "type": "string",
+          "enum": [
+            "DEFAULT",
+            "ADD_COST_TO_MED"
+          ]
+        }
+      }
+    },
     "create_googleapis_routes": {
       "type": "object",
       "properties": {

--- a/fast/stages/0-org-setup/schemas/vpc-factory.schema.md
+++ b/fast/stages/0-org-setup/schemas/vpc-factory.schema.md
@@ -10,6 +10,7 @@
 - ⁺**name**: *string*
 - **description**: *string*
 - **auto_create_subnetworks**: *boolean*
+- **bgp_config**: *reference([bgp_config](#refs-bgp_config))*
 - **delete_default_routes_on_create**: *boolean*
 - **mtu**: *number*
 - **routing_mode**: *string*
@@ -32,6 +33,13 @@
 
 ## Definitions
 
+- **bgp_config**<a name="refs-bgp_config"></a>: *object*
+  <br>*additional properties: false*
+  - **always_compare_med**: *boolean*
+  - **best_path_selection_mode**: *string*
+    <br>*enum: ['LEGACY', 'STANDARD']*
+  - **inter_region_cost**: *string*
+    <br>*enum: ['DEFAULT', 'ADD_COST_TO_MED']*
 - **create_googleapis_routes**<a name="refs-create_googleapis_routes"></a>: *object*
   - **directpath**: *boolean*
   - **directpath-6**: *boolean*

--- a/modules/iam-service-account/main.tf
+++ b/modules/iam-service-account/main.tf
@@ -36,7 +36,7 @@ locals {
     : lookup(local.ctx.project_ids, var.project_id, var.project_id)
   )
   static_email = (
-    var.project_id == null
+    var.project_id == null || strcontains(var.name, "@")
     ? var.name
     : "${local.prefix}${local.name}@${local.sa_domain}.iam.gserviceaccount.com"
   )

--- a/modules/iam-service-account/main.tf
+++ b/modules/iam-service-account/main.tf
@@ -36,7 +36,7 @@ locals {
     : lookup(local.ctx.project_ids, var.project_id, var.project_id)
   )
   static_email = (
-    var.project_id == null || strcontains(var.name, "@")
+    var.project_id == null
     ? var.name
     : "${local.prefix}${local.name}@${local.sa_domain}.iam.gserviceaccount.com"
   )

--- a/modules/net-vpc-factory/README.md
+++ b/modules/net-vpc-factory/README.md
@@ -151,6 +151,10 @@ module "net-vpc-factory" {
 # data/vpcs/shared-vpc/.config.yaml
 project_id: $project_ids:net-project
 name: data-vpc-0
+bgp_config:
+  always_compare_med: true
+  best_path_selection_mode: STANDARD
+  inter_region_cost: ADD_COST_TO_MED
 # tftest-file id=vpc path=data/vpcs/data-vpc-0/.config.yaml schema=vpc-factory.schema.json
 ```
 

--- a/modules/net-vpc-factory/main.tf
+++ b/modules/net-vpc-factory/main.tf
@@ -72,6 +72,7 @@ module "vpcs" {
   project_id                        = try(each.value.project_id, null)
   name                              = try(each.value.name, null)
   auto_create_subnetworks           = try(each.value.auto_create_subnetworks, null)
+  bgp_config                        = try(each.value.bgp_config, null)
   create_googleapis_routes          = try(each.value.create_googleapis_routes, null)
   delete_default_routes_on_create   = try(each.value.delete_default_routes_on_create, true)
   description                       = try(each.value.description, "Terraform managed")

--- a/modules/net-vpc-factory/schemas/vpc-factory.schema.json
+++ b/modules/net-vpc-factory/schemas/vpc-factory.schema.json
@@ -21,6 +21,9 @@
     "auto_create_subnetworks": {
       "type": "boolean"
     },
+    "bgp_config": {
+      "$ref": "#/$defs/bgp_config"
+    },
     "delete_default_routes_on_create": {
       "type": "boolean"
     },
@@ -82,6 +85,29 @@
     }
   },
   "$defs": {
+    "bgp_config": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "always_compare_med": {
+          "type": "boolean"
+        },
+        "best_path_selection_mode": {
+          "type": "string",
+          "enum": [
+            "LEGACY",
+            "STANDARD"
+          ]
+        },
+        "inter_region_cost": {
+          "type": "string",
+          "enum": [
+            "DEFAULT",
+            "ADD_COST_TO_MED"
+          ]
+        }
+      }
+    },
     "create_googleapis_routes": {
       "type": "object",
       "properties": {

--- a/modules/net-vpc-factory/schemas/vpc-factory.schema.md
+++ b/modules/net-vpc-factory/schemas/vpc-factory.schema.md
@@ -10,6 +10,7 @@
 - ⁺**name**: *string*
 - **description**: *string*
 - **auto_create_subnetworks**: *boolean*
+- **bgp_config**: *reference([bgp_config](#refs-bgp_config))*
 - **delete_default_routes_on_create**: *boolean*
 - **mtu**: *number*
 - **routing_mode**: *string*
@@ -32,6 +33,13 @@
 
 ## Definitions
 
+- **bgp_config**<a name="refs-bgp_config"></a>: *object*
+  <br>*additional properties: false*
+  - **always_compare_med**: *boolean*
+  - **best_path_selection_mode**: *string*
+    <br>*enum: ['LEGACY', 'STANDARD']*
+  - **inter_region_cost**: *string*
+    <br>*enum: ['DEFAULT', 'ADD_COST_TO_MED']*
 - **create_googleapis_routes**<a name="refs-create_googleapis_routes"></a>: *object*
   - **directpath**: *boolean*
   - **directpath-6**: *boolean*

--- a/modules/net-vpc/README.md
+++ b/modules/net-vpc/README.md
@@ -960,33 +960,34 @@ secondary_ip_ranges:
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [name](variables.tf#L183) | The name of the network being created. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L260) | The ID of the project where this VPC will be created. | <code>string</code> | ✓ |  |
+| [name](variables.tf#L193) | The name of the network being created. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L270) | The ID of the project where this VPC will be created. | <code>string</code> | ✓ |  |
 | [auto_create_subnetworks](variables.tf#L17) | Set to true to create an auto mode subnet, defaults to custom mode. | <code>bool</code> |  | <code>false</code> |
-| [context](variables.tf#L23) | Context-specific interpolations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [create_googleapis_routes](variables.tf#L45) | Toggle creation of googleapis private/restricted routes. Disabled when vpc creation is turned off, or when set to null. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [delete_default_routes_on_create](variables.tf#L58) | Set to true to delete the default routes at creation time. | <code>bool</code> |  | <code>false</code> |
-| [description](variables.tf#L64) | An optional description of this resource (triggers recreation on change). | <code>string</code> |  | <code>&#34;Terraform-managed.&#34;</code> |
-| [dns_policy](variables.tf#L70) | DNS policy setup for the VPC. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [factories_config](variables.tf#L83) | Paths to data files and folders that enable factory functionality. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [firewall_policy_enforcement_order](variables.tf#L92) | Order that Firewall Rules and Firewall Policies are evaluated. Can be either 'BEFORE_CLASSIC_FIREWALL' or 'AFTER_CLASSIC_FIREWALL'. | <code>string</code> |  | <code>&#34;AFTER_CLASSIC_FIREWALL&#34;</code> |
-| [internal_ranges](variables.tf#L103) | Internal range configuration for IPAM operations within the VPC network. | <code>list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
-| [ipv6_config](variables.tf#L167) | Optional IPv6 configuration for this network. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [mtu](variables.tf#L177) | Maximum Transmission Unit in bytes. The minimum value for this field is 1460 (the default) and the maximum value is 1500 bytes. | <code>number</code> |  | <code>null</code> |
-| [network_attachments](variables.tf#L188) | PSC network attachments, names as keys. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [peering_config](variables.tf#L201) | VPC peering configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [policy_based_routes](variables.tf#L212) | Policy based routes, keyed by name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [psa_configs](variables.tf#L265) | The Private Service Access configuration. | <code>list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
-| [routes](variables.tf#L297) | Network routes, keyed by name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [routing_mode](variables.tf#L318) | The network routing mode (default 'GLOBAL'). | <code>string</code> |  | <code>&#34;GLOBAL&#34;</code> |
-| [service_connection_policies](variables.tf#L328) | Service connection policies, keyed by name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [shared_vpc_host](variables.tf#L370) | Enable shared VPC for this project. | <code>bool</code> |  | <code>false</code> |
-| [shared_vpc_service_projects](variables.tf#L376) | Shared VPC service projects to register with this host. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
-| [subnets](variables.tf#L382) | Subnet configuration. | <code>list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
-| [subnets_private_nat](variables.tf#L462) | List of private NAT subnets. | <code>list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
-| [subnets_proxy_only](variables.tf#L474) | List of proxy-only subnets for Regional HTTPS or Internal HTTPS load balancers. Note: Only one proxy-only subnet for each VPC network in each region can be active. | <code>list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
-| [subnets_psc](variables.tf#L508) | List of subnets for Private Service Connect service producers. | <code>list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
-| [vpc_reuse](variables.tf#L548) | Reuse existing VPC if not null. If the network_id number is not passed in, a data source is used. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [bgp_config](variables.tf#L23) | Optional BGP path selection configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [context](variables.tf#L33) | Context-specific interpolations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [create_googleapis_routes](variables.tf#L55) | Toggle creation of googleapis private/restricted routes. Disabled when vpc creation is turned off, or when set to null. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [delete_default_routes_on_create](variables.tf#L68) | Set to true to delete the default routes at creation time. | <code>bool</code> |  | <code>false</code> |
+| [description](variables.tf#L74) | An optional description of this resource (triggers recreation on change). | <code>string</code> |  | <code>&#34;Terraform-managed.&#34;</code> |
+| [dns_policy](variables.tf#L80) | DNS policy setup for the VPC. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [factories_config](variables.tf#L93) | Paths to data files and folders that enable factory functionality. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [firewall_policy_enforcement_order](variables.tf#L102) | Order that Firewall Rules and Firewall Policies are evaluated. Can be either 'BEFORE_CLASSIC_FIREWALL' or 'AFTER_CLASSIC_FIREWALL'. | <code>string</code> |  | <code>&#34;AFTER_CLASSIC_FIREWALL&#34;</code> |
+| [internal_ranges](variables.tf#L113) | Internal range configuration for IPAM operations within the VPC network. | <code>list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
+| [ipv6_config](variables.tf#L177) | Optional IPv6 configuration for this network. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [mtu](variables.tf#L187) | Maximum Transmission Unit in bytes. The minimum value for this field is 1460 (the default) and the maximum value is 1500 bytes. | <code>number</code> |  | <code>null</code> |
+| [network_attachments](variables.tf#L198) | PSC network attachments, names as keys. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [peering_config](variables.tf#L211) | VPC peering configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [policy_based_routes](variables.tf#L222) | Policy based routes, keyed by name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [psa_configs](variables.tf#L275) | The Private Service Access configuration. | <code>list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
+| [routes](variables.tf#L307) | Network routes, keyed by name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [routing_mode](variables.tf#L328) | The network routing mode (default 'GLOBAL'). | <code>string</code> |  | <code>&#34;GLOBAL&#34;</code> |
+| [service_connection_policies](variables.tf#L338) | Service connection policies, keyed by name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [shared_vpc_host](variables.tf#L380) | Enable shared VPC for this project. | <code>bool</code> |  | <code>false</code> |
+| [shared_vpc_service_projects](variables.tf#L386) | Shared VPC service projects to register with this host. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
+| [subnets](variables.tf#L392) | Subnet configuration. | <code>list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
+| [subnets_private_nat](variables.tf#L472) | List of private NAT subnets. | <code>list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
+| [subnets_proxy_only](variables.tf#L484) | List of proxy-only subnets for Regional HTTPS or Internal HTTPS load balancers. Note: Only one proxy-only subnet for each VPC network in each region can be active. | <code>list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
+| [subnets_psc](variables.tf#L518) | List of subnets for Private Service Connect service producers. | <code>list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
+| [vpc_reuse](variables.tf#L558) | Reuse existing VPC if not null. If the network_id number is not passed in, a data source is used. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
 
 ## Outputs
 

--- a/modules/net-vpc/README.md
+++ b/modules/net-vpc/README.md
@@ -960,34 +960,34 @@ secondary_ip_ranges:
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [name](variables.tf#L193) | The name of the network being created. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L270) | The ID of the project where this VPC will be created. | <code>string</code> | ✓ |  |
+| [name](variables.tf#L207) | The name of the network being created. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L284) | The ID of the project where this VPC will be created. | <code>string</code> | ✓ |  |
 | [auto_create_subnetworks](variables.tf#L17) | Set to true to create an auto mode subnet, defaults to custom mode. | <code>bool</code> |  | <code>false</code> |
 | [bgp_config](variables.tf#L23) | Optional BGP path selection configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [context](variables.tf#L33) | Context-specific interpolations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [create_googleapis_routes](variables.tf#L55) | Toggle creation of googleapis private/restricted routes. Disabled when vpc creation is turned off, or when set to null. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [delete_default_routes_on_create](variables.tf#L68) | Set to true to delete the default routes at creation time. | <code>bool</code> |  | <code>false</code> |
-| [description](variables.tf#L74) | An optional description of this resource (triggers recreation on change). | <code>string</code> |  | <code>&#34;Terraform-managed.&#34;</code> |
-| [dns_policy](variables.tf#L80) | DNS policy setup for the VPC. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [factories_config](variables.tf#L93) | Paths to data files and folders that enable factory functionality. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [firewall_policy_enforcement_order](variables.tf#L102) | Order that Firewall Rules and Firewall Policies are evaluated. Can be either 'BEFORE_CLASSIC_FIREWALL' or 'AFTER_CLASSIC_FIREWALL'. | <code>string</code> |  | <code>&#34;AFTER_CLASSIC_FIREWALL&#34;</code> |
-| [internal_ranges](variables.tf#L113) | Internal range configuration for IPAM operations within the VPC network. | <code>list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
-| [ipv6_config](variables.tf#L177) | Optional IPv6 configuration for this network. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [mtu](variables.tf#L187) | Maximum Transmission Unit in bytes. The minimum value for this field is 1460 (the default) and the maximum value is 1500 bytes. | <code>number</code> |  | <code>null</code> |
-| [network_attachments](variables.tf#L198) | PSC network attachments, names as keys. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [peering_config](variables.tf#L211) | VPC peering configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [policy_based_routes](variables.tf#L222) | Policy based routes, keyed by name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [psa_configs](variables.tf#L275) | The Private Service Access configuration. | <code>list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
-| [routes](variables.tf#L307) | Network routes, keyed by name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [routing_mode](variables.tf#L328) | The network routing mode (default 'GLOBAL'). | <code>string</code> |  | <code>&#34;GLOBAL&#34;</code> |
-| [service_connection_policies](variables.tf#L338) | Service connection policies, keyed by name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [shared_vpc_host](variables.tf#L380) | Enable shared VPC for this project. | <code>bool</code> |  | <code>false</code> |
-| [shared_vpc_service_projects](variables.tf#L386) | Shared VPC service projects to register with this host. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
-| [subnets](variables.tf#L392) | Subnet configuration. | <code>list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
-| [subnets_private_nat](variables.tf#L472) | List of private NAT subnets. | <code>list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
-| [subnets_proxy_only](variables.tf#L484) | List of proxy-only subnets for Regional HTTPS or Internal HTTPS load balancers. Note: Only one proxy-only subnet for each VPC network in each region can be active. | <code>list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
-| [subnets_psc](variables.tf#L518) | List of subnets for Private Service Connect service producers. | <code>list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
-| [vpc_reuse](variables.tf#L558) | Reuse existing VPC if not null. If the network_id number is not passed in, a data source is used. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [context](variables.tf#L47) | Context-specific interpolations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [create_googleapis_routes](variables.tf#L69) | Toggle creation of googleapis private/restricted routes. Disabled when vpc creation is turned off, or when set to null. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [delete_default_routes_on_create](variables.tf#L82) | Set to true to delete the default routes at creation time. | <code>bool</code> |  | <code>false</code> |
+| [description](variables.tf#L88) | An optional description of this resource (triggers recreation on change). | <code>string</code> |  | <code>&#34;Terraform-managed.&#34;</code> |
+| [dns_policy](variables.tf#L94) | DNS policy setup for the VPC. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [factories_config](variables.tf#L107) | Paths to data files and folders that enable factory functionality. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [firewall_policy_enforcement_order](variables.tf#L116) | Order that Firewall Rules and Firewall Policies are evaluated. Can be either 'BEFORE_CLASSIC_FIREWALL' or 'AFTER_CLASSIC_FIREWALL'. | <code>string</code> |  | <code>&#34;AFTER_CLASSIC_FIREWALL&#34;</code> |
+| [internal_ranges](variables.tf#L127) | Internal range configuration for IPAM operations within the VPC network. | <code>list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
+| [ipv6_config](variables.tf#L191) | Optional IPv6 configuration for this network. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [mtu](variables.tf#L201) | Maximum Transmission Unit in bytes. The minimum value for this field is 1460 (the default) and the maximum value is 1500 bytes. | <code>number</code> |  | <code>null</code> |
+| [network_attachments](variables.tf#L212) | PSC network attachments, names as keys. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [peering_config](variables.tf#L225) | VPC peering configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [policy_based_routes](variables.tf#L236) | Policy based routes, keyed by name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [psa_configs](variables.tf#L289) | The Private Service Access configuration. | <code>list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
+| [routes](variables.tf#L321) | Network routes, keyed by name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [routing_mode](variables.tf#L342) | The network routing mode (default 'GLOBAL'). | <code>string</code> |  | <code>&#34;GLOBAL&#34;</code> |
+| [service_connection_policies](variables.tf#L352) | Service connection policies, keyed by name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [shared_vpc_host](variables.tf#L394) | Enable shared VPC for this project. | <code>bool</code> |  | <code>false</code> |
+| [shared_vpc_service_projects](variables.tf#L400) | Shared VPC service projects to register with this host. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
+| [subnets](variables.tf#L406) | Subnet configuration. | <code>list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
+| [subnets_private_nat](variables.tf#L486) | List of private NAT subnets. | <code>list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
+| [subnets_proxy_only](variables.tf#L498) | List of proxy-only subnets for Regional HTTPS or Internal HTTPS load balancers. Note: Only one proxy-only subnet for each VPC network in each region can be active. | <code>list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
+| [subnets_psc](variables.tf#L532) | List of subnets for Private Service Connect service producers. | <code>list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
+| [vpc_reuse](variables.tf#L572) | Reuse existing VPC if not null. If the network_id number is not passed in, a data source is used. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
 
 ## Outputs
 

--- a/modules/net-vpc/main.tf
+++ b/modules/net-vpc/main.tf
@@ -90,6 +90,9 @@ resource "google_compute_network" "network" {
   network_firewall_policy_enforcement_order = var.firewall_policy_enforcement_order
   enable_ula_internal_ipv6                  = var.ipv6_config.enable_ula_internal
   internal_ipv6_range                       = var.ipv6_config.internal_range
+  bgp_always_compare_med                    = try(var.bgp_config.always_compare_med, null)
+  bgp_best_path_selection_mode              = try(var.bgp_config.best_path_selection_mode, null)
+  bgp_inter_region_cost                     = try(var.bgp_config.inter_region_cost, null)
 }
 
 resource "google_compute_network_peering" "local" {

--- a/modules/net-vpc/variables.tf
+++ b/modules/net-vpc/variables.tf
@@ -28,6 +28,20 @@ variable "bgp_config" {
     inter_region_cost        = optional(string)
   })
   default = null
+  validation {
+    condition = (
+      try(var.bgp_config.best_path_selection_mode, null) == null ||
+      contains(["LEGACY", "STANDARD"], try(var.bgp_config.best_path_selection_mode, ""))
+    )
+    error_message = "best_path_selection_mode must be one of: LEGACY, STANDARD."
+  }
+  validation {
+    condition = (
+      try(var.bgp_config.inter_region_cost, null) == null ||
+      contains(["DEFAULT", "ADD_COST_TO_MED"], try(var.bgp_config.inter_region_cost, ""))
+    )
+    error_message = "inter_region_cost must be one of: DEFAULT, ADD_COST_TO_MED."
+  }
 }
 
 variable "context" {

--- a/modules/net-vpc/variables.tf
+++ b/modules/net-vpc/variables.tf
@@ -20,6 +20,16 @@ variable "auto_create_subnetworks" {
   default     = false
 }
 
+variable "bgp_config" {
+  description = "Optional BGP path selection configuration."
+  type = object({
+    always_compare_med       = optional(bool)
+    best_path_selection_mode = optional(string)
+    inter_region_cost        = optional(string)
+  })
+  default = null
+}
+
 variable "context" {
   description = "Context-specific interpolations."
   type = object({

--- a/tests/modules/net_vpc/bgp_config.tfvars
+++ b/tests/modules/net_vpc/bgp_config.tfvars
@@ -1,0 +1,5 @@
+bgp_config = {
+  always_compare_med       = true
+  best_path_selection_mode = "STANDARD"
+  inter_region_cost        = "ADD_COST_TO_MED"
+}

--- a/tests/modules/net_vpc/bgp_config.yaml
+++ b/tests/modules/net_vpc/bgp_config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,14 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-module: modules/net-vpc
-common_tfvars:
-  - common.tfvars
-
-tests:
-  bgp_config:
-  context:
-  shared_vpc:
-  psa_routes_export:
-  psa_routes_import:
-  psa_routes_import_export:
+values:
+  google_compute_network.network[0]:
+    auto_create_subnetworks: false
+    delete_default_routes_on_create: false
+    description: Terraform-managed.
+    enable_ula_internal_ipv6: null
+    name: test
+    network_firewall_policy_enforcement_order: AFTER_CLASSIC_FIREWALL
+    network_profile: null
+    params: []
+    project: test-project
+    routing_mode: GLOBAL
+    bgp_always_compare_med: true
+    bgp_best_path_selection_mode: STANDARD
+    bgp_inter_region_cost: ADD_COST_TO_MED

--- a/tests/modules/net_vpc_factory/examples/example.yaml
+++ b/tests/modules/net_vpc_factory/examples/example.yaml
@@ -38,6 +38,9 @@ values:
     timeouts: null
   module.net-vpc-factory.module.vpcs["data-vpc-0"].google_compute_network.network[0]:
     auto_create_subnetworks: false
+    bgp_always_compare_med: true
+    bgp_best_path_selection_mode: STANDARD
+    bgp_inter_region_cost: ADD_COST_TO_MED
     delete_bgp_always_compare_med: false
     delete_default_routes_on_create: true
     description: Terraform managed


### PR DESCRIPTION
- net-vpc: Add optional `bgp_config` variable and support configuring `bgp_always_compare_med`, `bgp_best_path_selection_mode`, and `bgp_inter_region_cost` on `google_compute_network`.


I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [x] Made sure all relevant tests pass