### PR TITLE
feat(fast/data-mongodb): add MongoDB Atlas database user resource

### DIFF
--- a/fast/project-templates/data-mongodb/README.md
+++ b/fast/project-templates/data-mongodb/README.md
@@ -15,7 +15,7 @@ This Terraform can of course be deployed using any pre-existing project. In that
 
 ## Variable Configuration
 
-Configuration is mostly done via the `atlas_config` and `vpc_config` variables. Note that:
+Configuration is mostly done via the `atlas_config`, `database_user`, and `vpc_config` variables. Note that:
 
 - VPC configuration can be set to reference a Shared VPC Host network like shown below, or an in-project network if that is preferred
 - the PSC CIDR block is used to allocate the required 50 endpoint addresses in the VPC, so it needs to be large enough to accommodate them
@@ -36,6 +36,10 @@ atlas_config = {
     private_key = "xxxxx-xxxx-xxxx-xxxx-xxxxxxxx"
   }
 }
+database_user = {
+  database_user_name     = "my-db-user"
+  database_user_password = "s3cr3t-p4ssw0rd"
+}
 project_id = "my-prod-shared-mongodb-0"
 vpc_config = {
   network_name   = "dev-spoke-0"
@@ -50,9 +54,10 @@ vpc_config = {
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
 | [atlas_config](variables.tf#L17) | MongoDB Atlas configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
-| [project_id](variables.tf#L40) | Project id where the registries will be created. | <code>string</code> | ✓ |  |
-| [vpc_config](variables.tf#L45) | VPC configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
-| [name](variables.tf#L33) | Prefix used for all resource names. | <code>string</code> |  | <code>&#34;mongodb&#34;</code> |
+| [database_user](variables.tf#L33) | MongoDB Atlas database user configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
+| [project_id](variables.tf#L48) | Project id where the registries will be created. | <code>string</code> | ✓ |  |
+| [vpc_config](variables.tf#L53) | VPC configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
+| [name](variables.tf#L41) | Prefix used for all resource names. | <code>string</code> |  | <code>&#34;mongodb&#34;</code> |
 
 ## Outputs
 
@@ -79,6 +84,10 @@ module "test" {
       private_key = "xxxxx-xxxx-xxxx-xxxx-xxxxxxxx"
     }
   }
+  database_user = {
+    database_user_name     = "my-db-user"
+    database_user_password = "s3cr3t-p4ssw0rd"
+  }
   project_id = "my-prod-shared-mongodb-0"
   vpc_config = {
     network_name   = "dev-spoke-0"
@@ -86,5 +95,5 @@ module "test" {
     psc_cidr_block = "10.8.11.192/26"
   }
 }
-# tftest modules=2 resources=104
+# tftest modules=2 resources=105
 ```

--- a/fast/project-templates/data-mongodb/main.tf
+++ b/fast/project-templates/data-mongodb/main.tf
@@ -73,3 +73,15 @@ resource "mongodbatlas_privatelink_endpoint_service" "default" {
     }
   }
 }
+
+resource "mongodbatlas_database_user" "database_user" {
+  username           = var.database_user.database_user_name
+  password           = var.database_user.database_user_password
+  project_id         = mongodbatlas_project.default.id
+  auth_database_name = "admin"
+
+  roles {
+    role_name     = "readAnyDatabase"
+    database_name = "admin"
+  }
+}

--- a/fast/project-templates/data-mongodb/variables.tf
+++ b/fast/project-templates/data-mongodb/variables.tf
@@ -30,6 +30,14 @@ variable "atlas_config" {
   })
 }
 
+variable "database_user" {
+  description = "MongoDB Atlas database user configuration."
+  type = object({
+    database_user_name     = string
+    database_user_password = string
+  })
+}
+
 variable "name" {
   description = "Prefix used for all resource names."
   type        = string


### PR DESCRIPTION
<!-- Put a description of what this PR is for here -->

Add MongoDB Atlas database user support to the `data-mongodb` project template.

A new `mongodbatlas_database_user` resource is provisioned as part of the template, configured via a new required `database_user` variable. The user is created with the `readAnyDatabase` role scoped to the `admin` database.

---
**Checklist**

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
