### PR TITLE
Add TPU VM and Queued Resource support to compute-vm module

### DIFF
--- a/modules/compute-vm/README.md
+++ b/modules/compute-vm/README.md
@@ -44,6 +44,10 @@ In both modes, an optional service account can be created and assigned to either
   - [Snapshot Schedules](#snapshot-schedules)
   - [Resource Manager Tags](#resource-manager-tags)
   - [Sole Tenancy](#sole-tenancy)
+  - [TPU](#tpu)
+    - [Direct TPU VM](#direct-tpu-vm)
+    - [Queued TPU Resource](#queued-tpu-resource)
+    - [TPU Instance Template](#tpu-instance-template)
 - [Variables](#variables)
 - [Outputs](#outputs)
 - [Fixtures](#fixtures)
@@ -1207,50 +1211,123 @@ module "sole-tenancy" {
 }
 # tftest inventory=sole-tenancy.yaml
 ```
+### TPU
+
+> [!IMPORTANT]
+> To deploy TPU resources:
+> 1. Enable the Cloud TPU API (`tpu.googleapis.com`) on the project.
+> 2. If using Shared VPC, ensure the TPU Service Agent (`service-<PROJECT_NUMBER>@gcp-sa-tpu.iam.gserviceaccount.com`) is granted the TPU Shared VPC Agent role (`roles/tpu.xpnAgent`) on the host project.
+
+#### Direct TPU VM
+
+This example shows how to deploy a TPU VM directly.
+
+```hcl
+module "tpu-direct" {
+  source       = "./fabric/modules/compute-vm"
+  project_id   = var.project_id
+  zone         = "${var.region}-b"
+  name         = "tpu-direct"
+  machine_type = "ct5lp-hightpu-1t"
+  network_interfaces = [{
+    network    = var.vpc.self_link
+    subnetwork = var.subnet.self_link
+  }]
+  tpu_config = {
+    runtime_version = "v2-alpha-tpuv5-lite"
+    queued          = false
+  }
+}
+# tftest modules=1 resources=1
+```
+
+#### Queued TPU Resource
+
+This example shows how to deploy a TPU VM as a Queued Resource.
+
+```hcl
+module "tpu-queued" {
+  source       = "./fabric/modules/compute-vm"
+  project_id   = var.project_id
+  zone         = "${var.region}-b"
+  name         = "tpu-queued"
+  machine_type = "ct5lp-hightpu-1t"
+  network_interfaces = [{
+    network    = var.vpc.self_link
+    subnetwork = var.subnet.self_link
+  }]
+  tpu_config = {
+    runtime_version = "v2-alpha-tpuv5-lite"
+  }
+}
+# tftest modules=1 resources=1
+```
+
+#### TPU Instance Template
+
+This example shows how to create an instance template for TPU VMs.
+
+```hcl
+module "tpu-template" {
+  source       = "./fabric/modules/compute-vm"
+  project_id   = var.project_id
+  zone         = "${var.region}-b"
+  name         = "tpu-template"
+  machine_type = "ct5lp-hightpu-1t"
+  network_interfaces = [{
+    network    = var.vpc.self_link
+    subnetwork = var.subnet.self_link
+  }]
+  create_template = {}
+  tpu_config      = {}
+}
+# tftest modules=1 resources=1
+```
 <!-- BEGIN TFDOC -->
 ## Variables
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [name](variables.tf#L356) | Instance name. | <code>string</code> | ✓ |  |
-| [network_interfaces](variables.tf#L368) | Network interfaces configuration. Use self links for Shared VPC, set addresses to null if not needed. | <code>list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> | ✓ |  |
-| [project_id](variables.tf#L408) | Project id. | <code>string</code> | ✓ |  |
-| [zone](variables.tf#L565) | Compute zone. | <code>string</code> | ✓ |  |
+| [name](variables.tf#L357) | Instance name. | <code>string</code> | ✓ |  |
+| [network_interfaces](variables.tf#L369) | Network interfaces configuration. Use self links for Shared VPC, set addresses to null if not needed. | <code>list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> | ✓ |  |
+| [project_id](variables.tf#L409) | Project id. | <code>string</code> | ✓ |  |
+| [zone](variables.tf#L589) | Compute zone. | <code>string</code> | ✓ |  |
 | [attached_disks](variables.tf#L17) | Additional disks. Source type is one of 'image' (zonal disks in vms and template), 'snapshot' (vm), 'existing', and null. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [boot_disk](variables.tf#L57) | Boot disk properties. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [can_ip_forward](variables.tf#L112) | Enable IP forwarding. | <code>bool</code> |  | <code>false</code> |
-| [confidential_compute](variables.tf#L118) | Confidential Compute configuration. Set to 'SEV' or 'SEV_SNP' to enable. | <code>string</code> |  | <code>null</code> |
-| [context](variables.tf#L128) | Context-specific interpolations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [create_template](variables.tf#L149) | Create instance template instead of instances. Defaults to a global template. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [description](variables.tf#L158) | Description of a Compute Instance. | <code>string</code> |  | <code>&#34;Managed by the compute-vm Terraform module.&#34;</code> |
-| [enable_display](variables.tf#L164) | Enable virtual display on the instances. | <code>bool</code> |  | <code>false</code> |
-| [encryption](variables.tf#L170) | Encryption options. Only one of kms_key_self_link and disk_encryption_key_raw may be set. If needed, you can specify to encrypt or not the boot disk. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [gpu](variables.tf#L181) | GPU information. Based on https://cloud.google.com/compute/docs/gpus. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [group](variables.tf#L216) | Instance group configuration. Set 'named_ports' to create a new unmanaged instance group, or provide an existing group self_link/id in 'membership' to join one. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [hostname](variables.tf#L225) | Instance FQDN name. | <code>string</code> |  | <code>null</code> |
-| [iam](variables.tf#L231) | IAM bindings in {ROLE => [MEMBERS]} format. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [instance_schedule](variables.tf#L237) | Assign or create and assign an instance schedule policy. Set active to null to detach a policy from vm before destroying. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [kms_autokeys](variables.tf#L261) | KMS Autokey key handles. If location is not specified it will be inferred from the zone. Key handle names will be added to the kms_keys context with an `autokeys/` prefix. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [labels](variables.tf#L279) | Instance labels. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
-| [lifecycle_config](variables.tf#L285) | Instance lifecycle and operational configurations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [machine_features_config](variables.tf#L307) | Machine-level configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [machine_type](variables.tf#L331) | Machine type. | <code>string</code> |  | <code>&#34;e2-micro&#34;</code> |
-| [metadata](variables.tf#L337) | Instance metadata. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
-| [metadata_startup_script](variables.tf#L343) | Instance startup script. Will trigger recreation on change, even after importing. | <code>string</code> |  | <code>null</code> |
-| [min_cpu_platform](variables.tf#L350) | Minimum CPU platform. | <code>string</code> |  | <code>null</code> |
-| [network_attached_interfaces](variables.tf#L361) | Network interfaces using network attachments. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
-| [network_performance_tier](variables.tf#L391) | Network performance total egress bandwidth tier. | <code>string</code> |  | <code>null</code> |
-| [network_tag_bindings](variables.tf#L401) | Resource manager tag bindings in arbitrary key => tag key or value id format. Set on both the instance only for networking purposes, and modifiable without impacting the main resource lifecycle. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
-| [project_number](variables.tf#L413) | Project number. Used in tag bindings to avoid a permadiff. | <code>string</code> |  | <code>null</code> |
-| [resource_policies](variables.tf#L419) | Resource policies to attach to the instance or template. | <code>list&#40;string&#41;</code> |  | <code>null</code> |
-| [scheduling_config](variables.tf#L426) | Scheduling configuration for the instance. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [scratch_disks](variables.tf#L461) | Scratch disks configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#8230;&#125;</code> |
-| [service_account](variables.tf#L474) | Service account email and scopes. If email is null, the default Compute service account will be used unless auto_create is true, in which case a service account will be created. Set the variable to null to avoid attaching a service account. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [shielded_config](variables.tf#L485) | Shielded VM configuration of the instances. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [snapshot_schedules](variables.tf#L495) | Snapshot schedule resource policies that can be attached to disks. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [tag_bindings](variables.tf#L538) | Resource manager tag bindings in arbitrary key => tag key or value id format. Set on both the instance and zonal disks, and modifiable without impacting the main resource lifecycle. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
-| [tag_bindings_immutable](variables.tf#L545) | Immutable resource manager tag bindings, in tagKeys/id => tagValues/id format. These are set on the instance or instance template at creation time, and trigger recreation if changed. | <code>map&#40;string&#41;</code> |  | <code>null</code> |
-| [tags](variables.tf#L559) | Instance network tags for firewall rule targets. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
+| [can_ip_forward](variables.tf#L113) | Enable IP forwarding. | <code>bool</code> |  | <code>false</code> |
+| [confidential_compute](variables.tf#L119) | Confidential Compute configuration. Set to 'SEV' or 'SEV_SNP' to enable. | <code>string</code> |  | <code>null</code> |
+| [context](variables.tf#L129) | Context-specific interpolations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [create_template](variables.tf#L150) | Create instance template instead of instances. Defaults to a global template. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [description](variables.tf#L159) | Description of a Compute Instance. | <code>string</code> |  | <code>&#34;Managed by the compute-vm Terraform module.&#34;</code> |
+| [enable_display](variables.tf#L165) | Enable virtual display on the instances. | <code>bool</code> |  | <code>false</code> |
+| [encryption](variables.tf#L171) | Encryption options. Only one of kms_key_self_link and disk_encryption_key_raw may be set. If needed, you can specify to encrypt or not the boot disk. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [gpu](variables.tf#L182) | GPU information. Based on https://cloud.google.com/compute/docs/gpus. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [group](variables.tf#L217) | Instance group configuration. Set 'named_ports' to create a new unmanaged instance group, or provide an existing group self_link/id in 'membership' to join one. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [hostname](variables.tf#L226) | Instance FQDN name. | <code>string</code> |  | <code>null</code> |
+| [iam](variables.tf#L232) | IAM bindings in {ROLE => [MEMBERS]} format. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [instance_schedule](variables.tf#L238) | Assign or create and assign an instance schedule policy. Set active to null to detach a policy from vm before destroying. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [kms_autokeys](variables.tf#L262) | KMS Autokey key handles. If location is not specified it will be inferred from the zone. Key handle names will be added to the kms_keys context with an `autokeys/` prefix. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [labels](variables.tf#L280) | Instance labels. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [lifecycle_config](variables.tf#L286) | Instance lifecycle and operational configurations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [machine_features_config](variables.tf#L308) | Machine-level configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [machine_type](variables.tf#L332) | Machine type. | <code>string</code> |  | <code>&#34;e2-micro&#34;</code> |
+| [metadata](variables.tf#L338) | Instance metadata. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [metadata_startup_script](variables.tf#L344) | Instance startup script. Will trigger recreation on change, even after importing. | <code>string</code> |  | <code>null</code> |
+| [min_cpu_platform](variables.tf#L351) | Minimum CPU platform. | <code>string</code> |  | <code>null</code> |
+| [network_attached_interfaces](variables.tf#L362) | Network interfaces using network attachments. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
+| [network_performance_tier](variables.tf#L392) | Network performance total egress bandwidth tier. | <code>string</code> |  | <code>null</code> |
+| [network_tag_bindings](variables.tf#L402) | Resource manager tag bindings in arbitrary key => tag key or value id format. Set on both the instance only for networking purposes, and modifiable without impacting the main resource lifecycle. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [project_number](variables.tf#L414) | Project number. Used in tag bindings to avoid a permadiff. | <code>string</code> |  | <code>null</code> |
+| [resource_policies](variables.tf#L420) | Resource policies to attach to the instance or template. | <code>list&#40;string&#41;</code> |  | <code>null</code> |
+| [scheduling_config](variables.tf#L427) | Scheduling configuration for the instance. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [scratch_disks](variables.tf#L462) | Scratch disks configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#8230;&#125;</code> |
+| [service_account](variables.tf#L475) | Service account email and scopes. If email is null, the default Compute service account will be used unless auto_create is true, in which case a service account will be created. Set the variable to null to avoid attaching a service account. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [shielded_config](variables.tf#L486) | Shielded VM configuration of the instances. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [snapshot_schedules](variables.tf#L496) | Snapshot schedule resource policies that can be attached to disks. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [tag_bindings](variables.tf#L539) | Resource manager tag bindings in arbitrary key => tag key or value id format. Set on both the instance and zonal disks, and modifiable without impacting the main resource lifecycle. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [tag_bindings_immutable](variables.tf#L546) | Immutable resource manager tag bindings, in tagKeys/id => tagValues/id format. These are set on the instance or instance template at creation time, and trigger recreation if changed. | <code>map&#40;string&#41;</code> |  | <code>null</code> |
+| [tags](variables.tf#L560) | Instance network tags for firewall rule targets. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
+| [tpu_config](variables.tf#L566) | TPU configuration. If null, a standard VM is created. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
 
 ## Outputs
 

--- a/modules/compute-vm/README.md
+++ b/modules/compute-vm/README.md
@@ -1336,16 +1336,16 @@ module "tpu-template" {
 | [external_ip](outputs.tf#L17) | Instance main interface external IP addresses. |  |
 | [group](outputs.tf#L26) | Instance group resource. |  |
 | [id](outputs.tf#L31) | Fully qualified instance id. |  |
-| [instance](outputs.tf#L36) | Instance resource. | ✓ |
-| [internal_ip](outputs.tf#L42) | Instance main interface internal IP address. |  |
-| [internal_ips](outputs.tf#L50) | Instance interfaces internal IP addresses. |  |
-| [login_command](outputs.tf#L58) | Command to SSH into the machine. |  |
-| [self_link](outputs.tf#L63) | Instance self links. |  |
-| [service_account](outputs.tf#L68) | Service account resource. |  |
-| [service_account_email](outputs.tf#L73) | Service account email. |  |
-| [service_account_iam_email](outputs.tf#L78) | Service account email. |  |
-| [template](outputs.tf#L87) | Template resource. |  |
-| [template_name](outputs.tf#L96) | Template name. |  |
+| [instance](outputs.tf#L41) | Instance resource. | ✓ |
+| [internal_ip](outputs.tf#L47) | Instance main interface internal IP address. |  |
+| [internal_ips](outputs.tf#L56) | Instance interfaces internal IP addresses. |  |
+| [login_command](outputs.tf#L70) | Command to SSH into the machine. |  |
+| [self_link](outputs.tf#L75) | Instance self links. |  |
+| [service_account](outputs.tf#L80) | Service account resource. |  |
+| [service_account_email](outputs.tf#L85) | Service account email. |  |
+| [service_account_iam_email](outputs.tf#L90) | Service account email. |  |
+| [template](outputs.tf#L99) | Template resource. |  |
+| [template_name](outputs.tf#L108) | Template name. |  |
 
 ## Fixtures
 

--- a/modules/compute-vm/disks.tf
+++ b/modules/compute-vm/disks.tf
@@ -33,7 +33,7 @@ locals {
 
 resource "google_compute_disk" "boot" {
   count = (
-    !local.is_template && var.boot_disk.use_independent_disk != null ? 1 : 0
+    !local.is_template && !local.is_tpu && var.boot_disk.use_independent_disk != null ? 1 : 0
   )
   project = local.project_id
   zone    = local.zone

--- a/modules/compute-vm/instance.tf
+++ b/modules/compute-vm/instance.tf
@@ -16,7 +16,7 @@
 
 resource "google_compute_instance" "default" {
   provider                   = google-beta
-  count                      = local.is_template ? 0 : 1
+  count                      = local.is_gce ? 1 : 0
   project                    = local.project_id
   zone                       = local.zone
   name                       = var.name

--- a/modules/compute-vm/main.tf
+++ b/modules/compute-vm/main.tf
@@ -28,14 +28,18 @@ locals {
     for k, v in google_kms_key_handle.default :
     "$kms_keys:autokeys/${k}" => v.kms_key
   })
-  ctx_p = "$"
-  gpu   = var.gpu != null
+  ctx_p       = "$"
+  gpu         = var.gpu != null
+  is_gce      = !local.is_template && !local.is_tpu
+  is_template = var.create_template != null
+  is_tpu      = var.tpu_config != null
   on_host_maintenance = coalesce(
     var.scheduling_config.on_host_maintenance,
     (
       var.scheduling_config.provisioning_model == "SPOT" ||
       var.confidential_compute != null ||
-      local.gpu
+      local.gpu ||
+      local.is_tpu
     ) ? "TERMINATE" : "MIGRATE"
   )
   project_id = lookup(local.ctx.project_ids, var.project_id, var.project_id)

--- a/modules/compute-vm/outputs.tf
+++ b/modules/compute-vm/outputs.tf
@@ -30,7 +30,12 @@ output "group" {
 
 output "id" {
   description = "Fully qualified instance id."
-  value       = try(google_compute_instance.default[0].id, null)
+  value = try(
+    google_compute_instance.default[0].id,
+    google_tpu_v2_vm.default[0].id,
+    google_tpu_v2_queued_resource.default[0].id,
+    null
+  )
 }
 
 output "instance" {
@@ -43,16 +48,23 @@ output "internal_ip" {
   description = "Instance main interface internal IP address."
   value = try(
     google_compute_instance.default[0].network_interface[0].network_ip,
+    google_tpu_v2_vm.default[0].network_endpoints[0].ip_address,
     null
   )
 }
 
 output "internal_ips" {
   description = "Instance interfaces internal IP addresses."
-  value = [
-    for nic in try(google_compute_instance.default[0].network_interface, [])
-    : nic.network_ip
-  ]
+  value = concat(
+    [
+      for nic in try(google_compute_instance.default[0].network_interface, [])
+      : nic.network_ip
+    ],
+    [
+      for ep in try(google_tpu_v2_vm.default[0].network_endpoints, [])
+      : ep.ip_address
+    ]
+  )
 }
 
 output "login_command" {

--- a/modules/compute-vm/template.tf
+++ b/modules/compute-vm/template.tf
@@ -15,7 +15,6 @@
  */
 
 locals {
-  is_template       = var.create_template != null
   template_regional = try(var.create_template.regional, null) == true
 }
 

--- a/modules/compute-vm/tpu.tf
+++ b/modules/compute-vm/tpu.tf
@@ -1,0 +1,118 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  is_tpu_queued = local.is_tpu && !local.is_template && try(var.tpu_config.queued, true)
+  is_tpu_direct = local.is_tpu && !local.is_template && !local.is_tpu_queued
+  tpu_accelerator_type = try(lookup(
+    local.tpu_machine_type_to_accelerator_type, var.machine_type, var.machine_type
+  ), null)
+  tpu_machine_type_to_accelerator_type = {
+    # TPU v5e (Lite)
+    "ct5lp-hightpu-1t" = "v5litepod-1"
+    "ct5lp-hightpu-4t" = "v5litepod-4"
+    "ct5lp-hightpu-8t" = "v5litepod-8"
+    # TPU v5p
+    "ct5p-hightpu-4t" = "v5p-8"
+    # TPU v6e (Trillium)
+    "ct6e-standard-1t" = "v6e-1"
+    "ct6e-standard-4t" = "v6e-4"
+    "ct6e-standard-8t" = "v6e-8"
+  }
+}
+
+check "tpu_machine_type_unparsed" {
+  assert {
+    condition = (
+      var.tpu_config == null ? true : (
+        try(regex("^(?:ct|v)([0-9])", var.machine_type), "---") != "---"
+      )
+    )
+    error_message = "WARNING: TPU machine type generation could not be parsed. TPU compatibility validation was skipped for the machine type."
+  }
+}
+
+check "tpu_runtime_unparsed" {
+  assert {
+    condition = (
+      var.tpu_config == null || var.tpu_config.runtime_version == null ? true : (
+        try(coalesce(regex("(?:tpuv([0-9])|\\-v([0-9])\\-)", var.tpu_config.runtime_version)...), "---") != "---"
+      )
+    )
+    error_message = "WARNING: TPU runtime version generation could not be parsed. TPU compatibility validation was skipped for the runtime."
+  }
+}
+
+resource "google_tpu_v2_vm" "tpu" {
+  provider         = google-beta
+  count            = local.is_tpu_direct ? 1 : 0
+  name             = var.name
+  project          = local.project_id
+  zone             = local.zone
+  accelerator_type = local.tpu_accelerator_type
+  runtime_version  = var.tpu_config.runtime_version
+  network_config {
+    network             = lookup(local.ctx.networks, var.network_interfaces[0].network, var.network_interfaces[0].network)
+    subnetwork          = lookup(local.ctx.subnets, var.network_interfaces[0].subnetwork, var.network_interfaces[0].subnetwork)
+    enable_external_ips = try(var.network_interfaces[0].nat, false)
+  }
+  scheduling_config {
+    preemptible = var.scheduling_config.provisioning_model == "SPOT"
+  }
+  dynamic "service_account" {
+    for_each = var.service_account == null ? [] : [""]
+    content {
+      email = local.service_account.email
+      scope = local.service_account.scopes
+    }
+  }
+  dynamic "data_disks" {
+    for_each = local.attached_disks_ordered
+    content {
+      source_disk = (
+        var.attached_disks[data_disks.value.key].source.attach != null
+        ? var.attached_disks[data_disks.value.key].source.attach
+        : data_disks.value.is_regional ? google_compute_region_disk.disks[data_disks.value.key].id : google_compute_disk.disks[data_disks.value.key].id
+      )
+      mode = var.attached_disks[data_disks.value.key].mode
+    }
+  }
+  metadata = var.metadata
+  labels   = var.labels
+}
+
+resource "google_tpu_v2_queued_resource" "tpu_queued" {
+  provider = google-beta
+  count    = local.is_tpu_queued ? 1 : 0
+  name     = var.name
+  project  = local.project_id
+  zone     = local.zone
+  tpu {
+    node_spec {
+      parent  = "projects/${local.project_id}/locations/${local.zone}"
+      node_id = var.name
+      node {
+        accelerator_type = local.tpu_accelerator_type
+        runtime_version  = var.tpu_config.runtime_version
+        network_config {
+          network             = lookup(local.ctx.networks, var.network_interfaces[0].network, var.network_interfaces[0].network)
+          subnetwork          = lookup(local.ctx.subnets, var.network_interfaces[0].subnetwork, var.network_interfaces[0].subnetwork)
+          enable_external_ips = try(var.network_interfaces[0].nat, false)
+        }
+      }
+    }
+  }
+}

--- a/modules/compute-vm/tpu.tf
+++ b/modules/compute-vm/tpu.tf
@@ -34,29 +34,7 @@ locals {
   }
 }
 
-check "tpu_machine_type_unparsed" {
-  assert {
-    condition = (
-      var.tpu_config == null ? true : (
-        try(regex("^(?:ct|v)([0-9])", var.machine_type), "---") != "---"
-      )
-    )
-    error_message = "WARNING: TPU machine type generation could not be parsed. TPU compatibility validation was skipped for the machine type."
-  }
-}
-
-check "tpu_runtime_unparsed" {
-  assert {
-    condition = (
-      var.tpu_config == null || var.tpu_config.runtime_version == null ? true : (
-        try(coalesce(regex("(?:tpuv([0-9])|\\-v([0-9])\\-)", var.tpu_config.runtime_version)...), "---") != "---"
-      )
-    )
-    error_message = "WARNING: TPU runtime version generation could not be parsed. TPU compatibility validation was skipped for the runtime."
-  }
-}
-
-resource "google_tpu_v2_vm" "tpu" {
+resource "google_tpu_v2_vm" "default" {
   provider         = google-beta
   count            = local.is_tpu_direct ? 1 : 0
   name             = var.name
@@ -94,7 +72,7 @@ resource "google_tpu_v2_vm" "tpu" {
   labels   = var.labels
 }
 
-resource "google_tpu_v2_queued_resource" "tpu_queued" {
+resource "google_tpu_v2_queued_resource" "default" {
   provider = google-beta
   count    = local.is_tpu_queued ? 1 : 0
   name     = var.name

--- a/modules/compute-vm/variables.tf
+++ b/modules/compute-vm/variables.tf
@@ -85,6 +85,7 @@ variable "boot_disk" {
   nullable = false
   validation {
     condition = (
+      var.tpu_config != null ||
       var.boot_disk.initialize_params != null ||
       var.boot_disk.source.attach != null ||
       var.boot_disk.source.snapshot != null ||
@@ -560,6 +561,29 @@ variable "tags" {
   description = "Instance network tags for firewall rule targets."
   type        = list(string)
   default     = []
+}
+
+variable "tpu_config" {
+  description = "TPU configuration. If null, a standard VM is created."
+  type = object({
+    runtime_version = optional(string)
+    queued          = optional(bool, true)
+  })
+  default = null
+  validation {
+    condition = (
+      var.tpu_config == null ||
+      var.create_template != null ||
+      var.tpu_config.runtime_version != null
+    )
+    error_message = "TPU runtime version must be specified when creating a TPU VM."
+  }
+  validation {
+    condition = try(var.tpu_config.runtime_version, null) == null || (
+      try(regex("^(?:ct|v)([0-9])", var.machine_type)[0], "---") == try(coalesce(regex("(?:tpuv([0-9])|\\-v([0-9])\\-)", var.tpu_config.runtime_version)...), "---")
+    )
+    error_message = "TPU machine type and runtime version compatibility check failed. Please ensure both are of the same generation (v5 or v6)."
+  }
 }
 
 variable "zone" {

--- a/tests/modules/compute-vm/common.tfvars
+++ b/tests/modules/compute-vm/common.tfvars
@@ -1,0 +1,7 @@
+project_id = "my-project"
+zone       = "us-central1-b"
+name       = "test"
+network_interfaces = [{
+  network    = "https://www.googleapis.com/compute/v1/projects/my-project/global/networks/default"
+  subnetwork = "https://www.googleapis.com/compute/v1/projects/my-project/regions/us-central1/subnetworks/default"
+}]

--- a/tests/modules/compute-vm/tftest.yaml
+++ b/tests/modules/compute-vm/tftest.yaml
@@ -1,0 +1,23 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module: modules/compute-vm
+
+common_tfvars:
+  - common.tfvars
+
+tests:
+  tpu_direct:
+  tpu_queued:
+  tpu_template:

--- a/tests/modules/compute-vm/tpu_direct.tfvars
+++ b/tests/modules/compute-vm/tpu_direct.tfvars
@@ -1,0 +1,5 @@
+machine_type = "ct5lp-hightpu-1t"
+tpu_config = {
+  runtime_version = "v2-alpha-tpuv5-lite"
+  queued          = false
+}

--- a/tests/modules/compute-vm/tpu_direct.yaml
+++ b/tests/modules/compute-vm/tpu_direct.yaml
@@ -1,0 +1,22 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values:
+  google_tpu_v2_vm.tpu[0]:
+    name: test
+    accelerator_type: v5litepod-1
+    runtime_version: v2-alpha-tpuv5-lite
+
+counts:
+  google_tpu_v2_vm: 1

--- a/tests/modules/compute-vm/tpu_direct.yaml
+++ b/tests/modules/compute-vm/tpu_direct.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 values:
-  google_tpu_v2_vm.tpu[0]:
+  google_tpu_v2_vm.default[0]:
     name: test
     accelerator_type: v5litepod-1
     runtime_version: v2-alpha-tpuv5-lite

--- a/tests/modules/compute-vm/tpu_queued.tfvars
+++ b/tests/modules/compute-vm/tpu_queued.tfvars
@@ -1,0 +1,4 @@
+machine_type = "ct5lp-hightpu-1t"
+tpu_config = {
+  runtime_version = "v2-alpha-tpuv5-lite"
+}

--- a/tests/modules/compute-vm/tpu_queued.yaml
+++ b/tests/modules/compute-vm/tpu_queued.yaml
@@ -1,0 +1,20 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values:
+  google_tpu_v2_queued_resource.tpu_queued[0]:
+    name: test
+
+counts:
+  google_tpu_v2_queued_resource: 1

--- a/tests/modules/compute-vm/tpu_queued.yaml
+++ b/tests/modules/compute-vm/tpu_queued.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 values:
-  google_tpu_v2_queued_resource.tpu_queued[0]:
+  google_tpu_v2_queued_resource.default[0]:
     name: test
 
 counts:

--- a/tests/modules/compute-vm/tpu_template.tfvars
+++ b/tests/modules/compute-vm/tpu_template.tfvars
@@ -1,0 +1,3 @@
+machine_type    = "ct5lp-hightpu-1t"
+create_template = {}
+tpu_config      = {}

--- a/tests/modules/compute-vm/tpu_template.yaml
+++ b/tests/modules/compute-vm/tpu_template.yaml
@@ -1,0 +1,20 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values:
+  google_compute_instance_template.default[0]:
+    machine_type: ct5lp-hightpu-1t
+
+counts:
+  google_compute_instance_template: 1

--- a/tools/check_documentation.py
+++ b/tools/check_documentation.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python3
-
+#
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "click",
+#   "marko",
+# ]
+# ///
 # Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
This PR introduces support for Cloud TPU VMs (v2) and Queued TPU resources to the `compute-vm` module.

### Key Changes

* **TPU VM Support**: Added the `google_tpu_v2_vm` resource to allow deploying TPU VMs directly.
* **Queued TPU Support**: Added the `google_tpu_v2_queued_resource` resource to allow requesting TPUs via the Queued Resources API.
* **Compatibility Validation**: Added input validations in `variables.tf` to ensure the selected `machine_type` matches the TPU `runtime_version` generation
(e.g., ensuring both are v5 or v6).
* **Documentation**: Updated `modules/compute-vm/README.md` with examples and a note on TPU deployment prerequisites:
  1. Activating the Cloud TPU API (`tpu.googleapis.com`).
  2. Granting the TPU Shared VPC Agent role (`roles/tpu.xpnAgent`) to the TPU Service Agent on the host project when using Shared VPC.
* **Unit Tests**: Added test scenarios in `tests/modules/compute-vm/` covering direct TPU, queued TPU, and TPU template configurations.

Tested by deploying a TPU and a TPU instance template in europe-west4 in a Shared VPC + VPC-SC setup.