### PR TITLE
Fix: tag bindings for network firewall policies using numeric IDs

### DIFF
--- a/modules/net-firewall-policy/tags.tf
+++ b/modules/net-firewall-policy/tags.tf
@@ -19,15 +19,20 @@ locals {
     for k, v in var.tag_bindings : k => lookup(local.ctx.tag_values, v, v)
   }
   location = local.use_hierarchical ? null : lookup(local.ctx.locations, var.region, var.region)
-  policy_id = one(concat(
-    google_compute_region_network_firewall_policy.net_regional[*].id,
-    google_compute_network_firewall_policy.net_global[*].id
+  _policy_numeric_id = one(concat(
+    google_compute_region_network_firewall_policy.net_regional[*].region_network_firewall_policy_id,
+    google_compute_network_firewall_policy.net_global[*].network_firewall_policy_id
   ))
+  policy_parent = local.use_hierarchical ? null : (
+    var.region == "global"
+    ? "//compute.googleapis.com/projects/${var.parent_id}/global/firewallPolicies/${local._policy_numeric_id}"
+    : "//compute.googleapis.com/projects/${var.parent_id}/regions/${var.region}/firewallPolicies/${local._policy_numeric_id}"
+  )
 }
 
 resource "google_tags_location_tag_binding" "binding" {
   for_each  = !local.use_hierarchical ? var.tag_bindings : {}
-  parent    = "//compute.googleapis.com/${local.policy_id}"
+  parent    = local.policy_parent
   location  = local.location
   tag_value = templatestring(local._tag_bindings[each.key], var.context.tag_vars)
 }


### PR DESCRIPTION
Fixes #4065.

### Rationale
When attempting to bind tags to a compute network firewall policy (regional or global), the Resource Manager tag binding API fails with a `PERMISSION_DENIED` (403) or `NOT_FOUND` (404) error if the resource name (e.g. `e2e-test-fw-policy-reg`) is used in the parent path.

The API requires the parent URI to reference the resource by its **numeric ID** (e.g. `3206880249904813976`) instead of its name.

This PR fixes the issue by:
1. Dynamically retrieving the numeric IDs (`region_network_firewall_policy_id` for regional, `network_firewall_policy_id` for global).
2. Constructing the parent URI using the numeric ID instead of the name.