### PR TITLE
Add HTTP keep alive timeout attribute to net-lb-app-ext-regional module

### DIFF
--- a/modules/net-lb-app-ext-regional/README.md
+++ b/modules/net-lb-app-ext-regional/README.md
@@ -853,10 +853,10 @@ For deploying changes to load balancer configuration please refer to [net-lb-app
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [name](variables.tf#L86) | Load balancer name. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L212) | Project id. | <code>string</code> | ✓ |  |
-| [region](variables.tf#L230) | Region where the load balancer is created. | <code>string</code> | ✓ |  |
-| [vpc_config](variables.tf#L250) | VPC-level configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
+| [name](variables.tf#L88) | Load balancer name. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L214) | Project id. | <code>string</code> | ✓ |  |
+| [region](variables.tf#L232) | Region where the load balancer is created. | <code>string</code> | ✓ |  |
+| [vpc_config](variables.tf#L252) | VPC-level configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
 | [address](variables.tf#L17) | Optional IP address used for the forwarding rule. | <code>string</code> |  | <code>null</code> |
 | [backend_service_configs](variables-backend-service.tf#L19) | Backend service level configuration. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [context](variables.tf#L23) | Context-specific interpolations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
@@ -864,13 +864,13 @@ For deploying changes to load balancer configuration please refer to [net-lb-app
 | [group_configs](variables.tf#L42) | Optional unmanaged groups to create. Can be referenced in backends via key or outputs. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [health_check_configs](variables-health-check.tf#L19) | Optional auto-created health check configurations, use the output self-link to set it in the auto healing policy. Refer to examples for usage. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#8230;&#125;</code> |
 | [http_proxy_config](variables.tf#L56) | HTTP proxy configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [https_proxy_config](variables.tf#L66) | HTTPS proxy connfiguration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [labels](variables.tf#L80) | Labels set on resources. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
-| [neg_configs](variables.tf#L91) | Optional network endpoint groups to create. Can be referenced in backends via key or outputs. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [network_tier_standard](variables.tf#L195) | Use standard network tier. | <code>bool</code> |  | <code>true</code> |
-| [ports](variables.tf#L202) | Optional ports for HTTP load balancer. | <code>list&#40;string&#41;</code> |  | <code>null</code> |
-| [protocol](variables.tf#L217) | Protocol supported by this load balancer. | <code>string</code> |  | <code>&#34;HTTP&#34;</code> |
-| [ssl_certificates](variables.tf#L235) | SSL target proxy certificates (only if protocol is HTTPS) for existing, custom, and managed certificates. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [https_proxy_config](variables.tf#L67) | HTTPS proxy connfiguration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [labels](variables.tf#L82) | Labels set on resources. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [neg_configs](variables.tf#L93) | Optional network endpoint groups to create. Can be referenced in backends via key or outputs. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [network_tier_standard](variables.tf#L197) | Use standard network tier. | <code>bool</code> |  | <code>true</code> |
+| [ports](variables.tf#L204) | Optional ports for HTTP load balancer. | <code>list&#40;string&#41;</code> |  | <code>null</code> |
+| [protocol](variables.tf#L219) | Protocol supported by this load balancer. | <code>string</code> |  | <code>&#34;HTTP&#34;</code> |
+| [ssl_certificates](variables.tf#L237) | SSL target proxy certificates (only if protocol is HTTPS) for existing, custom, and managed certificates. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [urlmap_config](variables-urlmap.tf#L19) | The URL map configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#8230;&#125;</code> |
 
 ## Outputs

--- a/modules/net-lb-app-ext-regional/main.tf
+++ b/modules/net-lb-app-ext-regional/main.tf
@@ -75,6 +75,7 @@ resource "google_compute_region_target_http_proxy" "default" {
   region      = local.region
   name        = coalesce(var.http_proxy_config.name, var.name)
   description = var.http_proxy_config.description
+  http_keep_alive_timeout_sec      = var.https_proxy_config.http_keepalive_timeout
   url_map     = google_compute_region_url_map.default.id
 }
 
@@ -85,6 +86,7 @@ resource "google_compute_region_target_https_proxy" "default" {
   region                           = local.region
   description                      = var.https_proxy_config.description
   certificate_manager_certificates = var.https_proxy_config.certificate_manager_certificates
+  http_keep_alive_timeout_sec      = var.https_proxy_config.http_keepalive_timeout
   ssl_certificates                 = length(local.proxy_ssl_certificates) == 0 ? null : local.proxy_ssl_certificates
   ssl_policy                       = var.https_proxy_config.ssl_policy
   url_map                          = google_compute_region_url_map.default.id

--- a/modules/net-lb-app-ext-regional/main.tf
+++ b/modules/net-lb-app-ext-regional/main.tf
@@ -70,13 +70,13 @@ resource "google_compute_region_ssl_certificate" "default" {
 }
 
 resource "google_compute_region_target_http_proxy" "default" {
-  count       = var.protocol == "HTTPS" ? 0 : 1
-  project     = local.project_id
-  region      = local.region
-  name        = coalesce(var.http_proxy_config.name, var.name)
-  description = var.http_proxy_config.description
-  http_keep_alive_timeout_sec      = var.https_proxy_config.http_keepalive_timeout
-  url_map     = google_compute_region_url_map.default.id
+  count                       = var.protocol == "HTTPS" ? 0 : 1
+  project                     = local.project_id
+  region                      = local.region
+  name                        = coalesce(var.http_proxy_config.name, var.name)
+  description                 = var.http_proxy_config.description
+  http_keep_alive_timeout_sec = var.https_proxy_config.http_keepalive_timeout
+  url_map                     = google_compute_region_url_map.default.id
 }
 
 resource "google_compute_region_target_https_proxy" "default" {

--- a/modules/net-lb-app-ext-regional/variables.tf
+++ b/modules/net-lb-app-ext-regional/variables.tf
@@ -58,6 +58,7 @@ variable "http_proxy_config" {
   type = object({
     name        = optional(string)
     description = optional(string, "Terraform managed.")
+    http_keepalive_timeout           = optional(string)
   })
   default  = {}
   nullable = false
@@ -70,6 +71,7 @@ variable "https_proxy_config" {
     description                      = optional(string, "Terraform managed.")
     certificate_manager_certificates = optional(list(string))
     certificate_map                  = optional(string)
+    http_keepalive_timeout           = optional(string)
     quic_override                    = optional(string)
     ssl_policy                       = optional(string)
   })

--- a/modules/net-lb-app-ext-regional/variables.tf
+++ b/modules/net-lb-app-ext-regional/variables.tf
@@ -56,9 +56,9 @@ variable "group_configs" {
 variable "http_proxy_config" {
   description = "HTTP proxy configuration."
   type = object({
-    name        = optional(string)
-    description = optional(string, "Terraform managed.")
-    http_keepalive_timeout           = optional(string)
+    name                   = optional(string)
+    description            = optional(string, "Terraform managed.")
+    http_keepalive_timeout = optional(string)
   })
   default  = {}
   nullable = false


### PR DESCRIPTION
…ute for HTTP and HTTPS proxy config variables. This to allow modification of this parameter for Regional Ext App LB

<!-- Put a description of what this PR is for here -->

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X ] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [ X] Ran `terraform fmt` on all modified files
- [ X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ X] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
