### PR TITLE
Fix folder schema

### DIFF
--- a/fast/stages/0-org-setup/schemas/folder.schema.json
+++ b/fast/stages/0-org-setup/schemas/folder.schema.json
@@ -530,25 +530,116 @@
       "pattern": "^(?:folders/[0-9]+|organizations/[0-9]+|\\$folder_ids:[a-z0-9_-]+)$"
     },
     "tag_bindings": {
-      "type": "object",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^[a-z0-9_-]+$": {
-          "type": "string"
-        }
-      }
+      "$ref": "#/$defs/tag_bindings"
     }
   },
   "$defs": {
-    "labels": {
+    "assured_workload_config": {
       "type": "object",
       "additionalProperties": false,
-      "patternProperties": {
-        "^[a-z][a-z0-9_-]{0,62}$": {
+      "properties": {
+        "compliance_regime": {
           "type": "string",
-          "pattern": "^[a-z0-9_-]{0,63}$"
+          "enum": [
+            "ASSURED_WORKLOADS_FOR_PARTNERS",
+            "AU_REGIONS_AND_US_SUPPORT",
+            "AUSTRALIA_DATA_BOUNDARY_AND_SUPPORT",
+            "CA_PROTECTED_B",
+            "CA_REGIONS_AND_SUPPORT",
+            "CANADA_CONTROLLED_GOODS",
+            "CANADA_DATA_BOUNDARY_AND_SUPPORT",
+            "CJIS",
+            "COMPLIANCE_REGIME_UNSPECIFIED",
+            "DATA_BOUNDARY_FOR_CANADA_CONTROLLED_GOODS",
+            "DATA_BOUNDARY_FOR_CANADA_PROTECTED_B",
+            "DATA_BOUNDARY_FOR_CJIS",
+            "DATA_BOUNDARY_FOR_FEDRAMP_HIGH",
+            "DATA_BOUNDARY_FOR_FEDRAMP_MODERATE",
+            "DATA_BOUNDARY_FOR_IL2",
+            "DATA_BOUNDARY_FOR_IL4",
+            "DATA_BOUNDARY_FOR_IL5",
+            "DATA_BOUNDARY_FOR_IRS_PUBLICATION_1075",
+            "DATA_BOUNDARY_FOR_ITAR",
+            "EU_DATA_BOUNDARY_AND_SUPPORT",
+            "EU_REGIONS_AND_SUPPORT",
+            "FEDRAMP_HIGH",
+            "FEDRAMP_MODERATE",
+            "HEALTHCARE_AND_LIFE_SCIENCES_CONTROLS",
+            "HEALTHCARE_AND_LIFE_SCIENCES_CONTROLS_US_SUPPORT",
+            "HIPAA",
+            "HITRUST",
+            "IL2",
+            "IL4",
+            "IL5",
+            "IRS_1075",
+            "ISR_REGIONS",
+            "ISR_REGIONS_AND_SUPPORT",
+            "ISRAEL_DATA_BOUNDARY_AND_SUPPORT",
+            "ITAR",
+            "JAPAN_DATA_BOUNDARY",
+            "JP_REGIONS_AND_SUPPORT",
+            "KSA_DATA_BOUNDARY_WITH_ACCESS_JUSTIFICATIONS",
+            "KSA_REGIONS_AND_SUPPORT_WITH_SOVEREIGNTY_CONTROLS",
+            "REGIONAL_CONTROLS",
+            "REGIONAL_DATA_BOUNDARY",
+            "US_DATA_BOUNDARY_AND_SUPPORT",
+            "US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES",
+            "US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES_WITH_SUPPORT",
+            "US_REGIONAL_ACCESS"
+          ]
+        },
+        "display_name": {
+          "type": "string"
+        },
+        "location": {
+          "type": "string"
+        },
+        "organization": {
+          "type": "string"
+        },
+        "enable_sovereign_controls": {
+          "type": "boolean"
+        },
+        "labels": {
+          "$ref": "#/$defs/labels"
+        },
+        "partner": {
+          "type": "string",
+          "enum": [
+            "LOCAL_CONTROLS_BY_S3NS",
+            "PARTNER_UNSPECIFIED",
+            "SOVEREIGN_CONTROLS_BY_CNTXT_NO_EKM",
+            "SOVEREIGN_CONTROLS_BY_CNTXT",
+            "SOVEREIGN_CONTROLS_BY_PSN",
+            "SOVEREIGN_CONTROLS_BY_SIA_MINSAIT",
+            "SOVEREIGN_CONTROLS_BY_T_SYSTEMS"
+          ]
+        },
+        "partner_permissions": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "assured_workloads_monitoring": {
+              "type": "boolean"
+            },
+            "data_logs_viewer": {
+              "type": "boolean"
+            },
+            "service_access_approver": {
+              "type": "boolean"
+            }
+          }
+        },
+        "violation_notifications_enabled": {
+          "type": "boolean"
         }
-      }
+      },
+      "required": [
+        "compliance_regime",
+        "display_name",
+        "location",
+        "organization"
+      ]
     },
     "bucket": {
       "type": "object",
@@ -837,6 +928,16 @@
         }
       }
     },
+    "labels": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z][a-z0-9_-]{0,62}$": {
+          "type": "string",
+          "pattern": "^[a-z0-9_-]{0,63}$"
+        }
+      }
+    },
     "pam_entitlements": {
       "type": "object",
       "additionalProperties": false,
@@ -951,112 +1052,14 @@
         }
       }
     },
-    "assured_workload_config": {
+    "tag_bindings": {
       "type": "object",
       "additionalProperties": false,
-      "properties": {
-        "compliance_regime": {
-          "type": "string",
-          "enum": [
-            "ASSURED_WORKLOADS_FOR_PARTNERS",
-            "AU_REGIONS_AND_US_SUPPORT",
-            "AUSTRALIA_DATA_BOUNDARY_AND_SUPPORT",
-            "CA_PROTECTED_B",
-            "CA_REGIONS_AND_SUPPORT",
-            "CANADA_CONTROLLED_GOODS",
-            "CANADA_DATA_BOUNDARY_AND_SUPPORT",
-            "CJIS",
-            "COMPLIANCE_REGIME_UNSPECIFIED",
-            "DATA_BOUNDARY_FOR_CANADA_CONTROLLED_GOODS",
-            "DATA_BOUNDARY_FOR_CANADA_PROTECTED_B",
-            "DATA_BOUNDARY_FOR_CJIS",
-            "DATA_BOUNDARY_FOR_FEDRAMP_HIGH",
-            "DATA_BOUNDARY_FOR_FEDRAMP_MODERATE",
-            "DATA_BOUNDARY_FOR_IL2",
-            "DATA_BOUNDARY_FOR_IL4",
-            "DATA_BOUNDARY_FOR_IL5",
-            "DATA_BOUNDARY_FOR_IRS_PUBLICATION_1075",
-            "DATA_BOUNDARY_FOR_ITAR",
-            "EU_DATA_BOUNDARY_AND_SUPPORT",
-            "EU_REGIONS_AND_SUPPORT",
-            "FEDRAMP_HIGH",
-            "FEDRAMP_MODERATE",
-            "HEALTHCARE_AND_LIFE_SCIENCES_CONTROLS",
-            "HEALTHCARE_AND_LIFE_SCIENCES_CONTROLS_US_SUPPORT",
-            "HIPAA",
-            "HITRUST",
-            "IL2",
-            "IL4",
-            "IL5",
-            "IRS_1075",
-            "ISR_REGIONS",
-            "ISR_REGIONS_AND_SUPPORT",
-            "ISRAEL_DATA_BOUNDARY_AND_SUPPORT",
-            "ITAR",
-            "JAPAN_DATA_BOUNDARY",
-            "JP_REGIONS_AND_SUPPORT",
-            "KSA_DATA_BOUNDARY_WITH_ACCESS_JUSTIFICATIONS",
-            "KSA_REGIONS_AND_SUPPORT_WITH_SOVEREIGNTY_CONTROLS",
-            "REGIONAL_CONTROLS",
-            "REGIONAL_DATA_BOUNDARY",
-            "US_DATA_BOUNDARY_AND_SUPPORT",
-            "US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES",
-            "US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES_WITH_SUPPORT",
-            "US_REGIONAL_ACCESS"
-          ]
-        },
-        "display_name": {
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
           "type": "string"
-        },
-        "location": {
-          "type": "string"
-        },
-        "organization": {
-          "type": "string"
-        },
-        "enable_sovereign_controls": {
-          "type": "boolean"
-        },
-        "labels": {
-          "$ref": "#/$defs/labels"
-        },
-        "partner": {
-          "type": "string",
-          "enum": [
-            "LOCAL_CONTROLS_BY_S3NS",
-            "PARTNER_UNSPECIFIED",
-            "SOVEREIGN_CONTROLS_BY_CNTXT_NO_EKM",
-            "SOVEREIGN_CONTROLS_BY_CNTXT",
-            "SOVEREIGN_CONTROLS_BY_PSN",
-            "SOVEREIGN_CONTROLS_BY_SIA_MINSAIT",
-            "SOVEREIGN_CONTROLS_BY_T_SYSTEMS"
-          ]
-        },
-        "partner_permissions": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "assured_workloads_monitoring": {
-              "type": "boolean"
-            },
-            "data_logs_viewer": {
-              "type": "boolean"
-            },
-            "service_access_approver": {
-              "type": "boolean"
-            }
-          }
-        },
-        "violation_notifications_enabled": {
-          "type": "boolean"
         }
-      },
-      "required": [
-        "compliance_regime",
-        "display_name",
-        "location",
-        "organization"
-      ]
+      }
     }
   }
 }

--- a/fast/stages/0-org-setup/schemas/folder.schema.md
+++ b/fast/stages/0-org-setup/schemas/folder.schema.md
@@ -166,16 +166,27 @@
 - **assured_workload_config**: *reference([assured_workload_config](#refs-assured_workload_config))*
 - **parent**: *string*
   <br>*pattern: ^(?:folders/[0-9]+|organizations/[0-9]+|\$folder_ids:[a-z0-9_-]+)$*
-- **tag_bindings**: *object*
-  <br>*additional properties: false*
-  - **`^[a-z0-9_-]+$`**: *string*
+- **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
 
 ## Definitions
 
-- **labels**<a name="refs-labels"></a>: *object*
+- **assured_workload_config**<a name="refs-assured_workload_config"></a>: *object*
   <br>*additional properties: false*
-  - **`^[a-z][a-z0-9_-]{0,62}$`**: *string*
-    <br>*pattern: ^[a-z0-9_-]{0,63}$*
+  - ⁺**compliance_regime**: *string*
+    <br>*enum: ['ASSURED_WORKLOADS_FOR_PARTNERS', 'AU_REGIONS_AND_US_SUPPORT', 'AUSTRALIA_DATA_BOUNDARY_AND_SUPPORT', 'CA_PROTECTED_B', 'CA_REGIONS_AND_SUPPORT', 'CANADA_CONTROLLED_GOODS', 'CANADA_DATA_BOUNDARY_AND_SUPPORT', 'CJIS', 'COMPLIANCE_REGIME_UNSPECIFIED', 'DATA_BOUNDARY_FOR_CANADA_CONTROLLED_GOODS', 'DATA_BOUNDARY_FOR_CANADA_PROTECTED_B', 'DATA_BOUNDARY_FOR_CJIS', 'DATA_BOUNDARY_FOR_FEDRAMP_HIGH', 'DATA_BOUNDARY_FOR_FEDRAMP_MODERATE', 'DATA_BOUNDARY_FOR_IL2', 'DATA_BOUNDARY_FOR_IL4', 'DATA_BOUNDARY_FOR_IL5', 'DATA_BOUNDARY_FOR_IRS_PUBLICATION_1075', 'DATA_BOUNDARY_FOR_ITAR', 'EU_DATA_BOUNDARY_AND_SUPPORT', 'EU_REGIONS_AND_SUPPORT', 'FEDRAMP_HIGH', 'FEDRAMP_MODERATE', 'HEALTHCARE_AND_LIFE_SCIENCES_CONTROLS', 'HEALTHCARE_AND_LIFE_SCIENCES_CONTROLS_US_SUPPORT', 'HIPAA', 'HITRUST', 'IL2', 'IL4', 'IL5', 'IRS_1075', 'ISR_REGIONS', 'ISR_REGIONS_AND_SUPPORT', 'ISRAEL_DATA_BOUNDARY_AND_SUPPORT', 'ITAR', 'JAPAN_DATA_BOUNDARY', 'JP_REGIONS_AND_SUPPORT', 'KSA_DATA_BOUNDARY_WITH_ACCESS_JUSTIFICATIONS', 'KSA_REGIONS_AND_SUPPORT_WITH_SOVEREIGNTY_CONTROLS', 'REGIONAL_CONTROLS', 'REGIONAL_DATA_BOUNDARY', 'US_DATA_BOUNDARY_AND_SUPPORT', 'US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES', 'US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES_WITH_SUPPORT', 'US_REGIONAL_ACCESS']*
+  - ⁺**display_name**: *string*
+  - ⁺**location**: *string*
+  - ⁺**organization**: *string*
+  - **enable_sovereign_controls**: *boolean*
+  - **labels**: *reference([labels](#refs-labels))*
+  - **partner**: *string*
+    <br>*enum: ['LOCAL_CONTROLS_BY_S3NS', 'PARTNER_UNSPECIFIED', 'SOVEREIGN_CONTROLS_BY_CNTXT_NO_EKM', 'SOVEREIGN_CONTROLS_BY_CNTXT', 'SOVEREIGN_CONTROLS_BY_PSN', 'SOVEREIGN_CONTROLS_BY_SIA_MINSAIT', 'SOVEREIGN_CONTROLS_BY_T_SYSTEMS']*
+  - **partner_permissions**: *object*
+    <br>*additional properties: false*
+    - **assured_workloads_monitoring**: *boolean*
+    - **data_logs_viewer**: *boolean*
+    - **service_access_approver**: *boolean*
+  - **violation_notifications_enabled**: *boolean*
 - **bucket**<a name="refs-bucket"></a>: *object*
   <br>*additional properties: false*
   - **name**: *string*
@@ -271,6 +282,10 @@
   <br>*additional properties: false*
   - **`^[a-z0-9-]+$`**: *array*
     - items: *string*
+- **labels**<a name="refs-labels"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z][a-z0-9_-]{0,62}$`**: *string*
+    <br>*pattern: ^[a-z0-9_-]{0,63}$*
 - **pam_entitlements**<a name="refs-pam_entitlements"></a>: *object*
   <br>*additional properties: false*
   - **`^[a-z][a-z0-9-]{0,61}[a-z0-9]$`**: *object*
@@ -304,20 +319,6 @@
         - items: *string*
       - **requester_email_recipients**: *array*
         - items: *string*
-- **assured_workload_config**<a name="refs-assured_workload_config"></a>: *object*
+- **tag_bindings**<a name="refs-tag_bindings"></a>: *object*
   <br>*additional properties: false*
-  - ⁺**compliance_regime**: *string*
-    <br>*enum: ['ASSURED_WORKLOADS_FOR_PARTNERS', 'AU_REGIONS_AND_US_SUPPORT', 'AUSTRALIA_DATA_BOUNDARY_AND_SUPPORT', 'CA_PROTECTED_B', 'CA_REGIONS_AND_SUPPORT', 'CANADA_CONTROLLED_GOODS', 'CANADA_DATA_BOUNDARY_AND_SUPPORT', 'CJIS', 'COMPLIANCE_REGIME_UNSPECIFIED', 'DATA_BOUNDARY_FOR_CANADA_CONTROLLED_GOODS', 'DATA_BOUNDARY_FOR_CANADA_PROTECTED_B', 'DATA_BOUNDARY_FOR_CJIS', 'DATA_BOUNDARY_FOR_FEDRAMP_HIGH', 'DATA_BOUNDARY_FOR_FEDRAMP_MODERATE', 'DATA_BOUNDARY_FOR_IL2', 'DATA_BOUNDARY_FOR_IL4', 'DATA_BOUNDARY_FOR_IL5', 'DATA_BOUNDARY_FOR_IRS_PUBLICATION_1075', 'DATA_BOUNDARY_FOR_ITAR', 'EU_DATA_BOUNDARY_AND_SUPPORT', 'EU_REGIONS_AND_SUPPORT', 'FEDRAMP_HIGH', 'FEDRAMP_MODERATE', 'HEALTHCARE_AND_LIFE_SCIENCES_CONTROLS', 'HEALTHCARE_AND_LIFE_SCIENCES_CONTROLS_US_SUPPORT', 'HIPAA', 'HITRUST', 'IL2', 'IL4', 'IL5', 'IRS_1075', 'ISR_REGIONS', 'ISR_REGIONS_AND_SUPPORT', 'ISRAEL_DATA_BOUNDARY_AND_SUPPORT', 'ITAR', 'JAPAN_DATA_BOUNDARY', 'JP_REGIONS_AND_SUPPORT', 'KSA_DATA_BOUNDARY_WITH_ACCESS_JUSTIFICATIONS', 'KSA_REGIONS_AND_SUPPORT_WITH_SOVEREIGNTY_CONTROLS', 'REGIONAL_CONTROLS', 'REGIONAL_DATA_BOUNDARY', 'US_DATA_BOUNDARY_AND_SUPPORT', 'US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES', 'US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES_WITH_SUPPORT', 'US_REGIONAL_ACCESS']*
-  - ⁺**display_name**: *string*
-  - ⁺**location**: *string*
-  - ⁺**organization**: *string*
-  - **enable_sovereign_controls**: *boolean*
-  - **labels**: *reference([labels](#refs-labels))*
-  - **partner**: *string*
-    <br>*enum: ['LOCAL_CONTROLS_BY_S3NS', 'PARTNER_UNSPECIFIED', 'SOVEREIGN_CONTROLS_BY_CNTXT_NO_EKM', 'SOVEREIGN_CONTROLS_BY_CNTXT', 'SOVEREIGN_CONTROLS_BY_PSN', 'SOVEREIGN_CONTROLS_BY_SIA_MINSAIT', 'SOVEREIGN_CONTROLS_BY_T_SYSTEMS']*
-  - **partner_permissions**: *object*
-    <br>*additional properties: false*
-    - **assured_workloads_monitoring**: *boolean*
-    - **data_logs_viewer**: *boolean*
-    - **service_access_approver**: *boolean*
-  - **violation_notifications_enabled**: *boolean*
+  - **`^[a-z0-9_-]+$`**: *string*

--- a/fast/stages/2-networking/schemas/folder.schema.json
+++ b/fast/stages/2-networking/schemas/folder.schema.json
@@ -530,25 +530,116 @@
       "pattern": "^(?:folders/[0-9]+|organizations/[0-9]+|\\$folder_ids:[a-z0-9_-]+)$"
     },
     "tag_bindings": {
-      "type": "object",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^[a-z0-9_-]+$": {
-          "type": "string"
-        }
-      }
+      "$ref": "#/$defs/tag_bindings"
     }
   },
   "$defs": {
-    "labels": {
+    "assured_workload_config": {
       "type": "object",
       "additionalProperties": false,
-      "patternProperties": {
-        "^[a-z][a-z0-9_-]{0,62}$": {
+      "properties": {
+        "compliance_regime": {
           "type": "string",
-          "pattern": "^[a-z0-9_-]{0,63}$"
+          "enum": [
+            "ASSURED_WORKLOADS_FOR_PARTNERS",
+            "AU_REGIONS_AND_US_SUPPORT",
+            "AUSTRALIA_DATA_BOUNDARY_AND_SUPPORT",
+            "CA_PROTECTED_B",
+            "CA_REGIONS_AND_SUPPORT",
+            "CANADA_CONTROLLED_GOODS",
+            "CANADA_DATA_BOUNDARY_AND_SUPPORT",
+            "CJIS",
+            "COMPLIANCE_REGIME_UNSPECIFIED",
+            "DATA_BOUNDARY_FOR_CANADA_CONTROLLED_GOODS",
+            "DATA_BOUNDARY_FOR_CANADA_PROTECTED_B",
+            "DATA_BOUNDARY_FOR_CJIS",
+            "DATA_BOUNDARY_FOR_FEDRAMP_HIGH",
+            "DATA_BOUNDARY_FOR_FEDRAMP_MODERATE",
+            "DATA_BOUNDARY_FOR_IL2",
+            "DATA_BOUNDARY_FOR_IL4",
+            "DATA_BOUNDARY_FOR_IL5",
+            "DATA_BOUNDARY_FOR_IRS_PUBLICATION_1075",
+            "DATA_BOUNDARY_FOR_ITAR",
+            "EU_DATA_BOUNDARY_AND_SUPPORT",
+            "EU_REGIONS_AND_SUPPORT",
+            "FEDRAMP_HIGH",
+            "FEDRAMP_MODERATE",
+            "HEALTHCARE_AND_LIFE_SCIENCES_CONTROLS",
+            "HEALTHCARE_AND_LIFE_SCIENCES_CONTROLS_US_SUPPORT",
+            "HIPAA",
+            "HITRUST",
+            "IL2",
+            "IL4",
+            "IL5",
+            "IRS_1075",
+            "ISR_REGIONS",
+            "ISR_REGIONS_AND_SUPPORT",
+            "ISRAEL_DATA_BOUNDARY_AND_SUPPORT",
+            "ITAR",
+            "JAPAN_DATA_BOUNDARY",
+            "JP_REGIONS_AND_SUPPORT",
+            "KSA_DATA_BOUNDARY_WITH_ACCESS_JUSTIFICATIONS",
+            "KSA_REGIONS_AND_SUPPORT_WITH_SOVEREIGNTY_CONTROLS",
+            "REGIONAL_CONTROLS",
+            "REGIONAL_DATA_BOUNDARY",
+            "US_DATA_BOUNDARY_AND_SUPPORT",
+            "US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES",
+            "US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES_WITH_SUPPORT",
+            "US_REGIONAL_ACCESS"
+          ]
+        },
+        "display_name": {
+          "type": "string"
+        },
+        "location": {
+          "type": "string"
+        },
+        "organization": {
+          "type": "string"
+        },
+        "enable_sovereign_controls": {
+          "type": "boolean"
+        },
+        "labels": {
+          "$ref": "#/$defs/labels"
+        },
+        "partner": {
+          "type": "string",
+          "enum": [
+            "LOCAL_CONTROLS_BY_S3NS",
+            "PARTNER_UNSPECIFIED",
+            "SOVEREIGN_CONTROLS_BY_CNTXT_NO_EKM",
+            "SOVEREIGN_CONTROLS_BY_CNTXT",
+            "SOVEREIGN_CONTROLS_BY_PSN",
+            "SOVEREIGN_CONTROLS_BY_SIA_MINSAIT",
+            "SOVEREIGN_CONTROLS_BY_T_SYSTEMS"
+          ]
+        },
+        "partner_permissions": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "assured_workloads_monitoring": {
+              "type": "boolean"
+            },
+            "data_logs_viewer": {
+              "type": "boolean"
+            },
+            "service_access_approver": {
+              "type": "boolean"
+            }
+          }
+        },
+        "violation_notifications_enabled": {
+          "type": "boolean"
         }
-      }
+      },
+      "required": [
+        "compliance_regime",
+        "display_name",
+        "location",
+        "organization"
+      ]
     },
     "bucket": {
       "type": "object",
@@ -837,6 +928,16 @@
         }
       }
     },
+    "labels": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z][a-z0-9_-]{0,62}$": {
+          "type": "string",
+          "pattern": "^[a-z0-9_-]{0,63}$"
+        }
+      }
+    },
     "pam_entitlements": {
       "type": "object",
       "additionalProperties": false,
@@ -951,112 +1052,14 @@
         }
       }
     },
-    "assured_workload_config": {
+    "tag_bindings": {
       "type": "object",
       "additionalProperties": false,
-      "properties": {
-        "compliance_regime": {
-          "type": "string",
-          "enum": [
-            "ASSURED_WORKLOADS_FOR_PARTNERS",
-            "AU_REGIONS_AND_US_SUPPORT",
-            "AUSTRALIA_DATA_BOUNDARY_AND_SUPPORT",
-            "CA_PROTECTED_B",
-            "CA_REGIONS_AND_SUPPORT",
-            "CANADA_CONTROLLED_GOODS",
-            "CANADA_DATA_BOUNDARY_AND_SUPPORT",
-            "CJIS",
-            "COMPLIANCE_REGIME_UNSPECIFIED",
-            "DATA_BOUNDARY_FOR_CANADA_CONTROLLED_GOODS",
-            "DATA_BOUNDARY_FOR_CANADA_PROTECTED_B",
-            "DATA_BOUNDARY_FOR_CJIS",
-            "DATA_BOUNDARY_FOR_FEDRAMP_HIGH",
-            "DATA_BOUNDARY_FOR_FEDRAMP_MODERATE",
-            "DATA_BOUNDARY_FOR_IL2",
-            "DATA_BOUNDARY_FOR_IL4",
-            "DATA_BOUNDARY_FOR_IL5",
-            "DATA_BOUNDARY_FOR_IRS_PUBLICATION_1075",
-            "DATA_BOUNDARY_FOR_ITAR",
-            "EU_DATA_BOUNDARY_AND_SUPPORT",
-            "EU_REGIONS_AND_SUPPORT",
-            "FEDRAMP_HIGH",
-            "FEDRAMP_MODERATE",
-            "HEALTHCARE_AND_LIFE_SCIENCES_CONTROLS",
-            "HEALTHCARE_AND_LIFE_SCIENCES_CONTROLS_US_SUPPORT",
-            "HIPAA",
-            "HITRUST",
-            "IL2",
-            "IL4",
-            "IL5",
-            "IRS_1075",
-            "ISR_REGIONS",
-            "ISR_REGIONS_AND_SUPPORT",
-            "ISRAEL_DATA_BOUNDARY_AND_SUPPORT",
-            "ITAR",
-            "JAPAN_DATA_BOUNDARY",
-            "JP_REGIONS_AND_SUPPORT",
-            "KSA_DATA_BOUNDARY_WITH_ACCESS_JUSTIFICATIONS",
-            "KSA_REGIONS_AND_SUPPORT_WITH_SOVEREIGNTY_CONTROLS",
-            "REGIONAL_CONTROLS",
-            "REGIONAL_DATA_BOUNDARY",
-            "US_DATA_BOUNDARY_AND_SUPPORT",
-            "US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES",
-            "US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES_WITH_SUPPORT",
-            "US_REGIONAL_ACCESS"
-          ]
-        },
-        "display_name": {
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
           "type": "string"
-        },
-        "location": {
-          "type": "string"
-        },
-        "organization": {
-          "type": "string"
-        },
-        "enable_sovereign_controls": {
-          "type": "boolean"
-        },
-        "labels": {
-          "$ref": "#/$defs/labels"
-        },
-        "partner": {
-          "type": "string",
-          "enum": [
-            "LOCAL_CONTROLS_BY_S3NS",
-            "PARTNER_UNSPECIFIED",
-            "SOVEREIGN_CONTROLS_BY_CNTXT_NO_EKM",
-            "SOVEREIGN_CONTROLS_BY_CNTXT",
-            "SOVEREIGN_CONTROLS_BY_PSN",
-            "SOVEREIGN_CONTROLS_BY_SIA_MINSAIT",
-            "SOVEREIGN_CONTROLS_BY_T_SYSTEMS"
-          ]
-        },
-        "partner_permissions": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "assured_workloads_monitoring": {
-              "type": "boolean"
-            },
-            "data_logs_viewer": {
-              "type": "boolean"
-            },
-            "service_access_approver": {
-              "type": "boolean"
-            }
-          }
-        },
-        "violation_notifications_enabled": {
-          "type": "boolean"
         }
-      },
-      "required": [
-        "compliance_regime",
-        "display_name",
-        "location",
-        "organization"
-      ]
+      }
     }
   }
 }

--- a/fast/stages/2-networking/schemas/folder.schema.md
+++ b/fast/stages/2-networking/schemas/folder.schema.md
@@ -166,16 +166,27 @@
 - **assured_workload_config**: *reference([assured_workload_config](#refs-assured_workload_config))*
 - **parent**: *string*
   <br>*pattern: ^(?:folders/[0-9]+|organizations/[0-9]+|\$folder_ids:[a-z0-9_-]+)$*
-- **tag_bindings**: *object*
-  <br>*additional properties: false*
-  - **`^[a-z0-9_-]+$`**: *string*
+- **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
 
 ## Definitions
 
-- **labels**<a name="refs-labels"></a>: *object*
+- **assured_workload_config**<a name="refs-assured_workload_config"></a>: *object*
   <br>*additional properties: false*
-  - **`^[a-z][a-z0-9_-]{0,62}$`**: *string*
-    <br>*pattern: ^[a-z0-9_-]{0,63}$*
+  - ⁺**compliance_regime**: *string*
+    <br>*enum: ['ASSURED_WORKLOADS_FOR_PARTNERS', 'AU_REGIONS_AND_US_SUPPORT', 'AUSTRALIA_DATA_BOUNDARY_AND_SUPPORT', 'CA_PROTECTED_B', 'CA_REGIONS_AND_SUPPORT', 'CANADA_CONTROLLED_GOODS', 'CANADA_DATA_BOUNDARY_AND_SUPPORT', 'CJIS', 'COMPLIANCE_REGIME_UNSPECIFIED', 'DATA_BOUNDARY_FOR_CANADA_CONTROLLED_GOODS', 'DATA_BOUNDARY_FOR_CANADA_PROTECTED_B', 'DATA_BOUNDARY_FOR_CJIS', 'DATA_BOUNDARY_FOR_FEDRAMP_HIGH', 'DATA_BOUNDARY_FOR_FEDRAMP_MODERATE', 'DATA_BOUNDARY_FOR_IL2', 'DATA_BOUNDARY_FOR_IL4', 'DATA_BOUNDARY_FOR_IL5', 'DATA_BOUNDARY_FOR_IRS_PUBLICATION_1075', 'DATA_BOUNDARY_FOR_ITAR', 'EU_DATA_BOUNDARY_AND_SUPPORT', 'EU_REGIONS_AND_SUPPORT', 'FEDRAMP_HIGH', 'FEDRAMP_MODERATE', 'HEALTHCARE_AND_LIFE_SCIENCES_CONTROLS', 'HEALTHCARE_AND_LIFE_SCIENCES_CONTROLS_US_SUPPORT', 'HIPAA', 'HITRUST', 'IL2', 'IL4', 'IL5', 'IRS_1075', 'ISR_REGIONS', 'ISR_REGIONS_AND_SUPPORT', 'ISRAEL_DATA_BOUNDARY_AND_SUPPORT', 'ITAR', 'JAPAN_DATA_BOUNDARY', 'JP_REGIONS_AND_SUPPORT', 'KSA_DATA_BOUNDARY_WITH_ACCESS_JUSTIFICATIONS', 'KSA_REGIONS_AND_SUPPORT_WITH_SOVEREIGNTY_CONTROLS', 'REGIONAL_CONTROLS', 'REGIONAL_DATA_BOUNDARY', 'US_DATA_BOUNDARY_AND_SUPPORT', 'US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES', 'US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES_WITH_SUPPORT', 'US_REGIONAL_ACCESS']*
+  - ⁺**display_name**: *string*
+  - ⁺**location**: *string*
+  - ⁺**organization**: *string*
+  - **enable_sovereign_controls**: *boolean*
+  - **labels**: *reference([labels](#refs-labels))*
+  - **partner**: *string*
+    <br>*enum: ['LOCAL_CONTROLS_BY_S3NS', 'PARTNER_UNSPECIFIED', 'SOVEREIGN_CONTROLS_BY_CNTXT_NO_EKM', 'SOVEREIGN_CONTROLS_BY_CNTXT', 'SOVEREIGN_CONTROLS_BY_PSN', 'SOVEREIGN_CONTROLS_BY_SIA_MINSAIT', 'SOVEREIGN_CONTROLS_BY_T_SYSTEMS']*
+  - **partner_permissions**: *object*
+    <br>*additional properties: false*
+    - **assured_workloads_monitoring**: *boolean*
+    - **data_logs_viewer**: *boolean*
+    - **service_access_approver**: *boolean*
+  - **violation_notifications_enabled**: *boolean*
 - **bucket**<a name="refs-bucket"></a>: *object*
   <br>*additional properties: false*
   - **name**: *string*
@@ -271,6 +282,10 @@
   <br>*additional properties: false*
   - **`^[a-z0-9-]+$`**: *array*
     - items: *string*
+- **labels**<a name="refs-labels"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z][a-z0-9_-]{0,62}$`**: *string*
+    <br>*pattern: ^[a-z0-9_-]{0,63}$*
 - **pam_entitlements**<a name="refs-pam_entitlements"></a>: *object*
   <br>*additional properties: false*
   - **`^[a-z][a-z0-9-]{0,61}[a-z0-9]$`**: *object*
@@ -304,20 +319,6 @@
         - items: *string*
       - **requester_email_recipients**: *array*
         - items: *string*
-- **assured_workload_config**<a name="refs-assured_workload_config"></a>: *object*
+- **tag_bindings**<a name="refs-tag_bindings"></a>: *object*
   <br>*additional properties: false*
-  - ⁺**compliance_regime**: *string*
-    <br>*enum: ['ASSURED_WORKLOADS_FOR_PARTNERS', 'AU_REGIONS_AND_US_SUPPORT', 'AUSTRALIA_DATA_BOUNDARY_AND_SUPPORT', 'CA_PROTECTED_B', 'CA_REGIONS_AND_SUPPORT', 'CANADA_CONTROLLED_GOODS', 'CANADA_DATA_BOUNDARY_AND_SUPPORT', 'CJIS', 'COMPLIANCE_REGIME_UNSPECIFIED', 'DATA_BOUNDARY_FOR_CANADA_CONTROLLED_GOODS', 'DATA_BOUNDARY_FOR_CANADA_PROTECTED_B', 'DATA_BOUNDARY_FOR_CJIS', 'DATA_BOUNDARY_FOR_FEDRAMP_HIGH', 'DATA_BOUNDARY_FOR_FEDRAMP_MODERATE', 'DATA_BOUNDARY_FOR_IL2', 'DATA_BOUNDARY_FOR_IL4', 'DATA_BOUNDARY_FOR_IL5', 'DATA_BOUNDARY_FOR_IRS_PUBLICATION_1075', 'DATA_BOUNDARY_FOR_ITAR', 'EU_DATA_BOUNDARY_AND_SUPPORT', 'EU_REGIONS_AND_SUPPORT', 'FEDRAMP_HIGH', 'FEDRAMP_MODERATE', 'HEALTHCARE_AND_LIFE_SCIENCES_CONTROLS', 'HEALTHCARE_AND_LIFE_SCIENCES_CONTROLS_US_SUPPORT', 'HIPAA', 'HITRUST', 'IL2', 'IL4', 'IL5', 'IRS_1075', 'ISR_REGIONS', 'ISR_REGIONS_AND_SUPPORT', 'ISRAEL_DATA_BOUNDARY_AND_SUPPORT', 'ITAR', 'JAPAN_DATA_BOUNDARY', 'JP_REGIONS_AND_SUPPORT', 'KSA_DATA_BOUNDARY_WITH_ACCESS_JUSTIFICATIONS', 'KSA_REGIONS_AND_SUPPORT_WITH_SOVEREIGNTY_CONTROLS', 'REGIONAL_CONTROLS', 'REGIONAL_DATA_BOUNDARY', 'US_DATA_BOUNDARY_AND_SUPPORT', 'US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES', 'US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES_WITH_SUPPORT', 'US_REGIONAL_ACCESS']*
-  - ⁺**display_name**: *string*
-  - ⁺**location**: *string*
-  - ⁺**organization**: *string*
-  - **enable_sovereign_controls**: *boolean*
-  - **labels**: *reference([labels](#refs-labels))*
-  - **partner**: *string*
-    <br>*enum: ['LOCAL_CONTROLS_BY_S3NS', 'PARTNER_UNSPECIFIED', 'SOVEREIGN_CONTROLS_BY_CNTXT_NO_EKM', 'SOVEREIGN_CONTROLS_BY_CNTXT', 'SOVEREIGN_CONTROLS_BY_PSN', 'SOVEREIGN_CONTROLS_BY_SIA_MINSAIT', 'SOVEREIGN_CONTROLS_BY_T_SYSTEMS']*
-  - **partner_permissions**: *object*
-    <br>*additional properties: false*
-    - **assured_workloads_monitoring**: *boolean*
-    - **data_logs_viewer**: *boolean*
-    - **service_access_approver**: *boolean*
-  - **violation_notifications_enabled**: *boolean*
+  - **`^[a-z0-9_-]+$`**: *string*

--- a/fast/stages/2-project-factory/schemas/folder.schema.json
+++ b/fast/stages/2-project-factory/schemas/folder.schema.json
@@ -530,25 +530,116 @@
       "pattern": "^(?:folders/[0-9]+|organizations/[0-9]+|\\$folder_ids:[a-z0-9_-]+)$"
     },
     "tag_bindings": {
-      "type": "object",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^[a-z0-9_-]+$": {
-          "type": "string"
-        }
-      }
+      "$ref": "#/$defs/tag_bindings"
     }
   },
   "$defs": {
-    "labels": {
+    "assured_workload_config": {
       "type": "object",
       "additionalProperties": false,
-      "patternProperties": {
-        "^[a-z][a-z0-9_-]{0,62}$": {
+      "properties": {
+        "compliance_regime": {
           "type": "string",
-          "pattern": "^[a-z0-9_-]{0,63}$"
+          "enum": [
+            "ASSURED_WORKLOADS_FOR_PARTNERS",
+            "AU_REGIONS_AND_US_SUPPORT",
+            "AUSTRALIA_DATA_BOUNDARY_AND_SUPPORT",
+            "CA_PROTECTED_B",
+            "CA_REGIONS_AND_SUPPORT",
+            "CANADA_CONTROLLED_GOODS",
+            "CANADA_DATA_BOUNDARY_AND_SUPPORT",
+            "CJIS",
+            "COMPLIANCE_REGIME_UNSPECIFIED",
+            "DATA_BOUNDARY_FOR_CANADA_CONTROLLED_GOODS",
+            "DATA_BOUNDARY_FOR_CANADA_PROTECTED_B",
+            "DATA_BOUNDARY_FOR_CJIS",
+            "DATA_BOUNDARY_FOR_FEDRAMP_HIGH",
+            "DATA_BOUNDARY_FOR_FEDRAMP_MODERATE",
+            "DATA_BOUNDARY_FOR_IL2",
+            "DATA_BOUNDARY_FOR_IL4",
+            "DATA_BOUNDARY_FOR_IL5",
+            "DATA_BOUNDARY_FOR_IRS_PUBLICATION_1075",
+            "DATA_BOUNDARY_FOR_ITAR",
+            "EU_DATA_BOUNDARY_AND_SUPPORT",
+            "EU_REGIONS_AND_SUPPORT",
+            "FEDRAMP_HIGH",
+            "FEDRAMP_MODERATE",
+            "HEALTHCARE_AND_LIFE_SCIENCES_CONTROLS",
+            "HEALTHCARE_AND_LIFE_SCIENCES_CONTROLS_US_SUPPORT",
+            "HIPAA",
+            "HITRUST",
+            "IL2",
+            "IL4",
+            "IL5",
+            "IRS_1075",
+            "ISR_REGIONS",
+            "ISR_REGIONS_AND_SUPPORT",
+            "ISRAEL_DATA_BOUNDARY_AND_SUPPORT",
+            "ITAR",
+            "JAPAN_DATA_BOUNDARY",
+            "JP_REGIONS_AND_SUPPORT",
+            "KSA_DATA_BOUNDARY_WITH_ACCESS_JUSTIFICATIONS",
+            "KSA_REGIONS_AND_SUPPORT_WITH_SOVEREIGNTY_CONTROLS",
+            "REGIONAL_CONTROLS",
+            "REGIONAL_DATA_BOUNDARY",
+            "US_DATA_BOUNDARY_AND_SUPPORT",
+            "US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES",
+            "US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES_WITH_SUPPORT",
+            "US_REGIONAL_ACCESS"
+          ]
+        },
+        "display_name": {
+          "type": "string"
+        },
+        "location": {
+          "type": "string"
+        },
+        "organization": {
+          "type": "string"
+        },
+        "enable_sovereign_controls": {
+          "type": "boolean"
+        },
+        "labels": {
+          "$ref": "#/$defs/labels"
+        },
+        "partner": {
+          "type": "string",
+          "enum": [
+            "LOCAL_CONTROLS_BY_S3NS",
+            "PARTNER_UNSPECIFIED",
+            "SOVEREIGN_CONTROLS_BY_CNTXT_NO_EKM",
+            "SOVEREIGN_CONTROLS_BY_CNTXT",
+            "SOVEREIGN_CONTROLS_BY_PSN",
+            "SOVEREIGN_CONTROLS_BY_SIA_MINSAIT",
+            "SOVEREIGN_CONTROLS_BY_T_SYSTEMS"
+          ]
+        },
+        "partner_permissions": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "assured_workloads_monitoring": {
+              "type": "boolean"
+            },
+            "data_logs_viewer": {
+              "type": "boolean"
+            },
+            "service_access_approver": {
+              "type": "boolean"
+            }
+          }
+        },
+        "violation_notifications_enabled": {
+          "type": "boolean"
         }
-      }
+      },
+      "required": [
+        "compliance_regime",
+        "display_name",
+        "location",
+        "organization"
+      ]
     },
     "bucket": {
       "type": "object",
@@ -837,6 +928,16 @@
         }
       }
     },
+    "labels": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z][a-z0-9_-]{0,62}$": {
+          "type": "string",
+          "pattern": "^[a-z0-9_-]{0,63}$"
+        }
+      }
+    },
     "pam_entitlements": {
       "type": "object",
       "additionalProperties": false,
@@ -951,112 +1052,14 @@
         }
       }
     },
-    "assured_workload_config": {
+    "tag_bindings": {
       "type": "object",
       "additionalProperties": false,
-      "properties": {
-        "compliance_regime": {
-          "type": "string",
-          "enum": [
-            "ASSURED_WORKLOADS_FOR_PARTNERS",
-            "AU_REGIONS_AND_US_SUPPORT",
-            "AUSTRALIA_DATA_BOUNDARY_AND_SUPPORT",
-            "CA_PROTECTED_B",
-            "CA_REGIONS_AND_SUPPORT",
-            "CANADA_CONTROLLED_GOODS",
-            "CANADA_DATA_BOUNDARY_AND_SUPPORT",
-            "CJIS",
-            "COMPLIANCE_REGIME_UNSPECIFIED",
-            "DATA_BOUNDARY_FOR_CANADA_CONTROLLED_GOODS",
-            "DATA_BOUNDARY_FOR_CANADA_PROTECTED_B",
-            "DATA_BOUNDARY_FOR_CJIS",
-            "DATA_BOUNDARY_FOR_FEDRAMP_HIGH",
-            "DATA_BOUNDARY_FOR_FEDRAMP_MODERATE",
-            "DATA_BOUNDARY_FOR_IL2",
-            "DATA_BOUNDARY_FOR_IL4",
-            "DATA_BOUNDARY_FOR_IL5",
-            "DATA_BOUNDARY_FOR_IRS_PUBLICATION_1075",
-            "DATA_BOUNDARY_FOR_ITAR",
-            "EU_DATA_BOUNDARY_AND_SUPPORT",
-            "EU_REGIONS_AND_SUPPORT",
-            "FEDRAMP_HIGH",
-            "FEDRAMP_MODERATE",
-            "HEALTHCARE_AND_LIFE_SCIENCES_CONTROLS",
-            "HEALTHCARE_AND_LIFE_SCIENCES_CONTROLS_US_SUPPORT",
-            "HIPAA",
-            "HITRUST",
-            "IL2",
-            "IL4",
-            "IL5",
-            "IRS_1075",
-            "ISR_REGIONS",
-            "ISR_REGIONS_AND_SUPPORT",
-            "ISRAEL_DATA_BOUNDARY_AND_SUPPORT",
-            "ITAR",
-            "JAPAN_DATA_BOUNDARY",
-            "JP_REGIONS_AND_SUPPORT",
-            "KSA_DATA_BOUNDARY_WITH_ACCESS_JUSTIFICATIONS",
-            "KSA_REGIONS_AND_SUPPORT_WITH_SOVEREIGNTY_CONTROLS",
-            "REGIONAL_CONTROLS",
-            "REGIONAL_DATA_BOUNDARY",
-            "US_DATA_BOUNDARY_AND_SUPPORT",
-            "US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES",
-            "US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES_WITH_SUPPORT",
-            "US_REGIONAL_ACCESS"
-          ]
-        },
-        "display_name": {
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
           "type": "string"
-        },
-        "location": {
-          "type": "string"
-        },
-        "organization": {
-          "type": "string"
-        },
-        "enable_sovereign_controls": {
-          "type": "boolean"
-        },
-        "labels": {
-          "$ref": "#/$defs/labels"
-        },
-        "partner": {
-          "type": "string",
-          "enum": [
-            "LOCAL_CONTROLS_BY_S3NS",
-            "PARTNER_UNSPECIFIED",
-            "SOVEREIGN_CONTROLS_BY_CNTXT_NO_EKM",
-            "SOVEREIGN_CONTROLS_BY_CNTXT",
-            "SOVEREIGN_CONTROLS_BY_PSN",
-            "SOVEREIGN_CONTROLS_BY_SIA_MINSAIT",
-            "SOVEREIGN_CONTROLS_BY_T_SYSTEMS"
-          ]
-        },
-        "partner_permissions": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "assured_workloads_monitoring": {
-              "type": "boolean"
-            },
-            "data_logs_viewer": {
-              "type": "boolean"
-            },
-            "service_access_approver": {
-              "type": "boolean"
-            }
-          }
-        },
-        "violation_notifications_enabled": {
-          "type": "boolean"
         }
-      },
-      "required": [
-        "compliance_regime",
-        "display_name",
-        "location",
-        "organization"
-      ]
+      }
     }
   }
 }

--- a/fast/stages/2-project-factory/schemas/folder.schema.md
+++ b/fast/stages/2-project-factory/schemas/folder.schema.md
@@ -166,16 +166,27 @@
 - **assured_workload_config**: *reference([assured_workload_config](#refs-assured_workload_config))*
 - **parent**: *string*
   <br>*pattern: ^(?:folders/[0-9]+|organizations/[0-9]+|\$folder_ids:[a-z0-9_-]+)$*
-- **tag_bindings**: *object*
-  <br>*additional properties: false*
-  - **`^[a-z0-9_-]+$`**: *string*
+- **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
 
 ## Definitions
 
-- **labels**<a name="refs-labels"></a>: *object*
+- **assured_workload_config**<a name="refs-assured_workload_config"></a>: *object*
   <br>*additional properties: false*
-  - **`^[a-z][a-z0-9_-]{0,62}$`**: *string*
-    <br>*pattern: ^[a-z0-9_-]{0,63}$*
+  - ⁺**compliance_regime**: *string*
+    <br>*enum: ['ASSURED_WORKLOADS_FOR_PARTNERS', 'AU_REGIONS_AND_US_SUPPORT', 'AUSTRALIA_DATA_BOUNDARY_AND_SUPPORT', 'CA_PROTECTED_B', 'CA_REGIONS_AND_SUPPORT', 'CANADA_CONTROLLED_GOODS', 'CANADA_DATA_BOUNDARY_AND_SUPPORT', 'CJIS', 'COMPLIANCE_REGIME_UNSPECIFIED', 'DATA_BOUNDARY_FOR_CANADA_CONTROLLED_GOODS', 'DATA_BOUNDARY_FOR_CANADA_PROTECTED_B', 'DATA_BOUNDARY_FOR_CJIS', 'DATA_BOUNDARY_FOR_FEDRAMP_HIGH', 'DATA_BOUNDARY_FOR_FEDRAMP_MODERATE', 'DATA_BOUNDARY_FOR_IL2', 'DATA_BOUNDARY_FOR_IL4', 'DATA_BOUNDARY_FOR_IL5', 'DATA_BOUNDARY_FOR_IRS_PUBLICATION_1075', 'DATA_BOUNDARY_FOR_ITAR', 'EU_DATA_BOUNDARY_AND_SUPPORT', 'EU_REGIONS_AND_SUPPORT', 'FEDRAMP_HIGH', 'FEDRAMP_MODERATE', 'HEALTHCARE_AND_LIFE_SCIENCES_CONTROLS', 'HEALTHCARE_AND_LIFE_SCIENCES_CONTROLS_US_SUPPORT', 'HIPAA', 'HITRUST', 'IL2', 'IL4', 'IL5', 'IRS_1075', 'ISR_REGIONS', 'ISR_REGIONS_AND_SUPPORT', 'ISRAEL_DATA_BOUNDARY_AND_SUPPORT', 'ITAR', 'JAPAN_DATA_BOUNDARY', 'JP_REGIONS_AND_SUPPORT', 'KSA_DATA_BOUNDARY_WITH_ACCESS_JUSTIFICATIONS', 'KSA_REGIONS_AND_SUPPORT_WITH_SOVEREIGNTY_CONTROLS', 'REGIONAL_CONTROLS', 'REGIONAL_DATA_BOUNDARY', 'US_DATA_BOUNDARY_AND_SUPPORT', 'US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES', 'US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES_WITH_SUPPORT', 'US_REGIONAL_ACCESS']*
+  - ⁺**display_name**: *string*
+  - ⁺**location**: *string*
+  - ⁺**organization**: *string*
+  - **enable_sovereign_controls**: *boolean*
+  - **labels**: *reference([labels](#refs-labels))*
+  - **partner**: *string*
+    <br>*enum: ['LOCAL_CONTROLS_BY_S3NS', 'PARTNER_UNSPECIFIED', 'SOVEREIGN_CONTROLS_BY_CNTXT_NO_EKM', 'SOVEREIGN_CONTROLS_BY_CNTXT', 'SOVEREIGN_CONTROLS_BY_PSN', 'SOVEREIGN_CONTROLS_BY_SIA_MINSAIT', 'SOVEREIGN_CONTROLS_BY_T_SYSTEMS']*
+  - **partner_permissions**: *object*
+    <br>*additional properties: false*
+    - **assured_workloads_monitoring**: *boolean*
+    - **data_logs_viewer**: *boolean*
+    - **service_access_approver**: *boolean*
+  - **violation_notifications_enabled**: *boolean*
 - **bucket**<a name="refs-bucket"></a>: *object*
   <br>*additional properties: false*
   - **name**: *string*
@@ -271,6 +282,10 @@
   <br>*additional properties: false*
   - **`^[a-z0-9-]+$`**: *array*
     - items: *string*
+- **labels**<a name="refs-labels"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z][a-z0-9_-]{0,62}$`**: *string*
+    <br>*pattern: ^[a-z0-9_-]{0,63}$*
 - **pam_entitlements**<a name="refs-pam_entitlements"></a>: *object*
   <br>*additional properties: false*
   - **`^[a-z][a-z0-9-]{0,61}[a-z0-9]$`**: *object*
@@ -304,20 +319,6 @@
         - items: *string*
       - **requester_email_recipients**: *array*
         - items: *string*
-- **assured_workload_config**<a name="refs-assured_workload_config"></a>: *object*
+- **tag_bindings**<a name="refs-tag_bindings"></a>: *object*
   <br>*additional properties: false*
-  - ⁺**compliance_regime**: *string*
-    <br>*enum: ['ASSURED_WORKLOADS_FOR_PARTNERS', 'AU_REGIONS_AND_US_SUPPORT', 'AUSTRALIA_DATA_BOUNDARY_AND_SUPPORT', 'CA_PROTECTED_B', 'CA_REGIONS_AND_SUPPORT', 'CANADA_CONTROLLED_GOODS', 'CANADA_DATA_BOUNDARY_AND_SUPPORT', 'CJIS', 'COMPLIANCE_REGIME_UNSPECIFIED', 'DATA_BOUNDARY_FOR_CANADA_CONTROLLED_GOODS', 'DATA_BOUNDARY_FOR_CANADA_PROTECTED_B', 'DATA_BOUNDARY_FOR_CJIS', 'DATA_BOUNDARY_FOR_FEDRAMP_HIGH', 'DATA_BOUNDARY_FOR_FEDRAMP_MODERATE', 'DATA_BOUNDARY_FOR_IL2', 'DATA_BOUNDARY_FOR_IL4', 'DATA_BOUNDARY_FOR_IL5', 'DATA_BOUNDARY_FOR_IRS_PUBLICATION_1075', 'DATA_BOUNDARY_FOR_ITAR', 'EU_DATA_BOUNDARY_AND_SUPPORT', 'EU_REGIONS_AND_SUPPORT', 'FEDRAMP_HIGH', 'FEDRAMP_MODERATE', 'HEALTHCARE_AND_LIFE_SCIENCES_CONTROLS', 'HEALTHCARE_AND_LIFE_SCIENCES_CONTROLS_US_SUPPORT', 'HIPAA', 'HITRUST', 'IL2', 'IL4', 'IL5', 'IRS_1075', 'ISR_REGIONS', 'ISR_REGIONS_AND_SUPPORT', 'ISRAEL_DATA_BOUNDARY_AND_SUPPORT', 'ITAR', 'JAPAN_DATA_BOUNDARY', 'JP_REGIONS_AND_SUPPORT', 'KSA_DATA_BOUNDARY_WITH_ACCESS_JUSTIFICATIONS', 'KSA_REGIONS_AND_SUPPORT_WITH_SOVEREIGNTY_CONTROLS', 'REGIONAL_CONTROLS', 'REGIONAL_DATA_BOUNDARY', 'US_DATA_BOUNDARY_AND_SUPPORT', 'US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES', 'US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES_WITH_SUPPORT', 'US_REGIONAL_ACCESS']*
-  - ⁺**display_name**: *string*
-  - ⁺**location**: *string*
-  - ⁺**organization**: *string*
-  - **enable_sovereign_controls**: *boolean*
-  - **labels**: *reference([labels](#refs-labels))*
-  - **partner**: *string*
-    <br>*enum: ['LOCAL_CONTROLS_BY_S3NS', 'PARTNER_UNSPECIFIED', 'SOVEREIGN_CONTROLS_BY_CNTXT_NO_EKM', 'SOVEREIGN_CONTROLS_BY_CNTXT', 'SOVEREIGN_CONTROLS_BY_PSN', 'SOVEREIGN_CONTROLS_BY_SIA_MINSAIT', 'SOVEREIGN_CONTROLS_BY_T_SYSTEMS']*
-  - **partner_permissions**: *object*
-    <br>*additional properties: false*
-    - **assured_workloads_monitoring**: *boolean*
-    - **data_logs_viewer**: *boolean*
-    - **service_access_approver**: *boolean*
-  - **violation_notifications_enabled**: *boolean*
+  - **`^[a-z0-9_-]+$`**: *string*

--- a/fast/stages/2-security/schemas/folder.schema.json
+++ b/fast/stages/2-security/schemas/folder.schema.json
@@ -530,25 +530,116 @@
       "pattern": "^(?:folders/[0-9]+|organizations/[0-9]+|\\$folder_ids:[a-z0-9_-]+)$"
     },
     "tag_bindings": {
-      "type": "object",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^[a-z0-9_-]+$": {
-          "type": "string"
-        }
-      }
+      "$ref": "#/$defs/tag_bindings"
     }
   },
   "$defs": {
-    "labels": {
+    "assured_workload_config": {
       "type": "object",
       "additionalProperties": false,
-      "patternProperties": {
-        "^[a-z][a-z0-9_-]{0,62}$": {
+      "properties": {
+        "compliance_regime": {
           "type": "string",
-          "pattern": "^[a-z0-9_-]{0,63}$"
+          "enum": [
+            "ASSURED_WORKLOADS_FOR_PARTNERS",
+            "AU_REGIONS_AND_US_SUPPORT",
+            "AUSTRALIA_DATA_BOUNDARY_AND_SUPPORT",
+            "CA_PROTECTED_B",
+            "CA_REGIONS_AND_SUPPORT",
+            "CANADA_CONTROLLED_GOODS",
+            "CANADA_DATA_BOUNDARY_AND_SUPPORT",
+            "CJIS",
+            "COMPLIANCE_REGIME_UNSPECIFIED",
+            "DATA_BOUNDARY_FOR_CANADA_CONTROLLED_GOODS",
+            "DATA_BOUNDARY_FOR_CANADA_PROTECTED_B",
+            "DATA_BOUNDARY_FOR_CJIS",
+            "DATA_BOUNDARY_FOR_FEDRAMP_HIGH",
+            "DATA_BOUNDARY_FOR_FEDRAMP_MODERATE",
+            "DATA_BOUNDARY_FOR_IL2",
+            "DATA_BOUNDARY_FOR_IL4",
+            "DATA_BOUNDARY_FOR_IL5",
+            "DATA_BOUNDARY_FOR_IRS_PUBLICATION_1075",
+            "DATA_BOUNDARY_FOR_ITAR",
+            "EU_DATA_BOUNDARY_AND_SUPPORT",
+            "EU_REGIONS_AND_SUPPORT",
+            "FEDRAMP_HIGH",
+            "FEDRAMP_MODERATE",
+            "HEALTHCARE_AND_LIFE_SCIENCES_CONTROLS",
+            "HEALTHCARE_AND_LIFE_SCIENCES_CONTROLS_US_SUPPORT",
+            "HIPAA",
+            "HITRUST",
+            "IL2",
+            "IL4",
+            "IL5",
+            "IRS_1075",
+            "ISR_REGIONS",
+            "ISR_REGIONS_AND_SUPPORT",
+            "ISRAEL_DATA_BOUNDARY_AND_SUPPORT",
+            "ITAR",
+            "JAPAN_DATA_BOUNDARY",
+            "JP_REGIONS_AND_SUPPORT",
+            "KSA_DATA_BOUNDARY_WITH_ACCESS_JUSTIFICATIONS",
+            "KSA_REGIONS_AND_SUPPORT_WITH_SOVEREIGNTY_CONTROLS",
+            "REGIONAL_CONTROLS",
+            "REGIONAL_DATA_BOUNDARY",
+            "US_DATA_BOUNDARY_AND_SUPPORT",
+            "US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES",
+            "US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES_WITH_SUPPORT",
+            "US_REGIONAL_ACCESS"
+          ]
+        },
+        "display_name": {
+          "type": "string"
+        },
+        "location": {
+          "type": "string"
+        },
+        "organization": {
+          "type": "string"
+        },
+        "enable_sovereign_controls": {
+          "type": "boolean"
+        },
+        "labels": {
+          "$ref": "#/$defs/labels"
+        },
+        "partner": {
+          "type": "string",
+          "enum": [
+            "LOCAL_CONTROLS_BY_S3NS",
+            "PARTNER_UNSPECIFIED",
+            "SOVEREIGN_CONTROLS_BY_CNTXT_NO_EKM",
+            "SOVEREIGN_CONTROLS_BY_CNTXT",
+            "SOVEREIGN_CONTROLS_BY_PSN",
+            "SOVEREIGN_CONTROLS_BY_SIA_MINSAIT",
+            "SOVEREIGN_CONTROLS_BY_T_SYSTEMS"
+          ]
+        },
+        "partner_permissions": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "assured_workloads_monitoring": {
+              "type": "boolean"
+            },
+            "data_logs_viewer": {
+              "type": "boolean"
+            },
+            "service_access_approver": {
+              "type": "boolean"
+            }
+          }
+        },
+        "violation_notifications_enabled": {
+          "type": "boolean"
         }
-      }
+      },
+      "required": [
+        "compliance_regime",
+        "display_name",
+        "location",
+        "organization"
+      ]
     },
     "bucket": {
       "type": "object",
@@ -837,6 +928,16 @@
         }
       }
     },
+    "labels": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z][a-z0-9_-]{0,62}$": {
+          "type": "string",
+          "pattern": "^[a-z0-9_-]{0,63}$"
+        }
+      }
+    },
     "pam_entitlements": {
       "type": "object",
       "additionalProperties": false,
@@ -951,112 +1052,14 @@
         }
       }
     },
-    "assured_workload_config": {
+    "tag_bindings": {
       "type": "object",
       "additionalProperties": false,
-      "properties": {
-        "compliance_regime": {
-          "type": "string",
-          "enum": [
-            "ASSURED_WORKLOADS_FOR_PARTNERS",
-            "AU_REGIONS_AND_US_SUPPORT",
-            "AUSTRALIA_DATA_BOUNDARY_AND_SUPPORT",
-            "CA_PROTECTED_B",
-            "CA_REGIONS_AND_SUPPORT",
-            "CANADA_CONTROLLED_GOODS",
-            "CANADA_DATA_BOUNDARY_AND_SUPPORT",
-            "CJIS",
-            "COMPLIANCE_REGIME_UNSPECIFIED",
-            "DATA_BOUNDARY_FOR_CANADA_CONTROLLED_GOODS",
-            "DATA_BOUNDARY_FOR_CANADA_PROTECTED_B",
-            "DATA_BOUNDARY_FOR_CJIS",
-            "DATA_BOUNDARY_FOR_FEDRAMP_HIGH",
-            "DATA_BOUNDARY_FOR_FEDRAMP_MODERATE",
-            "DATA_BOUNDARY_FOR_IL2",
-            "DATA_BOUNDARY_FOR_IL4",
-            "DATA_BOUNDARY_FOR_IL5",
-            "DATA_BOUNDARY_FOR_IRS_PUBLICATION_1075",
-            "DATA_BOUNDARY_FOR_ITAR",
-            "EU_DATA_BOUNDARY_AND_SUPPORT",
-            "EU_REGIONS_AND_SUPPORT",
-            "FEDRAMP_HIGH",
-            "FEDRAMP_MODERATE",
-            "HEALTHCARE_AND_LIFE_SCIENCES_CONTROLS",
-            "HEALTHCARE_AND_LIFE_SCIENCES_CONTROLS_US_SUPPORT",
-            "HIPAA",
-            "HITRUST",
-            "IL2",
-            "IL4",
-            "IL5",
-            "IRS_1075",
-            "ISR_REGIONS",
-            "ISR_REGIONS_AND_SUPPORT",
-            "ISRAEL_DATA_BOUNDARY_AND_SUPPORT",
-            "ITAR",
-            "JAPAN_DATA_BOUNDARY",
-            "JP_REGIONS_AND_SUPPORT",
-            "KSA_DATA_BOUNDARY_WITH_ACCESS_JUSTIFICATIONS",
-            "KSA_REGIONS_AND_SUPPORT_WITH_SOVEREIGNTY_CONTROLS",
-            "REGIONAL_CONTROLS",
-            "REGIONAL_DATA_BOUNDARY",
-            "US_DATA_BOUNDARY_AND_SUPPORT",
-            "US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES",
-            "US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES_WITH_SUPPORT",
-            "US_REGIONAL_ACCESS"
-          ]
-        },
-        "display_name": {
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
           "type": "string"
-        },
-        "location": {
-          "type": "string"
-        },
-        "organization": {
-          "type": "string"
-        },
-        "enable_sovereign_controls": {
-          "type": "boolean"
-        },
-        "labels": {
-          "$ref": "#/$defs/labels"
-        },
-        "partner": {
-          "type": "string",
-          "enum": [
-            "LOCAL_CONTROLS_BY_S3NS",
-            "PARTNER_UNSPECIFIED",
-            "SOVEREIGN_CONTROLS_BY_CNTXT_NO_EKM",
-            "SOVEREIGN_CONTROLS_BY_CNTXT",
-            "SOVEREIGN_CONTROLS_BY_PSN",
-            "SOVEREIGN_CONTROLS_BY_SIA_MINSAIT",
-            "SOVEREIGN_CONTROLS_BY_T_SYSTEMS"
-          ]
-        },
-        "partner_permissions": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "assured_workloads_monitoring": {
-              "type": "boolean"
-            },
-            "data_logs_viewer": {
-              "type": "boolean"
-            },
-            "service_access_approver": {
-              "type": "boolean"
-            }
-          }
-        },
-        "violation_notifications_enabled": {
-          "type": "boolean"
         }
-      },
-      "required": [
-        "compliance_regime",
-        "display_name",
-        "location",
-        "organization"
-      ]
+      }
     }
   }
 }

--- a/fast/stages/2-security/schemas/folder.schema.md
+++ b/fast/stages/2-security/schemas/folder.schema.md
@@ -166,16 +166,27 @@
 - **assured_workload_config**: *reference([assured_workload_config](#refs-assured_workload_config))*
 - **parent**: *string*
   <br>*pattern: ^(?:folders/[0-9]+|organizations/[0-9]+|\$folder_ids:[a-z0-9_-]+)$*
-- **tag_bindings**: *object*
-  <br>*additional properties: false*
-  - **`^[a-z0-9_-]+$`**: *string*
+- **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
 
 ## Definitions
 
-- **labels**<a name="refs-labels"></a>: *object*
+- **assured_workload_config**<a name="refs-assured_workload_config"></a>: *object*
   <br>*additional properties: false*
-  - **`^[a-z][a-z0-9_-]{0,62}$`**: *string*
-    <br>*pattern: ^[a-z0-9_-]{0,63}$*
+  - ⁺**compliance_regime**: *string*
+    <br>*enum: ['ASSURED_WORKLOADS_FOR_PARTNERS', 'AU_REGIONS_AND_US_SUPPORT', 'AUSTRALIA_DATA_BOUNDARY_AND_SUPPORT', 'CA_PROTECTED_B', 'CA_REGIONS_AND_SUPPORT', 'CANADA_CONTROLLED_GOODS', 'CANADA_DATA_BOUNDARY_AND_SUPPORT', 'CJIS', 'COMPLIANCE_REGIME_UNSPECIFIED', 'DATA_BOUNDARY_FOR_CANADA_CONTROLLED_GOODS', 'DATA_BOUNDARY_FOR_CANADA_PROTECTED_B', 'DATA_BOUNDARY_FOR_CJIS', 'DATA_BOUNDARY_FOR_FEDRAMP_HIGH', 'DATA_BOUNDARY_FOR_FEDRAMP_MODERATE', 'DATA_BOUNDARY_FOR_IL2', 'DATA_BOUNDARY_FOR_IL4', 'DATA_BOUNDARY_FOR_IL5', 'DATA_BOUNDARY_FOR_IRS_PUBLICATION_1075', 'DATA_BOUNDARY_FOR_ITAR', 'EU_DATA_BOUNDARY_AND_SUPPORT', 'EU_REGIONS_AND_SUPPORT', 'FEDRAMP_HIGH', 'FEDRAMP_MODERATE', 'HEALTHCARE_AND_LIFE_SCIENCES_CONTROLS', 'HEALTHCARE_AND_LIFE_SCIENCES_CONTROLS_US_SUPPORT', 'HIPAA', 'HITRUST', 'IL2', 'IL4', 'IL5', 'IRS_1075', 'ISR_REGIONS', 'ISR_REGIONS_AND_SUPPORT', 'ISRAEL_DATA_BOUNDARY_AND_SUPPORT', 'ITAR', 'JAPAN_DATA_BOUNDARY', 'JP_REGIONS_AND_SUPPORT', 'KSA_DATA_BOUNDARY_WITH_ACCESS_JUSTIFICATIONS', 'KSA_REGIONS_AND_SUPPORT_WITH_SOVEREIGNTY_CONTROLS', 'REGIONAL_CONTROLS', 'REGIONAL_DATA_BOUNDARY', 'US_DATA_BOUNDARY_AND_SUPPORT', 'US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES', 'US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES_WITH_SUPPORT', 'US_REGIONAL_ACCESS']*
+  - ⁺**display_name**: *string*
+  - ⁺**location**: *string*
+  - ⁺**organization**: *string*
+  - **enable_sovereign_controls**: *boolean*
+  - **labels**: *reference([labels](#refs-labels))*
+  - **partner**: *string*
+    <br>*enum: ['LOCAL_CONTROLS_BY_S3NS', 'PARTNER_UNSPECIFIED', 'SOVEREIGN_CONTROLS_BY_CNTXT_NO_EKM', 'SOVEREIGN_CONTROLS_BY_CNTXT', 'SOVEREIGN_CONTROLS_BY_PSN', 'SOVEREIGN_CONTROLS_BY_SIA_MINSAIT', 'SOVEREIGN_CONTROLS_BY_T_SYSTEMS']*
+  - **partner_permissions**: *object*
+    <br>*additional properties: false*
+    - **assured_workloads_monitoring**: *boolean*
+    - **data_logs_viewer**: *boolean*
+    - **service_access_approver**: *boolean*
+  - **violation_notifications_enabled**: *boolean*
 - **bucket**<a name="refs-bucket"></a>: *object*
   <br>*additional properties: false*
   - **name**: *string*
@@ -271,6 +282,10 @@
   <br>*additional properties: false*
   - **`^[a-z0-9-]+$`**: *array*
     - items: *string*
+- **labels**<a name="refs-labels"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z][a-z0-9_-]{0,62}$`**: *string*
+    <br>*pattern: ^[a-z0-9_-]{0,63}$*
 - **pam_entitlements**<a name="refs-pam_entitlements"></a>: *object*
   <br>*additional properties: false*
   - **`^[a-z][a-z0-9-]{0,61}[a-z0-9]$`**: *object*
@@ -304,20 +319,6 @@
         - items: *string*
       - **requester_email_recipients**: *array*
         - items: *string*
-- **assured_workload_config**<a name="refs-assured_workload_config"></a>: *object*
+- **tag_bindings**<a name="refs-tag_bindings"></a>: *object*
   <br>*additional properties: false*
-  - ⁺**compliance_regime**: *string*
-    <br>*enum: ['ASSURED_WORKLOADS_FOR_PARTNERS', 'AU_REGIONS_AND_US_SUPPORT', 'AUSTRALIA_DATA_BOUNDARY_AND_SUPPORT', 'CA_PROTECTED_B', 'CA_REGIONS_AND_SUPPORT', 'CANADA_CONTROLLED_GOODS', 'CANADA_DATA_BOUNDARY_AND_SUPPORT', 'CJIS', 'COMPLIANCE_REGIME_UNSPECIFIED', 'DATA_BOUNDARY_FOR_CANADA_CONTROLLED_GOODS', 'DATA_BOUNDARY_FOR_CANADA_PROTECTED_B', 'DATA_BOUNDARY_FOR_CJIS', 'DATA_BOUNDARY_FOR_FEDRAMP_HIGH', 'DATA_BOUNDARY_FOR_FEDRAMP_MODERATE', 'DATA_BOUNDARY_FOR_IL2', 'DATA_BOUNDARY_FOR_IL4', 'DATA_BOUNDARY_FOR_IL5', 'DATA_BOUNDARY_FOR_IRS_PUBLICATION_1075', 'DATA_BOUNDARY_FOR_ITAR', 'EU_DATA_BOUNDARY_AND_SUPPORT', 'EU_REGIONS_AND_SUPPORT', 'FEDRAMP_HIGH', 'FEDRAMP_MODERATE', 'HEALTHCARE_AND_LIFE_SCIENCES_CONTROLS', 'HEALTHCARE_AND_LIFE_SCIENCES_CONTROLS_US_SUPPORT', 'HIPAA', 'HITRUST', 'IL2', 'IL4', 'IL5', 'IRS_1075', 'ISR_REGIONS', 'ISR_REGIONS_AND_SUPPORT', 'ISRAEL_DATA_BOUNDARY_AND_SUPPORT', 'ITAR', 'JAPAN_DATA_BOUNDARY', 'JP_REGIONS_AND_SUPPORT', 'KSA_DATA_BOUNDARY_WITH_ACCESS_JUSTIFICATIONS', 'KSA_REGIONS_AND_SUPPORT_WITH_SOVEREIGNTY_CONTROLS', 'REGIONAL_CONTROLS', 'REGIONAL_DATA_BOUNDARY', 'US_DATA_BOUNDARY_AND_SUPPORT', 'US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES', 'US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES_WITH_SUPPORT', 'US_REGIONAL_ACCESS']*
-  - ⁺**display_name**: *string*
-  - ⁺**location**: *string*
-  - ⁺**organization**: *string*
-  - **enable_sovereign_controls**: *boolean*
-  - **labels**: *reference([labels](#refs-labels))*
-  - **partner**: *string*
-    <br>*enum: ['LOCAL_CONTROLS_BY_S3NS', 'PARTNER_UNSPECIFIED', 'SOVEREIGN_CONTROLS_BY_CNTXT_NO_EKM', 'SOVEREIGN_CONTROLS_BY_CNTXT', 'SOVEREIGN_CONTROLS_BY_PSN', 'SOVEREIGN_CONTROLS_BY_SIA_MINSAIT', 'SOVEREIGN_CONTROLS_BY_T_SYSTEMS']*
-  - **partner_permissions**: *object*
-    <br>*additional properties: false*
-    - **assured_workloads_monitoring**: *boolean*
-    - **data_logs_viewer**: *boolean*
-    - **service_access_approver**: *boolean*
-  - **violation_notifications_enabled**: *boolean*
+  - **`^[a-z0-9_-]+$`**: *string*

--- a/modules/project-factory/schemas/folder.schema.json
+++ b/modules/project-factory/schemas/folder.schema.json
@@ -530,25 +530,116 @@
       "pattern": "^(?:folders/[0-9]+|organizations/[0-9]+|\\$folder_ids:[a-z0-9_-]+)$"
     },
     "tag_bindings": {
-      "type": "object",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^[a-z0-9_-]+$": {
-          "type": "string"
-        }
-      }
+      "$ref": "#/$defs/tag_bindings"
     }
   },
   "$defs": {
-    "labels": {
+    "assured_workload_config": {
       "type": "object",
       "additionalProperties": false,
-      "patternProperties": {
-        "^[a-z][a-z0-9_-]{0,62}$": {
+      "properties": {
+        "compliance_regime": {
           "type": "string",
-          "pattern": "^[a-z0-9_-]{0,63}$"
+          "enum": [
+            "ASSURED_WORKLOADS_FOR_PARTNERS",
+            "AU_REGIONS_AND_US_SUPPORT",
+            "AUSTRALIA_DATA_BOUNDARY_AND_SUPPORT",
+            "CA_PROTECTED_B",
+            "CA_REGIONS_AND_SUPPORT",
+            "CANADA_CONTROLLED_GOODS",
+            "CANADA_DATA_BOUNDARY_AND_SUPPORT",
+            "CJIS",
+            "COMPLIANCE_REGIME_UNSPECIFIED",
+            "DATA_BOUNDARY_FOR_CANADA_CONTROLLED_GOODS",
+            "DATA_BOUNDARY_FOR_CANADA_PROTECTED_B",
+            "DATA_BOUNDARY_FOR_CJIS",
+            "DATA_BOUNDARY_FOR_FEDRAMP_HIGH",
+            "DATA_BOUNDARY_FOR_FEDRAMP_MODERATE",
+            "DATA_BOUNDARY_FOR_IL2",
+            "DATA_BOUNDARY_FOR_IL4",
+            "DATA_BOUNDARY_FOR_IL5",
+            "DATA_BOUNDARY_FOR_IRS_PUBLICATION_1075",
+            "DATA_BOUNDARY_FOR_ITAR",
+            "EU_DATA_BOUNDARY_AND_SUPPORT",
+            "EU_REGIONS_AND_SUPPORT",
+            "FEDRAMP_HIGH",
+            "FEDRAMP_MODERATE",
+            "HEALTHCARE_AND_LIFE_SCIENCES_CONTROLS",
+            "HEALTHCARE_AND_LIFE_SCIENCES_CONTROLS_US_SUPPORT",
+            "HIPAA",
+            "HITRUST",
+            "IL2",
+            "IL4",
+            "IL5",
+            "IRS_1075",
+            "ISR_REGIONS",
+            "ISR_REGIONS_AND_SUPPORT",
+            "ISRAEL_DATA_BOUNDARY_AND_SUPPORT",
+            "ITAR",
+            "JAPAN_DATA_BOUNDARY",
+            "JP_REGIONS_AND_SUPPORT",
+            "KSA_DATA_BOUNDARY_WITH_ACCESS_JUSTIFICATIONS",
+            "KSA_REGIONS_AND_SUPPORT_WITH_SOVEREIGNTY_CONTROLS",
+            "REGIONAL_CONTROLS",
+            "REGIONAL_DATA_BOUNDARY",
+            "US_DATA_BOUNDARY_AND_SUPPORT",
+            "US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES",
+            "US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES_WITH_SUPPORT",
+            "US_REGIONAL_ACCESS"
+          ]
+        },
+        "display_name": {
+          "type": "string"
+        },
+        "location": {
+          "type": "string"
+        },
+        "organization": {
+          "type": "string"
+        },
+        "enable_sovereign_controls": {
+          "type": "boolean"
+        },
+        "labels": {
+          "$ref": "#/$defs/labels"
+        },
+        "partner": {
+          "type": "string",
+          "enum": [
+            "LOCAL_CONTROLS_BY_S3NS",
+            "PARTNER_UNSPECIFIED",
+            "SOVEREIGN_CONTROLS_BY_CNTXT_NO_EKM",
+            "SOVEREIGN_CONTROLS_BY_CNTXT",
+            "SOVEREIGN_CONTROLS_BY_PSN",
+            "SOVEREIGN_CONTROLS_BY_SIA_MINSAIT",
+            "SOVEREIGN_CONTROLS_BY_T_SYSTEMS"
+          ]
+        },
+        "partner_permissions": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "assured_workloads_monitoring": {
+              "type": "boolean"
+            },
+            "data_logs_viewer": {
+              "type": "boolean"
+            },
+            "service_access_approver": {
+              "type": "boolean"
+            }
+          }
+        },
+        "violation_notifications_enabled": {
+          "type": "boolean"
         }
-      }
+      },
+      "required": [
+        "compliance_regime",
+        "display_name",
+        "location",
+        "organization"
+      ]
     },
     "bucket": {
       "type": "object",
@@ -837,6 +928,16 @@
         }
       }
     },
+    "labels": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z][a-z0-9_-]{0,62}$": {
+          "type": "string",
+          "pattern": "^[a-z0-9_-]{0,63}$"
+        }
+      }
+    },
     "pam_entitlements": {
       "type": "object",
       "additionalProperties": false,
@@ -951,112 +1052,14 @@
         }
       }
     },
-    "assured_workload_config": {
+    "tag_bindings": {
       "type": "object",
       "additionalProperties": false,
-      "properties": {
-        "compliance_regime": {
-          "type": "string",
-          "enum": [
-            "ASSURED_WORKLOADS_FOR_PARTNERS",
-            "AU_REGIONS_AND_US_SUPPORT",
-            "AUSTRALIA_DATA_BOUNDARY_AND_SUPPORT",
-            "CA_PROTECTED_B",
-            "CA_REGIONS_AND_SUPPORT",
-            "CANADA_CONTROLLED_GOODS",
-            "CANADA_DATA_BOUNDARY_AND_SUPPORT",
-            "CJIS",
-            "COMPLIANCE_REGIME_UNSPECIFIED",
-            "DATA_BOUNDARY_FOR_CANADA_CONTROLLED_GOODS",
-            "DATA_BOUNDARY_FOR_CANADA_PROTECTED_B",
-            "DATA_BOUNDARY_FOR_CJIS",
-            "DATA_BOUNDARY_FOR_FEDRAMP_HIGH",
-            "DATA_BOUNDARY_FOR_FEDRAMP_MODERATE",
-            "DATA_BOUNDARY_FOR_IL2",
-            "DATA_BOUNDARY_FOR_IL4",
-            "DATA_BOUNDARY_FOR_IL5",
-            "DATA_BOUNDARY_FOR_IRS_PUBLICATION_1075",
-            "DATA_BOUNDARY_FOR_ITAR",
-            "EU_DATA_BOUNDARY_AND_SUPPORT",
-            "EU_REGIONS_AND_SUPPORT",
-            "FEDRAMP_HIGH",
-            "FEDRAMP_MODERATE",
-            "HEALTHCARE_AND_LIFE_SCIENCES_CONTROLS",
-            "HEALTHCARE_AND_LIFE_SCIENCES_CONTROLS_US_SUPPORT",
-            "HIPAA",
-            "HITRUST",
-            "IL2",
-            "IL4",
-            "IL5",
-            "IRS_1075",
-            "ISR_REGIONS",
-            "ISR_REGIONS_AND_SUPPORT",
-            "ISRAEL_DATA_BOUNDARY_AND_SUPPORT",
-            "ITAR",
-            "JAPAN_DATA_BOUNDARY",
-            "JP_REGIONS_AND_SUPPORT",
-            "KSA_DATA_BOUNDARY_WITH_ACCESS_JUSTIFICATIONS",
-            "KSA_REGIONS_AND_SUPPORT_WITH_SOVEREIGNTY_CONTROLS",
-            "REGIONAL_CONTROLS",
-            "REGIONAL_DATA_BOUNDARY",
-            "US_DATA_BOUNDARY_AND_SUPPORT",
-            "US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES",
-            "US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES_WITH_SUPPORT",
-            "US_REGIONAL_ACCESS"
-          ]
-        },
-        "display_name": {
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
           "type": "string"
-        },
-        "location": {
-          "type": "string"
-        },
-        "organization": {
-          "type": "string"
-        },
-        "enable_sovereign_controls": {
-          "type": "boolean"
-        },
-        "labels": {
-          "$ref": "#/$defs/labels"
-        },
-        "partner": {
-          "type": "string",
-          "enum": [
-            "LOCAL_CONTROLS_BY_S3NS",
-            "PARTNER_UNSPECIFIED",
-            "SOVEREIGN_CONTROLS_BY_CNTXT_NO_EKM",
-            "SOVEREIGN_CONTROLS_BY_CNTXT",
-            "SOVEREIGN_CONTROLS_BY_PSN",
-            "SOVEREIGN_CONTROLS_BY_SIA_MINSAIT",
-            "SOVEREIGN_CONTROLS_BY_T_SYSTEMS"
-          ]
-        },
-        "partner_permissions": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "assured_workloads_monitoring": {
-              "type": "boolean"
-            },
-            "data_logs_viewer": {
-              "type": "boolean"
-            },
-            "service_access_approver": {
-              "type": "boolean"
-            }
-          }
-        },
-        "violation_notifications_enabled": {
-          "type": "boolean"
         }
-      },
-      "required": [
-        "compliance_regime",
-        "display_name",
-        "location",
-        "organization"
-      ]
+      }
     }
   }
 }

--- a/modules/project-factory/schemas/folder.schema.md
+++ b/modules/project-factory/schemas/folder.schema.md
@@ -166,16 +166,27 @@
 - **assured_workload_config**: *reference([assured_workload_config](#refs-assured_workload_config))*
 - **parent**: *string*
   <br>*pattern: ^(?:folders/[0-9]+|organizations/[0-9]+|\$folder_ids:[a-z0-9_-]+)$*
-- **tag_bindings**: *object*
-  <br>*additional properties: false*
-  - **`^[a-z0-9_-]+$`**: *string*
+- **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
 
 ## Definitions
 
-- **labels**<a name="refs-labels"></a>: *object*
+- **assured_workload_config**<a name="refs-assured_workload_config"></a>: *object*
   <br>*additional properties: false*
-  - **`^[a-z][a-z0-9_-]{0,62}$`**: *string*
-    <br>*pattern: ^[a-z0-9_-]{0,63}$*
+  - ⁺**compliance_regime**: *string*
+    <br>*enum: ['ASSURED_WORKLOADS_FOR_PARTNERS', 'AU_REGIONS_AND_US_SUPPORT', 'AUSTRALIA_DATA_BOUNDARY_AND_SUPPORT', 'CA_PROTECTED_B', 'CA_REGIONS_AND_SUPPORT', 'CANADA_CONTROLLED_GOODS', 'CANADA_DATA_BOUNDARY_AND_SUPPORT', 'CJIS', 'COMPLIANCE_REGIME_UNSPECIFIED', 'DATA_BOUNDARY_FOR_CANADA_CONTROLLED_GOODS', 'DATA_BOUNDARY_FOR_CANADA_PROTECTED_B', 'DATA_BOUNDARY_FOR_CJIS', 'DATA_BOUNDARY_FOR_FEDRAMP_HIGH', 'DATA_BOUNDARY_FOR_FEDRAMP_MODERATE', 'DATA_BOUNDARY_FOR_IL2', 'DATA_BOUNDARY_FOR_IL4', 'DATA_BOUNDARY_FOR_IL5', 'DATA_BOUNDARY_FOR_IRS_PUBLICATION_1075', 'DATA_BOUNDARY_FOR_ITAR', 'EU_DATA_BOUNDARY_AND_SUPPORT', 'EU_REGIONS_AND_SUPPORT', 'FEDRAMP_HIGH', 'FEDRAMP_MODERATE', 'HEALTHCARE_AND_LIFE_SCIENCES_CONTROLS', 'HEALTHCARE_AND_LIFE_SCIENCES_CONTROLS_US_SUPPORT', 'HIPAA', 'HITRUST', 'IL2', 'IL4', 'IL5', 'IRS_1075', 'ISR_REGIONS', 'ISR_REGIONS_AND_SUPPORT', 'ISRAEL_DATA_BOUNDARY_AND_SUPPORT', 'ITAR', 'JAPAN_DATA_BOUNDARY', 'JP_REGIONS_AND_SUPPORT', 'KSA_DATA_BOUNDARY_WITH_ACCESS_JUSTIFICATIONS', 'KSA_REGIONS_AND_SUPPORT_WITH_SOVEREIGNTY_CONTROLS', 'REGIONAL_CONTROLS', 'REGIONAL_DATA_BOUNDARY', 'US_DATA_BOUNDARY_AND_SUPPORT', 'US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES', 'US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES_WITH_SUPPORT', 'US_REGIONAL_ACCESS']*
+  - ⁺**display_name**: *string*
+  - ⁺**location**: *string*
+  - ⁺**organization**: *string*
+  - **enable_sovereign_controls**: *boolean*
+  - **labels**: *reference([labels](#refs-labels))*
+  - **partner**: *string*
+    <br>*enum: ['LOCAL_CONTROLS_BY_S3NS', 'PARTNER_UNSPECIFIED', 'SOVEREIGN_CONTROLS_BY_CNTXT_NO_EKM', 'SOVEREIGN_CONTROLS_BY_CNTXT', 'SOVEREIGN_CONTROLS_BY_PSN', 'SOVEREIGN_CONTROLS_BY_SIA_MINSAIT', 'SOVEREIGN_CONTROLS_BY_T_SYSTEMS']*
+  - **partner_permissions**: *object*
+    <br>*additional properties: false*
+    - **assured_workloads_monitoring**: *boolean*
+    - **data_logs_viewer**: *boolean*
+    - **service_access_approver**: *boolean*
+  - **violation_notifications_enabled**: *boolean*
 - **bucket**<a name="refs-bucket"></a>: *object*
   <br>*additional properties: false*
   - **name**: *string*
@@ -271,6 +282,10 @@
   <br>*additional properties: false*
   - **`^[a-z0-9-]+$`**: *array*
     - items: *string*
+- **labels**<a name="refs-labels"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z][a-z0-9_-]{0,62}$`**: *string*
+    <br>*pattern: ^[a-z0-9_-]{0,63}$*
 - **pam_entitlements**<a name="refs-pam_entitlements"></a>: *object*
   <br>*additional properties: false*
   - **`^[a-z][a-z0-9-]{0,61}[a-z0-9]$`**: *object*
@@ -304,20 +319,6 @@
         - items: *string*
       - **requester_email_recipients**: *array*
         - items: *string*
-- **assured_workload_config**<a name="refs-assured_workload_config"></a>: *object*
+- **tag_bindings**<a name="refs-tag_bindings"></a>: *object*
   <br>*additional properties: false*
-  - ⁺**compliance_regime**: *string*
-    <br>*enum: ['ASSURED_WORKLOADS_FOR_PARTNERS', 'AU_REGIONS_AND_US_SUPPORT', 'AUSTRALIA_DATA_BOUNDARY_AND_SUPPORT', 'CA_PROTECTED_B', 'CA_REGIONS_AND_SUPPORT', 'CANADA_CONTROLLED_GOODS', 'CANADA_DATA_BOUNDARY_AND_SUPPORT', 'CJIS', 'COMPLIANCE_REGIME_UNSPECIFIED', 'DATA_BOUNDARY_FOR_CANADA_CONTROLLED_GOODS', 'DATA_BOUNDARY_FOR_CANADA_PROTECTED_B', 'DATA_BOUNDARY_FOR_CJIS', 'DATA_BOUNDARY_FOR_FEDRAMP_HIGH', 'DATA_BOUNDARY_FOR_FEDRAMP_MODERATE', 'DATA_BOUNDARY_FOR_IL2', 'DATA_BOUNDARY_FOR_IL4', 'DATA_BOUNDARY_FOR_IL5', 'DATA_BOUNDARY_FOR_IRS_PUBLICATION_1075', 'DATA_BOUNDARY_FOR_ITAR', 'EU_DATA_BOUNDARY_AND_SUPPORT', 'EU_REGIONS_AND_SUPPORT', 'FEDRAMP_HIGH', 'FEDRAMP_MODERATE', 'HEALTHCARE_AND_LIFE_SCIENCES_CONTROLS', 'HEALTHCARE_AND_LIFE_SCIENCES_CONTROLS_US_SUPPORT', 'HIPAA', 'HITRUST', 'IL2', 'IL4', 'IL5', 'IRS_1075', 'ISR_REGIONS', 'ISR_REGIONS_AND_SUPPORT', 'ISRAEL_DATA_BOUNDARY_AND_SUPPORT', 'ITAR', 'JAPAN_DATA_BOUNDARY', 'JP_REGIONS_AND_SUPPORT', 'KSA_DATA_BOUNDARY_WITH_ACCESS_JUSTIFICATIONS', 'KSA_REGIONS_AND_SUPPORT_WITH_SOVEREIGNTY_CONTROLS', 'REGIONAL_CONTROLS', 'REGIONAL_DATA_BOUNDARY', 'US_DATA_BOUNDARY_AND_SUPPORT', 'US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES', 'US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES_WITH_SUPPORT', 'US_REGIONAL_ACCESS']*
-  - ⁺**display_name**: *string*
-  - ⁺**location**: *string*
-  - ⁺**organization**: *string*
-  - **enable_sovereign_controls**: *boolean*
-  - **labels**: *reference([labels](#refs-labels))*
-  - **partner**: *string*
-    <br>*enum: ['LOCAL_CONTROLS_BY_S3NS', 'PARTNER_UNSPECIFIED', 'SOVEREIGN_CONTROLS_BY_CNTXT_NO_EKM', 'SOVEREIGN_CONTROLS_BY_CNTXT', 'SOVEREIGN_CONTROLS_BY_PSN', 'SOVEREIGN_CONTROLS_BY_SIA_MINSAIT', 'SOVEREIGN_CONTROLS_BY_T_SYSTEMS']*
-  - **partner_permissions**: *object*
-    <br>*additional properties: false*
-    - **assured_workloads_monitoring**: *boolean*
-    - **data_logs_viewer**: *boolean*
-    - **service_access_approver**: *boolean*
-  - **violation_notifications_enabled**: *boolean*
+  - **`^[a-z0-9_-]+$`**: *string*

--- a/tools/skill-turn-harness/playbooks/playbook.schema.md
+++ b/tools/skill-turn-harness/playbooks/playbook.schema.md
@@ -1,0 +1,46 @@
+# None
+
+<!-- markdownlint-disable MD036 -->
+
+## Properties
+
+*additional properties: false*
+
+- ⁺**name**: *string*
+- **agent_model**: *string*
+- **evaluator_model**: *string*
+- **tmpdir**: *object*
+  <br>*additional properties: false*
+  - **link_paths**: *array*
+    - items: *string*
+- **timeout**: *integer*
+  <br>*default: 60*
+- **env**: *array*
+  - items: *string*
+- **steps**: *array*
+  - items: *object*
+    <br>*additional properties: false*
+    - ⁺**user_input**: *string*
+    - ⁺**expected_outcome**: *string*
+- **persona**: *object*
+  <br>*additional properties: false*
+  - **initial_user_input**: *string*
+  - ⁺**context**: *string*
+  - **max_turns**: *integer*
+    <br>*default: 10*
+  - ⁺**success_criteria**: *object*
+    <br>*additional properties: false*
+    - **llm_checks**: *array*
+      - items: *string*
+    - **flow_contains**: *array*
+      - items: *string*
+    - **files_exist**: *array*
+      - items: *string*
+    - **files_contain**: *object*
+      - **`.*`**: *array*
+        - items: *string*
+    - **tool_calls_contain**: *object*
+      - **`.*`**: *array*
+        - items: *string*
+
+## Definitions


### PR DESCRIPTION
PR #4006 introduced tag bindings for service accounts in project and folder schemas, and used an internal schema reference for their type. The folder schema did not have such reference, so it's generating an error. This PR fixes it.