### PR TITLE
Add conditional IAM bindings support for external resources in service account module

### DIFF
--- a/adrs/modules/20260727-sa-iam-conditions.md
+++ b/adrs/modules/20260727-sa-iam-conditions.md
@@ -1,0 +1,63 @@
+# Service Account External IAM Bindings with Condition Support
+
+**authors:** [ludomagno](https://github.com/ludomagno), Antigravity (AI Assistant)
+**date:** Jul 27, 2026
+
+## Status
+
+Approved
+
+## Context
+
+The `iam-service-account` module provides convenience variables (`iam_billing_roles`, `iam_folder_roles`, `iam_organization_roles`, `iam_project_roles`, `iam_sa_roles`, and `iam_storage_roles`) to grant IAM roles to the service account on external GCP resources. Currently, these variables are typed as `map(list(string))` (`{ entity_id => [roles] }`).
+
+To support IAM conditions on these external role grants, modifying the existing variables to use `any` or complex union types is problematic:
+1. The use of `any` disables HCL type validation at plan time and causes type evaluation side effects.
+2. An `any` type cannot be reliably translated into JSON schemas required for factory validation in `project-factory` and FAST stages.
+3. Changing the existing variable structure from lists of strings to lists of objects would introduce breaking changes for all existing consumers.
+
+## Decision
+
+We adopt the standard Cloud Foundation Fabric dual-variable pattern (Option B):
+
+1. **Preserve Existing Variables:** Retain `iam_billing_roles`, `iam_folder_roles`, `iam_organization_roles`, `iam_project_roles`, `iam_sa_roles`, and `iam_storage_roles` as `map(list(string))` without changes for backward compatibility and simple unconditional role grants.
+2. **Introduce Parallel Bindings Variables:** Add 6 new parallel variables:
+   - `iam_billing_bindings`
+   - `iam_folder_bindings`
+   - `iam_organization_bindings`
+   - `iam_project_bindings`
+   - `iam_sa_bindings`
+   - `iam_storage_bindings`
+3. **Strict Type Definition:** Define each new binding variable with explicit object typing and arbitrary map keys:
+   ```hcl
+   type = map(object({
+     entity    = string # 'project', 'bucket', 'folder', etc., depending on resource type
+     role      = string
+     condition = optional(object({
+       expression  = string
+       title       = string
+       description = optional(string)
+     }))
+   }))
+   ```
+4. **Unified Resource Processing:** In `iam.tf`, merge the flattened items from `iam_*_roles` (defaulting `condition = null`) with the items from `iam_*_bindings`. Update the 6 `google_*_iam_member` resources to iterate over the merged map and implement `dynamic "condition"` blocks supporting `templatestring()` interpolation via `var.context.condition_vars`.
+
+## Consequences
+
+* **Type Safety & Factory Parity:** Preserves strict HCL type checking and allows deterministic translation to JSON schemas for module and stage factories.
+* **Backward Compatibility:** Zero breaking changes for existing module consumers.
+* **State Stability:** Callers provide arbitrary map keys for conditional bindings, guaranteeing stable and unique Terraform state keys even when granting the same role to the same entity multiple times under different conditions.
+* **Interface Surface:** Adds 6 new variables to the public interface of the `iam-service-account` module.
+
+## Implementation Plan
+
+1. **`modules/iam-service-account`:**
+   - Add the 6 new binding variables in `variables-iam.tf`.
+   - Update local merge logic and add `dynamic "condition"` blocks to external IAM member resources in `iam.tf`.
+   - Regenerate documentation using `python3 tools/tfdoc.py --replace modules/iam-service-account`.
+   - Add test suites in `tests/modules/iam_service_account/` verifying conditional evaluation and state key stability.
+2. **`modules/project-factory`:**
+   - Plumb the new variables through `opts` in `projects-service-accounts.tf`.
+   - Update `schemas/project.schema.json` and `schemas/folder.schema.json` to include condition properties on service account role definitions, and regenerate documentation via `python3 tools/schema_docs.py`.
+3. **`fast/stages`:**
+   - Propagate schema updates to downstream copies of `project.schema.json` and `folder.schema.json` across FAST stages, verifying parity with `python3 tools/duplicate-diff.py`.

--- a/fast/stages/0-org-setup/schemas/folder.schema.json
+++ b/fast/stages/0-org-setup/schemas/folder.schema.json
@@ -148,20 +148,38 @@
                 "iam_bindings_additive": {
                   "$ref": "#/$defs/iam_bindings_additive"
                 },
+                "iam_billing_bindings": {
+                  "$ref": "#/$defs/iam_billing_bindings"
+                },
                 "iam_billing_roles": {
                   "$ref": "#/$defs/iam_billing_roles"
+                },
+                "iam_folder_bindings": {
+                  "$ref": "#/$defs/iam_folder_bindings"
                 },
                 "iam_folder_roles": {
                   "$ref": "#/$defs/iam_folder_roles"
                 },
+                "iam_organization_bindings": {
+                  "$ref": "#/$defs/iam_organization_bindings"
+                },
                 "iam_organization_roles": {
                   "$ref": "#/$defs/iam_organization_roles"
+                },
+                "iam_project_bindings": {
+                  "$ref": "#/$defs/iam_project_bindings"
                 },
                 "iam_project_roles": {
                   "$ref": "#/$defs/iam_project_roles"
                 },
+                "iam_sa_bindings": {
+                  "$ref": "#/$defs/iam_sa_bindings"
+                },
                 "iam_sa_roles": {
                   "$ref": "#/$defs/iam_sa_roles"
+                },
+                "iam_storage_bindings": {
+                  "$ref": "#/$defs/iam_storage_bindings"
                 },
                 "iam_storage_roles": {
                   "$ref": "#/$defs/iam_storage_roles"
@@ -850,6 +868,258 @@
               "items": {
                 "type": "string",
                 "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_billing_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "billing_account_id",
+            "role"
+          ],
+          "properties": {
+            "billing_account_id": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_folder_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "folder_id",
+            "role"
+          ],
+          "properties": {
+            "folder_id": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_organization_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "organization_id",
+            "role"
+          ],
+          "properties": {
+            "organization_id": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_project_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "project_id",
+            "role"
+          ],
+          "properties": {
+            "project_id": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_sa_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "role",
+            "service_account_id"
+          ],
+          "properties": {
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "service_account_id": {
+              "type": "string"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_storage_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "bucket",
+            "role"
+          ],
+          "properties": {
+            "bucket": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
               }
             }
           }

--- a/fast/stages/0-org-setup/schemas/folder.schema.md
+++ b/fast/stages/0-org-setup/schemas/folder.schema.md
@@ -48,11 +48,17 @@
       - **iam**: *reference([iam](#refs-iam))*
       - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
       - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
+      - **iam_billing_bindings**: *reference([iam_billing_bindings](#refs-iam_billing_bindings))*
       - **iam_billing_roles**: *reference([iam_billing_roles](#refs-iam_billing_roles))*
+      - **iam_folder_bindings**: *reference([iam_folder_bindings](#refs-iam_folder_bindings))*
       - **iam_folder_roles**: *reference([iam_folder_roles](#refs-iam_folder_roles))*
+      - **iam_organization_bindings**: *reference([iam_organization_bindings](#refs-iam_organization_bindings))*
       - **iam_organization_roles**: *reference([iam_organization_roles](#refs-iam_organization_roles))*
+      - **iam_project_bindings**: *reference([iam_project_bindings](#refs-iam_project_bindings))*
       - **iam_project_roles**: *reference([iam_project_roles](#refs-iam_project_roles))*
+      - **iam_sa_bindings**: *reference([iam_sa_bindings](#refs-iam_sa_bindings))*
       - **iam_sa_roles**: *reference([iam_sa_roles](#refs-iam_sa_roles))*
+      - **iam_storage_bindings**: *reference([iam_storage_bindings](#refs-iam_storage_bindings))*
       - **iam_storage_roles**: *reference([iam_storage_roles](#refs-iam_storage_roles))*
       - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
 - **autokey_config**: *object*
@@ -258,6 +264,78 @@
     - ⁺**roles**: *array*
       - items: *string*
         <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+- **iam_billing_bindings**<a name="refs-iam_billing_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**billing_account_id**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_folder_bindings**<a name="refs-iam_folder_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**folder_id**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_organization_bindings**<a name="refs-iam_organization_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**organization_id**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_project_bindings**<a name="refs-iam_project_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**project_id**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_sa_bindings**<a name="refs-iam_sa_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - ⁺**service_account_id**: *string*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_storage_bindings**<a name="refs-iam_storage_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**bucket**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
 - **iam_billing_roles**<a name="refs-iam_billing_roles"></a>: *object*
   <br>*additional properties: false*
   - **`^[a-z0-9-]+$`**: *array*

--- a/fast/stages/0-org-setup/schemas/project.schema.json
+++ b/fast/stages/0-org-setup/schemas/project.schema.json
@@ -129,20 +129,38 @@
                 "iam_bindings_additive": {
                   "$ref": "#/$defs/iam_bindings_additive"
                 },
+                "iam_billing_bindings": {
+                  "$ref": "#/$defs/iam_billing_bindings"
+                },
                 "iam_billing_roles": {
                   "$ref": "#/$defs/iam_billing_roles"
+                },
+                "iam_folder_bindings": {
+                  "$ref": "#/$defs/iam_folder_bindings"
                 },
                 "iam_folder_roles": {
                   "$ref": "#/$defs/iam_folder_roles"
                 },
+                "iam_organization_bindings": {
+                  "$ref": "#/$defs/iam_organization_bindings"
+                },
                 "iam_organization_roles": {
                   "$ref": "#/$defs/iam_organization_roles"
+                },
+                "iam_project_bindings": {
+                  "$ref": "#/$defs/iam_project_bindings"
                 },
                 "iam_project_roles": {
                   "$ref": "#/$defs/iam_project_roles"
                 },
+                "iam_sa_bindings": {
+                  "$ref": "#/$defs/iam_sa_bindings"
+                },
                 "iam_sa_roles": {
                   "$ref": "#/$defs/iam_sa_roles"
+                },
+                "iam_storage_bindings": {
+                  "$ref": "#/$defs/iam_storage_bindings"
                 },
                 "iam_storage_roles": {
                   "$ref": "#/$defs/iam_storage_roles"
@@ -800,17 +818,47 @@
             "iam_bindings_additive": {
               "$ref": "#/$defs/iam_bindings_additive"
             },
+            "iam_billing_bindings": {
+              "$ref": "#/$defs/iam_billing_bindings"
+            },
+            "iam_billing_roles": {
+              "$ref": "#/$defs/iam_billing_roles"
+            },
+            "iam_folder_bindings": {
+              "$ref": "#/$defs/iam_folder_bindings"
+            },
+            "iam_folder_roles": {
+              "$ref": "#/$defs/iam_folder_roles"
+            },
+            "iam_organization_bindings": {
+              "$ref": "#/$defs/iam_organization_bindings"
+            },
+            "iam_organization_roles": {
+              "$ref": "#/$defs/iam_organization_roles"
+            },
+            "iam_project_bindings": {
+              "$ref": "#/$defs/iam_project_bindings"
+            },
+            "iam_project_roles": {
+              "$ref": "#/$defs/iam_project_roles"
+            },
+            "iam_sa_bindings": {
+              "$ref": "#/$defs/iam_sa_bindings"
+            },
+            "iam_sa_roles": {
+              "$ref": "#/$defs/iam_sa_roles"
+            },
             "iam_self_roles": {
               "type": "array",
               "items": {
                 "type": "string"
               }
             },
-            "iam_project_roles": {
-              "$ref": "#/$defs/iam_project_roles"
+            "iam_storage_bindings": {
+              "$ref": "#/$defs/iam_storage_bindings"
             },
-            "iam_sa_roles": {
-              "$ref": "#/$defs/iam_sa_roles"
+            "iam_storage_roles": {
+              "$ref": "#/$defs/iam_storage_roles"
             },
             "tag_bindings": {
               "$ref": "#/$defs/tag_bindings"
@@ -1566,6 +1614,258 @@
               "items": {
                 "type": "string",
                 "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_billing_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "billing_account_id",
+            "role"
+          ],
+          "properties": {
+            "billing_account_id": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_folder_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "folder_id",
+            "role"
+          ],
+          "properties": {
+            "folder_id": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_organization_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "organization_id",
+            "role"
+          ],
+          "properties": {
+            "organization_id": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_project_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "project_id",
+            "role"
+          ],
+          "properties": {
+            "project_id": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_sa_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "role",
+            "service_account_id"
+          ],
+          "properties": {
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "service_account_id": {
+              "type": "string"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_storage_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "bucket",
+            "role"
+          ],
+          "properties": {
+            "bucket": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
               }
             }
           }

--- a/fast/stages/0-org-setup/schemas/project.schema.md
+++ b/fast/stages/0-org-setup/schemas/project.schema.md
@@ -43,11 +43,17 @@
       - **iam**: *reference([iam](#refs-iam))*
       - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
       - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
+      - **iam_billing_bindings**: *reference([iam_billing_bindings](#refs-iam_billing_bindings))*
       - **iam_billing_roles**: *reference([iam_billing_roles](#refs-iam_billing_roles))*
+      - **iam_folder_bindings**: *reference([iam_folder_bindings](#refs-iam_folder_bindings))*
       - **iam_folder_roles**: *reference([iam_folder_roles](#refs-iam_folder_roles))*
+      - **iam_organization_bindings**: *reference([iam_organization_bindings](#refs-iam_organization_bindings))*
       - **iam_organization_roles**: *reference([iam_organization_roles](#refs-iam_organization_roles))*
+      - **iam_project_bindings**: *reference([iam_project_bindings](#refs-iam_project_bindings))*
       - **iam_project_roles**: *reference([iam_project_roles](#refs-iam_project_roles))*
+      - **iam_sa_bindings**: *reference([iam_sa_bindings](#refs-iam_sa_bindings))*
       - **iam_sa_roles**: *reference([iam_sa_roles](#refs-iam_sa_roles))*
+      - **iam_storage_bindings**: *reference([iam_storage_bindings](#refs-iam_storage_bindings))*
       - **iam_storage_roles**: *reference([iam_storage_roles](#refs-iam_storage_roles))*
       - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
 - **billing_account**: *string*
@@ -248,10 +254,20 @@
     - **iam**: *reference([iam](#refs-iam))*
     - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
     - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
+    - **iam_billing_bindings**: *reference([iam_billing_bindings](#refs-iam_billing_bindings))*
+    - **iam_billing_roles**: *reference([iam_billing_roles](#refs-iam_billing_roles))*
+    - **iam_folder_bindings**: *reference([iam_folder_bindings](#refs-iam_folder_bindings))*
+    - **iam_folder_roles**: *reference([iam_folder_roles](#refs-iam_folder_roles))*
+    - **iam_organization_bindings**: *reference([iam_organization_bindings](#refs-iam_organization_bindings))*
+    - **iam_organization_roles**: *reference([iam_organization_roles](#refs-iam_organization_roles))*
+    - **iam_project_bindings**: *reference([iam_project_bindings](#refs-iam_project_bindings))*
+    - **iam_project_roles**: *reference([iam_project_roles](#refs-iam_project_roles))*
+    - **iam_sa_bindings**: *reference([iam_sa_bindings](#refs-iam_sa_bindings))*
+    - **iam_sa_roles**: *reference([iam_sa_roles](#refs-iam_sa_roles))*
     - **iam_self_roles**: *array*
       - items: *string*
-    - **iam_project_roles**: *reference([iam_project_roles](#refs-iam_project_roles))*
-    - **iam_sa_roles**: *reference([iam_sa_roles](#refs-iam_sa_roles))*
+    - **iam_storage_bindings**: *reference([iam_storage_bindings](#refs-iam_storage_bindings))*
+    - **iam_storage_roles**: *reference([iam_storage_roles](#refs-iam_storage_roles))*
     - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
 - **service_agents_config**: *object*
   <br>*additional properties: false*
@@ -447,6 +463,78 @@
     - ⁺**roles**: *array*
       - items: *string*
         <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+- **iam_billing_bindings**<a name="refs-iam_billing_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**billing_account_id**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_folder_bindings**<a name="refs-iam_folder_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**folder_id**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_organization_bindings**<a name="refs-iam_organization_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**organization_id**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_project_bindings**<a name="refs-iam_project_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**project_id**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_sa_bindings**<a name="refs-iam_sa_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - ⁺**service_account_id**: *string*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_storage_bindings**<a name="refs-iam_storage_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**bucket**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
 - **iam_billing_roles**<a name="refs-iam_billing_roles"></a>: *object*
   <br>*additional properties: false*
   - **`^[a-z0-9-]+$`**: *array*

--- a/fast/stages/2-networking/schemas/folder.schema.json
+++ b/fast/stages/2-networking/schemas/folder.schema.json
@@ -148,20 +148,38 @@
                 "iam_bindings_additive": {
                   "$ref": "#/$defs/iam_bindings_additive"
                 },
+                "iam_billing_bindings": {
+                  "$ref": "#/$defs/iam_billing_bindings"
+                },
                 "iam_billing_roles": {
                   "$ref": "#/$defs/iam_billing_roles"
+                },
+                "iam_folder_bindings": {
+                  "$ref": "#/$defs/iam_folder_bindings"
                 },
                 "iam_folder_roles": {
                   "$ref": "#/$defs/iam_folder_roles"
                 },
+                "iam_organization_bindings": {
+                  "$ref": "#/$defs/iam_organization_bindings"
+                },
                 "iam_organization_roles": {
                   "$ref": "#/$defs/iam_organization_roles"
+                },
+                "iam_project_bindings": {
+                  "$ref": "#/$defs/iam_project_bindings"
                 },
                 "iam_project_roles": {
                   "$ref": "#/$defs/iam_project_roles"
                 },
+                "iam_sa_bindings": {
+                  "$ref": "#/$defs/iam_sa_bindings"
+                },
                 "iam_sa_roles": {
                   "$ref": "#/$defs/iam_sa_roles"
+                },
+                "iam_storage_bindings": {
+                  "$ref": "#/$defs/iam_storage_bindings"
                 },
                 "iam_storage_roles": {
                   "$ref": "#/$defs/iam_storage_roles"
@@ -850,6 +868,258 @@
               "items": {
                 "type": "string",
                 "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_billing_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "billing_account_id",
+            "role"
+          ],
+          "properties": {
+            "billing_account_id": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_folder_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "folder_id",
+            "role"
+          ],
+          "properties": {
+            "folder_id": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_organization_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "organization_id",
+            "role"
+          ],
+          "properties": {
+            "organization_id": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_project_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "project_id",
+            "role"
+          ],
+          "properties": {
+            "project_id": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_sa_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "role",
+            "service_account_id"
+          ],
+          "properties": {
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "service_account_id": {
+              "type": "string"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_storage_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "bucket",
+            "role"
+          ],
+          "properties": {
+            "bucket": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
               }
             }
           }

--- a/fast/stages/2-networking/schemas/folder.schema.md
+++ b/fast/stages/2-networking/schemas/folder.schema.md
@@ -48,11 +48,17 @@
       - **iam**: *reference([iam](#refs-iam))*
       - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
       - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
+      - **iam_billing_bindings**: *reference([iam_billing_bindings](#refs-iam_billing_bindings))*
       - **iam_billing_roles**: *reference([iam_billing_roles](#refs-iam_billing_roles))*
+      - **iam_folder_bindings**: *reference([iam_folder_bindings](#refs-iam_folder_bindings))*
       - **iam_folder_roles**: *reference([iam_folder_roles](#refs-iam_folder_roles))*
+      - **iam_organization_bindings**: *reference([iam_organization_bindings](#refs-iam_organization_bindings))*
       - **iam_organization_roles**: *reference([iam_organization_roles](#refs-iam_organization_roles))*
+      - **iam_project_bindings**: *reference([iam_project_bindings](#refs-iam_project_bindings))*
       - **iam_project_roles**: *reference([iam_project_roles](#refs-iam_project_roles))*
+      - **iam_sa_bindings**: *reference([iam_sa_bindings](#refs-iam_sa_bindings))*
       - **iam_sa_roles**: *reference([iam_sa_roles](#refs-iam_sa_roles))*
+      - **iam_storage_bindings**: *reference([iam_storage_bindings](#refs-iam_storage_bindings))*
       - **iam_storage_roles**: *reference([iam_storage_roles](#refs-iam_storage_roles))*
       - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
 - **autokey_config**: *object*
@@ -258,6 +264,78 @@
     - ⁺**roles**: *array*
       - items: *string*
         <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+- **iam_billing_bindings**<a name="refs-iam_billing_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**billing_account_id**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_folder_bindings**<a name="refs-iam_folder_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**folder_id**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_organization_bindings**<a name="refs-iam_organization_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**organization_id**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_project_bindings**<a name="refs-iam_project_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**project_id**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_sa_bindings**<a name="refs-iam_sa_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - ⁺**service_account_id**: *string*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_storage_bindings**<a name="refs-iam_storage_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**bucket**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
 - **iam_billing_roles**<a name="refs-iam_billing_roles"></a>: *object*
   <br>*additional properties: false*
   - **`^[a-z0-9-]+$`**: *array*

--- a/fast/stages/2-networking/schemas/project.schema.json
+++ b/fast/stages/2-networking/schemas/project.schema.json
@@ -129,20 +129,38 @@
                 "iam_bindings_additive": {
                   "$ref": "#/$defs/iam_bindings_additive"
                 },
+                "iam_billing_bindings": {
+                  "$ref": "#/$defs/iam_billing_bindings"
+                },
                 "iam_billing_roles": {
                   "$ref": "#/$defs/iam_billing_roles"
+                },
+                "iam_folder_bindings": {
+                  "$ref": "#/$defs/iam_folder_bindings"
                 },
                 "iam_folder_roles": {
                   "$ref": "#/$defs/iam_folder_roles"
                 },
+                "iam_organization_bindings": {
+                  "$ref": "#/$defs/iam_organization_bindings"
+                },
                 "iam_organization_roles": {
                   "$ref": "#/$defs/iam_organization_roles"
+                },
+                "iam_project_bindings": {
+                  "$ref": "#/$defs/iam_project_bindings"
                 },
                 "iam_project_roles": {
                   "$ref": "#/$defs/iam_project_roles"
                 },
+                "iam_sa_bindings": {
+                  "$ref": "#/$defs/iam_sa_bindings"
+                },
                 "iam_sa_roles": {
                   "$ref": "#/$defs/iam_sa_roles"
+                },
+                "iam_storage_bindings": {
+                  "$ref": "#/$defs/iam_storage_bindings"
                 },
                 "iam_storage_roles": {
                   "$ref": "#/$defs/iam_storage_roles"
@@ -800,17 +818,47 @@
             "iam_bindings_additive": {
               "$ref": "#/$defs/iam_bindings_additive"
             },
+            "iam_billing_bindings": {
+              "$ref": "#/$defs/iam_billing_bindings"
+            },
+            "iam_billing_roles": {
+              "$ref": "#/$defs/iam_billing_roles"
+            },
+            "iam_folder_bindings": {
+              "$ref": "#/$defs/iam_folder_bindings"
+            },
+            "iam_folder_roles": {
+              "$ref": "#/$defs/iam_folder_roles"
+            },
+            "iam_organization_bindings": {
+              "$ref": "#/$defs/iam_organization_bindings"
+            },
+            "iam_organization_roles": {
+              "$ref": "#/$defs/iam_organization_roles"
+            },
+            "iam_project_bindings": {
+              "$ref": "#/$defs/iam_project_bindings"
+            },
+            "iam_project_roles": {
+              "$ref": "#/$defs/iam_project_roles"
+            },
+            "iam_sa_bindings": {
+              "$ref": "#/$defs/iam_sa_bindings"
+            },
+            "iam_sa_roles": {
+              "$ref": "#/$defs/iam_sa_roles"
+            },
             "iam_self_roles": {
               "type": "array",
               "items": {
                 "type": "string"
               }
             },
-            "iam_project_roles": {
-              "$ref": "#/$defs/iam_project_roles"
+            "iam_storage_bindings": {
+              "$ref": "#/$defs/iam_storage_bindings"
             },
-            "iam_sa_roles": {
-              "$ref": "#/$defs/iam_sa_roles"
+            "iam_storage_roles": {
+              "$ref": "#/$defs/iam_storage_roles"
             },
             "tag_bindings": {
               "$ref": "#/$defs/tag_bindings"
@@ -1566,6 +1614,258 @@
               "items": {
                 "type": "string",
                 "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_billing_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "billing_account_id",
+            "role"
+          ],
+          "properties": {
+            "billing_account_id": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_folder_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "folder_id",
+            "role"
+          ],
+          "properties": {
+            "folder_id": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_organization_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "organization_id",
+            "role"
+          ],
+          "properties": {
+            "organization_id": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_project_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "project_id",
+            "role"
+          ],
+          "properties": {
+            "project_id": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_sa_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "role",
+            "service_account_id"
+          ],
+          "properties": {
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "service_account_id": {
+              "type": "string"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_storage_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "bucket",
+            "role"
+          ],
+          "properties": {
+            "bucket": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
               }
             }
           }

--- a/fast/stages/2-networking/schemas/project.schema.md
+++ b/fast/stages/2-networking/schemas/project.schema.md
@@ -43,11 +43,17 @@
       - **iam**: *reference([iam](#refs-iam))*
       - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
       - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
+      - **iam_billing_bindings**: *reference([iam_billing_bindings](#refs-iam_billing_bindings))*
       - **iam_billing_roles**: *reference([iam_billing_roles](#refs-iam_billing_roles))*
+      - **iam_folder_bindings**: *reference([iam_folder_bindings](#refs-iam_folder_bindings))*
       - **iam_folder_roles**: *reference([iam_folder_roles](#refs-iam_folder_roles))*
+      - **iam_organization_bindings**: *reference([iam_organization_bindings](#refs-iam_organization_bindings))*
       - **iam_organization_roles**: *reference([iam_organization_roles](#refs-iam_organization_roles))*
+      - **iam_project_bindings**: *reference([iam_project_bindings](#refs-iam_project_bindings))*
       - **iam_project_roles**: *reference([iam_project_roles](#refs-iam_project_roles))*
+      - **iam_sa_bindings**: *reference([iam_sa_bindings](#refs-iam_sa_bindings))*
       - **iam_sa_roles**: *reference([iam_sa_roles](#refs-iam_sa_roles))*
+      - **iam_storage_bindings**: *reference([iam_storage_bindings](#refs-iam_storage_bindings))*
       - **iam_storage_roles**: *reference([iam_storage_roles](#refs-iam_storage_roles))*
       - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
 - **billing_account**: *string*
@@ -248,10 +254,20 @@
     - **iam**: *reference([iam](#refs-iam))*
     - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
     - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
+    - **iam_billing_bindings**: *reference([iam_billing_bindings](#refs-iam_billing_bindings))*
+    - **iam_billing_roles**: *reference([iam_billing_roles](#refs-iam_billing_roles))*
+    - **iam_folder_bindings**: *reference([iam_folder_bindings](#refs-iam_folder_bindings))*
+    - **iam_folder_roles**: *reference([iam_folder_roles](#refs-iam_folder_roles))*
+    - **iam_organization_bindings**: *reference([iam_organization_bindings](#refs-iam_organization_bindings))*
+    - **iam_organization_roles**: *reference([iam_organization_roles](#refs-iam_organization_roles))*
+    - **iam_project_bindings**: *reference([iam_project_bindings](#refs-iam_project_bindings))*
+    - **iam_project_roles**: *reference([iam_project_roles](#refs-iam_project_roles))*
+    - **iam_sa_bindings**: *reference([iam_sa_bindings](#refs-iam_sa_bindings))*
+    - **iam_sa_roles**: *reference([iam_sa_roles](#refs-iam_sa_roles))*
     - **iam_self_roles**: *array*
       - items: *string*
-    - **iam_project_roles**: *reference([iam_project_roles](#refs-iam_project_roles))*
-    - **iam_sa_roles**: *reference([iam_sa_roles](#refs-iam_sa_roles))*
+    - **iam_storage_bindings**: *reference([iam_storage_bindings](#refs-iam_storage_bindings))*
+    - **iam_storage_roles**: *reference([iam_storage_roles](#refs-iam_storage_roles))*
     - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
 - **service_agents_config**: *object*
   <br>*additional properties: false*
@@ -447,6 +463,78 @@
     - ⁺**roles**: *array*
       - items: *string*
         <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+- **iam_billing_bindings**<a name="refs-iam_billing_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**billing_account_id**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_folder_bindings**<a name="refs-iam_folder_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**folder_id**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_organization_bindings**<a name="refs-iam_organization_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**organization_id**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_project_bindings**<a name="refs-iam_project_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**project_id**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_sa_bindings**<a name="refs-iam_sa_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - ⁺**service_account_id**: *string*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_storage_bindings**<a name="refs-iam_storage_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**bucket**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
 - **iam_billing_roles**<a name="refs-iam_billing_roles"></a>: *object*
   <br>*additional properties: false*
   - **`^[a-z0-9-]+$`**: *array*

--- a/fast/stages/2-project-factory/schemas/folder.schema.json
+++ b/fast/stages/2-project-factory/schemas/folder.schema.json
@@ -148,20 +148,38 @@
                 "iam_bindings_additive": {
                   "$ref": "#/$defs/iam_bindings_additive"
                 },
+                "iam_billing_bindings": {
+                  "$ref": "#/$defs/iam_billing_bindings"
+                },
                 "iam_billing_roles": {
                   "$ref": "#/$defs/iam_billing_roles"
+                },
+                "iam_folder_bindings": {
+                  "$ref": "#/$defs/iam_folder_bindings"
                 },
                 "iam_folder_roles": {
                   "$ref": "#/$defs/iam_folder_roles"
                 },
+                "iam_organization_bindings": {
+                  "$ref": "#/$defs/iam_organization_bindings"
+                },
                 "iam_organization_roles": {
                   "$ref": "#/$defs/iam_organization_roles"
+                },
+                "iam_project_bindings": {
+                  "$ref": "#/$defs/iam_project_bindings"
                 },
                 "iam_project_roles": {
                   "$ref": "#/$defs/iam_project_roles"
                 },
+                "iam_sa_bindings": {
+                  "$ref": "#/$defs/iam_sa_bindings"
+                },
                 "iam_sa_roles": {
                   "$ref": "#/$defs/iam_sa_roles"
+                },
+                "iam_storage_bindings": {
+                  "$ref": "#/$defs/iam_storage_bindings"
                 },
                 "iam_storage_roles": {
                   "$ref": "#/$defs/iam_storage_roles"
@@ -850,6 +868,258 @@
               "items": {
                 "type": "string",
                 "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_billing_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "billing_account_id",
+            "role"
+          ],
+          "properties": {
+            "billing_account_id": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_folder_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "folder_id",
+            "role"
+          ],
+          "properties": {
+            "folder_id": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_organization_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "organization_id",
+            "role"
+          ],
+          "properties": {
+            "organization_id": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_project_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "project_id",
+            "role"
+          ],
+          "properties": {
+            "project_id": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_sa_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "role",
+            "service_account_id"
+          ],
+          "properties": {
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "service_account_id": {
+              "type": "string"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_storage_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "bucket",
+            "role"
+          ],
+          "properties": {
+            "bucket": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
               }
             }
           }

--- a/fast/stages/2-project-factory/schemas/folder.schema.md
+++ b/fast/stages/2-project-factory/schemas/folder.schema.md
@@ -48,11 +48,17 @@
       - **iam**: *reference([iam](#refs-iam))*
       - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
       - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
+      - **iam_billing_bindings**: *reference([iam_billing_bindings](#refs-iam_billing_bindings))*
       - **iam_billing_roles**: *reference([iam_billing_roles](#refs-iam_billing_roles))*
+      - **iam_folder_bindings**: *reference([iam_folder_bindings](#refs-iam_folder_bindings))*
       - **iam_folder_roles**: *reference([iam_folder_roles](#refs-iam_folder_roles))*
+      - **iam_organization_bindings**: *reference([iam_organization_bindings](#refs-iam_organization_bindings))*
       - **iam_organization_roles**: *reference([iam_organization_roles](#refs-iam_organization_roles))*
+      - **iam_project_bindings**: *reference([iam_project_bindings](#refs-iam_project_bindings))*
       - **iam_project_roles**: *reference([iam_project_roles](#refs-iam_project_roles))*
+      - **iam_sa_bindings**: *reference([iam_sa_bindings](#refs-iam_sa_bindings))*
       - **iam_sa_roles**: *reference([iam_sa_roles](#refs-iam_sa_roles))*
+      - **iam_storage_bindings**: *reference([iam_storage_bindings](#refs-iam_storage_bindings))*
       - **iam_storage_roles**: *reference([iam_storage_roles](#refs-iam_storage_roles))*
       - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
 - **autokey_config**: *object*
@@ -258,6 +264,78 @@
     - ⁺**roles**: *array*
       - items: *string*
         <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+- **iam_billing_bindings**<a name="refs-iam_billing_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**billing_account_id**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_folder_bindings**<a name="refs-iam_folder_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**folder_id**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_organization_bindings**<a name="refs-iam_organization_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**organization_id**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_project_bindings**<a name="refs-iam_project_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**project_id**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_sa_bindings**<a name="refs-iam_sa_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - ⁺**service_account_id**: *string*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_storage_bindings**<a name="refs-iam_storage_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**bucket**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
 - **iam_billing_roles**<a name="refs-iam_billing_roles"></a>: *object*
   <br>*additional properties: false*
   - **`^[a-z0-9-]+$`**: *array*

--- a/fast/stages/2-project-factory/schemas/project.schema.json
+++ b/fast/stages/2-project-factory/schemas/project.schema.json
@@ -129,20 +129,38 @@
                 "iam_bindings_additive": {
                   "$ref": "#/$defs/iam_bindings_additive"
                 },
+                "iam_billing_bindings": {
+                  "$ref": "#/$defs/iam_billing_bindings"
+                },
                 "iam_billing_roles": {
                   "$ref": "#/$defs/iam_billing_roles"
+                },
+                "iam_folder_bindings": {
+                  "$ref": "#/$defs/iam_folder_bindings"
                 },
                 "iam_folder_roles": {
                   "$ref": "#/$defs/iam_folder_roles"
                 },
+                "iam_organization_bindings": {
+                  "$ref": "#/$defs/iam_organization_bindings"
+                },
                 "iam_organization_roles": {
                   "$ref": "#/$defs/iam_organization_roles"
+                },
+                "iam_project_bindings": {
+                  "$ref": "#/$defs/iam_project_bindings"
                 },
                 "iam_project_roles": {
                   "$ref": "#/$defs/iam_project_roles"
                 },
+                "iam_sa_bindings": {
+                  "$ref": "#/$defs/iam_sa_bindings"
+                },
                 "iam_sa_roles": {
                   "$ref": "#/$defs/iam_sa_roles"
+                },
+                "iam_storage_bindings": {
+                  "$ref": "#/$defs/iam_storage_bindings"
                 },
                 "iam_storage_roles": {
                   "$ref": "#/$defs/iam_storage_roles"
@@ -800,17 +818,47 @@
             "iam_bindings_additive": {
               "$ref": "#/$defs/iam_bindings_additive"
             },
+            "iam_billing_bindings": {
+              "$ref": "#/$defs/iam_billing_bindings"
+            },
+            "iam_billing_roles": {
+              "$ref": "#/$defs/iam_billing_roles"
+            },
+            "iam_folder_bindings": {
+              "$ref": "#/$defs/iam_folder_bindings"
+            },
+            "iam_folder_roles": {
+              "$ref": "#/$defs/iam_folder_roles"
+            },
+            "iam_organization_bindings": {
+              "$ref": "#/$defs/iam_organization_bindings"
+            },
+            "iam_organization_roles": {
+              "$ref": "#/$defs/iam_organization_roles"
+            },
+            "iam_project_bindings": {
+              "$ref": "#/$defs/iam_project_bindings"
+            },
+            "iam_project_roles": {
+              "$ref": "#/$defs/iam_project_roles"
+            },
+            "iam_sa_bindings": {
+              "$ref": "#/$defs/iam_sa_bindings"
+            },
+            "iam_sa_roles": {
+              "$ref": "#/$defs/iam_sa_roles"
+            },
             "iam_self_roles": {
               "type": "array",
               "items": {
                 "type": "string"
               }
             },
-            "iam_project_roles": {
-              "$ref": "#/$defs/iam_project_roles"
+            "iam_storage_bindings": {
+              "$ref": "#/$defs/iam_storage_bindings"
             },
-            "iam_sa_roles": {
-              "$ref": "#/$defs/iam_sa_roles"
+            "iam_storage_roles": {
+              "$ref": "#/$defs/iam_storage_roles"
             },
             "tag_bindings": {
               "$ref": "#/$defs/tag_bindings"
@@ -1566,6 +1614,258 @@
               "items": {
                 "type": "string",
                 "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_billing_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "billing_account_id",
+            "role"
+          ],
+          "properties": {
+            "billing_account_id": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_folder_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "folder_id",
+            "role"
+          ],
+          "properties": {
+            "folder_id": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_organization_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "organization_id",
+            "role"
+          ],
+          "properties": {
+            "organization_id": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_project_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "project_id",
+            "role"
+          ],
+          "properties": {
+            "project_id": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_sa_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "role",
+            "service_account_id"
+          ],
+          "properties": {
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "service_account_id": {
+              "type": "string"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_storage_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "bucket",
+            "role"
+          ],
+          "properties": {
+            "bucket": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
               }
             }
           }

--- a/fast/stages/2-project-factory/schemas/project.schema.md
+++ b/fast/stages/2-project-factory/schemas/project.schema.md
@@ -43,11 +43,17 @@
       - **iam**: *reference([iam](#refs-iam))*
       - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
       - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
+      - **iam_billing_bindings**: *reference([iam_billing_bindings](#refs-iam_billing_bindings))*
       - **iam_billing_roles**: *reference([iam_billing_roles](#refs-iam_billing_roles))*
+      - **iam_folder_bindings**: *reference([iam_folder_bindings](#refs-iam_folder_bindings))*
       - **iam_folder_roles**: *reference([iam_folder_roles](#refs-iam_folder_roles))*
+      - **iam_organization_bindings**: *reference([iam_organization_bindings](#refs-iam_organization_bindings))*
       - **iam_organization_roles**: *reference([iam_organization_roles](#refs-iam_organization_roles))*
+      - **iam_project_bindings**: *reference([iam_project_bindings](#refs-iam_project_bindings))*
       - **iam_project_roles**: *reference([iam_project_roles](#refs-iam_project_roles))*
+      - **iam_sa_bindings**: *reference([iam_sa_bindings](#refs-iam_sa_bindings))*
       - **iam_sa_roles**: *reference([iam_sa_roles](#refs-iam_sa_roles))*
+      - **iam_storage_bindings**: *reference([iam_storage_bindings](#refs-iam_storage_bindings))*
       - **iam_storage_roles**: *reference([iam_storage_roles](#refs-iam_storage_roles))*
       - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
 - **billing_account**: *string*
@@ -248,10 +254,20 @@
     - **iam**: *reference([iam](#refs-iam))*
     - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
     - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
+    - **iam_billing_bindings**: *reference([iam_billing_bindings](#refs-iam_billing_bindings))*
+    - **iam_billing_roles**: *reference([iam_billing_roles](#refs-iam_billing_roles))*
+    - **iam_folder_bindings**: *reference([iam_folder_bindings](#refs-iam_folder_bindings))*
+    - **iam_folder_roles**: *reference([iam_folder_roles](#refs-iam_folder_roles))*
+    - **iam_organization_bindings**: *reference([iam_organization_bindings](#refs-iam_organization_bindings))*
+    - **iam_organization_roles**: *reference([iam_organization_roles](#refs-iam_organization_roles))*
+    - **iam_project_bindings**: *reference([iam_project_bindings](#refs-iam_project_bindings))*
+    - **iam_project_roles**: *reference([iam_project_roles](#refs-iam_project_roles))*
+    - **iam_sa_bindings**: *reference([iam_sa_bindings](#refs-iam_sa_bindings))*
+    - **iam_sa_roles**: *reference([iam_sa_roles](#refs-iam_sa_roles))*
     - **iam_self_roles**: *array*
       - items: *string*
-    - **iam_project_roles**: *reference([iam_project_roles](#refs-iam_project_roles))*
-    - **iam_sa_roles**: *reference([iam_sa_roles](#refs-iam_sa_roles))*
+    - **iam_storage_bindings**: *reference([iam_storage_bindings](#refs-iam_storage_bindings))*
+    - **iam_storage_roles**: *reference([iam_storage_roles](#refs-iam_storage_roles))*
     - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
 - **service_agents_config**: *object*
   <br>*additional properties: false*
@@ -447,6 +463,78 @@
     - ⁺**roles**: *array*
       - items: *string*
         <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+- **iam_billing_bindings**<a name="refs-iam_billing_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**billing_account_id**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_folder_bindings**<a name="refs-iam_folder_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**folder_id**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_organization_bindings**<a name="refs-iam_organization_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**organization_id**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_project_bindings**<a name="refs-iam_project_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**project_id**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_sa_bindings**<a name="refs-iam_sa_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - ⁺**service_account_id**: *string*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_storage_bindings**<a name="refs-iam_storage_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**bucket**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
 - **iam_billing_roles**<a name="refs-iam_billing_roles"></a>: *object*
   <br>*additional properties: false*
   - **`^[a-z0-9-]+$`**: *array*

--- a/fast/stages/2-security/schemas/folder.schema.json
+++ b/fast/stages/2-security/schemas/folder.schema.json
@@ -148,20 +148,38 @@
                 "iam_bindings_additive": {
                   "$ref": "#/$defs/iam_bindings_additive"
                 },
+                "iam_billing_bindings": {
+                  "$ref": "#/$defs/iam_billing_bindings"
+                },
                 "iam_billing_roles": {
                   "$ref": "#/$defs/iam_billing_roles"
+                },
+                "iam_folder_bindings": {
+                  "$ref": "#/$defs/iam_folder_bindings"
                 },
                 "iam_folder_roles": {
                   "$ref": "#/$defs/iam_folder_roles"
                 },
+                "iam_organization_bindings": {
+                  "$ref": "#/$defs/iam_organization_bindings"
+                },
                 "iam_organization_roles": {
                   "$ref": "#/$defs/iam_organization_roles"
+                },
+                "iam_project_bindings": {
+                  "$ref": "#/$defs/iam_project_bindings"
                 },
                 "iam_project_roles": {
                   "$ref": "#/$defs/iam_project_roles"
                 },
+                "iam_sa_bindings": {
+                  "$ref": "#/$defs/iam_sa_bindings"
+                },
                 "iam_sa_roles": {
                   "$ref": "#/$defs/iam_sa_roles"
+                },
+                "iam_storage_bindings": {
+                  "$ref": "#/$defs/iam_storage_bindings"
                 },
                 "iam_storage_roles": {
                   "$ref": "#/$defs/iam_storage_roles"
@@ -850,6 +868,258 @@
               "items": {
                 "type": "string",
                 "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_billing_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "billing_account_id",
+            "role"
+          ],
+          "properties": {
+            "billing_account_id": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_folder_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "folder_id",
+            "role"
+          ],
+          "properties": {
+            "folder_id": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_organization_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "organization_id",
+            "role"
+          ],
+          "properties": {
+            "organization_id": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_project_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "project_id",
+            "role"
+          ],
+          "properties": {
+            "project_id": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_sa_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "role",
+            "service_account_id"
+          ],
+          "properties": {
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "service_account_id": {
+              "type": "string"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_storage_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "bucket",
+            "role"
+          ],
+          "properties": {
+            "bucket": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
               }
             }
           }

--- a/fast/stages/2-security/schemas/folder.schema.md
+++ b/fast/stages/2-security/schemas/folder.schema.md
@@ -48,11 +48,17 @@
       - **iam**: *reference([iam](#refs-iam))*
       - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
       - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
+      - **iam_billing_bindings**: *reference([iam_billing_bindings](#refs-iam_billing_bindings))*
       - **iam_billing_roles**: *reference([iam_billing_roles](#refs-iam_billing_roles))*
+      - **iam_folder_bindings**: *reference([iam_folder_bindings](#refs-iam_folder_bindings))*
       - **iam_folder_roles**: *reference([iam_folder_roles](#refs-iam_folder_roles))*
+      - **iam_organization_bindings**: *reference([iam_organization_bindings](#refs-iam_organization_bindings))*
       - **iam_organization_roles**: *reference([iam_organization_roles](#refs-iam_organization_roles))*
+      - **iam_project_bindings**: *reference([iam_project_bindings](#refs-iam_project_bindings))*
       - **iam_project_roles**: *reference([iam_project_roles](#refs-iam_project_roles))*
+      - **iam_sa_bindings**: *reference([iam_sa_bindings](#refs-iam_sa_bindings))*
       - **iam_sa_roles**: *reference([iam_sa_roles](#refs-iam_sa_roles))*
+      - **iam_storage_bindings**: *reference([iam_storage_bindings](#refs-iam_storage_bindings))*
       - **iam_storage_roles**: *reference([iam_storage_roles](#refs-iam_storage_roles))*
       - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
 - **autokey_config**: *object*
@@ -258,6 +264,78 @@
     - ⁺**roles**: *array*
       - items: *string*
         <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+- **iam_billing_bindings**<a name="refs-iam_billing_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**billing_account_id**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_folder_bindings**<a name="refs-iam_folder_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**folder_id**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_organization_bindings**<a name="refs-iam_organization_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**organization_id**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_project_bindings**<a name="refs-iam_project_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**project_id**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_sa_bindings**<a name="refs-iam_sa_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - ⁺**service_account_id**: *string*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_storage_bindings**<a name="refs-iam_storage_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**bucket**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
 - **iam_billing_roles**<a name="refs-iam_billing_roles"></a>: *object*
   <br>*additional properties: false*
   - **`^[a-z0-9-]+$`**: *array*

--- a/fast/stages/2-security/schemas/project.schema.json
+++ b/fast/stages/2-security/schemas/project.schema.json
@@ -129,20 +129,38 @@
                 "iam_bindings_additive": {
                   "$ref": "#/$defs/iam_bindings_additive"
                 },
+                "iam_billing_bindings": {
+                  "$ref": "#/$defs/iam_billing_bindings"
+                },
                 "iam_billing_roles": {
                   "$ref": "#/$defs/iam_billing_roles"
+                },
+                "iam_folder_bindings": {
+                  "$ref": "#/$defs/iam_folder_bindings"
                 },
                 "iam_folder_roles": {
                   "$ref": "#/$defs/iam_folder_roles"
                 },
+                "iam_organization_bindings": {
+                  "$ref": "#/$defs/iam_organization_bindings"
+                },
                 "iam_organization_roles": {
                   "$ref": "#/$defs/iam_organization_roles"
+                },
+                "iam_project_bindings": {
+                  "$ref": "#/$defs/iam_project_bindings"
                 },
                 "iam_project_roles": {
                   "$ref": "#/$defs/iam_project_roles"
                 },
+                "iam_sa_bindings": {
+                  "$ref": "#/$defs/iam_sa_bindings"
+                },
                 "iam_sa_roles": {
                   "$ref": "#/$defs/iam_sa_roles"
+                },
+                "iam_storage_bindings": {
+                  "$ref": "#/$defs/iam_storage_bindings"
                 },
                 "iam_storage_roles": {
                   "$ref": "#/$defs/iam_storage_roles"
@@ -800,17 +818,47 @@
             "iam_bindings_additive": {
               "$ref": "#/$defs/iam_bindings_additive"
             },
+            "iam_billing_bindings": {
+              "$ref": "#/$defs/iam_billing_bindings"
+            },
+            "iam_billing_roles": {
+              "$ref": "#/$defs/iam_billing_roles"
+            },
+            "iam_folder_bindings": {
+              "$ref": "#/$defs/iam_folder_bindings"
+            },
+            "iam_folder_roles": {
+              "$ref": "#/$defs/iam_folder_roles"
+            },
+            "iam_organization_bindings": {
+              "$ref": "#/$defs/iam_organization_bindings"
+            },
+            "iam_organization_roles": {
+              "$ref": "#/$defs/iam_organization_roles"
+            },
+            "iam_project_bindings": {
+              "$ref": "#/$defs/iam_project_bindings"
+            },
+            "iam_project_roles": {
+              "$ref": "#/$defs/iam_project_roles"
+            },
+            "iam_sa_bindings": {
+              "$ref": "#/$defs/iam_sa_bindings"
+            },
+            "iam_sa_roles": {
+              "$ref": "#/$defs/iam_sa_roles"
+            },
             "iam_self_roles": {
               "type": "array",
               "items": {
                 "type": "string"
               }
             },
-            "iam_project_roles": {
-              "$ref": "#/$defs/iam_project_roles"
+            "iam_storage_bindings": {
+              "$ref": "#/$defs/iam_storage_bindings"
             },
-            "iam_sa_roles": {
-              "$ref": "#/$defs/iam_sa_roles"
+            "iam_storage_roles": {
+              "$ref": "#/$defs/iam_storage_roles"
             },
             "tag_bindings": {
               "$ref": "#/$defs/tag_bindings"
@@ -1566,6 +1614,258 @@
               "items": {
                 "type": "string",
                 "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_billing_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "billing_account_id",
+            "role"
+          ],
+          "properties": {
+            "billing_account_id": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_folder_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "folder_id",
+            "role"
+          ],
+          "properties": {
+            "folder_id": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_organization_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "organization_id",
+            "role"
+          ],
+          "properties": {
+            "organization_id": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_project_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "project_id",
+            "role"
+          ],
+          "properties": {
+            "project_id": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_sa_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "role",
+            "service_account_id"
+          ],
+          "properties": {
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "service_account_id": {
+              "type": "string"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_storage_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "bucket",
+            "role"
+          ],
+          "properties": {
+            "bucket": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
               }
             }
           }

--- a/fast/stages/2-security/schemas/project.schema.md
+++ b/fast/stages/2-security/schemas/project.schema.md
@@ -43,11 +43,17 @@
       - **iam**: *reference([iam](#refs-iam))*
       - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
       - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
+      - **iam_billing_bindings**: *reference([iam_billing_bindings](#refs-iam_billing_bindings))*
       - **iam_billing_roles**: *reference([iam_billing_roles](#refs-iam_billing_roles))*
+      - **iam_folder_bindings**: *reference([iam_folder_bindings](#refs-iam_folder_bindings))*
       - **iam_folder_roles**: *reference([iam_folder_roles](#refs-iam_folder_roles))*
+      - **iam_organization_bindings**: *reference([iam_organization_bindings](#refs-iam_organization_bindings))*
       - **iam_organization_roles**: *reference([iam_organization_roles](#refs-iam_organization_roles))*
+      - **iam_project_bindings**: *reference([iam_project_bindings](#refs-iam_project_bindings))*
       - **iam_project_roles**: *reference([iam_project_roles](#refs-iam_project_roles))*
+      - **iam_sa_bindings**: *reference([iam_sa_bindings](#refs-iam_sa_bindings))*
       - **iam_sa_roles**: *reference([iam_sa_roles](#refs-iam_sa_roles))*
+      - **iam_storage_bindings**: *reference([iam_storage_bindings](#refs-iam_storage_bindings))*
       - **iam_storage_roles**: *reference([iam_storage_roles](#refs-iam_storage_roles))*
       - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
 - **billing_account**: *string*
@@ -248,10 +254,20 @@
     - **iam**: *reference([iam](#refs-iam))*
     - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
     - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
+    - **iam_billing_bindings**: *reference([iam_billing_bindings](#refs-iam_billing_bindings))*
+    - **iam_billing_roles**: *reference([iam_billing_roles](#refs-iam_billing_roles))*
+    - **iam_folder_bindings**: *reference([iam_folder_bindings](#refs-iam_folder_bindings))*
+    - **iam_folder_roles**: *reference([iam_folder_roles](#refs-iam_folder_roles))*
+    - **iam_organization_bindings**: *reference([iam_organization_bindings](#refs-iam_organization_bindings))*
+    - **iam_organization_roles**: *reference([iam_organization_roles](#refs-iam_organization_roles))*
+    - **iam_project_bindings**: *reference([iam_project_bindings](#refs-iam_project_bindings))*
+    - **iam_project_roles**: *reference([iam_project_roles](#refs-iam_project_roles))*
+    - **iam_sa_bindings**: *reference([iam_sa_bindings](#refs-iam_sa_bindings))*
+    - **iam_sa_roles**: *reference([iam_sa_roles](#refs-iam_sa_roles))*
     - **iam_self_roles**: *array*
       - items: *string*
-    - **iam_project_roles**: *reference([iam_project_roles](#refs-iam_project_roles))*
-    - **iam_sa_roles**: *reference([iam_sa_roles](#refs-iam_sa_roles))*
+    - **iam_storage_bindings**: *reference([iam_storage_bindings](#refs-iam_storage_bindings))*
+    - **iam_storage_roles**: *reference([iam_storage_roles](#refs-iam_storage_roles))*
     - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
 - **service_agents_config**: *object*
   <br>*additional properties: false*
@@ -447,6 +463,78 @@
     - ⁺**roles**: *array*
       - items: *string*
         <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+- **iam_billing_bindings**<a name="refs-iam_billing_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**billing_account_id**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_folder_bindings**<a name="refs-iam_folder_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**folder_id**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_organization_bindings**<a name="refs-iam_organization_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**organization_id**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_project_bindings**<a name="refs-iam_project_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**project_id**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_sa_bindings**<a name="refs-iam_sa_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - ⁺**service_account_id**: *string*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_storage_bindings**<a name="refs-iam_storage_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**bucket**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
 - **iam_billing_roles**<a name="refs-iam_billing_roles"></a>: *object*
   <br>*additional properties: false*
   - **`^[a-z0-9-]+$`**: *array*

--- a/modules/iam-service-account/README.md
+++ b/modules/iam-service-account/README.md
@@ -94,6 +94,39 @@ module "service-account-cond" {
         my_tag = "tagValues/123456789"
       }
     }
+    folder_ids = {
+      test = "folders/1234567890"
+    }
+  }
+  iam_billing_bindings = {
+    binding-0 = {
+      billing_account_id = "ABCDE-12345-ABCDE"
+      role               = "roles/billing.user"
+      condition = {
+        expression = "resource.matchTag('1234567890/env', '$${tags.my_tag}')"
+        title      = "conditional-access"
+      }
+    }
+  }
+  iam_folder_bindings = {
+    binding-0 = {
+      folder_id = "$folder_ids:test"
+      role      = "roles/resourcemanager.folderAdmin"
+      condition = {
+        expression = "resource.matchTag('1234567890/env', '$${tags.my_tag}')"
+        title      = "conditional-access"
+      }
+    }
+  }
+  iam_organization_bindings = {
+    binding-0 = {
+      organization_id = "organizations/1234567890"
+      role            = "roles/resourcemanager.organizationAdmin"
+      condition = {
+        expression = "resource.matchTag('1234567890/env', '$${tags.my_tag}')"
+        title      = "conditional-access"
+      }
+    }
   }
   iam_project_bindings = {
     binding-0 = {
@@ -105,8 +138,28 @@ module "service-account-cond" {
       }
     }
   }
+  iam_sa_bindings = {
+    binding-0 = {
+      service_account_id = "projects/${var.project_id}/serviceAccounts/my-test-sa@${var.project_id}.iam.gserviceaccount.com"
+      role               = "roles/iam.serviceAccountUser"
+      condition = {
+        expression = "resource.matchTag('1234567890/env', '$${tags.my_tag}')"
+        title      = "conditional-access"
+      }
+    }
+  }
+  iam_storage_bindings = {
+    binding-0 = {
+      bucket = "my-bucket"
+      role   = "roles/storage.objectAdmin"
+      condition = {
+        expression = "resource.matchTag('1234567890/env', '$${tags.my_tag}')"
+        title      = "conditional-access"
+      }
+    }
+  }
 }
-# tftest modules=1 resources=2 inventory=iam-bindings.yaml
+# tftest modules=1 resources=7 inventory=iam-bindings.yaml
 ```
 
 ## Reusing Existing Service Accounts

--- a/modules/iam-service-account/README.md
+++ b/modules/iam-service-account/README.md
@@ -50,12 +50,12 @@ The authoritative and additive approaches can be used together, provided differe
 
 The following variables control **additive** IAM bindings on external resources where this module's managed service account is the principal:
 
-- `iam_billing_roles`
-- `iam_folder_roles`
-- `iam_organization_roles`
-- `iam_project_roles`
-- `iam_sa_roles`
-- `iam_storage_roles`
+- `iam_billing_roles` and `iam_billing_bindings`
+- `iam_folder_roles` and `iam_folder_bindings`
+- `iam_organization_roles` and `iam_organization_bindings`
+- `iam_project_roles` and `iam_project_bindings`
+- `iam_sa_roles` and `iam_sa_bindings`
+- `iam_storage_roles` and `iam_storage_bindings`
 
 IAM also supports variable interpolation for both roles and principals and for the foreign resources where the service account is the principal, via the respective attributes in the `var.context` variable. Basic usage is shown in the example below.
 
@@ -81,6 +81,32 @@ module "service-account-with-tags" {
   }
 }
 # tftest modules=1 resources=3 inventory=iam.yaml
+```
+
+```hcl
+module "service-account-cond" {
+  source     = "./fabric/modules/iam-service-account"
+  project_id = var.project_id
+  name       = "test-sa-cond"
+  context = {
+    condition_vars = {
+      tags = {
+        my_tag = "tagValues/123456789"
+      }
+    }
+  }
+  iam_project_bindings = {
+    binding-0 = {
+      project_id = var.project_id
+      role       = "roles/storage.admin"
+      condition = {
+        expression = "resource.matchTag('1234567890/env', '$${tags.my_tag}')"
+        title      = "conditional-access"
+      }
+    }
+  }
+}
+# tftest modules=1 resources=2 inventory=iam-bindings.yaml
 ```
 
 ## Reusing Existing Service Accounts
@@ -157,16 +183,22 @@ module "service-account-with-tags" {
 | [description](variables.tf#L48) | Optional description. | <code>string</code> |  | <code>null</code> |
 | [display_name](variables.tf#L55) | Display name of the service account to create. | <code>string</code> |  | <code>&#34;Terraform-managed.&#34;</code> |
 | [iam](variables-iam.tf#L17) | IAM bindings in {ROLE => [MEMBERS]} format. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [iam_billing_roles](variables-iam.tf#L24) | Billing account roles granted to this service account, by billing account id. Non-authoritative. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [iam_bindings](variables-iam.tf#L31) | Authoritative IAM bindings in {KEY => {role = ROLE, members = [], condition = {}}}. Keys are arbitrary. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [iam_bindings_additive](variables-iam.tf#L46) | Individual additive IAM bindings. Keys are arbitrary. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [iam_by_principals](variables-iam.tf#L68) | Authoritative IAM binding in {PRINCIPAL => [ROLES]} format. Principals need to be statically defined to avoid errors. Merged internally with the `iam` variable. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [iam_by_principals_additive](variables-iam.tf#L61) | Additive IAM binding in {PRINCIPAL => [ROLES]} format. Principals need to be statically defined to avoid errors. Merged internally with the `iam_bindings_additive` variable. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [iam_folder_roles](variables-iam.tf#L75) | Folder roles granted to this service account, by folder id. Non-authoritative. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [iam_organization_roles](variables-iam.tf#L82) | Organization roles granted to this service account, by organization id. Non-authoritative. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [iam_project_roles](variables-iam.tf#L89) | Project roles granted to this service account, by project id. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [iam_sa_roles](variables-iam.tf#L96) | Service account roles granted to this service account, by service account name. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [iam_storage_roles](variables-iam.tf#L103) | Storage roles granted to this service account, by bucket name. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [iam_billing_bindings](variables-iam.tf#L24) | Billing account role bindings granted to this service account, by arbitrary key. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [iam_billing_roles](variables-iam.tf#L39) | Billing account roles granted to this service account, by billing account id. Non-authoritative. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [iam_bindings](variables-iam.tf#L46) | Authoritative IAM bindings in {KEY => {role = ROLE, members = [], condition = {}}}. Keys are arbitrary. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [iam_bindings_additive](variables-iam.tf#L61) | Individual additive IAM bindings. Keys are arbitrary. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [iam_by_principals](variables-iam.tf#L83) | Authoritative IAM binding in {PRINCIPAL => [ROLES]} format. Principals need to be statically defined to avoid errors. Merged internally with the `iam` variable. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [iam_by_principals_additive](variables-iam.tf#L76) | Additive IAM binding in {PRINCIPAL => [ROLES]} format. Principals need to be statically defined to avoid errors. Merged internally with the `iam_bindings_additive` variable. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [iam_folder_bindings](variables-iam.tf#L90) | Folder role bindings granted to this service account, by arbitrary key. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [iam_folder_roles](variables-iam.tf#L105) | Folder roles granted to this service account, by folder id. Non-authoritative. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [iam_organization_bindings](variables-iam.tf#L112) | Organization role bindings granted to this service account, by arbitrary key. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [iam_organization_roles](variables-iam.tf#L127) | Organization roles granted to this service account, by organization id. Non-authoritative. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [iam_project_bindings](variables-iam.tf#L134) | Project role bindings granted to this service account, by arbitrary key. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [iam_project_roles](variables-iam.tf#L149) | Project roles granted to this service account, by project id. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [iam_sa_bindings](variables-iam.tf#L156) | Service account role bindings granted to this service account, by arbitrary key. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [iam_sa_roles](variables-iam.tf#L171) | Service account roles granted to this service account, by service account name. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [iam_storage_bindings](variables-iam.tf#L178) | Storage role bindings granted to this service account, by arbitrary key. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [iam_storage_roles](variables-iam.tf#L193) | Storage roles granted to this service account, by bucket name. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [prefix](variables.tf#L68) | Prefix applied to service account names. | <code>string</code> |  | <code>null</code> |
 | [project_id](variables.tf#L79) | Project id where service account will be created. This can be left null when reusing service accounts. | <code>string</code> |  | <code>null</code> |
 | [project_number](variables.tf#L93) | Project number of var.project_id. Set this to avoid permadiffs when creating tag bindings. This can be left null when reusing service accounts and tags are not used. | <code>string</code> |  | <code>null</code> |

--- a/modules/iam-service-account/iam.tf
+++ b/modules/iam-service-account/iam.tf
@@ -31,13 +31,17 @@ locals {
       try(local._iam_principals[role], [])
     )
   }
-  iam_billing_pairs = flatten([
+  iam_billing_pairs = merge(flatten([
     for entity, roles in var.iam_billing_roles : [
-      for role in roles : [
-        { entity = entity, role = role }
-      ]
+      for role in roles : [{
+        "${entity}-${role}" = {
+          billing_account_id = entity
+          role               = role
+          condition          = null
+        }
+      }]
     ]
-  ])
+  ])...)
   iam_bindings_additive = merge(
     var.iam_bindings_additive,
     [
@@ -51,41 +55,61 @@ locals {
       }
     ]...
   )
-  iam_folder_pairs = flatten([
+  iam_folder_pairs = merge(flatten([
     for entity, roles in var.iam_folder_roles : [
-      for role in roles : [
-        { entity = entity, role = role }
-      ]
+      for role in roles : [{
+        "${entity}-${role}" = {
+          folder_id = entity
+          role      = role
+          condition = null
+        }
+      }]
     ]
-  ])
-  iam_organization_pairs = flatten([
+  ])...)
+  iam_organization_pairs = merge(flatten([
     for entity, roles in var.iam_organization_roles : [
-      for role in roles : [
-        { entity = entity, role = role }
-      ]
+      for role in roles : [{
+        "${entity}-${role}" = {
+          organization_id = entity
+          role            = role
+          condition       = null
+        }
+      }]
     ]
-  ])
-  iam_project_pairs = flatten([
+  ])...)
+  iam_project_pairs = merge(flatten([
     for entity, roles in var.iam_project_roles : [
-      for role in roles : [
-        { entity = entity, role = role }
-      ]
+      for role in roles : [{
+        "${entity}-${role}" = {
+          project_id = entity
+          role       = role
+          condition  = null
+        }
+      }]
     ]
-  ])
-  iam_sa_pairs = flatten([
+  ])...)
+  iam_sa_pairs = merge(flatten([
     for entity, roles in var.iam_sa_roles : [
-      for role in roles : [
-        { entity = entity, role = role }
-      ]
+      for role in roles : [{
+        "${entity}-${role}" = {
+          service_account_id = entity
+          role               = role
+          condition          = null
+        }
+      }]
     ]
-  ])
-  iam_storage_pairs = flatten([
+  ])...)
+  iam_storage_pairs = merge(flatten([
     for entity, roles in var.iam_storage_roles : [
-      for role in roles : [
-        { entity = entity, role = role }
-      ]
+      for role in roles : [{
+        "${entity}-${role}" = {
+          bucket    = entity
+          role      = role
+          condition = null
+        }
+      }]
     ]
-  ])
+  ])...)
 }
 
 resource "google_service_account_iam_binding" "authoritative" {
@@ -152,15 +176,22 @@ moved {
 }
 
 resource "google_billing_account_iam_member" "billing_roles" {
-  for_each = {
-    for pair in local.iam_billing_pairs :
-    "${pair.entity}-${pair.role}" => pair
-  }
-  billing_account_id = each.value.entity
+  for_each           = merge(local.iam_billing_pairs, var.iam_billing_bindings)
+  billing_account_id = each.value.billing_account_id
   role = lookup(
     local.ctx.custom_roles, each.value.role, each.value.role
   )
   member = local.iam_email
+  dynamic "condition" {
+    for_each = each.value.condition == null ? [] : [""]
+    content {
+      expression = templatestring(
+        each.value.condition.expression, var.context.condition_vars
+      )
+      title       = each.value.condition.title
+      description = each.value.condition.description
+    }
+  }
 }
 
 moved {
@@ -169,15 +200,22 @@ moved {
 }
 
 resource "google_folder_iam_member" "folder_roles" {
-  for_each = {
-    for pair in local.iam_folder_pairs :
-    "${pair.entity}-${pair.role}" => pair
-  }
-  folder = lookup(local.ctx.folder_ids, each.value.entity, each.value.entity)
+  for_each = merge(local.iam_folder_pairs, var.iam_folder_bindings)
+  folder   = lookup(local.ctx.folder_ids, each.value.folder_id, each.value.folder_id)
   role = lookup(
     local.ctx.custom_roles, each.value.role, each.value.role
   )
   member = local.iam_email
+  dynamic "condition" {
+    for_each = each.value.condition == null ? [] : [""]
+    content {
+      expression = templatestring(
+        each.value.condition.expression, var.context.condition_vars
+      )
+      title       = each.value.condition.title
+      description = each.value.condition.description
+    }
+  }
 }
 
 moved {
@@ -186,15 +224,22 @@ moved {
 }
 
 resource "google_organization_iam_member" "organization_roles" {
-  for_each = {
-    for pair in local.iam_organization_pairs :
-    "${pair.entity}-${pair.role}" => pair
-  }
-  org_id = each.value.entity
+  for_each = merge(local.iam_organization_pairs, var.iam_organization_bindings)
+  org_id   = each.value.organization_id
   role = lookup(
     local.ctx.custom_roles, each.value.role, each.value.role
   )
   member = local.iam_email
+  dynamic "condition" {
+    for_each = each.value.condition == null ? [] : [""]
+    content {
+      expression = templatestring(
+        each.value.condition.expression, var.context.condition_vars
+      )
+      title       = each.value.condition.title
+      description = each.value.condition.description
+    }
+  }
 }
 
 moved {
@@ -203,29 +248,41 @@ moved {
 }
 
 resource "google_project_iam_member" "project_roles" {
-  for_each = {
-    for pair in local.iam_project_pairs :
-    "${pair.entity}-${pair.role}" => pair
-  }
-  project = lookup(local.ctx.project_ids, each.value.entity, each.value.entity)
+  for_each = merge(local.iam_project_pairs, var.iam_project_bindings)
+  project  = lookup(local.ctx.project_ids, each.value.project_id, each.value.project_id)
   role = lookup(
     local.ctx.custom_roles, each.value.role, each.value.role
   )
   member = local.iam_email
+  dynamic "condition" {
+    for_each = each.value.condition == null ? [] : [""]
+    content {
+      expression = templatestring(
+        each.value.condition.expression, var.context.condition_vars
+      )
+      title       = each.value.condition.title
+      description = each.value.condition.description
+    }
+  }
 }
 
 resource "google_service_account_iam_member" "additive" {
-  for_each = {
-    for pair in local.iam_sa_pairs :
-    "${pair.entity}-${pair.role}" => pair
-  }
-  service_account_id = lookup(
-    local.ctx.service_account_ids, each.value.entity, each.value.entity
-  )
+  for_each           = merge(local.iam_sa_pairs, var.iam_sa_bindings)
+  service_account_id = lookup(local.ctx.service_account_ids, each.value.service_account_id, each.value.service_account_id)
   role = lookup(
     local.ctx.custom_roles, each.value.role, each.value.role
   )
   member = local.iam_email
+  dynamic "condition" {
+    for_each = each.value.condition == null ? [] : [""]
+    content {
+      expression = templatestring(
+        each.value.condition.expression, var.context.condition_vars
+      )
+      title       = each.value.condition.title
+      description = each.value.condition.description
+    }
+  }
 }
 
 moved {
@@ -234,15 +291,20 @@ moved {
 }
 
 resource "google_storage_bucket_iam_member" "bucket_roles" {
-  for_each = {
-    for pair in local.iam_storage_pairs :
-    "${pair.entity}-${pair.role}" => pair
-  }
-  bucket = lookup(
-    local.ctx.storage_buckets, each.value.entity, each.value.entity
-  )
+  for_each = merge(local.iam_storage_pairs, var.iam_storage_bindings)
+  bucket   = lookup(local.ctx.storage_buckets, each.value.bucket, each.value.bucket)
   role = lookup(
     local.ctx.custom_roles, each.value.role, each.value.role
   )
   member = local.iam_email
+  dynamic "condition" {
+    for_each = each.value.condition == null ? [] : [""]
+    content {
+      expression = templatestring(
+        each.value.condition.expression, var.context.condition_vars
+      )
+      title       = each.value.condition.title
+      description = each.value.condition.description
+    }
+  }
 }

--- a/modules/iam-service-account/variables-iam.tf
+++ b/modules/iam-service-account/variables-iam.tf
@@ -21,6 +21,21 @@ variable "iam" {
   nullable    = false
 }
 
+variable "iam_billing_bindings" {
+  description = "Billing account role bindings granted to this service account, by arbitrary key."
+  type = map(object({
+    billing_account_id = string
+    role               = string
+    condition = optional(object({
+      expression  = string
+      title       = string
+      description = optional(string)
+    }))
+  }))
+  nullable = false
+  default  = {}
+}
+
 variable "iam_billing_roles" {
   description = "Billing account roles granted to this service account, by billing account id. Non-authoritative."
   type        = map(list(string))
@@ -72,11 +87,41 @@ variable "iam_by_principals" {
   nullable    = false
 }
 
+variable "iam_folder_bindings" {
+  description = "Folder role bindings granted to this service account, by arbitrary key."
+  type = map(object({
+    folder_id = string
+    role      = string
+    condition = optional(object({
+      expression  = string
+      title       = string
+      description = optional(string)
+    }))
+  }))
+  nullable = false
+  default  = {}
+}
+
 variable "iam_folder_roles" {
   description = "Folder roles granted to this service account, by folder id. Non-authoritative."
   type        = map(list(string))
   default     = {}
   nullable    = false
+}
+
+variable "iam_organization_bindings" {
+  description = "Organization role bindings granted to this service account, by arbitrary key."
+  type = map(object({
+    organization_id = string
+    role            = string
+    condition = optional(object({
+      expression  = string
+      title       = string
+      description = optional(string)
+    }))
+  }))
+  nullable = false
+  default  = {}
 }
 
 variable "iam_organization_roles" {
@@ -86,6 +131,21 @@ variable "iam_organization_roles" {
   nullable    = false
 }
 
+variable "iam_project_bindings" {
+  description = "Project role bindings granted to this service account, by arbitrary key."
+  type = map(object({
+    project_id = string
+    role       = string
+    condition = optional(object({
+      expression  = string
+      title       = string
+      description = optional(string)
+    }))
+  }))
+  nullable = false
+  default  = {}
+}
+
 variable "iam_project_roles" {
   description = "Project roles granted to this service account, by project id."
   type        = map(list(string))
@@ -93,11 +153,41 @@ variable "iam_project_roles" {
   nullable    = false
 }
 
+variable "iam_sa_bindings" {
+  description = "Service account role bindings granted to this service account, by arbitrary key."
+  type = map(object({
+    service_account_id = string
+    role               = string
+    condition = optional(object({
+      expression  = string
+      title       = string
+      description = optional(string)
+    }))
+  }))
+  nullable = false
+  default  = {}
+}
+
 variable "iam_sa_roles" {
   description = "Service account roles granted to this service account, by service account name."
   type        = map(list(string))
   default     = {}
   nullable    = false
+}
+
+variable "iam_storage_bindings" {
+  description = "Storage role bindings granted to this service account, by arbitrary key."
+  type = map(object({
+    bucket = string
+    role   = string
+    condition = optional(object({
+      expression  = string
+      title       = string
+      description = optional(string)
+    }))
+  }))
+  nullable = false
+  default  = {}
 }
 
 variable "iam_storage_roles" {

--- a/modules/project-factory/README.md
+++ b/modules/project-factory/README.md
@@ -779,6 +779,13 @@ service_accounts:
     iam:
       roles/iam.serviceAccountTokenCreator:
         - $iam_principals:service_accounts/dev-tb-app0-0/automation/rw
+    iam_project_bindings:
+      cond-0:
+        project_id: $project_ids:dev-tb-app0-0
+        role: roles/storage.objectViewer
+        condition:
+          expression: resource.name.startsWith('projects/test')
+          title: conditional-access
 data_access_logs:
   storage.googleapis.com:
     DATA_READ:

--- a/modules/project-factory/automation.tf
+++ b/modules/project-factory/automation.tf
@@ -158,24 +158,29 @@ module "automation-service-accounts" {
     }
     tag_values = local.ctx_tag_values
   })
-  iam                    = lookup(each.value, "iam", {})
-  iam_bindings           = lookup(each.value, "iam_bindings", {})
-  iam_bindings_additive  = lookup(each.value, "iam_bindings_additive", {})
-  iam_billing_roles      = lookup(each.value, "iam_billing_roles", {})
-  iam_folder_roles       = lookup(each.value, "iam_folder_roles", {})
-  iam_organization_roles = lookup(each.value, "iam_organization_roles", {})
-  iam_project_roles      = lookup(each.value, "iam_project_roles", {})
-  # iam_sa_roles           = lookup(each.value, "iam_sa_roles", {})
+  iam                       = lookup(each.value, "iam", {})
+  iam_bindings              = lookup(each.value, "iam_bindings", {})
+  iam_bindings_additive     = lookup(each.value, "iam_bindings_additive", {})
+  iam_billing_bindings      = lookup(each.value, "iam_billing_bindings", {})
+  iam_billing_roles         = lookup(each.value, "iam_billing_roles", {})
+  iam_folder_bindings       = lookup(each.value, "iam_folder_bindings", {})
+  iam_folder_roles          = lookup(each.value, "iam_folder_roles", {})
+  iam_organization_bindings = lookup(each.value, "iam_organization_bindings", {})
+  iam_organization_roles    = lookup(each.value, "iam_organization_roles", {})
+  iam_project_bindings      = lookup(each.value, "iam_project_bindings", {})
+  iam_project_roles         = lookup(each.value, "iam_project_roles", {})
+  # iam_sa_roles              = lookup(each.value, "iam_sa_roles", {})
   # we don't interpolate buckets here as we can't use a dynamic key
-  iam_storage_roles = lookup(each.value, "iam_storage_roles", {})
-  tag_bindings      = lookup(each.value, "tag_bindings", {})
+  iam_storage_bindings = lookup(each.value, "iam_storage_bindings", {})
+  iam_storage_roles    = lookup(each.value, "iam_storage_roles", {})
+  tag_bindings         = lookup(each.value, "tag_bindings", {})
 }
 
 module "automation-service-accounts-iam" {
   source = "../iam-service-account"
   for_each = {
     for k, v in local.automation_sas :
-    k => v if lookup(v, "iam_sa_roles", null) != null
+    k => v if lookup(v, "iam_sa_roles", null) != null || lookup(v, "iam_sa_bindings", null) != null
   }
   project_id = each.value.automation_project
   prefix     = each.value.prefix
@@ -186,5 +191,6 @@ module "automation-service-accounts-iam" {
   context = merge(local.ctx, {
     service_account_ids = local.projects_sas_ids
   })
-  iam_sa_roles = lookup(each.value, "iam_sa_roles", {})
+  iam_sa_bindings = lookup(each.value, "iam_sa_bindings", {})
+  iam_sa_roles    = lookup(each.value, "iam_sa_roles", {})
 }

--- a/modules/project-factory/projects-service-accounts.tf
+++ b/modules/project-factory/projects-service-accounts.tf
@@ -27,22 +27,28 @@ locals {
           try(local.data_defaults.defaults.service_accounts.display_name, null),
           "Terraform-managed."
         )
-        iam                    = try(opts.iam, {})
-        iam_bindings           = try(opts.iam_bindings, {})
-        iam_bindings_additive  = try(opts.iam_bindings_additive, {})
-        iam_billing_roles      = try(opts.iam_billing_roles, {})
-        iam_folder_roles       = try(opts.iam_folder_roles, {})
-        iam_organization_roles = try(opts.iam_organization_roles, {})
-        iam_sa_roles           = try(opts.iam_sa_roles, {})
-        iam_project_roles      = try(opts.iam_project_roles, {})
+        iam                       = try(opts.iam, {})
+        iam_bindings              = try(opts.iam_bindings, {})
+        iam_bindings_additive     = try(opts.iam_bindings_additive, {})
+        iam_billing_bindings      = try(opts.iam_billing_bindings, {})
+        iam_billing_roles         = try(opts.iam_billing_roles, {})
+        iam_folder_bindings       = try(opts.iam_folder_bindings, {})
+        iam_folder_roles          = try(opts.iam_folder_roles, {})
+        iam_organization_bindings = try(opts.iam_organization_bindings, {})
+        iam_organization_roles    = try(opts.iam_organization_roles, {})
+        iam_project_bindings      = try(opts.iam_project_bindings, {})
+        iam_project_roles         = try(opts.iam_project_roles, {})
+        iam_sa_bindings           = try(opts.iam_sa_bindings, {})
+        iam_sa_roles              = try(opts.iam_sa_roles, {})
         iam_self_roles = distinct(concat(
           try(local.data_defaults.overrides.service_accounts.iam_self_roles, []),
           try(opts.iam_self_roles, []),
           try(local.data_defaults.defaults.service_accounts.iam_self_roles, []),
         ))
-        iam_storage_roles = try(opts.iam_storage_roles, {})
-        tag_bindings      = try(opts.tag_bindings, {})
-        opts              = opts
+        iam_storage_bindings = try(opts.iam_storage_bindings, {})
+        iam_storage_roles    = try(opts.iam_storage_roles, {})
+        tag_bindings         = try(opts.tag_bindings, {})
+        opts                 = opts
       }
     ]
   ])
@@ -94,17 +100,22 @@ module "service-accounts" {
     project_ids = local.ctx_project_ids
     tag_values  = local.ctx_tag_values
   })
-  iam_billing_roles      = each.value.iam_billing_roles
-  iam_folder_roles       = each.value.iam_folder_roles
-  iam_organization_roles = each.value.iam_organization_roles
+  iam_billing_bindings      = each.value.iam_billing_bindings
+  iam_billing_roles         = each.value.iam_billing_roles
+  iam_folder_bindings       = each.value.iam_folder_bindings
+  iam_folder_roles          = each.value.iam_folder_roles
+  iam_organization_bindings = each.value.iam_organization_bindings
+  iam_organization_roles    = each.value.iam_organization_roles
+  iam_project_bindings      = each.value.iam_project_bindings
   iam_project_roles = merge(
     each.value.iam_project_roles,
     {
       "$project_ids:${each.value.project_key}" = each.value.iam_self_roles
     }
   )
-  iam_storage_roles = each.value.iam_storage_roles
-  tag_bindings      = each.value.tag_bindings
+  iam_storage_bindings = each.value.iam_storage_bindings
+  iam_storage_roles    = each.value.iam_storage_roles
+  tag_bindings         = each.value.tag_bindings
 }
 
 moved {
@@ -117,7 +128,7 @@ module "service-accounts-iam" {
   for_each = {
     for k in local.projects_service_accounts :
     "${k.project_key}/${k.name}" => k
-    if k.iam_sa_roles != {} || k.iam != {}
+    if k.iam_sa_roles != {} || k.iam_sa_bindings != {} || k.iam != {}
   }
   project_id = (
     module.service-accounts[each.key].service_account.project
@@ -144,5 +155,6 @@ module "service-accounts-iam" {
   iam                   = each.value.iam
   iam_bindings          = each.value.iam_bindings
   iam_bindings_additive = each.value.iam_bindings_additive
+  iam_sa_bindings       = each.value.iam_sa_bindings
   iam_sa_roles          = each.value.iam_sa_roles
 }

--- a/modules/project-factory/schemas/folder.schema.json
+++ b/modules/project-factory/schemas/folder.schema.json
@@ -148,20 +148,38 @@
                 "iam_bindings_additive": {
                   "$ref": "#/$defs/iam_bindings_additive"
                 },
+                "iam_billing_bindings": {
+                  "$ref": "#/$defs/iam_billing_bindings"
+                },
                 "iam_billing_roles": {
                   "$ref": "#/$defs/iam_billing_roles"
+                },
+                "iam_folder_bindings": {
+                  "$ref": "#/$defs/iam_folder_bindings"
                 },
                 "iam_folder_roles": {
                   "$ref": "#/$defs/iam_folder_roles"
                 },
+                "iam_organization_bindings": {
+                  "$ref": "#/$defs/iam_organization_bindings"
+                },
                 "iam_organization_roles": {
                   "$ref": "#/$defs/iam_organization_roles"
+                },
+                "iam_project_bindings": {
+                  "$ref": "#/$defs/iam_project_bindings"
                 },
                 "iam_project_roles": {
                   "$ref": "#/$defs/iam_project_roles"
                 },
+                "iam_sa_bindings": {
+                  "$ref": "#/$defs/iam_sa_bindings"
+                },
                 "iam_sa_roles": {
                   "$ref": "#/$defs/iam_sa_roles"
+                },
+                "iam_storage_bindings": {
+                  "$ref": "#/$defs/iam_storage_bindings"
                 },
                 "iam_storage_roles": {
                   "$ref": "#/$defs/iam_storage_roles"
@@ -850,6 +868,258 @@
               "items": {
                 "type": "string",
                 "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_billing_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "billing_account_id",
+            "role"
+          ],
+          "properties": {
+            "billing_account_id": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_folder_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "folder_id",
+            "role"
+          ],
+          "properties": {
+            "folder_id": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_organization_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "organization_id",
+            "role"
+          ],
+          "properties": {
+            "organization_id": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_project_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "project_id",
+            "role"
+          ],
+          "properties": {
+            "project_id": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_sa_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "role",
+            "service_account_id"
+          ],
+          "properties": {
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "service_account_id": {
+              "type": "string"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_storage_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "bucket",
+            "role"
+          ],
+          "properties": {
+            "bucket": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
               }
             }
           }

--- a/modules/project-factory/schemas/folder.schema.md
+++ b/modules/project-factory/schemas/folder.schema.md
@@ -48,11 +48,17 @@
       - **iam**: *reference([iam](#refs-iam))*
       - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
       - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
+      - **iam_billing_bindings**: *reference([iam_billing_bindings](#refs-iam_billing_bindings))*
       - **iam_billing_roles**: *reference([iam_billing_roles](#refs-iam_billing_roles))*
+      - **iam_folder_bindings**: *reference([iam_folder_bindings](#refs-iam_folder_bindings))*
       - **iam_folder_roles**: *reference([iam_folder_roles](#refs-iam_folder_roles))*
+      - **iam_organization_bindings**: *reference([iam_organization_bindings](#refs-iam_organization_bindings))*
       - **iam_organization_roles**: *reference([iam_organization_roles](#refs-iam_organization_roles))*
+      - **iam_project_bindings**: *reference([iam_project_bindings](#refs-iam_project_bindings))*
       - **iam_project_roles**: *reference([iam_project_roles](#refs-iam_project_roles))*
+      - **iam_sa_bindings**: *reference([iam_sa_bindings](#refs-iam_sa_bindings))*
       - **iam_sa_roles**: *reference([iam_sa_roles](#refs-iam_sa_roles))*
+      - **iam_storage_bindings**: *reference([iam_storage_bindings](#refs-iam_storage_bindings))*
       - **iam_storage_roles**: *reference([iam_storage_roles](#refs-iam_storage_roles))*
       - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
 - **autokey_config**: *object*
@@ -258,6 +264,78 @@
     - ⁺**roles**: *array*
       - items: *string*
         <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+- **iam_billing_bindings**<a name="refs-iam_billing_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**billing_account_id**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_folder_bindings**<a name="refs-iam_folder_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**folder_id**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_organization_bindings**<a name="refs-iam_organization_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**organization_id**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_project_bindings**<a name="refs-iam_project_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**project_id**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_sa_bindings**<a name="refs-iam_sa_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - ⁺**service_account_id**: *string*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_storage_bindings**<a name="refs-iam_storage_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**bucket**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
 - **iam_billing_roles**<a name="refs-iam_billing_roles"></a>: *object*
   <br>*additional properties: false*
   - **`^[a-z0-9-]+$`**: *array*

--- a/modules/project-factory/schemas/project.schema.json
+++ b/modules/project-factory/schemas/project.schema.json
@@ -129,20 +129,38 @@
                 "iam_bindings_additive": {
                   "$ref": "#/$defs/iam_bindings_additive"
                 },
+                "iam_billing_bindings": {
+                  "$ref": "#/$defs/iam_billing_bindings"
+                },
                 "iam_billing_roles": {
                   "$ref": "#/$defs/iam_billing_roles"
+                },
+                "iam_folder_bindings": {
+                  "$ref": "#/$defs/iam_folder_bindings"
                 },
                 "iam_folder_roles": {
                   "$ref": "#/$defs/iam_folder_roles"
                 },
+                "iam_organization_bindings": {
+                  "$ref": "#/$defs/iam_organization_bindings"
+                },
                 "iam_organization_roles": {
                   "$ref": "#/$defs/iam_organization_roles"
+                },
+                "iam_project_bindings": {
+                  "$ref": "#/$defs/iam_project_bindings"
                 },
                 "iam_project_roles": {
                   "$ref": "#/$defs/iam_project_roles"
                 },
+                "iam_sa_bindings": {
+                  "$ref": "#/$defs/iam_sa_bindings"
+                },
                 "iam_sa_roles": {
                   "$ref": "#/$defs/iam_sa_roles"
+                },
+                "iam_storage_bindings": {
+                  "$ref": "#/$defs/iam_storage_bindings"
                 },
                 "iam_storage_roles": {
                   "$ref": "#/$defs/iam_storage_roles"
@@ -800,17 +818,47 @@
             "iam_bindings_additive": {
               "$ref": "#/$defs/iam_bindings_additive"
             },
+            "iam_billing_bindings": {
+              "$ref": "#/$defs/iam_billing_bindings"
+            },
+            "iam_billing_roles": {
+              "$ref": "#/$defs/iam_billing_roles"
+            },
+            "iam_folder_bindings": {
+              "$ref": "#/$defs/iam_folder_bindings"
+            },
+            "iam_folder_roles": {
+              "$ref": "#/$defs/iam_folder_roles"
+            },
+            "iam_organization_bindings": {
+              "$ref": "#/$defs/iam_organization_bindings"
+            },
+            "iam_organization_roles": {
+              "$ref": "#/$defs/iam_organization_roles"
+            },
+            "iam_project_bindings": {
+              "$ref": "#/$defs/iam_project_bindings"
+            },
+            "iam_project_roles": {
+              "$ref": "#/$defs/iam_project_roles"
+            },
+            "iam_sa_bindings": {
+              "$ref": "#/$defs/iam_sa_bindings"
+            },
+            "iam_sa_roles": {
+              "$ref": "#/$defs/iam_sa_roles"
+            },
             "iam_self_roles": {
               "type": "array",
               "items": {
                 "type": "string"
               }
             },
-            "iam_project_roles": {
-              "$ref": "#/$defs/iam_project_roles"
+            "iam_storage_bindings": {
+              "$ref": "#/$defs/iam_storage_bindings"
             },
-            "iam_sa_roles": {
-              "$ref": "#/$defs/iam_sa_roles"
+            "iam_storage_roles": {
+              "$ref": "#/$defs/iam_storage_roles"
             },
             "tag_bindings": {
               "$ref": "#/$defs/tag_bindings"
@@ -1566,6 +1614,258 @@
               "items": {
                 "type": "string",
                 "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_billing_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "billing_account_id",
+            "role"
+          ],
+          "properties": {
+            "billing_account_id": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_folder_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "folder_id",
+            "role"
+          ],
+          "properties": {
+            "folder_id": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_organization_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "organization_id",
+            "role"
+          ],
+          "properties": {
+            "organization_id": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_project_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "project_id",
+            "role"
+          ],
+          "properties": {
+            "project_id": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_sa_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "role",
+            "service_account_id"
+          ],
+          "properties": {
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "service_account_id": {
+              "type": "string"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "iam_storage_bindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z0-9_-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "bucket",
+            "role"
+          ],
+          "properties": {
+            "bucket": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string",
+              "pattern": "^(?:roles/|\\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)"
+            },
+            "condition": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "expression",
+                "title"
+              ],
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
               }
             }
           }

--- a/modules/project-factory/schemas/project.schema.md
+++ b/modules/project-factory/schemas/project.schema.md
@@ -43,11 +43,17 @@
       - **iam**: *reference([iam](#refs-iam))*
       - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
       - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
+      - **iam_billing_bindings**: *reference([iam_billing_bindings](#refs-iam_billing_bindings))*
       - **iam_billing_roles**: *reference([iam_billing_roles](#refs-iam_billing_roles))*
+      - **iam_folder_bindings**: *reference([iam_folder_bindings](#refs-iam_folder_bindings))*
       - **iam_folder_roles**: *reference([iam_folder_roles](#refs-iam_folder_roles))*
+      - **iam_organization_bindings**: *reference([iam_organization_bindings](#refs-iam_organization_bindings))*
       - **iam_organization_roles**: *reference([iam_organization_roles](#refs-iam_organization_roles))*
+      - **iam_project_bindings**: *reference([iam_project_bindings](#refs-iam_project_bindings))*
       - **iam_project_roles**: *reference([iam_project_roles](#refs-iam_project_roles))*
+      - **iam_sa_bindings**: *reference([iam_sa_bindings](#refs-iam_sa_bindings))*
       - **iam_sa_roles**: *reference([iam_sa_roles](#refs-iam_sa_roles))*
+      - **iam_storage_bindings**: *reference([iam_storage_bindings](#refs-iam_storage_bindings))*
       - **iam_storage_roles**: *reference([iam_storage_roles](#refs-iam_storage_roles))*
       - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
 - **billing_account**: *string*
@@ -248,10 +254,20 @@
     - **iam**: *reference([iam](#refs-iam))*
     - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
     - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
+    - **iam_billing_bindings**: *reference([iam_billing_bindings](#refs-iam_billing_bindings))*
+    - **iam_billing_roles**: *reference([iam_billing_roles](#refs-iam_billing_roles))*
+    - **iam_folder_bindings**: *reference([iam_folder_bindings](#refs-iam_folder_bindings))*
+    - **iam_folder_roles**: *reference([iam_folder_roles](#refs-iam_folder_roles))*
+    - **iam_organization_bindings**: *reference([iam_organization_bindings](#refs-iam_organization_bindings))*
+    - **iam_organization_roles**: *reference([iam_organization_roles](#refs-iam_organization_roles))*
+    - **iam_project_bindings**: *reference([iam_project_bindings](#refs-iam_project_bindings))*
+    - **iam_project_roles**: *reference([iam_project_roles](#refs-iam_project_roles))*
+    - **iam_sa_bindings**: *reference([iam_sa_bindings](#refs-iam_sa_bindings))*
+    - **iam_sa_roles**: *reference([iam_sa_roles](#refs-iam_sa_roles))*
     - **iam_self_roles**: *array*
       - items: *string*
-    - **iam_project_roles**: *reference([iam_project_roles](#refs-iam_project_roles))*
-    - **iam_sa_roles**: *reference([iam_sa_roles](#refs-iam_sa_roles))*
+    - **iam_storage_bindings**: *reference([iam_storage_bindings](#refs-iam_storage_bindings))*
+    - **iam_storage_roles**: *reference([iam_storage_roles](#refs-iam_storage_roles))*
     - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
 - **service_agents_config**: *object*
   <br>*additional properties: false*
@@ -447,6 +463,78 @@
     - ⁺**roles**: *array*
       - items: *string*
         <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+- **iam_billing_bindings**<a name="refs-iam_billing_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**billing_account_id**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_folder_bindings**<a name="refs-iam_folder_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**folder_id**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_organization_bindings**<a name="refs-iam_organization_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**organization_id**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_project_bindings**<a name="refs-iam_project_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**project_id**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_sa_bindings**<a name="refs-iam_sa_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - ⁺**service_account_id**: *string*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
+- **iam_storage_bindings**<a name="refs-iam_storage_bindings"></a>: *object*
+  <br>*additional properties: false*
+  - **`^[a-z0-9_-]+$`**: *object*
+    <br>*additional properties: false*
+    - ⁺**bucket**: *string*
+    - ⁺**role**: *string*
+      <br>*pattern: ^(?:roles/|\$custom_roles:|organizations/[0-9]+/roles/|([a-z0-9.]+:)?projects/[a-z0-9-]+/roles/)*
+    - **condition**: *object*
+      <br>*additional properties: false*
+      - ⁺**expression**: *string*
+      - ⁺**title**: *string*
+      - **description**: *string*
 - **iam_billing_roles**<a name="refs-iam_billing_roles"></a>: *object*
   <br>*additional properties: false*
   - **`^[a-z0-9-]+$`**: *array*

--- a/modules/project-factory/variables-projects.tf
+++ b/modules/project-factory/variables-projects.tf
@@ -136,12 +136,66 @@ variable "projects" {
             description = optional(string)
           }))
         })), {})
-        iam_billing_roles      = optional(map(list(string)), {})
-        iam_folder_roles       = optional(map(list(string)), {})
+        iam_billing_bindings = optional(map(object({
+          billing_account_id = string
+          role               = string
+          condition = optional(object({
+            expression  = string
+            title       = string
+            description = optional(string)
+          }))
+        })), {})
+        iam_billing_roles = optional(map(list(string)), {})
+        iam_folder_bindings = optional(map(object({
+          folder_id = string
+          role      = string
+          condition = optional(object({
+            expression  = string
+            title       = string
+            description = optional(string)
+          }))
+        })), {})
+        iam_folder_roles = optional(map(list(string)), {})
+        iam_organization_bindings = optional(map(object({
+          organization_id = string
+          role            = string
+          condition = optional(object({
+            expression  = string
+            title       = string
+            description = optional(string)
+          }))
+        })), {})
         iam_organization_roles = optional(map(list(string)), {})
-        iam_project_roles      = optional(map(list(string)), {})
-        iam_sa_roles           = optional(map(list(string)), {})
-        iam_storage_roles      = optional(map(list(string)), {})
+        iam_project_bindings = optional(map(object({
+          project_id = string
+          role       = string
+          condition = optional(object({
+            expression  = string
+            title       = string
+            description = optional(string)
+          }))
+        })), {})
+        iam_project_roles = optional(map(list(string)), {})
+        iam_sa_bindings = optional(map(object({
+          service_account_id = string
+          role               = string
+          condition = optional(object({
+            expression  = string
+            title       = string
+            description = optional(string)
+          }))
+        })), {})
+        iam_sa_roles = optional(map(list(string)), {})
+        iam_storage_bindings = optional(map(object({
+          bucket = string
+          role   = string
+          condition = optional(object({
+            expression  = string
+            title       = string
+            description = optional(string)
+          }))
+        })), {})
+        iam_storage_roles = optional(map(list(string)), {})
       })), {})
     }))
     billing_account = optional(string)
@@ -486,9 +540,89 @@ variable "projects" {
       })), {})
     })), {})
     service_accounts = optional(map(object({
-      display_name      = optional(string)
-      iam_self_roles    = optional(list(string), [])
+      description  = optional(string)
+      display_name = optional(string)
+      iam          = optional(map(list(string)), {})
+      iam_bindings = optional(map(object({
+        members = list(string)
+        role    = string
+        condition = optional(object({
+          expression  = string
+          title       = string
+          description = optional(string)
+        }))
+      })), {})
+      iam_bindings_additive = optional(map(object({
+        member = string
+        role   = string
+        condition = optional(object({
+          expression  = string
+          title       = string
+          description = optional(string)
+        }))
+      })), {})
+      iam_billing_bindings = optional(map(object({
+        billing_account_id = string
+        role               = string
+        condition = optional(object({
+          expression  = string
+          title       = string
+          description = optional(string)
+        }))
+      })), {})
+      iam_billing_roles = optional(map(list(string)), {})
+      iam_folder_bindings = optional(map(object({
+        folder_id = string
+        role      = string
+        condition = optional(object({
+          expression  = string
+          title       = string
+          description = optional(string)
+        }))
+      })), {})
+      iam_folder_roles = optional(map(list(string)), {})
+      iam_organization_bindings = optional(map(object({
+        organization_id = string
+        role            = string
+        condition = optional(object({
+          expression  = string
+          title       = string
+          description = optional(string)
+        }))
+      })), {})
+      iam_organization_roles = optional(map(list(string)), {})
+      iam_project_bindings = optional(map(object({
+        project_id = string
+        role       = string
+        condition = optional(object({
+          expression  = string
+          title       = string
+          description = optional(string)
+        }))
+      })), {})
       iam_project_roles = optional(map(list(string)), {})
+      iam_sa_bindings = optional(map(object({
+        service_account_id = string
+        role               = string
+        condition = optional(object({
+          expression  = string
+          title       = string
+          description = optional(string)
+        }))
+      })), {})
+      iam_sa_roles   = optional(map(list(string)), {})
+      iam_self_roles = optional(list(string), [])
+      iam_storage_bindings = optional(map(object({
+        bucket = string
+        role   = string
+        condition = optional(object({
+          expression  = string
+          title       = string
+          description = optional(string)
+        }))
+      })), {})
+      iam_storage_roles = optional(map(list(string)), {})
+      tag_bindings      = optional(map(string), {})
     })), {})
     service_agents_config = optional(object({
       create_primary_agents      = optional(bool, true)

--- a/tests/modules/iam_service_account/examples/iam-bindings.yaml
+++ b/tests/modules/iam_service_account/examples/iam-bindings.yaml
@@ -1,0 +1,41 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values:
+  module.service-account-cond.google_project_iam_member.project_roles["binding-0"]:
+    condition:
+    - description: null
+      expression: resource.matchTag('1234567890/env', 'tagValues/123456789')
+      title: conditional-access
+    project: project-id
+    role: roles/storage.admin
+  module.service-account-cond.google_service_account.service_account[0]:
+    account_id: test-sa-cond
+    create_ignore_already_exists: null
+    deletion_policy: DELETE
+    description: null
+    disabled: false
+    display_name: Terraform-managed.
+    email: test-sa-cond@project-id.iam.gserviceaccount.com
+    member: serviceAccount:test-sa-cond@project-id.iam.gserviceaccount.com
+    project: project-id
+    timeouts: null
+
+counts:
+  google_project_iam_member: 1
+  google_service_account: 1
+  modules: 1
+  resources: 2
+
+outputs: {}

--- a/tests/modules/iam_service_account/examples/iam-bindings.yaml
+++ b/tests/modules/iam_service_account/examples/iam-bindings.yaml
@@ -13,6 +13,27 @@
 # limitations under the License.
 
 values:
+  module.service-account-cond.google_billing_account_iam_member.billing_roles["binding-0"]:
+    billing_account_id: ABCDE-12345-ABCDE
+    condition:
+    - description: null
+      expression: resource.matchTag('1234567890/env', 'tagValues/123456789')
+      title: conditional-access
+    role: roles/billing.user
+  module.service-account-cond.google_folder_iam_member.folder_roles["binding-0"]:
+    condition:
+    - description: null
+      expression: resource.matchTag('1234567890/env', 'tagValues/123456789')
+      title: conditional-access
+    folder: folders/1234567890
+    role: roles/resourcemanager.folderAdmin
+  module.service-account-cond.google_organization_iam_member.organization_roles["binding-0"]:
+    condition:
+    - description: null
+      expression: resource.matchTag('1234567890/env', 'tagValues/123456789')
+      title: conditional-access
+    org_id: organizations/1234567890
+    role: roles/resourcemanager.organizationAdmin
   module.service-account-cond.google_project_iam_member.project_roles["binding-0"]:
     condition:
     - description: null
@@ -31,11 +52,31 @@ values:
     member: serviceAccount:test-sa-cond@project-id.iam.gserviceaccount.com
     project: project-id
     timeouts: null
+  module.service-account-cond.google_service_account_iam_member.additive["binding-0"]:
+    condition:
+    - description: null
+      expression: resource.matchTag('1234567890/env', 'tagValues/123456789')
+      title: conditional-access
+    role: roles/iam.serviceAccountUser
+    service_account_id: projects/project-id/serviceAccounts/my-test-sa@project-id.iam.gserviceaccount.com
+  module.service-account-cond.google_storage_bucket_iam_member.bucket_roles["binding-0"]:
+    bucket: my-bucket
+    condition:
+    - description: null
+      expression: resource.matchTag('1234567890/env', 'tagValues/123456789')
+      title: conditional-access
+    role: roles/storage.objectAdmin
+    timeouts: null
 
 counts:
+  google_billing_account_iam_member: 1
+  google_folder_iam_member: 1
+  google_organization_iam_member: 1
   google_project_iam_member: 1
   google_service_account: 1
+  google_service_account_iam_member: 1
+  google_storage_bucket_iam_member: 1
   modules: 1
-  resources: 2
+  resources: 7
 
 outputs: {}

--- a/tests/modules/project_factory/examples/example.yaml
+++ b/tests/modules/project_factory/examples/example.yaml
@@ -981,6 +981,13 @@ values:
   : condition: []
     project: test-pf-dev-tb-app0-0
     role: roles/monitoring.metricWriter
+  ? module.project-factory.module.service-accounts["dev-tb-app0-0/vm-default"].google_project_iam_member.project_roles["cond-0"]
+  : condition:
+    - description: null
+      expression: resource.name.startsWith('projects/test')
+      title: conditional-access
+    project: test-pf-dev-tb-app0-0
+    role: roles/storage.objectViewer
   module.project-factory.module.service-accounts["dev-tb-app0-0/vm-default"].google_service_account.service_account[0]:
     account_id: vm-default
     create_ignore_already_exists: null
@@ -1053,7 +1060,7 @@ counts:
   google_project: 4
   google_project_iam_audit_config: 1
   google_project_iam_binding: 6
-  google_project_iam_member: 22
+  google_project_iam_member: 23
   google_project_service: 14
   google_project_service_identity: 5
   google_pubsub_subscription: 1
@@ -1071,7 +1078,7 @@ counts:
   google_tags_tag_value: 2
   google_tags_tag_value_iam_binding: 1
   modules: 39
-  resources: 121
+  resources: 122
   terraform_data: 2
 
 outputs: {}


### PR DESCRIPTION
### Summary
Add support for IAM conditions when granting roles to managed service accounts on external GCP resources (`billing_account`, `folder`, `organization`, `project`, `service_account`, `storage_bucket`).

### Changes
- **ADR:** Added `adrs/modules/20260727-sa-iam-conditions.md` documenting the dual-variable design pattern.
- **Variables:** Introduced 6 parallel conditional binding variables in `modules/iam-service-account/variables-iam.tf`: `iam_billing_bindings`, `iam_folder_bindings`, `iam_organization_bindings`, `iam_project_bindings`, `iam_sa_bindings`, and `iam_storage_bindings`.
- **Resources:** Updated locals and `google_*_iam_member` resources in `modules/iam-service-account/iam.tf` to merge legacy role lists with conditional bindings and implement `dynamic "condition"` blocks supporting `templatestring()` interpolation via `var.context.condition_vars`.
- **Documentation & Tests:** Updated `README.md` tables and added conditional binding example coverage in `tests/modules/iam_service_account/examples/iam-bindings.yaml`.