### PR TITLE
Add DNS peering support to agent-gateway module

### DIFF
--- a/default-versions.tf
+++ b/default-versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/default-versions.tofu
+++ b/default-versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/fast/project-templates/managed-kafka/versions.tf
+++ b/fast/project-templates/managed-kafka/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/__experimental_deprecated/alloydb-instance/versions.tf
+++ b/modules/__experimental_deprecated/alloydb-instance/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/__experimental_deprecated/alloydb-instance/versions.tofu
+++ b/modules/__experimental_deprecated/alloydb-instance/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/__experimental_deprecated/net-neg/versions.tf
+++ b/modules/__experimental_deprecated/net-neg/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/__experimental_deprecated/net-neg/versions.tofu
+++ b/modules/__experimental_deprecated/net-neg/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/__experimental_deprecated/project-iam-magic/versions.tf
+++ b/modules/__experimental_deprecated/project-iam-magic/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/__experimental_deprecated/project-iam-magic/versions.tofu
+++ b/modules/__experimental_deprecated/project-iam-magic/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/agent-engine/versions.tf
+++ b/modules/agent-engine/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/agent-engine/versions.tofu
+++ b/modules/agent-engine/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/agent-gateway/README.md
+++ b/modules/agent-gateway/README.md
@@ -6,6 +6,7 @@ The module facilitates the deployments of Agent Gateways.
 - [API](#api)
 - [Minimal Gateway deployment](#minimal-gateway-deployment)
 - [PSC-I: attach to an existing service attachment](#psc-i-attach-to-an-existing-service-attachment)
+- [DNS Peering configuration](#dns-peering-configuration)
 - [Connect to self-managed proxies](#connect-to-self-managed-proxies)
 - [Context](#context)
 - [Variables](#variables)
@@ -47,6 +48,29 @@ module "agent-gateway" {
   }
 }
 # tftest inventory=psc-i.yaml
+```
+
+## DNS Peering configuration
+
+You can configure DNS peering to forward DNS queries for specific domains to a target network in another project.
+
+```hcl
+module "agent-gateway" {
+  source      = "./fabric/modules/agent-gateway"
+  name        = "my-gateway"
+  project_id  = "my-project-id"
+  region      = "europe-west1"
+  access_path = "AGENT_TO_ANYWHERE"
+  networking_config = {
+    psc_i_network_attachment_id = "projects/my-project-id/regions/europe-west1/serviceAttachments/my-sa"
+    dns_peering_config = {
+      domains        = ["agents.internal."]
+      target_network = "projects/my-host-project/global/networks/my-vpc"
+      target_project = "my-host-project"
+    }
+  }
+}
+# tftest inventory=peering.yaml
 ```
 
 ## Connect to self-managed proxies
@@ -98,18 +122,17 @@ module "agent-gateway" {
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [name](variables.tf#L77) | The name of the Agent Gateway. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L93) | The ID of the project where the data stores and the agents will be created. | <code>string</code> | ✓ |  |
-| [region](variables.tf#L126) | The region where the agent gateway is created. | <code>string</code> | ✓ |  |
+| [name](variables.tf#L78) | The name of the Agent Gateway. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L100) | The ID of the project where the data stores and the agents will be created. | <code>string</code> | ✓ |  |
+| [region](variables.tf#L121) | The region where the agent gateway is created. | <code>string</code> | ✓ |  |
 | [access_path](variables.tf#L17) | The direction the gateway applies to: ingress (CLIENT_TO_AGENT) or egress (AGENT_TO_ANYWHERE) (if var.is_google_managed = false). | <code>string</code> |  | <code>null</code> |
 | [context](variables.tf#L47) | Context-specific interpolations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [description](variables.tf#L58) | The description of the Agent Gateway. | <code>string</code> |  | <code>&#34;Terraform managed.&#34;</code> |
-| [is_google_managed](variables.tf#L64) | Whether the Agent Gateway is Google or self-managed. | <code>bool</code> |  | <code>true</code> |
-| [labels](variables.tf#L71) | Labels to associate to the Agent Gateway. | <code>map&#40;string&#41;</code> |  | <code>null</code> |
-| [networking_config](variables.tf#L84) | The Agent Gateway networking configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [protocols](variables.tf#L99) | The protocols managed by the Agent Gateway. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#34;MCP&#34;&#93;</code> |
-| [proxy_uri](variables.tf#L111) | The uri of a compatible self-managed proxy (if var.is_google_managed = false). | <code>string</code> |  | <code>null</code> |
-| [registries](variables.tf#L132) | A list of Agent Registries containing the agents, MCP servers and tools governed by the Agent Gateway. Note: Currently limited to project-scoped registries Must be of format //agentregistry.googleapis.com/{version}/projects/{{project}}/locations/{{location}}. | <code>list&#40;string&#41;</code> |  | <code>null</code> |
+| [description](variables.tf#L59) | The description of the Agent Gateway. | <code>string</code> |  | <code>&#34;Terraform managed.&#34;</code> |
+| [is_google_managed](variables.tf#L65) | Whether the Agent Gateway is Google or self-managed. | <code>bool</code> |  | <code>true</code> |
+| [labels](variables.tf#L72) | Labels to associate to the Agent Gateway. | <code>map&#40;string&#41;</code> |  | <code>null</code> |
+| [networking_config](variables.tf#L85) | The Agent Gateway networking configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [proxy_uri](variables.tf#L106) | The uri of a compatible self-managed proxy (if var.is_google_managed = false). | <code>string</code> |  | <code>null</code> |
+| [registries](variables.tf#L127) | A list of Agent Registries containing the agents, MCP servers and tools governed by the Agent Gateway. Note: Currently limited to project-scoped registries Must be of format //agentregistry.googleapis.com/{version}/projects/{{project}}/locations/{{location}}. | <code>list&#40;string&#41;</code> |  | <code>null</code> |
 
 ## Outputs
 

--- a/modules/agent-gateway/main.tf
+++ b/modules/agent-gateway/main.tf
@@ -41,8 +41,8 @@ resource "google_network_services_agent_gateway" "default" {
   name        = var.name
   description = var.description
   labels      = var.labels
-  protocols   = var.protocols
   registries  = var.registries
+
 
   dynamic "google_managed" {
     for_each = var.is_google_managed ? [""] : []
@@ -58,14 +58,35 @@ resource "google_network_services_agent_gateway" "default" {
   }
 
   dynamic "network_config" {
-    for_each = local.network_attachment_id == null ? [] : [""]
+    for_each = local.network_attachment_id != null || var.networking_config.dns_peering_config != null ? [""] : []
 
     content {
-      egress {
-        network_attachment = local.network_attachment_id
+      dynamic "egress" {
+        for_each = local.network_attachment_id != null ? [""] : []
+        content {
+          network_attachment = local.network_attachment_id
+        }
+      }
+
+      dynamic "dns_peering_config" {
+        for_each = var.networking_config.dns_peering_config != null ? [""] : []
+        content {
+          domains = var.networking_config.dns_peering_config.domains
+          target_network = lookup(
+            local.ctx.networks,
+            var.networking_config.dns_peering_config.target_network,
+            var.networking_config.dns_peering_config.target_network
+          )
+          target_project = lookup(
+            local.ctx.project_ids,
+            var.networking_config.dns_peering_config.target_project,
+            var.networking_config.dns_peering_config.target_project
+          )
+        }
       }
     }
   }
+
 
   dynamic "self_managed" {
     for_each = var.is_google_managed ? [] : [""]

--- a/modules/agent-gateway/variables.tf
+++ b/modules/agent-gateway/variables.tf
@@ -48,6 +48,7 @@ variable "context" {
   description = "Context-specific interpolations."
   type = object({
     locations               = optional(map(string), {})
+    networks                = optional(map(string), {})
     project_ids             = optional(map(string), {})
     psc_network_attachments = optional(map(string), {})
   })
@@ -84,28 +85,22 @@ variable "name" {
 variable "networking_config" {
   description = "The Agent Gateway networking configuration."
   type = object({
+    dns_peering_config = optional(object({
+      domains        = list(string)
+      target_network = string
+      target_project = string
+    }))
     psc_i_network_attachment_id = optional(string)
   })
   nullable = false
   default  = {}
 }
 
+
 variable "project_id" {
   description = "The ID of the project where the data stores and the agents will be created."
   type        = string
   nullable    = false
-}
-
-variable "protocols" {
-  description = "The protocols managed by the Agent Gateway."
-  type        = list(string)
-  nullable    = false
-  default     = ["MCP"]
-
-  validation {
-    condition     = length(var.protocols) == 0 || (length(var.protocols) == 1 && var.protocols[0] == "MCP")
-    error_message = "var.protocols can be one of the following: [], [\"MCP\"]."
-  }
 }
 
 variable "proxy_uri" {

--- a/modules/agent-gateway/versions.tf
+++ b/modules/agent-gateway/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/agent-gateway/versions.tofu
+++ b/modules/agent-gateway/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/ai-applications/versions.tf
+++ b/modules/ai-applications/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/ai-applications/versions.tofu
+++ b/modules/ai-applications/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/alloydb/versions.tf
+++ b/modules/alloydb/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/alloydb/versions.tofu
+++ b/modules/alloydb/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/analytics-hub/versions.tf
+++ b/modules/analytics-hub/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/analytics-hub/versions.tofu
+++ b/modules/analytics-hub/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/api-gateway/versions.tf
+++ b/modules/api-gateway/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/api-gateway/versions.tofu
+++ b/modules/api-gateway/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/apigee/versions.tf
+++ b/modules/apigee/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/apigee/versions.tofu
+++ b/modules/apigee/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/artifact-registry/versions.tf
+++ b/modules/artifact-registry/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/artifact-registry/versions.tofu
+++ b/modules/artifact-registry/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/backup-dr/versions.tf
+++ b/modules/backup-dr/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/backup-dr/versions.tofu
+++ b/modules/backup-dr/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/bigquery-connection/versions.tf
+++ b/modules/bigquery-connection/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/bigquery-connection/versions.tofu
+++ b/modules/bigquery-connection/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/bigquery-dataset/versions.tf
+++ b/modules/bigquery-dataset/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/bigquery-dataset/versions.tofu
+++ b/modules/bigquery-dataset/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/bigtable-instance/versions.tf
+++ b/modules/bigtable-instance/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/bigtable-instance/versions.tofu
+++ b/modules/bigtable-instance/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/billing-account/versions.tf
+++ b/modules/billing-account/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/billing-account/versions.tofu
+++ b/modules/billing-account/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/binauthz/versions.tf
+++ b/modules/binauthz/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/binauthz/versions.tofu
+++ b/modules/binauthz/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/certificate-authority-service/versions.tf
+++ b/modules/certificate-authority-service/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/certificate-authority-service/versions.tofu
+++ b/modules/certificate-authority-service/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/certificate-manager/versions.tf
+++ b/modules/certificate-manager/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/certificate-manager/versions.tofu
+++ b/modules/certificate-manager/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-build-v2-connection/versions.tf
+++ b/modules/cloud-build-v2-connection/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-build-v2-connection/versions.tofu
+++ b/modules/cloud-build-v2-connection/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/__need_fixing/onprem/versions.tf
+++ b/modules/cloud-config-container/__need_fixing/onprem/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/__need_fixing/onprem/versions.tofu
+++ b/modules/cloud-config-container/__need_fixing/onprem/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/__need_fixing/squid/versions.tf
+++ b/modules/cloud-config-container/__need_fixing/squid/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/__need_fixing/squid/versions.tofu
+++ b/modules/cloud-config-container/__need_fixing/squid/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/bindplane/versions.tf
+++ b/modules/cloud-config-container/bindplane/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/bindplane/versions.tofu
+++ b/modules/cloud-config-container/bindplane/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/coredns/versions.tf
+++ b/modules/cloud-config-container/coredns/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/coredns/versions.tofu
+++ b/modules/cloud-config-container/coredns/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/cos-generic-metadata/versions.tf
+++ b/modules/cloud-config-container/cos-generic-metadata/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/cos-generic-metadata/versions.tofu
+++ b/modules/cloud-config-container/cos-generic-metadata/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/envoy-sni-dyn-fwd-proxy/versions.tf
+++ b/modules/cloud-config-container/envoy-sni-dyn-fwd-proxy/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/envoy-sni-dyn-fwd-proxy/versions.tofu
+++ b/modules/cloud-config-container/envoy-sni-dyn-fwd-proxy/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/envoy-traffic-director/versions.tf
+++ b/modules/cloud-config-container/envoy-traffic-director/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/envoy-traffic-director/versions.tofu
+++ b/modules/cloud-config-container/envoy-traffic-director/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/mysql/versions.tf
+++ b/modules/cloud-config-container/mysql/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/mysql/versions.tofu
+++ b/modules/cloud-config-container/mysql/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/nginx-tls/versions.tf
+++ b/modules/cloud-config-container/nginx-tls/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/nginx-tls/versions.tofu
+++ b/modules/cloud-config-container/nginx-tls/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/nginx/versions.tf
+++ b/modules/cloud-config-container/nginx/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/nginx/versions.tofu
+++ b/modules/cloud-config-container/nginx/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/simple-nva/versions.tf
+++ b/modules/cloud-config-container/simple-nva/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-config-container/simple-nva/versions.tofu
+++ b/modules/cloud-config-container/simple-nva/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-deploy/versions.tf
+++ b/modules/cloud-deploy/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-deploy/versions.tofu
+++ b/modules/cloud-deploy/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-function-v1/versions.tf
+++ b/modules/cloud-function-v1/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-function-v1/versions.tofu
+++ b/modules/cloud-function-v1/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-function-v2/versions.tf
+++ b/modules/cloud-function-v2/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-function-v2/versions.tofu
+++ b/modules/cloud-function-v2/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-identity-group/versions.tf
+++ b/modules/cloud-identity-group/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-identity-group/versions.tofu
+++ b/modules/cloud-identity-group/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-run-v2/versions.tf
+++ b/modules/cloud-run-v2/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloud-run-v2/versions.tofu
+++ b/modules/cloud-run-v2/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloudsql-instance/versions.tf
+++ b/modules/cloudsql-instance/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/cloudsql-instance/versions.tofu
+++ b/modules/cloudsql-instance/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/compute-mig/versions.tf
+++ b/modules/compute-mig/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/compute-mig/versions.tofu
+++ b/modules/compute-mig/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/compute-vm/versions.tf
+++ b/modules/compute-vm/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/compute-vm/versions.tofu
+++ b/modules/compute-vm/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/container-registry/versions.tf
+++ b/modules/container-registry/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/container-registry/versions.tofu
+++ b/modules/container-registry/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/data-catalog-policy-tag/versions.tf
+++ b/modules/data-catalog-policy-tag/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/data-catalog-policy-tag/versions.tofu
+++ b/modules/data-catalog-policy-tag/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/data-catalog-tag-template/versions.tf
+++ b/modules/data-catalog-tag-template/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/data-catalog-tag-template/versions.tofu
+++ b/modules/data-catalog-tag-template/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/data-catalog-tag/versions.tf
+++ b/modules/data-catalog-tag/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/data-catalog-tag/versions.tofu
+++ b/modules/data-catalog-tag/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/dataform-repository/versions.tf
+++ b/modules/dataform-repository/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/dataform-repository/versions.tofu
+++ b/modules/dataform-repository/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/datafusion/versions.tf
+++ b/modules/datafusion/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/datafusion/versions.tofu
+++ b/modules/datafusion/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/dataplex-aspect-types/versions.tf
+++ b/modules/dataplex-aspect-types/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/dataplex-aspect-types/versions.tofu
+++ b/modules/dataplex-aspect-types/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/dataplex-datascan/versions.tf
+++ b/modules/dataplex-datascan/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/dataplex-datascan/versions.tofu
+++ b/modules/dataplex-datascan/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/dataplex/versions.tf
+++ b/modules/dataplex/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/dataplex/versions.tofu
+++ b/modules/dataplex/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/dataproc/versions.tf
+++ b/modules/dataproc/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/dataproc/versions.tofu
+++ b/modules/dataproc/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/dns-response-policy/versions.tf
+++ b/modules/dns-response-policy/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/dns-response-policy/versions.tofu
+++ b/modules/dns-response-policy/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/dns/versions.tf
+++ b/modules/dns/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/dns/versions.tofu
+++ b/modules/dns/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/endpoints/versions.tf
+++ b/modules/endpoints/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/endpoints/versions.tofu
+++ b/modules/endpoints/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/firestore/versions.tf
+++ b/modules/firestore/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/firestore/versions.tofu
+++ b/modules/firestore/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/folder/versions.tf
+++ b/modules/folder/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/folder/versions.tofu
+++ b/modules/folder/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/gcs/versions.tf
+++ b/modules/gcs/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/gcs/versions.tofu
+++ b/modules/gcs/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/gcve-private-cloud/versions.tf
+++ b/modules/gcve-private-cloud/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/gcve-private-cloud/versions.tofu
+++ b/modules/gcve-private-cloud/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/gke-cluster-autopilot/versions.tf
+++ b/modules/gke-cluster-autopilot/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/gke-cluster-autopilot/versions.tofu
+++ b/modules/gke-cluster-autopilot/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/gke-cluster-standard/versions.tf
+++ b/modules/gke-cluster-standard/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/gke-cluster-standard/versions.tofu
+++ b/modules/gke-cluster-standard/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/gke-hub/versions.tf
+++ b/modules/gke-hub/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/gke-hub/versions.tofu
+++ b/modules/gke-hub/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/gke-nodepool/versions.tf
+++ b/modules/gke-nodepool/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/gke-nodepool/versions.tofu
+++ b/modules/gke-nodepool/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/iam-service-account/versions.tf
+++ b/modules/iam-service-account/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/iam-service-account/versions.tofu
+++ b/modules/iam-service-account/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/kms/versions.tf
+++ b/modules/kms/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/kms/versions.tofu
+++ b/modules/kms/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/logging-bucket/versions.tf
+++ b/modules/logging-bucket/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/logging-bucket/versions.tofu
+++ b/modules/logging-bucket/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/looker-core/versions.tf
+++ b/modules/looker-core/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/looker-core/versions.tofu
+++ b/modules/looker-core/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/managed-kafka/versions.tf
+++ b/modules/managed-kafka/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/managed-kafka/versions.tofu
+++ b/modules/managed-kafka/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/ncc-spoke-ra/versions.tf
+++ b/modules/ncc-spoke-ra/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/ncc-spoke-ra/versions.tofu
+++ b/modules/ncc-spoke-ra/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-address/versions.tf
+++ b/modules/net-address/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-address/versions.tofu
+++ b/modules/net-address/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-cloudnat/versions.tf
+++ b/modules/net-cloudnat/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-cloudnat/versions.tofu
+++ b/modules/net-cloudnat/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-firewall-policy/versions.tf
+++ b/modules/net-firewall-policy/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-firewall-policy/versions.tofu
+++ b/modules/net-firewall-policy/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-ipsec-over-interconnect/versions.tf
+++ b/modules/net-ipsec-over-interconnect/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-ipsec-over-interconnect/versions.tofu
+++ b/modules/net-ipsec-over-interconnect/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-lb-app-ext-regional/versions.tf
+++ b/modules/net-lb-app-ext-regional/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-lb-app-ext-regional/versions.tofu
+++ b/modules/net-lb-app-ext-regional/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-lb-app-ext/versions.tf
+++ b/modules/net-lb-app-ext/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-lb-app-ext/versions.tofu
+++ b/modules/net-lb-app-ext/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-lb-app-int-cross-region/versions.tf
+++ b/modules/net-lb-app-int-cross-region/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-lb-app-int-cross-region/versions.tofu
+++ b/modules/net-lb-app-int-cross-region/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-lb-app-int/versions.tf
+++ b/modules/net-lb-app-int/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-lb-app-int/versions.tofu
+++ b/modules/net-lb-app-int/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-lb-ext/versions.tf
+++ b/modules/net-lb-ext/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-lb-ext/versions.tofu
+++ b/modules/net-lb-ext/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-lb-int/versions.tf
+++ b/modules/net-lb-int/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-lb-int/versions.tofu
+++ b/modules/net-lb-int/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-lb-proxy-int-cross-region/versions.tf
+++ b/modules/net-lb-proxy-int-cross-region/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-lb-proxy-int-cross-region/versions.tofu
+++ b/modules/net-lb-proxy-int-cross-region/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-lb-proxy-int/versions.tf
+++ b/modules/net-lb-proxy-int/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-lb-proxy-int/versions.tofu
+++ b/modules/net-lb-proxy-int/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-swp/versions.tf
+++ b/modules/net-swp/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-swp/versions.tofu
+++ b/modules/net-swp/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-vlan-attachment/versions.tf
+++ b/modules/net-vlan-attachment/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-vlan-attachment/versions.tofu
+++ b/modules/net-vlan-attachment/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-vpc-firewall/versions.tf
+++ b/modules/net-vpc-firewall/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-vpc-firewall/versions.tofu
+++ b/modules/net-vpc-firewall/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-vpc-peering/versions.tf
+++ b/modules/net-vpc-peering/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-vpc-peering/versions.tofu
+++ b/modules/net-vpc-peering/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-vpc/versions.tf
+++ b/modules/net-vpc/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-vpc/versions.tofu
+++ b/modules/net-vpc/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-vpn-dynamic/versions.tf
+++ b/modules/net-vpn-dynamic/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-vpn-dynamic/versions.tofu
+++ b/modules/net-vpn-dynamic/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-vpn-ha/versions.tf
+++ b/modules/net-vpn-ha/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-vpn-ha/versions.tofu
+++ b/modules/net-vpn-ha/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-vpn-static/versions.tf
+++ b/modules/net-vpn-static/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/net-vpn-static/versions.tofu
+++ b/modules/net-vpn-static/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/organization/versions.tf
+++ b/modules/organization/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/organization/versions.tofu
+++ b/modules/organization/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/project/versions.tf
+++ b/modules/project/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/project/versions.tofu
+++ b/modules/project/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/projects-data-source/versions.tf
+++ b/modules/projects-data-source/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/projects-data-source/versions.tofu
+++ b/modules/projects-data-source/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/pubsub/versions.tf
+++ b/modules/pubsub/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/pubsub/versions.tofu
+++ b/modules/pubsub/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/secops-rules/versions.tf
+++ b/modules/secops-rules/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/secops-rules/versions.tofu
+++ b/modules/secops-rules/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/secret-manager/versions.tf
+++ b/modules/secret-manager/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/secret-manager/versions.tofu
+++ b/modules/secret-manager/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/secure-source-manager-instance/versions.tf
+++ b/modules/secure-source-manager-instance/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/secure-source-manager-instance/versions.tofu
+++ b/modules/secure-source-manager-instance/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/service-directory/versions.tf
+++ b/modules/service-directory/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/service-directory/versions.tofu
+++ b/modules/service-directory/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/source-repository/versions.tf
+++ b/modules/source-repository/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/source-repository/versions.tofu
+++ b/modules/source-repository/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/spanner-instance/versions.tf
+++ b/modules/spanner-instance/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/spanner-instance/versions.tofu
+++ b/modules/spanner-instance/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/vpc-sc/versions.tf
+++ b/modules/vpc-sc/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/vpc-sc/versions.tofu
+++ b/modules/vpc-sc/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/workstation-cluster/versions.tf
+++ b/modules/workstation-cluster/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/modules/workstation-cluster/versions.tofu
+++ b/modules/workstation-cluster/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/tests/examples_e2e/setup_module/versions.tf
+++ b/tests/examples_e2e/setup_module/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/tests/examples_e2e/setup_module/versions.tofu
+++ b/tests/examples_e2e/setup_module/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/tests/modules/agent_engine/examples/container.yaml
+++ b/tests/modules/agent_engine/examples/container.yaml
@@ -56,7 +56,7 @@ values:
     terraform_labels:
       goog-terraform-provisioned: 'true'
     timeouts: null
-    
+
 counts:
   google_project_iam_member: 2
   google_vertex_ai_reasoning_engine: 1

--- a/tests/modules/agent_engine/examples/container.yaml
+++ b/tests/modules/agent_engine/examples/container.yaml
@@ -22,7 +22,6 @@ values:
     project: project-id
     role: roles/storage.objectViewer
   module.agent_engine.google_vertex_ai_reasoning_engine.managed[0]:
-    context_spec: []
     deletion_policy: DELETE
     description: Terraform managed.
     display_name: my-agent
@@ -33,16 +32,23 @@ values:
     project: project-id
     region: europe-west8
     spec:
-    - agent_framework: null
+    - agent_card: null
+      agent_framework: null
+      build_spec: []
       class_methods: null
       container_spec:
       - image_uri: us-central1-docker.pkg.dev/my-project/my-repo/my-image:latest
       deployment_spec:
-      - env:
+      - agent_gateway_config: []
+        agent_server_mode: null
+        dedicated_ingress_endpoint_enabled: null
+        env:
         - name: FOO
           value: bar
+        keep_alive_probe: []
         psc_interface_config: []
         secret_env: []
+      example_store: null
       identity_type: AGENT_IDENTITY
       package_spec: []
       service_account: null
@@ -50,7 +56,7 @@ values:
     terraform_labels:
       goog-terraform-provisioned: 'true'
     timeouts: null
-
+    
 counts:
   google_project_iam_member: 2
   google_vertex_ai_reasoning_engine: 1

--- a/tests/modules/agent_engine/examples/context.yaml
+++ b/tests/modules/agent_engine/examples/context.yaml
@@ -22,7 +22,6 @@ values:
     project: test-project-1
     role: roles/storage.objectViewer
   module.agent_engine.google_vertex_ai_reasoning_engine.managed[0]:
-    context_spec: []
     deletion_policy: DELETE
     description: Terraform managed.
     display_name: my-agent
@@ -33,11 +32,17 @@ values:
     project: test-project-1
     region: europe-west1
     spec:
-    - agent_framework: google-adk
+    - agent_card: null
+      agent_framework: google-adk
+      build_spec: []
       class_methods: null
       container_spec: []
       deployment_spec:
-      - env: []
+      - agent_gateway_config: []
+        agent_server_mode: null
+        dedicated_ingress_endpoint_enabled: null
+        env: []
+        keep_alive_probe: []
         psc_interface_config:
         - dns_peering_configs:
           - domain: example.com
@@ -48,11 +53,13 @@ values:
             target_project: company-dns-project
           network_attachment: projects/test-project-1/regions/europe-west1/networkAttachments/core-service
         secret_env: []
+      example_store: null
       identity_type: AGENT_IDENTITY
       package_spec: []
       service_account: my-sa@$test-project-1.iam.gserviceaccount.com
       source_code_spec:
-      - developer_connect_source: []
+      - agent_config_source: []
+        developer_connect_source: []
         image_spec: []
         inline_source:
         - source_archive: H4sIAMCUSmkAA+1Y727bNhB3CwzbtM/b55v7oQmQyPprJyk8QE2y1ahrZ7HTriiKgJFom4skqhRV2yj6Hvu8PdL2AgP2CHuAHWXZiZP+C5C4WKsfQNjiHY+/I3l3og7I5AElARU1/VjQFxkTNKKxTHU5kZVrgmEYdceBSiMHVCy34Vo2qP4ZXAdM17Qs1eomGJZp160KTK6LwLuQpZIIpBJmPkkElfQteolgERHToeBZ8ib5zBNY/P5PYDqQsaC5ZWw5DUuzDYgki2jTbNTrzrbrGNt6fatuGbhljvaxuZa4ftxc1J9hHv+24dqGbVyKf8uxl+PfbNgNtwLG9VO5jM88/itffPdl5Xal8oj40O3BL1BA9VW+xmZhe4FNPf/xYSa9fv+w+KtG/Ibtmwsqt876v/V5pJMkCameCP6SxiT2aeXW7cpf//z+1b9/b/15DU6WeBsOFvX/5vLA++o/Bv3F+m869bL+rwJXqf9uA9qt+97h7oPW4319QqQU+puCt+n93PLMbo/tHvRH3c4jzdmGHg5qP33XoHMRX75prAw3X/3fX//Ni/FvNsy6Udb/VWDI+TCkm37Is2CTsCQkcsBF9IwM8UQc03jIYpo+/6Fp6qZl6IZW6JPgNO9zdVPLxybMPw1ps2nrSutje1XiQ3Fw7v6f77meTK97jivc/03LdVX8u65R1v9V4J3139natnXbMvA2ZrlbZVR/gri5qD/DFe7/Rfy7bt0u6/9KUN7/P2uc1f+bywNXuP/P679tO2X9XwWuUv/L+/+nh5uv/u+t/5btXIx/13adsv6vAne+r2WpqJ2wuEbjl5BM5YjHtqbdgV2eTAUbjiSoz3/wU37xh3Z7V7uD0jbzaZzSALIYiwfIEQUvIT7+FJINeExFyngMlm7AmlKoFqLq+j20MOUZRGQKMZeQpRRNsBQGDOegE58mElgMmCiSkKn0AGMmR/k0hREdTTwtTPATSVCboH6CT4PzekBkTlhhJGWS7tRq4/EY849iq3MxrIUzzbTWbu3ud3r7m8g4H3MUhzRNofhGFsDJFFTaYj45QZohGQMXQIaCokxyRXgsmGTxcANSPpBjIihaCVgqBTvJ5NJqzemh0+cVcL1IDFWvB61eFe57vVZvA208afUfdI/68MQ7PPQ6/dZ+D7qHsNvt7LX6rW4Hn34Er/MUHrY6extAca1wGjrBA438kSRT60gDtWg9SpcIDPiMUJpQnw2Yj37FwwzzAgwxN4sY3YGEioilajdTpBeglZBFTBKZ91xySte0geARzD4W6SQ41fM8kyoeXEhoh5GnOmZqOIukE8L0pY9Oc10vOPWSRNO0gA5gSFE+8UdIkR4LIumapjbWz4SgsT89VvZ2AJcTmlA96u1VN5blki+k+0eHF6UBGlzIQ3xIJaqs76BWQUYdBexNsQeXNuFqAZuLXh3pzQgBDKrz00YSpg8EiU8HGfopVOWrvVqa83VBBCAhgkRp85UGC1SVT9WdZR83zitIfl4seSF7rZTWc6YyE/GCsP5ryuO1dS0PckFxfvD2HkK++EWYcR6mmuBczm6H6OJ8x2buRTygYbM6pBGLGYaLuzkISToq3GAxLmHmq8PRrKoYxTjA4BzRMBlkIRA8SJh0Y1moxwRfOO4u+C+2N5/67kwnZ9R8dmn7n+P2aNqc5OyorOWPzTP66+X7RIkSJUpcwn+2Vos4ACgAAA==

--- a/tests/modules/agent_engine/examples/deletion-protection.yaml
+++ b/tests/modules/agent_engine/examples/deletion-protection.yaml
@@ -63,6 +63,7 @@ values:
     name: dependencies.tar.gz
     retention: []
     source: assets/src/dependencies.tar.gz
+    source_md5hash: 49a4c43e6bef605c2fa6ddabac48ba6a
     temporary_hold: null
     timeouts: null
   module.agent_engine.google_storage_bucket_object.pickle[0]:
@@ -81,6 +82,7 @@ values:
     name: pickle.pkl
     retention: []
     source: assets/src/pickle.pkl
+    source_md5hash: 493cf9bf3e59e39913e61916549f95a5
     temporary_hold: null
     timeouts: null
   module.agent_engine.google_storage_bucket_object.requirements[0]:
@@ -99,10 +101,10 @@ values:
     name: requirements.txt
     retention: []
     source: assets/src/requirements.txt
+    source_md5hash: 0acf2b14e855722af60e03e8fa8b04ff
     temporary_hold: null
     timeouts: null
   module.agent_engine.google_vertex_ai_reasoning_engine.managed[0]:
-    context_spec: []
     deletion_policy: FORCE
     description: Terraform managed.
     display_name: my-agent
@@ -113,10 +115,12 @@ values:
     project: project-id
     region: europe-west8
     spec:
-    - agent_framework: google-adk
+    - agent_card: null
+      agent_framework: google-adk
+      build_spec: []
       class_methods: null
       container_spec: []
-      deployment_spec: []
+      example_store: null
       identity_type: AGENT_IDENTITY
       package_spec:
       - dependency_files_gcs_uri: gs://my-agent/dependencies.tar.gz

--- a/tests/modules/agent_engine/examples/encryption.yaml
+++ b/tests/modules/agent_engine/examples/encryption.yaml
@@ -22,7 +22,6 @@ values:
     project: project-id
     role: roles/storage.objectViewer
   module.agent_engine.google_vertex_ai_reasoning_engine.managed[0]:
-    context_spec: []
     deletion_policy: DELETE
     description: Terraform managed.
     display_name: my-agent
@@ -34,15 +33,18 @@ values:
     project: project-id
     region: europe-west8
     spec:
-    - agent_framework: google-adk
+    - agent_card: null
+      agent_framework: google-adk
+      build_spec: []
       class_methods: null
       container_spec: []
-      deployment_spec: []
+      example_store: null
       identity_type: AGENT_IDENTITY
       package_spec: []
       service_account: null
       source_code_spec:
-      - developer_connect_source: []
+      - agent_config_source: []
+        developer_connect_source: []
         image_spec: []
         inline_source:
         - source_archive: H4sIAMCUSmkAA+1Y727bNhB3CwzbtM/b55v7oQmQyPprJyk8QE2y1ahrZ7HTriiKgJFom4skqhRV2yj6Hvu8PdL2AgP2CHuAHWXZiZP+C5C4WKsfQNjiHY+/I3l3og7I5AElARU1/VjQFxkTNKKxTHU5kZVrgmEYdceBSiMHVCy34Vo2qP4ZXAdM17Qs1eomGJZp160KTK6LwLuQpZIIpBJmPkkElfQteolgERHToeBZ8ib5zBNY/P5PYDqQsaC5ZWw5DUuzDYgki2jTbNTrzrbrGNt6fatuGbhljvaxuZa4ftxc1J9hHv+24dqGbVyKf8uxl+PfbNgNtwLG9VO5jM88/itffPdl5Xal8oj40O3BL1BA9VW+xmZhe4FNPf/xYSa9fv+w+KtG/Ibtmwsqt876v/V5pJMkCameCP6SxiT2aeXW7cpf//z+1b9/b/15DU6WeBsOFvX/5vLA++o/Bv3F+m869bL+rwJXqf9uA9qt+97h7oPW4319QqQU+puCt+n93PLMbo/tHvRH3c4jzdmGHg5qP33XoHMRX75prAw3X/3fX//Ni/FvNsy6Udb/VWDI+TCkm37Is2CTsCQkcsBF9IwM8UQc03jIYpo+/6Fp6qZl6IZW6JPgNO9zdVPLxybMPw1ps2nrSutje1XiQ3Fw7v6f77meTK97jivc/03LdVX8u65R1v9V4J3139natnXbMvA2ZrlbZVR/gri5qD/DFe7/Rfy7bt0u6/9KUN7/P2uc1f+bywNXuP/P679tO2X9XwWuUv/L+/+nh5uv/u+t/5btXIx/13adsv6vAne+r2WpqJ2wuEbjl5BM5YjHtqbdgV2eTAUbjiSoz3/wU37xh3Z7V7uD0jbzaZzSALIYiwfIEQUvIT7+FJINeExFyngMlm7AmlKoFqLq+j20MOUZRGQKMZeQpRRNsBQGDOegE58mElgMmCiSkKn0AGMmR/k0hREdTTwtTPATSVCboH6CT4PzekBkTlhhJGWS7tRq4/EY849iq3MxrIUzzbTWbu3ud3r7m8g4H3MUhzRNofhGFsDJFFTaYj45QZohGQMXQIaCokxyRXgsmGTxcANSPpBjIihaCVgqBTvJ5NJqzemh0+cVcL1IDFWvB61eFe57vVZvA208afUfdI/68MQ7PPQ6/dZ+D7qHsNvt7LX6rW4Hn34Er/MUHrY6extAca1wGjrBA438kSRT60gDtWg9SpcIDPiMUJpQnw2Yj37FwwzzAgwxN4sY3YGEioilajdTpBeglZBFTBKZ91xySte0geARzD4W6SQ41fM8kyoeXEhoh5GnOmZqOIukE8L0pY9Oc10vOPWSRNO0gA5gSFE+8UdIkR4LIumapjbWz4SgsT89VvZ2AJcTmlA96u1VN5blki+k+0eHF6UBGlzIQ3xIJaqs76BWQUYdBexNsQeXNuFqAZuLXh3pzQgBDKrz00YSpg8EiU8HGfopVOWrvVqa83VBBCAhgkRp85UGC1SVT9WdZR83zitIfl4seSF7rZTWc6YyE/GCsP5ryuO1dS0PckFxfvD2HkK++EWYcR6mmuBczm6H6OJ8x2buRTygYbM6pBGLGYaLuzkISToq3GAxLmHmq8PRrKoYxTjA4BzRMBlkIRA8SJh0Y1moxwRfOO4u+C+2N5/67kwnZ9R8dmn7n+P2aNqc5OyorOWPzTP66+X7RIkSJUpcwn+2Vos4ACgAAA==

--- a/tests/modules/agent_engine/examples/environment.yaml
+++ b/tests/modules/agent_engine/examples/environment.yaml
@@ -69,7 +69,7 @@ values:
     terraform_labels:
       goog-terraform-provisioned: 'true'
     timeouts: null
-    
+
 counts:
   google_project_iam_member: 2
   google_vertex_ai_reasoning_engine: 1

--- a/tests/modules/agent_engine/examples/environment.yaml
+++ b/tests/modules/agent_engine/examples/environment.yaml
@@ -22,7 +22,6 @@ values:
     project: project-id
     role: roles/storage.objectViewer
   module.agent_engine.google_vertex_ai_reasoning_engine.managed[0]:
-    context_spec: []
     deletion_policy: DELETE
     description: Terraform managed.
     display_name: my-agent
@@ -33,24 +32,32 @@ values:
     project: project-id
     region: europe-west8
     spec:
-    - agent_framework: google-adk
+    - agent_card: null
+      agent_framework: google-adk
+      build_spec: []
       class_methods: null
       container_spec: []
       deployment_spec:
-      - env:
+      - agent_gateway_config: []
+        agent_server_mode: null
+        dedicated_ingress_endpoint_enabled: null
+        env:
         - name: FOO
           value: bar
+        keep_alive_probe: []
         psc_interface_config: []
         secret_env:
         - name: MY_SECRET
           secret_ref:
           - secret: projects/project-id/secrets/my-secret
             version: latest
+      example_store: null
       identity_type: AGENT_IDENTITY
       package_spec: []
       service_account: null
       source_code_spec:
-      - developer_connect_source: []
+      - agent_config_source: []
+        developer_connect_source: []
         image_spec: []
         inline_source:
         - source_archive: H4sIAMCUSmkAA+1Y727bNhB3CwzbtM/b55v7oQmQyPprJyk8QE2y1ahrZ7HTriiKgJFom4skqhRV2yj6Hvu8PdL2AgP2CHuAHWXZiZP+C5C4WKsfQNjiHY+/I3l3og7I5AElARU1/VjQFxkTNKKxTHU5kZVrgmEYdceBSiMHVCy34Vo2qP4ZXAdM17Qs1eomGJZp160KTK6LwLuQpZIIpBJmPkkElfQteolgERHToeBZ8ib5zBNY/P5PYDqQsaC5ZWw5DUuzDYgki2jTbNTrzrbrGNt6fatuGbhljvaxuZa4ftxc1J9hHv+24dqGbVyKf8uxl+PfbNgNtwLG9VO5jM88/itffPdl5Xal8oj40O3BL1BA9VW+xmZhe4FNPf/xYSa9fv+w+KtG/Ibtmwsqt876v/V5pJMkCameCP6SxiT2aeXW7cpf//z+1b9/b/15DU6WeBsOFvX/5vLA++o/Bv3F+m869bL+rwJXqf9uA9qt+97h7oPW4319QqQU+puCt+n93PLMbo/tHvRH3c4jzdmGHg5qP33XoHMRX75prAw3X/3fX//Ni/FvNsy6Udb/VWDI+TCkm37Is2CTsCQkcsBF9IwM8UQc03jIYpo+/6Fp6qZl6IZW6JPgNO9zdVPLxybMPw1ps2nrSutje1XiQ3Fw7v6f77meTK97jivc/03LdVX8u65R1v9V4J3139natnXbMvA2ZrlbZVR/gri5qD/DFe7/Rfy7bt0u6/9KUN7/P2uc1f+bywNXuP/P679tO2X9XwWuUv/L+/+nh5uv/u+t/5btXIx/13adsv6vAne+r2WpqJ2wuEbjl5BM5YjHtqbdgV2eTAUbjiSoz3/wU37xh3Z7V7uD0jbzaZzSALIYiwfIEQUvIT7+FJINeExFyngMlm7AmlKoFqLq+j20MOUZRGQKMZeQpRRNsBQGDOegE58mElgMmCiSkKn0AGMmR/k0hREdTTwtTPATSVCboH6CT4PzekBkTlhhJGWS7tRq4/EY849iq3MxrIUzzbTWbu3ud3r7m8g4H3MUhzRNofhGFsDJFFTaYj45QZohGQMXQIaCokxyRXgsmGTxcANSPpBjIihaCVgqBTvJ5NJqzemh0+cVcL1IDFWvB61eFe57vVZvA208afUfdI/68MQ7PPQ6/dZ+D7qHsNvt7LX6rW4Hn34Er/MUHrY6extAca1wGjrBA438kSRT60gDtWg9SpcIDPiMUJpQnw2Yj37FwwzzAgwxN4sY3YGEioilajdTpBeglZBFTBKZ91xySte0geARzD4W6SQ41fM8kyoeXEhoh5GnOmZqOIukE8L0pY9Oc10vOPWSRNO0gA5gSFE+8UdIkR4LIumapjbWz4SgsT89VvZ2AJcTmlA96u1VN5blki+k+0eHF6UBGlzIQ3xIJaqs76BWQUYdBexNsQeXNuFqAZuLXh3pzQgBDKrz00YSpg8EiU8HGfopVOWrvVqa83VBBCAhgkRp85UGC1SVT9WdZR83zitIfl4seSF7rZTWc6YyE/GCsP5ryuO1dS0PckFxfvD2HkK++EWYcR6mmuBczm6H6OJ8x2buRTygYbM6pBGLGYaLuzkISToq3GAxLmHmq8PRrKoYxTjA4BzRMBlkIRA8SJh0Y1moxwRfOO4u+C+2N5/67kwnZ9R8dmn7n+P2aNqc5OyorOWPzTP66+X7RIkSJUpcwn+2Vos4ACgAAA==
@@ -62,7 +69,7 @@ values:
     terraform_labels:
       goog-terraform-provisioned: 'true'
     timeouts: null
-
+    
 counts:
   google_project_iam_member: 2
   google_vertex_ai_reasoning_engine: 1

--- a/tests/modules/agent_engine/examples/image-spec.yaml
+++ b/tests/modules/agent_engine/examples/image-spec.yaml
@@ -53,7 +53,7 @@ values:
     terraform_labels:
       goog-terraform-provisioned: 'true'
     timeouts: null
-    
+
 counts:
   google_project_iam_member: 2
   google_vertex_ai_reasoning_engine: 1

--- a/tests/modules/agent_engine/examples/image-spec.yaml
+++ b/tests/modules/agent_engine/examples/image-spec.yaml
@@ -22,7 +22,6 @@ values:
     project: project-id
     role: roles/storage.objectViewer
   module.agent_engine.google_vertex_ai_reasoning_engine.managed[0]:
-    context_spec: []
     deletion_policy: DELETE
     description: Terraform managed.
     display_name: my-agent
@@ -33,15 +32,18 @@ values:
     project: project-id
     region: europe-west8
     spec:
-    - agent_framework: google-adk
+    - agent_card: null
+      agent_framework: google-adk
+      build_spec: []
       class_methods: null
       container_spec: []
-      deployment_spec: []
+      example_store: null
       identity_type: AGENT_IDENTITY
       package_spec: []
       service_account: null
       source_code_spec:
-      - developer_connect_source: []
+      - agent_config_source: []
+        developer_connect_source: []
         image_spec:
         - build_args:
             ENV: production
@@ -51,7 +53,7 @@ values:
     terraform_labels:
       goog-terraform-provisioned: 'true'
     timeouts: null
-
+    
 counts:
   google_project_iam_member: 2
   google_vertex_ai_reasoning_engine: 1

--- a/tests/modules/agent_engine/examples/memory-bank.yaml
+++ b/tests/modules/agent_engine/examples/memory-bank.yaml
@@ -69,7 +69,7 @@ values:
     terraform_labels:
       goog-terraform-provisioned: 'true'
     timeouts: null
-    
+
 counts:
   google_project_iam_member: 2
   google_vertex_ai_reasoning_engine: 1

--- a/tests/modules/agent_engine/examples/memory-bank.yaml
+++ b/tests/modules/agent_engine/examples/memory-bank.yaml
@@ -23,12 +23,15 @@ values:
     role: roles/storage.objectViewer
   module.agent_engine.google_vertex_ai_reasoning_engine.managed[0]:
     context_spec:
-    - memory_bank_config:
-      - disable_memory_revisions: false
+    - example_store_config: []
+      memory_bank_config:
+      - customization_configs: []
+        disable_memory_revisions: false
         generation_config:
         - model: projects/my-project/locations/us-central1/publishers/google/models/gemini-2.0-flash-001
         similarity_search_config:
         - embedding_model: projects/my-project/locations/us-central1/publishers/google/models/text-embedding-005
+        structured_memory_configs: []
         ttl_config:
         - default_ttl: 2592000s
           granular_ttl_config: []
@@ -43,15 +46,18 @@ values:
     project: project-id
     region: europe-west8
     spec:
-    - agent_framework: google-adk
+    - agent_card: null
+      agent_framework: google-adk
+      build_spec: []
       class_methods: null
       container_spec: []
-      deployment_spec: []
+      example_store: null
       identity_type: AGENT_IDENTITY
       package_spec: []
       service_account: null
       source_code_spec:
-      - developer_connect_source: []
+      - agent_config_source: []
+        developer_connect_source: []
         image_spec: []
         inline_source:
         - source_archive: H4sIAMCUSmkAA+1Y727bNhB3CwzbtM/b55v7oQmQyPprJyk8QE2y1ahrZ7HTriiKgJFom4skqhRV2yj6Hvu8PdL2AgP2CHuAHWXZiZP+C5C4WKsfQNjiHY+/I3l3og7I5AElARU1/VjQFxkTNKKxTHU5kZVrgmEYdceBSiMHVCy34Vo2qP4ZXAdM17Qs1eomGJZp160KTK6LwLuQpZIIpBJmPkkElfQteolgERHToeBZ8ib5zBNY/P5PYDqQsaC5ZWw5DUuzDYgki2jTbNTrzrbrGNt6fatuGbhljvaxuZa4ftxc1J9hHv+24dqGbVyKf8uxl+PfbNgNtwLG9VO5jM88/itffPdl5Xal8oj40O3BL1BA9VW+xmZhe4FNPf/xYSa9fv+w+KtG/Ibtmwsqt876v/V5pJMkCameCP6SxiT2aeXW7cpf//z+1b9/b/15DU6WeBsOFvX/5vLA++o/Bv3F+m869bL+rwJXqf9uA9qt+97h7oPW4319QqQU+puCt+n93PLMbo/tHvRH3c4jzdmGHg5qP33XoHMRX75prAw3X/3fX//Ni/FvNsy6Udb/VWDI+TCkm37Is2CTsCQkcsBF9IwM8UQc03jIYpo+/6Fp6qZl6IZW6JPgNO9zdVPLxybMPw1ps2nrSutje1XiQ3Fw7v6f77meTK97jivc/03LdVX8u65R1v9V4J3139natnXbMvA2ZrlbZVR/gri5qD/DFe7/Rfy7bt0u6/9KUN7/P2uc1f+bywNXuP/P679tO2X9XwWuUv/L+/+nh5uv/u+t/5btXIx/13adsv6vAne+r2WpqJ2wuEbjl5BM5YjHtqbdgV2eTAUbjiSoz3/wU37xh3Z7V7uD0jbzaZzSALIYiwfIEQUvIT7+FJINeExFyngMlm7AmlKoFqLq+j20MOUZRGQKMZeQpRRNsBQGDOegE58mElgMmCiSkKn0AGMmR/k0hREdTTwtTPATSVCboH6CT4PzekBkTlhhJGWS7tRq4/EY849iq3MxrIUzzbTWbu3ud3r7m8g4H3MUhzRNofhGFsDJFFTaYj45QZohGQMXQIaCokxyRXgsmGTxcANSPpBjIihaCVgqBTvJ5NJqzemh0+cVcL1IDFWvB61eFe57vVZvA208afUfdI/68MQ7PPQ6/dZ+D7qHsNvt7LX6rW4Hn34Er/MUHrY6extAca1wGjrBA438kSRT60gDtWg9SpcIDPiMUJpQnw2Yj37FwwzzAgwxN4sY3YGEioilajdTpBeglZBFTBKZ91xySte0geARzD4W6SQ41fM8kyoeXEhoh5GnOmZqOIukE8L0pY9Oc10vOPWSRNO0gA5gSFE+8UdIkR4LIumapjbWz4SgsT89VvZ2AJcTmlA96u1VN5blki+k+0eHF6UBGlzIQ3xIJaqs76BWQUYdBexNsQeXNuFqAZuLXh3pzQgBDKrz00YSpg8EiU8HGfopVOWrvVqa83VBBCAhgkRp85UGC1SVT9WdZR83zitIfl4seSF7rZTWc6YyE/GCsP5ryuO1dS0PckFxfvD2HkK++EWYcR6mmuBczm6H6OJ8x2buRTygYbM6pBGLGYaLuzkISToq3GAxLmHmq8PRrKoYxTjA4BzRMBlkIRA8SJh0Y1moxwRfOO4u+C+2N5/67kwnZ9R8dmn7n+P2aNqc5OyorOWPzTP66+X7RIkSJUpcwn+2Vos4ACgAAA==
@@ -63,7 +69,7 @@ values:
     terraform_labels:
       goog-terraform-provisioned: 'true'
     timeouts: null
-
+    
 counts:
   google_project_iam_member: 2
   google_vertex_ai_reasoning_engine: 1

--- a/tests/modules/agent_engine/examples/minimal-pickle.yaml
+++ b/tests/modules/agent_engine/examples/minimal-pickle.yaml
@@ -132,7 +132,7 @@ values:
     terraform_labels:
       goog-terraform-provisioned: 'true'
     timeouts: null
-    
+
 counts:
   google_project_iam_member: 2
   google_storage_bucket: 1

--- a/tests/modules/agent_engine/examples/minimal-pickle.yaml
+++ b/tests/modules/agent_engine/examples/minimal-pickle.yaml
@@ -63,6 +63,7 @@ values:
     name: dependencies.tar.gz
     retention: []
     source: assets/src/dependencies.tar.gz
+    source_md5hash: 49a4c43e6bef605c2fa6ddabac48ba6a
     temporary_hold: null
     timeouts: null
   module.agent_engine.google_storage_bucket_object.pickle[0]:
@@ -81,6 +82,7 @@ values:
     name: pickle.pkl
     retention: []
     source: assets/src/pickle.pkl
+    source_md5hash: 493cf9bf3e59e39913e61916549f95a5
     temporary_hold: null
     timeouts: null
   module.agent_engine.google_storage_bucket_object.requirements[0]:
@@ -99,10 +101,10 @@ values:
     name: requirements.txt
     retention: []
     source: assets/src/requirements.txt
+    source_md5hash: 0acf2b14e855722af60e03e8fa8b04ff
     temporary_hold: null
     timeouts: null
   module.agent_engine.google_vertex_ai_reasoning_engine.managed[0]:
-    context_spec: []
     deletion_policy: DELETE
     description: Terraform managed.
     display_name: my-agent
@@ -113,10 +115,12 @@ values:
     project: project-id
     region: europe-west8
     spec:
-    - agent_framework: google-adk
+    - agent_card: null
+      agent_framework: google-adk
+      build_spec: []
       class_methods: null
       container_spec: []
-      deployment_spec: []
+      example_store: null
       identity_type: AGENT_IDENTITY
       package_spec:
       - dependency_files_gcs_uri: gs://my-agent/dependencies.tar.gz
@@ -128,7 +132,7 @@ values:
     terraform_labels:
       goog-terraform-provisioned: 'true'
     timeouts: null
-
+    
 counts:
   google_project_iam_member: 2
   google_storage_bucket: 1

--- a/tests/modules/agent_engine/examples/minimal.yaml
+++ b/tests/modules/agent_engine/examples/minimal.yaml
@@ -22,7 +22,6 @@ values:
     project: project-id
     role: roles/storage.objectViewer
   module.agent_engine.google_vertex_ai_reasoning_engine.managed[0]:
-    context_spec: []
     deletion_policy: DELETE
     description: Terraform managed.
     display_name: my-agent
@@ -33,15 +32,18 @@ values:
     project: project-id
     region: europe-west8
     spec:
-    - agent_framework: google-adk
+    - agent_card: null
+      agent_framework: google-adk
+      build_spec: []
       class_methods: null
       container_spec: []
-      deployment_spec: []
+      example_store: null
       identity_type: AGENT_IDENTITY
       package_spec: []
       service_account: null
       source_code_spec:
-      - developer_connect_source: []
+      - agent_config_source: []
+        developer_connect_source: []
         image_spec: []
         inline_source:
         - source_archive: H4sIAMCUSmkAA+1Y727bNhB3CwzbtM/b55v7oQmQyPprJyk8QE2y1ahrZ7HTriiKgJFom4skqhRV2yj6Hvu8PdL2AgP2CHuAHWXZiZP+C5C4WKsfQNjiHY+/I3l3og7I5AElARU1/VjQFxkTNKKxTHU5kZVrgmEYdceBSiMHVCy34Vo2qP4ZXAdM17Qs1eomGJZp160KTK6LwLuQpZIIpBJmPkkElfQteolgERHToeBZ8ib5zBNY/P5PYDqQsaC5ZWw5DUuzDYgki2jTbNTrzrbrGNt6fatuGbhljvaxuZa4ftxc1J9hHv+24dqGbVyKf8uxl+PfbNgNtwLG9VO5jM88/itffPdl5Xal8oj40O3BL1BA9VW+xmZhe4FNPf/xYSa9fv+w+KtG/Ibtmwsqt876v/V5pJMkCameCP6SxiT2aeXW7cpf//z+1b9/b/15DU6WeBsOFvX/5vLA++o/Bv3F+m869bL+rwJXqf9uA9qt+97h7oPW4319QqQU+puCt+n93PLMbo/tHvRH3c4jzdmGHg5qP33XoHMRX75prAw3X/3fX//Ni/FvNsy6Udb/VWDI+TCkm37Is2CTsCQkcsBF9IwM8UQc03jIYpo+/6Fp6qZl6IZW6JPgNO9zdVPLxybMPw1ps2nrSutje1XiQ3Fw7v6f77meTK97jivc/03LdVX8u65R1v9V4J3139natnXbMvA2ZrlbZVR/gri5qD/DFe7/Rfy7bt0u6/9KUN7/P2uc1f+bywNXuP/P679tO2X9XwWuUv/L+/+nh5uv/u+t/5btXIx/13adsv6vAne+r2WpqJ2wuEbjl5BM5YjHtqbdgV2eTAUbjiSoz3/wU37xh3Z7V7uD0jbzaZzSALIYiwfIEQUvIT7+FJINeExFyngMlm7AmlKoFqLq+j20MOUZRGQKMZeQpRRNsBQGDOegE58mElgMmCiSkKn0AGMmR/k0hREdTTwtTPATSVCboH6CT4PzekBkTlhhJGWS7tRq4/EY849iq3MxrIUzzbTWbu3ud3r7m8g4H3MUhzRNofhGFsDJFFTaYj45QZohGQMXQIaCokxyRXgsmGTxcANSPpBjIihaCVgqBTvJ5NJqzemh0+cVcL1IDFWvB61eFe57vVZvA208afUfdI/68MQ7PPQ6/dZ+D7qHsNvt7LX6rW4Hn34Er/MUHrY6extAca1wGjrBA438kSRT60gDtWg9SpcIDPiMUJpQnw2Yj37FwwzzAgwxN4sY3YGEioilajdTpBeglZBFTBKZ91xySte0geARzD4W6SQ41fM8kyoeXEhoh5GnOmZqOIukE8L0pY9Oc10vOPWSRNO0gA5gSFE+8UdIkR4LIumapjbWz4SgsT89VvZ2AJcTmlA96u1VN5blki+k+0eHF6UBGlzIQ3xIJaqs76BWQUYdBexNsQeXNuFqAZuLXh3pzQgBDKrz00YSpg8EiU8HGfopVOWrvVqa83VBBCAhgkRp85UGC1SVT9WdZR83zitIfl4seSF7rZTWc6YyE/GCsP5ryuO1dS0PckFxfvD2HkK++EWYcR6mmuBczm6H6OJ8x2buRTygYbM6pBGLGYaLuzkISToq3GAxLmHmq8PRrKoYxTjA4BzRMBlkIRA8SJh0Y1moxwRfOO4u+C+2N5/67kwnZ9R8dmn7n+P2aNqc5OyorOWPzTP66+X7RIkSJUpcwn+2Vos4ACgAAA==

--- a/tests/modules/agent_engine/examples/pickle-gcs.yaml
+++ b/tests/modules/agent_engine/examples/pickle-gcs.yaml
@@ -48,7 +48,6 @@ values:
     timeouts: null
     uniform_bucket_level_access: true
   module.agent_engine.google_vertex_ai_reasoning_engine.managed[0]:
-    context_spec: []
     deletion_policy: DELETE
     description: Terraform managed.
     display_name: my-agent
@@ -59,10 +58,12 @@ values:
     project: project-id
     region: europe-west8
     spec:
-    - agent_framework: google-adk
+    - agent_card: null
+      agent_framework: google-adk
+      build_spec: []
       class_methods: null
       container_spec: []
-      deployment_spec: []
+      example_store: null
       identity_type: AGENT_IDENTITY
       package_spec:
       - dependency_files_gcs_uri: gs://my-bucket/dependencies.tar.gz
@@ -74,7 +75,7 @@ values:
     terraform_labels:
       goog-terraform-provisioned: 'true'
     timeouts: null
-
+    
 counts:
   google_project_iam_member: 2
   google_storage_bucket: 1

--- a/tests/modules/agent_engine/examples/pickle-gcs.yaml
+++ b/tests/modules/agent_engine/examples/pickle-gcs.yaml
@@ -75,7 +75,7 @@ values:
     terraform_labels:
       goog-terraform-provisioned: 'true'
     timeouts: null
-    
+
 counts:
   google_project_iam_member: 2
   google_storage_bucket: 1

--- a/tests/modules/agent_engine/examples/psc-i.yaml
+++ b/tests/modules/agent_engine/examples/psc-i.yaml
@@ -22,7 +22,6 @@ values:
     project: project-id
     role: roles/storage.objectViewer
   module.agent_engine.google_vertex_ai_reasoning_engine.managed[0]:
-    context_spec: []
     deletion_policy: DELETE
     description: Terraform managed.
     display_name: my-agent
@@ -33,11 +32,17 @@ values:
     project: project-id
     region: europe-west8
     spec:
-    - agent_framework: google-adk
+    - agent_card: null
+      agent_framework: google-adk
+      build_spec: []
       class_methods: null
       container_spec: []
       deployment_spec:
-      - env: []
+      - agent_gateway_config: []
+        agent_server_mode: null
+        dedicated_ingress_endpoint_enabled: null
+        env: []
+        keep_alive_probe: []
         psc_interface_config:
         - dns_peering_configs:
           - domain: googleapis.com.
@@ -45,11 +50,13 @@ values:
             target_project: project-id
           network_attachment: projects/project-id/regions/europe-west8/networkAttachments/my-nat
         secret_env: []
+      example_store: null
       identity_type: AGENT_IDENTITY
       package_spec: []
       service_account: null
       source_code_spec:
-      - developer_connect_source: []
+      - agent_config_source: []
+        developer_connect_source: []
         image_spec: []
         inline_source:
         - source_archive: H4sIAMCUSmkAA+1Y727bNhB3CwzbtM/b55v7oQmQyPprJyk8QE2y1ahrZ7HTriiKgJFom4skqhRV2yj6Hvu8PdL2AgP2CHuAHWXZiZP+C5C4WKsfQNjiHY+/I3l3og7I5AElARU1/VjQFxkTNKKxTHU5kZVrgmEYdceBSiMHVCy34Vo2qP4ZXAdM17Qs1eomGJZp160KTK6LwLuQpZIIpBJmPkkElfQteolgERHToeBZ8ib5zBNY/P5PYDqQsaC5ZWw5DUuzDYgki2jTbNTrzrbrGNt6fatuGbhljvaxuZa4ftxc1J9hHv+24dqGbVyKf8uxl+PfbNgNtwLG9VO5jM88/itffPdl5Xal8oj40O3BL1BA9VW+xmZhe4FNPf/xYSa9fv+w+KtG/Ibtmwsqt876v/V5pJMkCameCP6SxiT2aeXW7cpf//z+1b9/b/15DU6WeBsOFvX/5vLA++o/Bv3F+m869bL+rwJXqf9uA9qt+97h7oPW4319QqQU+puCt+n93PLMbo/tHvRH3c4jzdmGHg5qP33XoHMRX75prAw3X/3fX//Ni/FvNsy6Udb/VWDI+TCkm37Is2CTsCQkcsBF9IwM8UQc03jIYpo+/6Fp6qZl6IZW6JPgNO9zdVPLxybMPw1ps2nrSutje1XiQ3Fw7v6f77meTK97jivc/03LdVX8u65R1v9V4J3139natnXbMvA2ZrlbZVR/gri5qD/DFe7/Rfy7bt0u6/9KUN7/P2uc1f+bywNXuP/P679tO2X9XwWuUv/L+/+nh5uv/u+t/5btXIx/13adsv6vAne+r2WpqJ2wuEbjl5BM5YjHtqbdgV2eTAUbjiSoz3/wU37xh3Z7V7uD0jbzaZzSALIYiwfIEQUvIT7+FJINeExFyngMlm7AmlKoFqLq+j20MOUZRGQKMZeQpRRNsBQGDOegE58mElgMmCiSkKn0AGMmR/k0hREdTTwtTPATSVCboH6CT4PzekBkTlhhJGWS7tRq4/EY849iq3MxrIUzzbTWbu3ud3r7m8g4H3MUhzRNofhGFsDJFFTaYj45QZohGQMXQIaCokxyRXgsmGTxcANSPpBjIihaCVgqBTvJ5NJqzemh0+cVcL1IDFWvB61eFe57vVZvA208afUfdI/68MQ7PPQ6/dZ+D7qHsNvt7LX6rW4Hn34Er/MUHrY6extAca1wGjrBA438kSRT60gDtWg9SpcIDPiMUJpQnw2Yj37FwwzzAgwxN4sY3YGEioilajdTpBeglZBFTBKZ91xySte0geARzD4W6SQ41fM8kyoeXEhoh5GnOmZqOIukE8L0pY9Oc10vOPWSRNO0gA5gSFE+8UdIkR4LIumapjbWz4SgsT89VvZ2AJcTmlA96u1VN5blki+k+0eHF6UBGlzIQ3xIJaqs76BWQUYdBexNsQeXNuFqAZuLXh3pzQgBDKrz00YSpg8EiU8HGfopVOWrvVqa83VBBCAhgkRp85UGC1SVT9WdZR83zitIfl4seSF7rZTWc6YyE/GCsP5ryuO1dS0PckFxfvD2HkK++EWYcR6mmuBczm6H6OJ8x2buRTygYbM6pBGLGYaLuzkISToq3GAxLmHmq8PRrKoYxTjA4BzRMBlkIRA8SJh0Y1moxwRfOO4u+C+2N5/67kwnZ9R8dmn7n+P2aNqc5OyorOWPzTP66+X7RIkSJUpcwn+2Vos4ACgAAA==

--- a/tests/modules/agent_engine/examples/sa-create.yaml
+++ b/tests/modules/agent_engine/examples/sa-create.yaml
@@ -35,7 +35,6 @@ values:
     project: project-id
     timeouts: null
   module.agent_engine.google_vertex_ai_reasoning_engine.managed[0]:
-    context_spec: []
     deletion_policy: DELETE
     description: Terraform managed.
     display_name: my-agent
@@ -46,15 +45,18 @@ values:
     project: project-id
     region: europe-west8
     spec:
-    - agent_framework: google-adk
+    - agent_card: null
+      agent_framework: google-adk
+      build_spec: []
       class_methods: null
       container_spec: []
-      deployment_spec: []
+      example_store: null
       identity_type: SERVICE_ACCOUNT
       package_spec: []
       service_account: my-agent@project-id.iam.gserviceaccount.com
       source_code_spec:
-      - developer_connect_source: []
+      - agent_config_source: []
+        developer_connect_source: []
         image_spec: []
         inline_source:
         - source_archive: H4sIAMCUSmkAA+1Y727bNhB3CwzbtM/b55v7oQmQyPprJyk8QE2y1ahrZ7HTriiKgJFom4skqhRV2yj6Hvu8PdL2AgP2CHuAHWXZiZP+C5C4WKsfQNjiHY+/I3l3og7I5AElARU1/VjQFxkTNKKxTHU5kZVrgmEYdceBSiMHVCy34Vo2qP4ZXAdM17Qs1eomGJZp160KTK6LwLuQpZIIpBJmPkkElfQteolgERHToeBZ8ib5zBNY/P5PYDqQsaC5ZWw5DUuzDYgki2jTbNTrzrbrGNt6fatuGbhljvaxuZa4ftxc1J9hHv+24dqGbVyKf8uxl+PfbNgNtwLG9VO5jM88/itffPdl5Xal8oj40O3BL1BA9VW+xmZhe4FNPf/xYSa9fv+w+KtG/Ibtmwsqt876v/V5pJMkCameCP6SxiT2aeXW7cpf//z+1b9/b/15DU6WeBsOFvX/5vLA++o/Bv3F+m869bL+rwJXqf9uA9qt+97h7oPW4319QqQU+puCt+n93PLMbo/tHvRH3c4jzdmGHg5qP33XoHMRX75prAw3X/3fX//Ni/FvNsy6Udb/VWDI+TCkm37Is2CTsCQkcsBF9IwM8UQc03jIYpo+/6Fp6qZl6IZW6JPgNO9zdVPLxybMPw1ps2nrSutje1XiQ3Fw7v6f77meTK97jivc/03LdVX8u65R1v9V4J3139natnXbMvA2ZrlbZVR/gri5qD/DFe7/Rfy7bt0u6/9KUN7/P2uc1f+bywNXuP/P679tO2X9XwWuUv/L+/+nh5uv/u+t/5btXIx/13adsv6vAne+r2WpqJ2wuEbjl5BM5YjHtqbdgV2eTAUbjiSoz3/wU37xh3Z7V7uD0jbzaZzSALIYiwfIEQUvIT7+FJINeExFyngMlm7AmlKoFqLq+j20MOUZRGQKMZeQpRRNsBQGDOegE58mElgMmCiSkKn0AGMmR/k0hREdTTwtTPATSVCboH6CT4PzekBkTlhhJGWS7tRq4/EY849iq3MxrIUzzbTWbu3ud3r7m8g4H3MUhzRNofhGFsDJFFTaYj45QZohGQMXQIaCokxyRXgsmGTxcANSPpBjIihaCVgqBTvJ5NJqzemh0+cVcL1IDFWvB61eFe57vVZvA208afUfdI/68MQ7PPQ6/dZ+D7qHsNvt7LX6rW4Hn34Er/MUHrY6extAca1wGjrBA438kSRT60gDtWg9SpcIDPiMUJpQnw2Yj37FwwzzAgwxN4sY3YGEioilajdTpBeglZBFTBKZ91xySte0geARzD4W6SQ41fM8kyoeXEhoh5GnOmZqOIukE8L0pY9Oc10vOPWSRNO0gA5gSFE+8UdIkR4LIumapjbWz4SgsT89VvZ2AJcTmlA96u1VN5blki+k+0eHF6UBGlzIQ3xIJaqs76BWQUYdBexNsQeXNuFqAZuLXh3pzQgBDKrz00YSpg8EiU8HGfopVOWrvVqa83VBBCAhgkRp85UGC1SVT9WdZR83zitIfl4seSF7rZTWc6YyE/GCsP5ryuO1dS0PckFxfvD2HkK++EWYcR6mmuBczm6H6OJ8x2buRTygYbM6pBGLGYaLuzkISToq3GAxLmHmq8PRrKoYxTjA4BzRMBlkIRA8SJh0Y1moxwRfOO4u+C+2N5/67kwnZ9R8dmn7n+P2aNqc5OyorOWPzTP66+X7RIkSJUpcwn+2Vos4ACgAAA==
@@ -66,7 +68,7 @@ values:
     terraform_labels:
       goog-terraform-provisioned: 'true'
     timeouts: null
-
+    
 counts:
   google_project_iam_member: 2
   google_service_account: 1

--- a/tests/modules/agent_engine/examples/sa-create.yaml
+++ b/tests/modules/agent_engine/examples/sa-create.yaml
@@ -68,7 +68,7 @@ values:
     terraform_labels:
       goog-terraform-provisioned: 'true'
     timeouts: null
-    
+
 counts:
   google_project_iam_member: 2
   google_service_account: 1

--- a/tests/modules/agent_engine/examples/sa-external.yaml
+++ b/tests/modules/agent_engine/examples/sa-external.yaml
@@ -14,7 +14,6 @@
 
 values:
   module.agent_engine.google_vertex_ai_reasoning_engine.managed[0]:
-    context_spec: []
     deletion_policy: DELETE
     description: Terraform managed.
     display_name: my-agent
@@ -25,15 +24,18 @@ values:
     project: project-id
     region: europe-west8
     spec:
-    - agent_framework: google-adk
+    - agent_card: null
+      agent_framework: google-adk
+      build_spec: []
       class_methods: null
       container_spec: []
-      deployment_spec: []
+      example_store: null
       identity_type: SERVICE_ACCOUNT
       package_spec: []
       service_account: my-agent@project-id.iam.gserviceaccount.com
       source_code_spec:
-      - developer_connect_source: []
+      - agent_config_source: []
+        developer_connect_source: []
         image_spec: []
         inline_source:
         - source_archive: H4sIAMCUSmkAA+1Y727bNhB3CwzbtM/b55v7oQmQyPprJyk8QE2y1ahrZ7HTriiKgJFom4skqhRV2yj6Hvu8PdL2AgP2CHuAHWXZiZP+C5C4WKsfQNjiHY+/I3l3og7I5AElARU1/VjQFxkTNKKxTHU5kZVrgmEYdceBSiMHVCy34Vo2qP4ZXAdM17Qs1eomGJZp160KTK6LwLuQpZIIpBJmPkkElfQteolgERHToeBZ8ib5zBNY/P5PYDqQsaC5ZWw5DUuzDYgki2jTbNTrzrbrGNt6fatuGbhljvaxuZa4ftxc1J9hHv+24dqGbVyKf8uxl+PfbNgNtwLG9VO5jM88/itffPdl5Xal8oj40O3BL1BA9VW+xmZhe4FNPf/xYSa9fv+w+KtG/Ibtmwsqt876v/V5pJMkCameCP6SxiT2aeXW7cpf//z+1b9/b/15DU6WeBsOFvX/5vLA++o/Bv3F+m869bL+rwJXqf9uA9qt+97h7oPW4319QqQU+puCt+n93PLMbo/tHvRH3c4jzdmGHg5qP33XoHMRX75prAw3X/3fX//Ni/FvNsy6Udb/VWDI+TCkm37Is2CTsCQkcsBF9IwM8UQc03jIYpo+/6Fp6qZl6IZW6JPgNO9zdVPLxybMPw1ps2nrSutje1XiQ3Fw7v6f77meTK97jivc/03LdVX8u65R1v9V4J3139natnXbMvA2ZrlbZVR/gri5qD/DFe7/Rfy7bt0u6/9KUN7/P2uc1f+bywNXuP/P679tO2X9XwWuUv/L+/+nh5uv/u+t/5btXIx/13adsv6vAne+r2WpqJ2wuEbjl5BM5YjHtqbdgV2eTAUbjiSoz3/wU37xh3Z7V7uD0jbzaZzSALIYiwfIEQUvIT7+FJINeExFyngMlm7AmlKoFqLq+j20MOUZRGQKMZeQpRRNsBQGDOegE58mElgMmCiSkKn0AGMmR/k0hREdTTwtTPATSVCboH6CT4PzekBkTlhhJGWS7tRq4/EY849iq3MxrIUzzbTWbu3ud3r7m8g4H3MUhzRNofhGFsDJFFTaYj45QZohGQMXQIaCokxyRXgsmGTxcANSPpBjIihaCVgqBTvJ5NJqzemh0+cVcL1IDFWvB61eFe57vVZvA208afUfdI/68MQ7PPQ6/dZ+D7qHsNvt7LX6rW4Hn34Er/MUHrY6extAca1wGjrBA438kSRT60gDtWg9SpcIDPiMUJpQnw2Yj37FwwzzAgwxN4sY3YGEioilajdTpBeglZBFTBKZ91xySte0geARzD4W6SQ41fM8kyoeXEhoh5GnOmZqOIukE8L0pY9Oc10vOPWSRNO0gA5gSFE+8UdIkR4LIumapjbWz4SgsT89VvZ2AJcTmlA96u1VN5blki+k+0eHF6UBGlzIQ3xIJaqs76BWQUYdBexNsQeXNuFqAZuLXh3pzQgBDKrz00YSpg8EiU8HGfopVOWrvVqa83VBBCAhgkRp85UGC1SVT9WdZR83zitIfl4seSF7rZTWc6YyE/GCsP5ryuO1dS0PckFxfvD2HkK++EWYcR6mmuBczm6H6OJ8x2buRTygYbM6pBGLGYaLuzkISToq3GAxLmHmq8PRrKoYxTjA4BzRMBlkIRA8SJh0Y1moxwRfOO4u+C+2N5/67kwnZ9R8dmn7n+P2aNqc5OyorOWPzTP66+X7RIkSJUpcwn+2Vos4ACgAAA==

--- a/tests/modules/agent_engine/examples/unmanaged.yaml
+++ b/tests/modules/agent_engine/examples/unmanaged.yaml
@@ -22,7 +22,6 @@ values:
     project: project-id
     role: roles/storage.objectViewer
   module.agent_engine.google_vertex_ai_reasoning_engine.unmanaged[0]:
-    context_spec: []
     deletion_policy: DELETE
     description: Terraform managed.
     display_name: my-agent
@@ -33,15 +32,18 @@ values:
     project: project-id
     region: europe-west8
     spec:
-    - agent_framework: google-adk
+    - agent_card: null
+      agent_framework: google-adk
+      build_spec: []
       class_methods: null
       container_spec: []
-      deployment_spec: []
+      example_store: null
       identity_type: AGENT_IDENTITY
       package_spec: []
       service_account: null
       source_code_spec:
-      - developer_connect_source: []
+      - agent_config_source: []
+        developer_connect_source: []
         image_spec: []
         inline_source:
         - source_archive: H4sIAMCUSmkAA+1Y727bNhB3CwzbtM/b55v7oQmQyPprJyk8QE2y1ahrZ7HTriiKgJFom4skqhRV2yj6Hvu8PdL2AgP2CHuAHWXZiZP+C5C4WKsfQNjiHY+/I3l3og7I5AElARU1/VjQFxkTNKKxTHU5kZVrgmEYdceBSiMHVCy34Vo2qP4ZXAdM17Qs1eomGJZp160KTK6LwLuQpZIIpBJmPkkElfQteolgERHToeBZ8ib5zBNY/P5PYDqQsaC5ZWw5DUuzDYgki2jTbNTrzrbrGNt6fatuGbhljvaxuZa4ftxc1J9hHv+24dqGbVyKf8uxl+PfbNgNtwLG9VO5jM88/itffPdl5Xal8oj40O3BL1BA9VW+xmZhe4FNPf/xYSa9fv+w+KtG/Ibtmwsqt876v/V5pJMkCameCP6SxiT2aeXW7cpf//z+1b9/b/15DU6WeBsOFvX/5vLA++o/Bv3F+m869bL+rwJXqf9uA9qt+97h7oPW4319QqQU+puCt+n93PLMbo/tHvRH3c4jzdmGHg5qP33XoHMRX75prAw3X/3fX//Ni/FvNsy6Udb/VWDI+TCkm37Is2CTsCQkcsBF9IwM8UQc03jIYpo+/6Fp6qZl6IZW6JPgNO9zdVPLxybMPw1ps2nrSutje1XiQ3Fw7v6f77meTK97jivc/03LdVX8u65R1v9V4J3139natnXbMvA2ZrlbZVR/gri5qD/DFe7/Rfy7bt0u6/9KUN7/P2uc1f+bywNXuP/P679tO2X9XwWuUv/L+/+nh5uv/u+t/5btXIx/13adsv6vAne+r2WpqJ2wuEbjl5BM5YjHtqbdgV2eTAUbjiSoz3/wU37xh3Z7V7uD0jbzaZzSALIYiwfIEQUvIT7+FJINeExFyngMlm7AmlKoFqLq+j20MOUZRGQKMZeQpRRNsBQGDOegE58mElgMmCiSkKn0AGMmR/k0hREdTTwtTPATSVCboH6CT4PzekBkTlhhJGWS7tRq4/EY849iq3MxrIUzzbTWbu3ud3r7m8g4H3MUhzRNofhGFsDJFFTaYj45QZohGQMXQIaCokxyRXgsmGTxcANSPpBjIihaCVgqBTvJ5NJqzemh0+cVcL1IDFWvB61eFe57vVZvA208afUfdI/68MQ7PPQ6/dZ+D7qHsNvt7LX6rW4Hn34Er/MUHrY6extAca1wGjrBA438kSRT60gDtWg9SpcIDPiMUJpQnw2Yj37FwwzzAgwxN4sY3YGEioilajdTpBeglZBFTBKZ91xySte0geARzD4W6SQ41fM8kyoeXEhoh5GnOmZqOIukE8L0pY9Oc10vOPWSRNO0gA5gSFE+8UdIkR4LIumapjbWz4SgsT89VvZ2AJcTmlA96u1VN5blki+k+0eHF6UBGlzIQ3xIJaqs76BWQUYdBexNsQeXNuFqAZuLXh3pzQgBDKrz00YSpg8EiU8HGfopVOWrvVqa83VBBCAhgkRp85UGC1SVT9WdZR83zitIfl4seSF7rZTWc6YyE/GCsP5ryuO1dS0PckFxfvD2HkK++EWYcR6mmuBczm6H6OJ8x2buRTygYbM6pBGLGYaLuzkISToq3GAxLmHmq8PRrKoYxTjA4BzRMBlkIRA8SJh0Y1moxwRfOO4u+C+2N5/67kwnZ9R8dmn7n+P2aNqc5OyorOWPzTP66+X7RIkSJUpcwn+2Vos4ACgAAA==

--- a/tests/modules/agent_gateway/examples/context.yaml
+++ b/tests/modules/agent_gateway/examples/context.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,6 +14,7 @@
 
 values:
   module.agent-gateway.google_network_services_agent_gateway.default:
+    deletion_policy: DELETE
     description: Terraform managed.
     effective_labels:
       goog-terraform-provisioned: 'true'
@@ -23,11 +24,11 @@ values:
     location: europe-west1
     name: my-gateway
     network_config:
-    - egress:
+    - dns_peering_config: []
+      egress:
       - network_attachment: projects/my-project-id/regions/europe-west1/serviceAttachments/my-sa
     project: my-prj-id
-    protocols:
-    - MCP
+    protocols: null
     registries: null
     self_managed: []
     terraform_labels:

--- a/tests/modules/agent_gateway/examples/minimal.yaml
+++ b/tests/modules/agent_gateway/examples/minimal.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,6 +14,7 @@
 
 values:
   module.agent-gateway.google_network_services_agent_gateway.default:
+    deletion_policy: DELETE
     description: Terraform managed.
     effective_labels:
       goog-terraform-provisioned: 'true'
@@ -24,8 +25,7 @@ values:
     name: my-gateway
     network_config: []
     project: my-project-id
-    protocols:
-    - MCP
+    protocols: null
     registries: null
     self_managed: []
     terraform_labels:

--- a/tests/modules/agent_gateway/examples/peering.yaml
+++ b/tests/modules/agent_gateway/examples/peering.yaml
@@ -1,0 +1,47 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values:
+  module.agent-gateway.google_network_services_agent_gateway.default:
+    deletion_policy: DELETE
+    description: Terraform managed.
+    effective_labels:
+      goog-terraform-provisioned: 'true'
+    google_managed:
+    - governed_access_path: AGENT_TO_ANYWHERE
+    labels: null
+    location: europe-west1
+    name: my-gateway
+    network_config:
+    - dns_peering_config:
+      - domains:
+        - agents.internal.
+        target_network: projects/my-host-project/global/networks/my-vpc
+        target_project: my-host-project
+      egress:
+      - network_attachment: projects/my-project-id/regions/europe-west1/serviceAttachments/my-sa
+    project: my-project-id
+    protocols: null
+    registries: null
+    self_managed: []
+    terraform_labels:
+      goog-terraform-provisioned: 'true'
+    timeouts: null
+
+counts:
+  google_network_services_agent_gateway: 1
+  modules: 1
+  resources: 1
+
+outputs: {}

--- a/tests/modules/agent_gateway/examples/proxy.yaml
+++ b/tests/modules/agent_gateway/examples/proxy.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,6 +14,7 @@
 
 values:
   module.agent-gateway.google_network_services_agent_gateway.default:
+    deletion_policy: DELETE
     description: Terraform managed.
     effective_labels:
       goog-terraform-provisioned: 'true'
@@ -23,8 +24,7 @@ values:
     name: my-gateway
     network_config: []
     project: my-project-id
-    protocols:
-    - MCP
+    protocols: null
     registries: null
     self_managed:
     - resource_uri: my-proxy-uri

--- a/tests/modules/agent_gateway/examples/psc-i.yaml
+++ b/tests/modules/agent_gateway/examples/psc-i.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,6 +14,7 @@
 
 values:
   module.agent-gateway.google_network_services_agent_gateway.default:
+    deletion_policy: DELETE
     description: Terraform managed.
     effective_labels:
       goog-terraform-provisioned: 'true'
@@ -23,11 +24,11 @@ values:
     location: europe-west1
     name: my-gateway
     network_config:
-    - egress:
+    - dns_peering_config: []
+      egress:
       - network_attachment: projects/my-project-id/regions/europe-west1/serviceAttachments/my-sa
     project: my-project-id
-    protocols:
-    - MCP
+    protocols: null
     registries: null
     self_managed: []
     terraform_labels:

--- a/tools/lockfile/versions.tf
+++ b/tools/lockfile/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {

--- a/tools/lockfile/versions.tofu
+++ b/tools/lockfile/versions.tofu
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.33.0, < 8.0.0" # tftest
+      version = ">= 7.40.0, < 8.0.0" # tftest
     }
   }
   provider_meta "google" {


### PR DESCRIPTION
**Breaking Changes**

```upgrade-note
`provider`: Minimum version bumped to 7.40.0.
```

```upgrade-note
`modules/agent-gateway`: Removed deprecated `protocols` variable (field deprecated upstream).
```
