### PR TITLE
Add GKE Backup Restore Plans support to GKE modules

### DIFF
--- a/modules/gke-cluster-autopilot/README.md
+++ b/modules/gke-cluster-autopilot/README.md
@@ -291,26 +291,26 @@ module "cluster-1" {
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [location](variables.tf#L186) | Autopilot clusters are always regional. | <code>string</code> | ✓ |  |
-| [name](variables.tf#L269) | Cluster name. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L302) | Cluster project ID. | <code>string</code> | ✓ |  |
-| [vpc_config](variables.tf#L318) | VPC-level configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
+| [location](variables.tf#L252) | Autopilot clusters are always regional. | <code>string</code> | ✓ |  |
+| [name](variables.tf#L335) | Cluster name. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L368) | Cluster project ID. | <code>string</code> | ✓ |  |
+| [vpc_config](variables.tf#L384) | VPC-level configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
 | [access_config](variables.tf#L17) | Control plane endpoint and nodes access configurations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [backup_configs](variables.tf#L49) | Configuration for Backup for GKE. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [deletion_protection](variables.tf#L71) | Whether or not to allow Terraform to destroy the cluster. Unless this field is set to false in Terraform state, a terraform destroy or terraform apply that would delete the cluster will fail. | <code>bool</code> |  | <code>true</code> |
-| [description](variables.tf#L78) | Cluster description. | <code>string</code> |  | <code>null</code> |
-| [enable_addons](variables.tf#L84) | Addons enabled in the cluster (true means enabled). | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [enable_features](variables.tf#L98) | Enable cluster-level features. Certain features allow configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [fleet_project](variables.tf#L168) | The name of the fleet host project where this cluster will be registered. | <code>string</code> |  | <code>null</code> |
-| [issue_client_certificate](variables.tf#L174) | Enable issuing client certificate. | <code>bool</code> |  | <code>false</code> |
-| [labels](variables.tf#L180) | Cluster resource labels. | <code>map&#40;string&#41;</code> |  | <code>null</code> |
-| [logging_config](variables.tf#L191) | Logging configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [maintenance_config](variables.tf#L202) | Maintenance window configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#8230;&#125;</code> |
-| [min_master_version](variables.tf#L225) | Minimum version of the master, defaults to the version of the most recent official release. | <code>string</code> |  | <code>null</code> |
-| [monitoring_config](variables.tf#L231) | Monitoring configuration. System metrics collection cannot be disabled. Control plane metrics are optional. Kube state metrics are optional. Google Cloud Managed Service for Prometheus is enabled by default. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [node_config](variables.tf#L274) | Configuration for nodes and nodepools. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [node_locations](variables.tf#L295) | Zones in which the cluster's nodes are located. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
-| [release_channel](variables.tf#L307) | Release channel for GKE upgrades. Clusters created in the Autopilot mode must use a release channel. Choose between \"RAPID\", \"REGULAR\", and \"STABLE\". | <code>string</code> |  | <code>&#34;REGULAR&#34;</code> |
+| [deletion_protection](variables.tf#L137) | Whether or not to allow Terraform to destroy the cluster. Unless this field is set to false in Terraform state, a terraform destroy or terraform apply that would delete the cluster will fail. | <code>bool</code> |  | <code>true</code> |
+| [description](variables.tf#L144) | Cluster description. | <code>string</code> |  | <code>null</code> |
+| [enable_addons](variables.tf#L150) | Addons enabled in the cluster (true means enabled). | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [enable_features](variables.tf#L164) | Enable cluster-level features. Certain features allow configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [fleet_project](variables.tf#L234) | The name of the fleet host project where this cluster will be registered. | <code>string</code> |  | <code>null</code> |
+| [issue_client_certificate](variables.tf#L240) | Enable issuing client certificate. | <code>bool</code> |  | <code>false</code> |
+| [labels](variables.tf#L246) | Cluster resource labels. | <code>map&#40;string&#41;</code> |  | <code>null</code> |
+| [logging_config](variables.tf#L257) | Logging configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [maintenance_config](variables.tf#L268) | Maintenance window configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#8230;&#125;</code> |
+| [min_master_version](variables.tf#L291) | Minimum version of the master, defaults to the version of the most recent official release. | <code>string</code> |  | <code>null</code> |
+| [monitoring_config](variables.tf#L297) | Monitoring configuration. System metrics collection cannot be disabled. Control plane metrics are optional. Kube state metrics are optional. Google Cloud Managed Service for Prometheus is enabled by default. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [node_config](variables.tf#L340) | Configuration for nodes and nodepools. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [node_locations](variables.tf#L361) | Zones in which the cluster's nodes are located. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
+| [release_channel](variables.tf#L373) | Release channel for GKE upgrades. Clusters created in the Autopilot mode must use a release channel. Choose between \"RAPID\", \"REGULAR\", and \"STABLE\". | <code>string</code> |  | <code>&#34;REGULAR&#34;</code> |
 
 ## Outputs
 

--- a/modules/gke-cluster-autopilot/main.tf
+++ b/modules/gke-cluster-autopilot/main.tf
@@ -460,6 +460,88 @@ resource "google_gke_backup_backup_plan" "backup_plan" {
   }
 }
 
+resource "google_gke_backup_restore_plan" "restore_plan" {
+  for_each = (
+    var.backup_configs.enable_backup_agent
+    ? var.backup_configs.restore_plans
+    : {}
+  )
+  name        = each.key
+  description = each.value.description
+  cluster     = google_container_cluster.cluster.id
+  location    = each.value.region
+  project     = var.project_id
+  labels      = each.value.labels
+
+  backup_plan = (
+    try(google_gke_backup_backup_plan.backup_plan[each.value.backup_plan].id, null) != null
+    ? google_gke_backup_backup_plan.backup_plan[each.value.backup_plan].id
+    : each.value.backup_plan
+  )
+
+  restore_config {
+    volume_data_restore_policy       = each.value.volume_data_restore_policy
+    cluster_resource_conflict_policy = each.value.cluster_resource_conflict_policy
+    namespaced_resource_restore_mode = each.value.namespaced_resource_restore_mode
+
+    all_namespaces = each.value.all_namespaces
+    no_namespaces  = each.value.no_namespaces
+
+    dynamic "selected_namespaces" {
+      for_each = each.value.namespaces != null ? [""] : []
+      content {
+        namespaces = each.value.namespaces
+      }
+    }
+
+    dynamic "excluded_namespaces" {
+      for_each = each.value.excluded_namespaces != null ? [""] : []
+      content {
+        namespaces = each.value.excluded_namespaces
+      }
+    }
+
+    dynamic "selected_applications" {
+      for_each = each.value.applications != null ? [""] : []
+      content {
+        dynamic "namespaced_names" {
+          for_each = flatten([for k, vs in each.value.applications : [
+            for v in vs : { namespace = k, name = v }
+          ]])
+          content {
+            namespace = namespaced_names.value.namespace
+            name      = namespaced_names.value.name
+          }
+        }
+      }
+    }
+
+    dynamic "cluster_resource_restore_scope" {
+      for_each = each.value.cluster_resource_restore_scope != null ? [""] : []
+      content {
+        all_group_kinds = each.value.cluster_resource_restore_scope.all_group_kinds
+        no_group_kinds  = each.value.cluster_resource_restore_scope.no_group_kinds
+
+        dynamic "selected_group_kinds" {
+          for_each = each.value.cluster_resource_restore_scope.selected_group_kinds != null ? each.value.cluster_resource_restore_scope.selected_group_kinds : []
+          content {
+            resource_group = selected_group_kinds.value.resource_group
+            resource_kind  = selected_group_kinds.value.resource_kind
+          }
+        }
+
+        dynamic "excluded_group_kinds" {
+          for_each = each.value.cluster_resource_restore_scope.excluded_group_kinds != null ? each.value.cluster_resource_restore_scope.excluded_group_kinds : []
+          content {
+            resource_group = excluded_group_kinds.value.resource_group
+            resource_kind  = excluded_group_kinds.value.resource_kind
+          }
+        }
+      }
+    }
+  }
+}
+
 resource "google_pubsub_topic" "notifications" {
   count = (
     try(var.enable_features.upgrade_notifications, null) != null &&

--- a/modules/gke-cluster-autopilot/variables.tf
+++ b/modules/gke-cluster-autopilot/variables.tf
@@ -63,9 +63,75 @@ variable "backup_configs" {
       retention_policy_lock             = optional(bool, false)
       retention_policy_delete_lock_days = optional(string)
     })), {})
+    restore_plans = optional(map(object({
+      region                           = string
+      backup_plan                      = string
+      description                      = optional(string)
+      labels                           = optional(map(string))
+      cluster_resource_conflict_policy = optional(string)
+      namespaced_resource_restore_mode = optional(string)
+      volume_data_restore_policy       = optional(string)
+      all_namespaces                   = optional(bool)
+      no_namespaces                    = optional(bool)
+      namespaces                       = optional(list(string))
+      excluded_namespaces              = optional(list(string))
+      applications                     = optional(map(list(string)))
+      cluster_resource_restore_scope = optional(object({
+        all_group_kinds = optional(bool)
+        no_group_kinds  = optional(bool)
+        selected_group_kinds = optional(list(object({
+          resource_group = optional(string)
+          resource_kind  = optional(string)
+        })))
+        excluded_group_kinds = optional(list(object({
+          resource_group = optional(string)
+          resource_kind  = optional(string)
+        })))
+      }))
+    })), {})
   })
   default  = {}
   nullable = false
+
+  validation {
+    condition = alltrue([
+      for k, v in var.backup_configs.backup_plans : (
+        v.schedule == null || v.retention_policy_days != null
+      )
+    ])
+    error_message = "Backup plans with a defined schedule require retention_policy_days to be set."
+  }
+
+  validation {
+    condition = alltrue([
+      for k, v in var.backup_configs.restore_plans : (
+        (v.cluster_resource_restore_scope == null || try(v.cluster_resource_restore_scope.no_group_kinds, false) == true) &&
+        v.cluster_resource_conflict_policy == null
+      ) ||
+      contains(["USE_EXISTING_VERSION", "USE_BACKUP_VERSION"], try(v.cluster_resource_conflict_policy, ""))
+    ])
+    error_message = "cluster_resource_conflict_policy must be set to a valid value (USE_EXISTING_VERSION, USE_BACKUP_VERSION) if cluster_resource_restore_scope is configured and not set to no_group_kinds."
+  }
+
+  validation {
+    condition = alltrue([
+      for k, v in var.backup_configs.restore_plans : (
+        (try(v.no_namespaces, false) == true && v.namespaced_resource_restore_mode == null) ||
+        contains(["DELETE_AND_RESTORE", "FAIL_ON_CONFLICT", "MERGE_SKIP_ON_CONFLICT", "MERGE_REPLACE_VOLUME_ON_CONFLICT", "MERGE_REPLACE_ON_CONFLICT"], try(v.namespaced_resource_restore_mode, ""))
+      )
+    ])
+    error_message = "namespaced_resource_restore_mode must be set to a valid value (DELETE_AND_RESTORE, FAIL_ON_CONFLICT, MERGE_SKIP_ON_CONFLICT, MERGE_REPLACE_VOLUME_ON_CONFLICT, MERGE_REPLACE_ON_CONFLICT) unless no_namespaces is set to true."
+  }
+
+  validation {
+    condition = alltrue([
+      for k, v in var.backup_configs.restore_plans : (
+        v.volume_data_restore_policy == null ||
+        contains(["RESTORE_VOLUME_DATA_FROM_BACKUP", "REUSE_VOLUME_HANDLE_FROM_BACKUP", "NO_VOLUME_DATA_RESTORATION"], v.volume_data_restore_policy)
+      )
+    ])
+    error_message = "Invalid volume_data_restore_policy. Allowed values are RESTORE_VOLUME_DATA_FROM_BACKUP, REUSE_VOLUME_HANDLE_FROM_BACKUP, NO_VOLUME_DATA_RESTORATION."
+  }
 }
 
 variable "deletion_protection" {

--- a/modules/gke-cluster-standard/README.md
+++ b/modules/gke-cluster-standard/README.md
@@ -411,16 +411,28 @@ module "cluster-1" {
     enable_backup_agent = true
     backup_plans = {
       "backup-1" = {
-        region   = "europe-west2"
-        schedule = "0 9 * * 1"
         applications = {
           namespace-1 = ["app-1", "app-2"]
         }
+        region                = "europe-west2"
+        retention_policy_days = 7
+        schedule              = "0 9 * * 1"
+      }
+    }
+    restore_plans = {
+      "restore-1" = {
+        region                           = "europe-west2"
+        backup_plan                      = "backup-1"
+        description                      = "Test restore plan"
+        all_namespaces                   = true
+        cluster_resource_conflict_policy = "USE_EXISTING_VERSION"
+        namespaced_resource_restore_mode = "DELETE_AND_RESTORE"
+        volume_data_restore_policy       = "RESTORE_VOLUME_DATA_FROM_BACKUP"
       }
     }
   }
 }
-# tftest modules=1 resources=2 inventory=backup.yaml
+# tftest modules=1 resources=3 inventory=backup.yaml
 ```
 
 ## Automatic creation of new secondary ranges
@@ -515,30 +527,30 @@ module "cluster-1" {
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [location](variables.tf#L304) | Cluster zone or region. | <code>string</code> | ✓ |  |
-| [name](variables.tf#L419) | Cluster name. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L471) | Cluster project id. | <code>string</code> | ✓ |  |
-| [vpc_config](variables.tf#L482) | VPC-level configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
+| [location](variables.tf#L370) | Cluster zone or region. | <code>string</code> | ✓ |  |
+| [name](variables.tf#L485) | Cluster name. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L537) | Cluster project id. | <code>string</code> | ✓ |  |
+| [vpc_config](variables.tf#L548) | VPC-level configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
 | [access_config](variables.tf#L17) | Control plane endpoint and nodes access configurations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [backup_configs](variables.tf#L49) | Configuration for Backup for GKE. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [cluster_autoscaling](variables.tf#L72) | Enable and configure limits for Node Auto-Provisioning with Cluster Autoscaler. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [default_nodepool](variables.tf#L152) | Enable default nodepool. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [deletion_protection](variables.tf#L170) | Whether or not to allow Terraform to destroy the cluster. Unless this field is set to false in Terraform state, a terraform destroy or terraform apply that would delete the cluster will fail. | <code>bool</code> |  | <code>true</code> |
-| [description](variables.tf#L177) | Cluster description. | <code>string</code> |  | <code>null</code> |
-| [enable_addons](variables.tf#L183) | Addons enabled in the cluster (true means enabled). | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [enable_features](variables.tf#L205) | Enable cluster-level features. Certain features allow configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [fleet_project](variables.tf#L285) | The name of the fleet host project where this cluster will be registered. | <code>string</code> |  | <code>null</code> |
-| [issue_client_certificate](variables.tf#L291) | Enable issuing client certificate. | <code>bool</code> |  | <code>false</code> |
-| [labels](variables.tf#L297) | Cluster resource labels. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
-| [logging_config](variables.tf#L309) | Logging configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [maintenance_config](variables.tf#L330) | Maintenance window configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#8230;&#125;</code> |
-| [max_pods_per_node](variables.tf#L353) | Maximum number of pods per node in this cluster. | <code>number</code> |  | <code>110</code> |
-| [min_master_version](variables.tf#L359) | Minimum version of the master, defaults to the version of the most recent official release. | <code>string</code> |  | <code>null</code> |
-| [monitoring_config](variables.tf#L365) | Monitoring configuration. Google Cloud Managed Service for Prometheus is enabled by default. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [node_config](variables.tf#L424) | Node-level configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [node_locations](variables.tf#L447) | Zones in which the cluster's nodes are located. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
-| [node_pool_auto_config](variables.tf#L454) | Node pool configs that apply to auto-provisioned node pools in autopilot clusters and node auto-provisioning-enabled clusters. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [release_channel](variables.tf#L476) | Release channel for GKE upgrades. | <code>string</code> |  | <code>null</code> |
+| [cluster_autoscaling](variables.tf#L138) | Enable and configure limits for Node Auto-Provisioning with Cluster Autoscaler. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [default_nodepool](variables.tf#L218) | Enable default nodepool. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [deletion_protection](variables.tf#L236) | Whether or not to allow Terraform to destroy the cluster. Unless this field is set to false in Terraform state, a terraform destroy or terraform apply that would delete the cluster will fail. | <code>bool</code> |  | <code>true</code> |
+| [description](variables.tf#L243) | Cluster description. | <code>string</code> |  | <code>null</code> |
+| [enable_addons](variables.tf#L249) | Addons enabled in the cluster (true means enabled). | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [enable_features](variables.tf#L271) | Enable cluster-level features. Certain features allow configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [fleet_project](variables.tf#L351) | The name of the fleet host project where this cluster will be registered. | <code>string</code> |  | <code>null</code> |
+| [issue_client_certificate](variables.tf#L357) | Enable issuing client certificate. | <code>bool</code> |  | <code>false</code> |
+| [labels](variables.tf#L363) | Cluster resource labels. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [logging_config](variables.tf#L375) | Logging configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [maintenance_config](variables.tf#L396) | Maintenance window configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#8230;&#125;</code> |
+| [max_pods_per_node](variables.tf#L419) | Maximum number of pods per node in this cluster. | <code>number</code> |  | <code>110</code> |
+| [min_master_version](variables.tf#L425) | Minimum version of the master, defaults to the version of the most recent official release. | <code>string</code> |  | <code>null</code> |
+| [monitoring_config](variables.tf#L431) | Monitoring configuration. Google Cloud Managed Service for Prometheus is enabled by default. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [node_config](variables.tf#L490) | Node-level configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [node_locations](variables.tf#L513) | Zones in which the cluster's nodes are located. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
+| [node_pool_auto_config](variables.tf#L520) | Node pool configs that apply to auto-provisioned node pools in autopilot clusters and node auto-provisioning-enabled clusters. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [release_channel](variables.tf#L542) | Release channel for GKE upgrades. | <code>string</code> |  | <code>null</code> |
 
 ## Outputs
 

--- a/modules/gke-cluster-standard/main.tf
+++ b/modules/gke-cluster-standard/main.tf
@@ -697,6 +697,88 @@ resource "google_gke_backup_backup_plan" "backup_plan" {
   }
 }
 
+resource "google_gke_backup_restore_plan" "restore_plan" {
+  for_each = (
+    var.backup_configs.enable_backup_agent
+    ? var.backup_configs.restore_plans
+    : {}
+  )
+  name        = each.key
+  description = each.value.description
+  cluster     = google_container_cluster.cluster.id
+  location    = each.value.region
+  project     = var.project_id
+  labels      = each.value.labels
+
+  backup_plan = (
+    try(google_gke_backup_backup_plan.backup_plan[each.value.backup_plan].id, null) != null
+    ? google_gke_backup_backup_plan.backup_plan[each.value.backup_plan].id
+    : each.value.backup_plan
+  )
+
+  restore_config {
+    volume_data_restore_policy       = each.value.volume_data_restore_policy
+    cluster_resource_conflict_policy = each.value.cluster_resource_conflict_policy
+    namespaced_resource_restore_mode = each.value.namespaced_resource_restore_mode
+
+    all_namespaces = each.value.all_namespaces
+    no_namespaces  = each.value.no_namespaces
+
+    dynamic "selected_namespaces" {
+      for_each = each.value.namespaces != null ? [""] : []
+      content {
+        namespaces = each.value.namespaces
+      }
+    }
+
+    dynamic "excluded_namespaces" {
+      for_each = each.value.excluded_namespaces != null ? [""] : []
+      content {
+        namespaces = each.value.excluded_namespaces
+      }
+    }
+
+    dynamic "selected_applications" {
+      for_each = each.value.applications != null ? [""] : []
+      content {
+        dynamic "namespaced_names" {
+          for_each = flatten([for k, vs in each.value.applications : [
+            for v in vs : { namespace = k, name = v }
+          ]])
+          content {
+            namespace = namespaced_names.value.namespace
+            name      = namespaced_names.value.name
+          }
+        }
+      }
+    }
+
+    dynamic "cluster_resource_restore_scope" {
+      for_each = each.value.cluster_resource_restore_scope != null ? [""] : []
+      content {
+        all_group_kinds = each.value.cluster_resource_restore_scope.all_group_kinds
+        no_group_kinds  = each.value.cluster_resource_restore_scope.no_group_kinds
+
+        dynamic "selected_group_kinds" {
+          for_each = each.value.cluster_resource_restore_scope.selected_group_kinds != null ? each.value.cluster_resource_restore_scope.selected_group_kinds : []
+          content {
+            resource_group = selected_group_kinds.value.resource_group
+            resource_kind  = selected_group_kinds.value.resource_kind
+          }
+        }
+
+        dynamic "excluded_group_kinds" {
+          for_each = each.value.cluster_resource_restore_scope.excluded_group_kinds != null ? each.value.cluster_resource_restore_scope.excluded_group_kinds : []
+          content {
+            resource_group = excluded_group_kinds.value.resource_group
+            resource_kind  = excluded_group_kinds.value.resource_kind
+          }
+        }
+      }
+    }
+  }
+}
+
 resource "google_pubsub_topic" "notifications" {
   count = (
     try(var.enable_features.upgrade_notifications, null) != null &&

--- a/modules/gke-cluster-standard/variables.tf
+++ b/modules/gke-cluster-standard/variables.tf
@@ -64,9 +64,75 @@ variable "backup_configs" {
       retention_policy_lock             = optional(bool, false)
       retention_policy_delete_lock_days = optional(number)
     })), {})
+    restore_plans = optional(map(object({
+      region                           = string
+      backup_plan                      = string
+      description                      = optional(string)
+      labels                           = optional(map(string))
+      cluster_resource_conflict_policy = optional(string)
+      namespaced_resource_restore_mode = optional(string)
+      volume_data_restore_policy       = optional(string)
+      all_namespaces                   = optional(bool)
+      no_namespaces                    = optional(bool)
+      namespaces                       = optional(list(string))
+      excluded_namespaces              = optional(list(string))
+      applications                     = optional(map(list(string)))
+      cluster_resource_restore_scope = optional(object({
+        all_group_kinds = optional(bool)
+        no_group_kinds  = optional(bool)
+        selected_group_kinds = optional(list(object({
+          resource_group = optional(string)
+          resource_kind  = optional(string)
+        })))
+        excluded_group_kinds = optional(list(object({
+          resource_group = optional(string)
+          resource_kind  = optional(string)
+        })))
+      }))
+    })), {})
   })
   default  = {}
   nullable = false
+
+  validation {
+    condition = alltrue([
+      for k, v in var.backup_configs.backup_plans : (
+        v.schedule == null || v.retention_policy_days != null
+      )
+    ])
+    error_message = "Backup plans with a defined schedule require retention_policy_days to be set."
+  }
+
+  validation {
+    condition = alltrue([
+      for k, v in var.backup_configs.restore_plans : (
+        (v.cluster_resource_restore_scope == null || try(v.cluster_resource_restore_scope.no_group_kinds, false) == true) &&
+        v.cluster_resource_conflict_policy == null
+      ) ||
+      contains(["USE_EXISTING_VERSION", "USE_BACKUP_VERSION"], try(v.cluster_resource_conflict_policy, ""))
+    ])
+    error_message = "cluster_resource_conflict_policy must be set to a valid value (USE_EXISTING_VERSION, USE_BACKUP_VERSION) if cluster_resource_restore_scope is configured and not set to no_group_kinds."
+  }
+
+  validation {
+    condition = alltrue([
+      for k, v in var.backup_configs.restore_plans : (
+        (try(v.no_namespaces, false) == true && v.namespaced_resource_restore_mode == null) ||
+        contains(["DELETE_AND_RESTORE", "FAIL_ON_CONFLICT", "MERGE_SKIP_ON_CONFLICT", "MERGE_REPLACE_VOLUME_ON_CONFLICT", "MERGE_REPLACE_ON_CONFLICT"], try(v.namespaced_resource_restore_mode, ""))
+      )
+    ])
+    error_message = "namespaced_resource_restore_mode must be set to a valid value (DELETE_AND_RESTORE, FAIL_ON_CONFLICT, MERGE_SKIP_ON_CONFLICT, MERGE_REPLACE_VOLUME_ON_CONFLICT, MERGE_REPLACE_ON_CONFLICT) unless no_namespaces is set to true."
+  }
+
+  validation {
+    condition = alltrue([
+      for k, v in var.backup_configs.restore_plans : (
+        v.volume_data_restore_policy == null ||
+        contains(["RESTORE_VOLUME_DATA_FROM_BACKUP", "REUSE_VOLUME_HANDLE_FROM_BACKUP", "NO_VOLUME_DATA_RESTORATION"], v.volume_data_restore_policy)
+      )
+    ])
+    error_message = "Invalid volume_data_restore_policy. Allowed values are RESTORE_VOLUME_DATA_FROM_BACKUP, REUSE_VOLUME_HANDLE_FROM_BACKUP, NO_VOLUME_DATA_RESTORATION."
+  }
 }
 
 variable "cluster_autoscaling" {

--- a/tests/modules/gke_cluster_standard/examples/backup.yaml
+++ b/tests/modules/gke_cluster_standard/examples/backup.yaml
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,30 +14,211 @@
 
 values:
   module.cluster-1.google_container_cluster.cluster:
+    addons_config:
+    - cloudrun_config:
+      - disabled: true
+        load_balancer_type: null
+      config_connector_config:
+      - enabled: false
+      dns_cache_config:
+      - enabled: true
+      gce_persistent_disk_csi_driver_config:
+      - enabled: true
+      gcp_filestore_csi_driver_config:
+      - enabled: true
+      gcs_fuse_csi_driver_config:
+      - enabled: true
+      gke_backup_agent_config:
+      - enabled: true
+      horizontal_pod_autoscaling:
+      - disabled: false
+      http_load_balancing:
+      - disabled: false
+      istio_config:
+      - auth: null
+        disabled: true
+      kalm_config:
+      - enabled: false
+      network_policy_config:
+      - disabled: true
+      stateful_ha_config:
+      - enabled: false
+    allow_net_admin: null
+    binary_authorization: []
+    control_plane_endpoints_config:
+    - dns_endpoint_config:
+      - allow_external_traffic: true
+        enable_k8s_certs_via_dns: null
+        enable_k8s_tokens_via_dns: null
+      ip_endpoints_config:
+      - enabled: false
+    cost_management_config:
+    - enabled: true
+    datapath_provider: ADVANCED_DATAPATH
+    dataplane_optimization_mode: null
+    default_max_pods_per_node: 110
+    deletion_policy: DELETE
+    deletion_protection: true
+    description: null
+    disable_l4_lb_firewall_reconciliation: false
+    dns_config: []
+    effective_labels:
+      goog-terraform-provisioned: 'true'
+    enable_autopilot: null
+    enable_cilium_clusterwide_network_policy: false
+    enable_fqdn_network_policy: true
+    enable_intranode_visibility: false
+    enable_k8s_beta_apis: []
+    enable_kubernetes_alpha: false
+    enable_l4_ilb_subsetting: false
+    enable_legacy_abac: false
+    enable_multi_networking: false
+    enable_shielded_nodes: false
+    enable_tpu: false
+    fleet: []
+    ignore_node_count_changes: null
+    in_transit_encryption_config: null
+    initial_node_count: 1
+    ip_allocation_policy:
+    - additional_ip_ranges_config: []
+      additional_pod_ranges_config: []
+      stack_type: IPV4
     location: europe-west1-b
+    logging_config:
+    - enable_components:
+      - SYSTEM_COMPONENTS
+    maintenance_policy:
+    - daily_maintenance_window:
+      - start_time: 03:00
+      disruption_budget: []
+      maintenance_exclusion: []
+      recurring_maintenance_window: []
+      recurring_window: []
+    master_auth:
+    - client_certificate_config:
+      - issue_client_certificate: false
+    min_master_version: null
+    monitoring_config:
+    - enable_components:
+      - SYSTEM_COMPONENTS
+      managed_prometheus:
+      - enabled: true
     name: cluster-1
-
+    network: https://www.googleapis.com/compute/v1/projects/xxx/global/networks/aaa
+    network_performance_config: []
+    network_policy: []
+    node_config:
+    - advanced_machine_features: []
+      boot_disk_kms_key: null
+      enable_confidential_storage: null
+      ephemeral_storage_config: []
+      ephemeral_storage_local_ssd_config: []
+      fast_socket: []
+      flex_start: null
+      gvnic: []
+      host_maintenance_policy: []
+      local_nvme_ssd_block_config: []
+      local_ssd_encryption_mode: null
+      max_run_duration: null
+      node_group: null
+      preemptible: false
+      reservation_affinity: []
+      resource_labels: null
+      resource_manager_tags: null
+      sandbox_config: []
+      secondary_boot_disks: []
+      sole_tenant_config: []
+      spot: false
+      storage_pools: null
+      tags: null
+      taint: []
+      taint_config: []
+    node_pool_defaults:
+    - node_config_defaults:
+      - gcfs_config:
+        - enabled: false
+    pod_security_policy_config: []
+    private_cluster_config:
+    - enable_private_endpoint: true
+      enable_private_nodes: true
+      private_endpoint_subnetwork: null
+    project: project-id
+    remove_default_node_pool: true
+    resource_labels: null
+    resource_usage_export_config: []
+    secret_manager_config: []
+    secret_sync_config: []
+    skip_node_pool_refresh: null
+    subnetwork: subnet_self_link
+    terraform_labels:
+      goog-terraform-provisioned: 'true'
+    timeouts: null
+    user_managed_keys_config: []
+    workload_identity_config:
+    - workload_pool: project-id.svc.id.goog
   module.cluster-1.google_gke_backup_backup_plan.backup_plan["backup-1"]:
     backup_config:
     - all_namespaces: null
       encryption_key: []
       include_secrets: true
       include_volume_data: true
+      permissive_mode: null
       selected_applications:
       - namespaced_names:
-        - namespace: namespace-1
-          name: app-1
-        - namespace: namespace-1
-          name: app-2
+        - name: app-1
+          namespace: namespace-1
+        - name: app-2
+          namespace: namespace-1
+      selected_namespace_labels: []
       selected_namespaces: []
     backup_schedule:
     - cron_schedule: 0 9 * * 1
+      rpo_config: []
+    deletion_policy: DELETE
+    description: null
+    effective_labels:
+      goog-terraform-provisioned: 'true'
+    labels: null
     location: europe-west2
     name: backup-1
     project: project-id
     retention_policy:
-    - locked: false
+    - backup_retain_days: 7
+      locked: false
+    terraform_labels:
+      goog-terraform-provisioned: 'true'
+    timeouts: null
+  module.cluster-1.google_gke_backup_restore_plan.restore_plan["restore-1"]:
+    deletion_policy: DELETE
+    description: Test restore plan
+    effective_labels:
+      goog-terraform-provisioned: 'true'
+    labels: null
+    location: europe-west2
+    name: restore-1
+    project: project-id
+    restore_config:
+    - all_namespaces: true
+      cluster_resource_conflict_policy: USE_EXISTING_VERSION
+      cluster_resource_restore_scope: []
+      excluded_namespaces: []
+      namespaced_resource_restore_mode: DELETE_AND_RESTORE
+      no_namespaces: null
+      restore_order: []
+      selected_applications: []
+      selected_namespaces: []
+      transformation_rules: []
+      volume_data_restore_policy: RESTORE_VOLUME_DATA_FROM_BACKUP
+      volume_data_restore_policy_bindings: []
+    terraform_labels:
+      goog-terraform-provisioned: 'true'
+    timeouts: null
 
 counts:
   google_container_cluster: 1
   google_gke_backup_backup_plan: 1
+  google_gke_backup_restore_plan: 1
+  modules: 1
+  resources: 3
+
+outputs: {}


### PR DESCRIPTION
This PR adds optional support for GKE Backup Restore Plans (`google_gke_backup_restore_plan`) in both standard and autopilot GKE cluster modules.

### Rationale
Currently, CFF GKE modules support GKE Backup Plans, but not Restore Plans. Adding Restore Plans allows users to manage the full Backup for GKE disaster recovery lifecycle (both backup and restore configurations) directly within the GKE modules.

### Changes
- Updated `backup_configs` variable in `gke-cluster-standard` and `gke-cluster-autopilot` to support a new `restore_plans` map.
- Added `google_gke_backup_restore_plan` resource to standard and autopilot cluster modules.
- Implemented validations in `backup_configs` to ensure that:
    - `retention_policy_days` is set when a `schedule` is defined.
    - `namespaced_resource_restore_mode` is set to a valid value when restore scope is not empty.
    - `cluster_resource_conflict_policy` is set to a valid value when cluster restore scope is not empty.
    - `volume_data_restore_policy` is set to a valid value.
- Updated GKE standard cluster README example to demonstrate GKE Backup and Restore plans usage.
- Updated tests and regenerated inventory.
