### PR TITLE
Fix: tag bindings for network firewall policies

### DIFF
--- a/fast/stages/2-networking/factory-firewall-policies.tf
+++ b/fast/stages/2-networking/factory-firewall-policies.tf
@@ -31,6 +31,7 @@ locals {
       attachments   = try(v.attachments, {})
       ingress_rules = try(v.ingress_rules, {})
       egress_rules  = try(v.egress_rules, {})
+      tag_bindings  = try(v.tag_bindings, {})
     })
   }
 }
@@ -49,10 +50,12 @@ module "firewall-policies" {
   region        = try(each.value.region, null)
   egress_rules  = each.value.egress_rules
   ingress_rules = each.value.ingress_rules
+  tag_bindings  = each.value.tag_bindings
   context = {
     folder_ids       = local.ctx_folders
     cidr_ranges_sets = local.ctx.cidr_ranges_sets
     tag_values       = local.ctx.tag_values
     locations        = local.ctx.locations
+    tag_vars         = local.ctx.tag_vars
   }
 }

--- a/fast/stages/2-networking/schemas/firewall-policy.schema.json
+++ b/fast/stages/2-networking/schemas/firewall-policy.schema.json
@@ -33,6 +33,16 @@
     "egress_rules": {
       "$ref": "#/$defs/rules",
       "description": "A map of egress firewall rules."
+    },
+    "tag_bindings": {
+      "type": "object",
+      "description": "Tag bindings for this firewall policy, in key => tag value id format.",
+      "patternProperties": {
+        "^[a-zA-Z0-9_/-]+$": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
     }
   },
   "$defs": {

--- a/fast/stages/2-networking/schemas/firewall-policy.schema.md
+++ b/fast/stages/2-networking/schemas/firewall-policy.schema.md
@@ -14,6 +14,9 @@
 - **region**: *string*
 - **ingress_rules**: *reference([rules](#refs-rules))*
 - **egress_rules**: *reference([rules](#refs-rules))*
+- **tag_bindings**: *object*
+  <br>*additional properties: false*
+  - **`^[a-zA-Z0-9_/-]+$`**: *string*
 
 ## Definitions
 

--- a/modules/net-firewall-policy/README.md
+++ b/modules/net-firewall-policy/README.md
@@ -93,6 +93,9 @@ module "firewall-policy" {
   attachments = {
     my-vpc = module.vpc.self_link
   }
+  tag_bindings = {
+    foo = "tagValues/12345678"
+  }
   egress_rules = {
     smtp = {
       priority = 900
@@ -128,7 +131,8 @@ module "firewall-policy" {
     }
   }
 }
-# tftest modules=2 resources=10 inventory=global-net.yaml
+# tftest modules=2 resources=11 inventory=global-net.yaml
+
 ```
 
 ### Regional Network policy
@@ -509,18 +513,19 @@ The following variable is defined at the top level of the rule (not within the `
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [name](variables.tf#L197) | Policy name. | <code>string</code> | ✓ |  |
-| [parent_id](variables.tf#L203) | Parent node where the policy will be created, `folders/nnn` or `organizations/nnn` for hierarchical policy, project id for a network policy. | <code>string</code> | ✓ |  |
+| [name](variables.tf#L201) | Policy name. | <code>string</code> | ✓ |  |
+| [parent_id](variables.tf#L207) | Parent node where the policy will be created, `folders/nnn` or `organizations/nnn` for hierarchical policy, project id for a network policy. | <code>string</code> | ✓ |  |
 | [attachments](variables.tf#L17) | Ids of the resources to which this policy will be attached, in descriptive name => self link format. Specify folders or organization for hierarchical policy, VPCs for network policy. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
 | [context](variables.tf#L24) | Context-specific interpolations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [description](variables.tf#L40) | Policy description. | <code>string</code> |  | <code>null</code> |
-| [egress_mirroring_rules](variables.tf#L46) | List of egress packet mirroring rule definitions, action can be 'mirror', 'do_not_mirror', or 'goto_next'. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [egress_rules](variables.tf#L77) | List of egress rule definitions, action can be 'allow', 'deny', 'goto_next' or 'apply_security_profile_group'. The match.layer4configs map is in protocol => optional [ports] format. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [factories_config](variables.tf#L115) | Paths to folders for the optional factories. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [ingress_mirroring_rules](variables.tf#L128) | List of ingress packet mirroring rule definitions, action can be 'mirror', 'do_not_mirror', or 'goto_next'. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [ingress_rules](variables.tf#L159) | List of ingress rule definitions, action can be 'allow', 'deny', 'goto_next' or 'apply_security_profile_group'. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [region](variables.tf#L209) | Policy region. Leave null for hierarchical policy, set to 'global' for a global network policy. | <code>string</code> |  | <code>null</code> |
-| [security_profile_group_ids](variables.tf#L215) | The optional security groups ids to be referenced in factories. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [description](variables.tf#L44) | Policy description. | <code>string</code> |  | <code>null</code> |
+| [egress_mirroring_rules](variables.tf#L50) | List of egress packet mirroring rule definitions, action can be 'mirror', 'do_not_mirror', or 'goto_next'. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [egress_rules](variables.tf#L81) | List of egress rule definitions, action can be 'allow', 'deny', 'goto_next' or 'apply_security_profile_group'. The match.layer4configs map is in protocol => optional [ports] format. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [factories_config](variables.tf#L119) | Paths to folders for the optional factories. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [ingress_mirroring_rules](variables.tf#L132) | List of ingress packet mirroring rule definitions, action can be 'mirror', 'do_not_mirror', or 'goto_next'. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [ingress_rules](variables.tf#L163) | List of ingress rule definitions, action can be 'allow', 'deny', 'goto_next' or 'apply_security_profile_group'. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [region](variables.tf#L213) | Policy region. Leave null for hierarchical policy, set to 'global' for a global network policy. | <code>string</code> |  | <code>null</code> |
+| [security_profile_group_ids](variables.tf#L219) | The optional security groups ids to be referenced in factories. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [tag_bindings](variables.tf#L226) | Tag bindings for this firewall policy, in key => tag value id format. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
 
 ## Outputs
 

--- a/modules/net-firewall-policy/tags.tf
+++ b/modules/net-firewall-policy/tags.tf
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  _tag_bindings = {
+    for k, v in var.tag_bindings : k => lookup(local.ctx.tag_values, v, v)
+  }
+  location = local.use_hierarchical ? null : lookup(local.ctx.locations, var.region, var.region)
+  policy_id = one(concat(
+    google_compute_region_network_firewall_policy.net_regional[*].id,
+    google_compute_network_firewall_policy.net_global[*].id
+  ))
+}
+
+resource "google_tags_location_tag_binding" "binding" {
+  for_each  = !local.use_hierarchical ? var.tag_bindings : {}
+  parent    = "//compute.googleapis.com/${local.policy_id}"
+  location  = local.location
+  tag_value = templatestring(local._tag_bindings[each.key], var.context.tag_vars)
+}

--- a/modules/net-firewall-policy/tags.tf
+++ b/modules/net-firewall-policy/tags.tf
@@ -19,15 +19,20 @@ locals {
     for k, v in var.tag_bindings : k => lookup(local.ctx.tag_values, v, v)
   }
   location = local.use_hierarchical ? null : lookup(local.ctx.locations, var.region, var.region)
-  policy_id = one(concat(
-    google_compute_region_network_firewall_policy.net_regional[*].id,
-    google_compute_network_firewall_policy.net_global[*].id
+  _policy_numeric_id = one(concat(
+    google_compute_region_network_firewall_policy.net_regional[*].region_network_firewall_policy_id,
+    google_compute_network_firewall_policy.net_global[*].network_firewall_policy_id
   ))
+  policy_parent = local.use_hierarchical ? null : (
+    var.region == "global"
+    ? "//compute.googleapis.com/projects/${var.parent_id}/global/firewallPolicies/${local._policy_numeric_id}"
+    : "//compute.googleapis.com/projects/${var.parent_id}/regions/${var.region}/firewallPolicies/${local._policy_numeric_id}"
+  )
 }
 
 resource "google_tags_location_tag_binding" "binding" {
   for_each  = !local.use_hierarchical ? var.tag_bindings : {}
-  parent    = "//compute.googleapis.com/${local.policy_id}"
+  parent    = local.policy_parent
   location  = local.location
   tag_value = templatestring(local._tag_bindings[each.key], var.context.tag_vars)
 }

--- a/modules/net-firewall-policy/variables.tf
+++ b/modules/net-firewall-policy/variables.tf
@@ -32,6 +32,10 @@ variable "context" {
     networks         = optional(map(string), {})
     project_ids      = optional(map(string), {})
     tag_values       = optional(map(string), {})
+    tag_vars = optional(object({
+      projects     = optional(map(map(string)), {})
+      organization = optional(map(string), {})
+    }), {})
   })
   default  = {}
   nullable = false
@@ -214,6 +218,13 @@ variable "region" {
 
 variable "security_profile_group_ids" {
   description = "The optional security groups ids to be referenced in factories."
+  type        = map(string)
+  nullable    = false
+  default     = {}
+}
+
+variable "tag_bindings" {
+  description = "Tag bindings for this firewall policy, in key => tag value id format."
   type        = map(string)
   nullable    = false
   default     = {}

--- a/tests/fast/stages/s2_networking/data-testfw/firewall-policies/global.yaml
+++ b/tests/fast/stages/s2_networking/data-testfw/firewall-policies/global.yaml
@@ -15,3 +15,5 @@
 name: global-policy
 parent_id: folders/12345
 region: global
+tag_bindings:
+  foo: tagValues/12345

--- a/tests/fast/stages/s2_networking/fw_policies.yaml
+++ b/tests/fast/stages/s2_networking/fw_policies.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,9 +12,47 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+values:
+  module.firewall-policies["global-policy"].google_compute_network_firewall_policy.net_global[0]:
+    deletion_policy: DELETE
+    description: null
+    name: global-policy
+    project: folders/12345
+    timeouts: null
+  module.firewall-policies["global-policy"].google_tags_location_tag_binding.binding["foo"]:
+    deletion_policy: DELETE
+    location: global
+    tag_value: tagValues/12345
+    timeouts: null
+  module.firewall-policies["regional-policy"].google_compute_region_network_firewall_policy.net_regional[0]:
+    deletion_policy: DELETE
+    description: null
+    name: regional-policy
+    project: folders/12345
+    region: europe-west1
+    timeouts: null
+  module.projects.terraform_data.defaults_preconditions:
+    input: null
+    output: null
+    triggers_replace: null
+  module.projects.terraform_data.project_preconditions:
+    input: null
+    output: null
+    triggers_replace: null
+
 counts:
   google_compute_network_firewall_policy: 1
   google_compute_region_network_firewall_policy: 1
+  google_tags_location_tag_binding: 1
   modules: 3
-  resources: 4
+  resources: 5
   terraform_data: 2
+
+outputs:
+  host_project_ids: {}
+  host_project_numbers: {}
+  subnet_ips: {}
+  subnet_proxy_only_self_links: {}
+  subnet_psc_self_links: {}
+  subnet_self_links: {}
+  vpc_self_links: {}

--- a/tests/modules/net_firewall_policy/context-g.tfvars
+++ b/tests/modules/net_firewall_policy/context-g.tfvars
@@ -58,3 +58,7 @@ ingress_rules = {
     }
   }
 }
+
+tag_bindings = {
+  "test" = "$tag_values:test"
+}

--- a/tests/modules/net_firewall_policy/context-g.yaml
+++ b/tests/modules/net_firewall_policy/context-g.yaml
@@ -1,10 +1,10 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,18 +14,21 @@
 
 values:
   google_compute_network_firewall_policy.net_global[0]:
+    deletion_policy: DELETE
     description: null
     name: test-1
     project: foo-test-0
     timeouts: null
   google_compute_network_firewall_policy_association.net_global["test"]:
     attachment_target: projects/foo-dev-net-spoke-0/global/networks/dev-spoke-0
+    deletion_policy: DELETE
     firewall_policy: test-1
     name: test-1-test
     project: foo-test-0
     timeouts: null
   google_compute_network_firewall_policy_rule.net_global["egress/smtp"]:
     action: deny
+    deletion_policy: DELETE
     description: null
     direction: EGRESS
     disabled: false
@@ -49,6 +52,7 @@ values:
       src_address_groups: null
       src_fqdns: null
       src_ip_ranges: null
+      src_networks: null
       src_region_codes: null
       src_secure_tags:
       - name: tagValues/1234567890
@@ -57,6 +61,7 @@ values:
     project: foo-test-0
     rule_name: smtp
     security_profile_group: null
+    target_forwarding_rules: null
     target_secure_tags: []
     target_service_accounts:
     - serviceAccount:test@test-project.iam.gserviceaccount.com
@@ -64,6 +69,7 @@ values:
     tls_inspect: null
   google_compute_network_firewall_policy_rule.net_global["ingress/icmp"]:
     action: allow
+    deletion_policy: DELETE
     description: null
     direction: INGRESS
     disabled: false
@@ -86,6 +92,7 @@ values:
       - 192.168.0.0/24
       - 10.0.0.1/32
       - 8.8.8.8
+      src_networks: null
       src_region_codes: null
       src_secure_tags: []
       src_threat_intelligences: null
@@ -93,15 +100,25 @@ values:
     project: foo-test-0
     rule_name: icmp
     security_profile_group: null
+    target_forwarding_rules: null
     target_secure_tags:
     - name: tagValues/1234567890
     target_service_accounts: null
     timeouts: null
     tls_inspect: null
+  google_tags_location_tag_binding.binding["test"]:
+    deletion_policy: DELETE
+    location: global
+    tag_value: tagValues/1234567890
+    timeouts: null
 
 counts:
   google_compute_network_firewall_policy: 1
   google_compute_network_firewall_policy_association: 1
   google_compute_network_firewall_policy_rule: 2
+  google_tags_location_tag_binding: 1
   modules: 0
-  resources: 4
+  resources: 5
+
+outputs:
+  id: __missing__

--- a/tests/modules/net_firewall_policy/context-r.tfvars
+++ b/tests/modules/net_firewall_policy/context-r.tfvars
@@ -58,3 +58,7 @@ ingress_rules = {
     }
   }
 }
+
+tag_bindings = {
+  "test" = "$tag_values:test"
+}

--- a/tests/modules/net_firewall_policy/context-r.yaml
+++ b/tests/modules/net_firewall_policy/context-r.yaml
@@ -1,10 +1,10 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,6 +14,7 @@
 
 values:
   google_compute_region_network_firewall_policy.net_regional[0]:
+    deletion_policy: DELETE
     description: null
     name: test-1
     project: foo-test-0
@@ -21,6 +22,7 @@ values:
     timeouts: null
   google_compute_region_network_firewall_policy_association.net_regional["test"]:
     attachment_target: projects/foo-dev-net-spoke-0/global/networks/dev-spoke-0
+    deletion_policy: DELETE
     firewall_policy: test-1
     name: test-1-test
     project: foo-test-0
@@ -28,6 +30,7 @@ values:
     timeouts: null
   google_compute_region_network_firewall_policy_rule.net_regional["egress/smtp"]:
     action: deny
+    deletion_policy: DELETE
     description: null
     direction: EGRESS
     disabled: false
@@ -51,6 +54,7 @@ values:
       src_address_groups: null
       src_fqdns: null
       src_ip_ranges: null
+      src_networks: null
       src_region_codes: null
       src_secure_tags:
       - name: tagValues/1234567890
@@ -60,6 +64,7 @@ values:
     region: europe-west8
     rule_name: smtp
     security_profile_group: null
+    target_forwarding_rules: null
     target_secure_tags: []
     target_service_accounts:
     - serviceAccount:test@test-project.iam.gserviceaccount.com
@@ -67,6 +72,7 @@ values:
     tls_inspect: null
   google_compute_region_network_firewall_policy_rule.net_regional["ingress/icmp"]:
     action: allow
+    deletion_policy: DELETE
     description: null
     direction: INGRESS
     disabled: false
@@ -89,6 +95,7 @@ values:
       - 192.168.0.0/24
       - 10.0.0.1/32
       - 8.8.8.8
+      src_networks: null
       src_region_codes: null
       src_secure_tags: []
       src_threat_intelligences: null
@@ -97,15 +104,25 @@ values:
     region: europe-west8
     rule_name: icmp
     security_profile_group: null
+    target_forwarding_rules: null
     target_secure_tags:
     - name: tagValues/1234567890
     target_service_accounts: null
     timeouts: null
     tls_inspect: null
+  google_tags_location_tag_binding.binding["test"]:
+    deletion_policy: DELETE
+    location: europe-west8
+    tag_value: tagValues/1234567890
+    timeouts: null
 
 counts:
   google_compute_region_network_firewall_policy: 1
   google_compute_region_network_firewall_policy_association: 1
   google_compute_region_network_firewall_policy_rule: 2
+  google_tags_location_tag_binding: 1
   modules: 0
-  resources: 4
+  resources: 5
+
+outputs:
+  id: __missing__

--- a/tests/modules/net_firewall_policy/examples/global-net.yaml
+++ b/tests/modules/net_firewall_policy/examples/global-net.yaml
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,14 +14,21 @@
 
 values:
   module.firewall-policy.google_compute_network_firewall_policy.net_global[0]:
+    deletion_policy: DELETE
+    description: null
     name: test-1
     project: my-project
+    timeouts: null
   module.firewall-policy.google_compute_network_firewall_policy_association.net_global["my-vpc"]:
+    deletion_policy: DELETE
     firewall_policy: test-1
     name: test-1-my-vpc
     project: my-project
+    timeouts: null
   module.firewall-policy.google_compute_network_firewall_policy_rule.net_global["egress/smtp"]:
     action: deny
+    deletion_policy: DELETE
+    description: null
     direction: EGRESS
     disabled: false
     enable_logging: null
@@ -40,16 +47,23 @@ values:
       src_address_groups: null
       src_fqdns: null
       src_ip_ranges: null
+      src_networks: null
       src_region_codes: null
       src_secure_tags: []
       src_threat_intelligences: null
     priority: 900
     project: my-project
     rule_name: smtp
+    security_profile_group: null
+    target_forwarding_rules: null
     target_secure_tags: []
     target_service_accounts: null
+    timeouts: null
+    tls_inspect: null
   module.firewall-policy.google_compute_network_firewall_policy_rule.net_global["ingress/icmp"]:
     action: allow
+    deletion_policy: DELETE
+    description: null
     direction: INGRESS
     disabled: false
     enable_logging: null
@@ -67,16 +81,23 @@ values:
       src_fqdns: null
       src_ip_ranges:
       - 0.0.0.0/0
+      src_networks: null
       src_region_codes: null
       src_secure_tags: []
       src_threat_intelligences: null
     priority: 1000
     project: my-project
     rule_name: icmp
+    security_profile_group: null
+    target_forwarding_rules: null
     target_secure_tags: []
     target_service_accounts: null
+    timeouts: null
+    tls_inspect: null
   module.firewall-policy.google_compute_network_firewall_policy_rule.net_global["ingress/mgmt"]:
     action: allow
+    deletion_policy: DELETE
+    description: null
     direction: INGRESS
     disabled: false
     enable_logging: true
@@ -94,16 +115,23 @@ values:
       src_fqdns: null
       src_ip_ranges:
       - 10.1.1.0/24
+      src_networks: null
       src_region_codes: null
       src_secure_tags: []
       src_threat_intelligences: null
     priority: 1001
     project: my-project
     rule_name: mgmt
+    security_profile_group: null
+    target_forwarding_rules: null
     target_secure_tags: []
     target_service_accounts: null
+    timeouts: null
+    tls_inspect: null
   module.firewall-policy.google_compute_network_firewall_policy_rule.net_global["ingress/ssh"]:
     action: allow
+    deletion_policy: DELETE
+    description: null
     direction: INGRESS
     disabled: false
     enable_logging: true
@@ -122,16 +150,92 @@ values:
       src_fqdns: null
       src_ip_ranges:
       - 10.0.0.0/8
+      src_networks: null
       src_region_codes: null
       src_secure_tags: []
       src_threat_intelligences: null
     priority: 1002
     project: my-project
     rule_name: ssh
+    security_profile_group: null
+    target_forwarding_rules: null
     target_secure_tags: []
     target_service_accounts: null
+    timeouts: null
+    tls_inspect: null
+  module.firewall-policy.google_tags_location_tag_binding.binding["foo"]:
+    deletion_policy: DELETE
+    location: global
+    tag_value: tagValues/12345678
+    timeouts: null
+  module.vpc.google_compute_network.network[0]:
+    auto_create_subnetworks: false
+    delete_bgp_always_compare_med: false
+    delete_default_routes_on_create: false
+    deletion_policy: DELETE
+    description: Terraform-managed.
+    enable_ula_internal_ipv6: null
+    name: my-network
+    network_firewall_policy_enforcement_order: AFTER_CLASSIC_FIREWALL
+    network_profile: null
+    params: []
+    project: my-project
+    routing_mode: GLOBAL
+    timeouts: null
+  module.vpc.google_compute_route.gateway["directpath-googleapis"]:
+    deletion_policy: DELETE
+    description: Terraform-managed.
+    dest_range: 34.126.0.0/18
+    name: my-network-directpath-googleapis
+    network: my-network
+    next_hop_gateway: default-internet-gateway
+    next_hop_ilb: null
+    next_hop_instance: null
+    next_hop_vpn_tunnel: null
+    params: []
+    priority: 1000
+    project: my-project
+    tags: null
+    timeouts: null
+  module.vpc.google_compute_route.gateway["private-googleapis"]:
+    deletion_policy: DELETE
+    description: Terraform-managed.
+    dest_range: 199.36.153.8/30
+    name: my-network-private-googleapis
+    network: my-network
+    next_hop_gateway: default-internet-gateway
+    next_hop_ilb: null
+    next_hop_instance: null
+    next_hop_vpn_tunnel: null
+    params: []
+    priority: 1000
+    project: my-project
+    tags: null
+    timeouts: null
+  module.vpc.google_compute_route.gateway["restricted-googleapis"]:
+    deletion_policy: DELETE
+    description: Terraform-managed.
+    dest_range: 199.36.153.4/30
+    name: my-network-restricted-googleapis
+    network: my-network
+    next_hop_gateway: default-internet-gateway
+    next_hop_ilb: null
+    next_hop_instance: null
+    next_hop_vpn_tunnel: null
+    params: []
+    priority: 1000
+    project: my-project
+    tags: null
+    timeouts: null
 
 counts:
+  google_compute_network: 1
   google_compute_network_firewall_policy: 1
   google_compute_network_firewall_policy_association: 1
   google_compute_network_firewall_policy_rule: 4
+  google_compute_route: 3
+  google_tags_location_tag_binding: 1
+  modules: 2
+  resources: 11
+
+outputs: {}


### PR DESCRIPTION
Fixes #4065. Added support for tag bindings using numeric IDs to prevent permission errors.