### PR TITLE
Fix `name` output in iam-service-account module

### DIFF
--- a/modules/iam-service-account/README.md
+++ b/modules/iam-service-account/README.md
@@ -180,7 +180,7 @@ module "service-account-with-tags" {
 | [email](outputs.tf#L17) | Service account email. |  |
 | [iam_email](outputs.tf#L25) | IAM-format service account email. |  |
 | [id](outputs.tf#L33) | Fully qualified service account id. |  |
-| [name](outputs.tf#L41) | Service account name. |  |
+| [name](outputs.tf#L41) | Service account email (mirrors email output for symmetry when chaining create and reuse). |  |
 | [service_account](outputs.tf#L49) | Service account resource. |  |
 | [unique_id](outputs.tf#L54) | Fully qualified service account id. |  |
 <!-- END TFDOC -->

--- a/modules/iam-service-account/outputs.tf
+++ b/modules/iam-service-account/outputs.tf
@@ -39,8 +39,8 @@ output "id" {
 }
 
 output "name" {
-  description = "Service account name."
-  value       = local.static_id
+  description = "Service account email (mirrors email output for symmetry when chaining create and reuse)."
+  value       = local.static_email
   depends_on = [
     local.service_account
   ]

--- a/tests/modules/iam_service_account/universe.yaml
+++ b/tests/modules/iam_service_account/universe.yaml
@@ -31,4 +31,4 @@ outputs:
   email: prefix-sa-name@my-project-id.universe.iam.gserviceaccount.com
   iam_email: serviceAccount:prefix-sa-name@my-project-id.universe.iam.gserviceaccount.com
   id: projects/universe:my-project-id/serviceAccounts/prefix-sa-name@my-project-id.universe.iam.gserviceaccount.com
-  name: projects/universe:my-project-id/serviceAccounts/prefix-sa-name@my-project-id.universe.iam.gserviceaccount.com
+  name: prefix-sa-name@my-project-id.universe.iam.gserviceaccount.com


### PR DESCRIPTION
This PR updates `output "name"` in `modules/iam-service-account` to return `local.static_email` instead of `local.static_id`.

Fixes #4062

### Context & Rationale
Previously, `output "name"` returned `local.static_id` (`projects/<project>/serviceAccounts/<email>`), which duplicated `output "id"`. 

When chaining a service account creation module call to a service account reuse module call via `name = module.sa.name`, passing a `projects/...` URI causes GCP IAM API calls in the reuse module to fail with HTTP 400 errors (`Service account projects/... does not exist`), as IAM APIs expect the service account email.

Updating `output "name"` to return `local.static_email` provides symmetry when passing `module.sa.name` into `var.name` of a reused service account module instance.