### PR TITLE
Add support for Workstation Boost Configurations to `workstation-cluster` module

### DIFF
--- a/fast/project-templates/gce-workstation-cluster/data/workstation-configs/default.yaml
+++ b/fast/project-templates/gce-workstation-cluster/data/workstation-configs/default.yaml
@@ -23,6 +23,17 @@ gce_instance:
   service_account: $iam_principals:service_accounts/prod-gce-ws-0/ws-default
   service_account_scopes:
     - https://www.googleapis.com/auth/cloud-platform
+  boost_configs:
+    boost-1:
+      machine_type: n1-standard-2
+      accelerators:
+        nvidia-tesla-t4: 1
+    boost-2:
+      machine_type: n1-standard-4
+      accelerators: {}
+      pool_size: 2
+      boot_disk_size_gb: 30
+      enable_nested_virtualization: true
 persistent_directories:
   - mount_path: /home
     gce_pd:

--- a/modules/workstation-cluster/README.md
+++ b/modules/workstation-cluster/README.md
@@ -6,6 +6,7 @@ This module allows to create a workstation cluster with associated workstation c
 - [Simple example](#simple-example)
 - [Private cluster](#private-cluster)
 - [Custom image](#custom-image)
+- [Boost configs](#boost-configs)
 - [IAM](#iam)
 - [Variables](#variables)
 - [Outputs](#outputs)
@@ -111,6 +112,57 @@ module "workstation-cluster" {
   }
 }
 # tftest modules=1 resources=3 inventory=custom-image.yaml
+```
+
+## Boost configs
+
+Example showing how to create a cluster with a workstation config that includes a [boost configuration](https://docs.cloud.google.com/workstations/docs/boost-workstation) to temporarily allow the workstation to use a more powerful set of resources on demand:
+
+```hcl
+module "workstation-cluster" {
+  source     = "./fabric/modules/workstation-cluster"
+  project_id = var.project_id
+  id         = "my-workstation-cluster"
+  location   = var.region
+  network_config = {
+    network    = var.vpc.self_link
+    subnetwork = var.subnet.self_link
+  }
+  workstation_configs = {
+    my-workstation-config = {
+      gce_instance = {
+        machine_type                = "n1-standard-2"
+        boot_disk_size_gb           = 10
+        disable_public_ip_addresses = true
+        boost_configs = {
+          boost-1 = {
+            machine_type = "n1-standard-2"
+            accelerators = [
+              {
+                type  = "nvidia-tesla-t4"
+                count = 1
+              }
+            ]
+          }
+          boost-2 = {
+            machine_type                 = "n1-standard-4"
+            pool_size                    = 2
+            boot_disk_size_gb            = 30
+            enable_nested_virtualization = true
+          }
+        }
+      }
+      workstations = {
+        my-workstation = {
+          labels = {
+            team = "my-team"
+          }
+        }
+      }
+    }
+  }
+}
+# tftest modules=1 resources=3 inventory=boost-configs.yaml
 ```
 
 ## IAM

--- a/modules/workstation-cluster/README.md
+++ b/modules/workstation-cluster/README.md
@@ -137,12 +137,9 @@ module "workstation-cluster" {
         boost_configs = {
           boost-1 = {
             machine_type = "n1-standard-2"
-            accelerators = [
-              {
-                type  = "nvidia-tesla-t4"
-                count = 1
-              }
-            ]
+            accelerators = {
+              "nvidia-tesla-t4" = 1
+            }
           }
           boost-2 = {
             machine_type                 = "n1-standard-4"

--- a/modules/workstation-cluster/factory.tf
+++ b/modules/workstation-cluster/factory.tf
@@ -63,14 +63,14 @@ locals {
           service_account              = try(v.gce_instance.service_account, null)
           service_account_scopes       = try(v.gce_instance.service_account_scopes, null)
           tags                         = try(v.gce_instance.tags, null)
-          accelerators                 = try(v.gce_instance.accelerators, [])
+          accelerators                 = try(v.gce_instance.accelerators, {})
           boost_configs = {
             for kk, vv in try(v.gce_instance.boost_configs, {}) : kk => {
               machine_type                 = try(vv.machine_type, null)
               boot_disk_size_gb            = try(vv.boot_disk_size_gb, null)
               enable_nested_virtualization = try(vv.enable_nested_virtualization, null)
               pool_size                    = try(vv.pool_size, null)
-              accelerators                 = try(vv.accelerators, [])
+              accelerators                 = try(vv.accelerators, {})
             }
           }
           shielded_instance_config = (

--- a/modules/workstation-cluster/factory.tf
+++ b/modules/workstation-cluster/factory.tf
@@ -64,6 +64,15 @@ locals {
           service_account_scopes       = try(v.gce_instance.service_account_scopes, null)
           tags                         = try(v.gce_instance.tags, null)
           accelerators                 = try(v.gce_instance.accelerators, [])
+          boost_configs = {
+            for kk, vv in try(v.gce_instance.boost_configs, {}) : kk => {
+              machine_type                 = try(vv.machine_type, null)
+              boot_disk_size_gb            = try(vv.boot_disk_size_gb, null)
+              enable_nested_virtualization = try(vv.enable_nested_virtualization, null)
+              pool_size                    = try(vv.pool_size, null)
+              accelerators                 = try(vv.accelerators, [])
+            }
+          }
           shielded_instance_config = (
             try(v.gce_instance.shielded_instance_config, null) == null ? null : {
               enable_secure_boot = try(

--- a/modules/workstation-cluster/main.tf
+++ b/modules/workstation-cluster/main.tf
@@ -122,8 +122,8 @@ resource "google_workstations_workstation_config" "configs" {
         dynamic "accelerators" {
           for_each = each.value.gce_instance.accelerators
           content {
-            type  = accelerators.value.type
-            count = accelerators.value.count
+            type  = accelerators.key
+            count = accelerators.value
           }
         }
         dynamic "boost_configs" {
@@ -137,8 +137,8 @@ resource "google_workstations_workstation_config" "configs" {
             dynamic "accelerators" {
               for_each = boost_configs.value.accelerators
               content {
-                type  = accelerators.value.type
-                count = accelerators.value.count
+                type  = accelerators.key
+                count = accelerators.value
               }
             }
           }

--- a/modules/workstation-cluster/main.tf
+++ b/modules/workstation-cluster/main.tf
@@ -126,6 +126,23 @@ resource "google_workstations_workstation_config" "configs" {
             count = accelerators.value.count
           }
         }
+        dynamic "boost_configs" {
+          for_each = each.value.gce_instance.boost_configs
+          content {
+            id                           = boost_configs.key
+            machine_type                 = boost_configs.value.machine_type
+            boot_disk_size_gb            = boost_configs.value.boot_disk_size_gb
+            enable_nested_virtualization = boost_configs.value.enable_nested_virtualization
+            pool_size                    = boost_configs.value.pool_size
+            dynamic "accelerators" {
+              for_each = boost_configs.value.accelerators
+              content {
+                type  = accelerators.value.type
+                count = accelerators.value.count
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/modules/workstation-cluster/schemas/workstation-config.schema.json
+++ b/modules/workstation-cluster/schemas/workstation-config.schema.json
@@ -158,23 +158,47 @@
           "default": false
         },
         "accelerators": {
-          "type": "array",
-          "description": "Accelerator configuration (optional, defaults to []).",
-          "items": {
+          "type": "object",
+          "description": "Accelerator configuration by type (optional, defaults to {}).",
+          "additionalProperties": {
+            "type": "number"
+          },
+          "default": {}
+        },
+        "boost_configs": {
+          "type": "object",
+          "description": "Boost configurations by ID (optional, defaults to {}).",
+          "additionalProperties": {
             "type": "object",
-            "additionalProperties": false,
             "properties": {
-              "type": {
+              "machine_type": {
                 "type": "string",
-                "description": "Accelerator type (optional)."
+                "description": "Boost instaconfigce machine type (optional)."
               },
-              "count": {
+              "boot_disk_size_gb": {
                 "type": "number",
-                "description": "Number of accelerators (optional)."
+                "description": "Boost instance boot disk size in GB (optional)."
+              },
+              "enable_nested_virtualization": {
+                "type": "boolean",
+                "description": "Whether to enable nested virtualization on the boost instance (optional, defaults to false).",
+                "default": false
+              },
+              "pool_size": {
+                "type": "number",
+                "description": "Size of the boost config instance pool (optional)."
+              },
+              "accelerators": {
+                "type": "object",
+                "description": "Boost instance accelerator configuration by type (optional, defaults to {}).",
+                "additionalProperties": {
+                  "type": "number"
+                },
+                "default": {}
               }
             }
           },
-          "default": []
+          "default": {}
         }
       }
     },

--- a/modules/workstation-cluster/schemas/workstation-config.schema.md
+++ b/modules/workstation-cluster/schemas/workstation-config.schema.md
@@ -44,11 +44,10 @@
     - **enable_vtpm**: *boolean*
     - **enable_integrity_monitoring**: *boolean*
   - **enable_confidential_compute**: *boolean*
-  - **accelerators**: *array*
-    - items: *object*
-      <br>*additional properties: false*
-      - **type**: *string*
-      - **count**: *number*
+  - **accelerators**: *object*
+    <br>*additional properties: number*
+  - **boost_configs**: *object*
+    <br>*additional properties: object*
 - **iam**: *object*
   <br>*additional properties: array*
 - **iam_bindings**: *object*

--- a/modules/workstation-cluster/variables.tf
+++ b/modules/workstation-cluster/variables.tf
@@ -129,7 +129,7 @@ variable "workstation_configs" {
       boost_configs = optional(map(object({
         machine_type                 = optional(string)
         boot_disk_size_gb            = optional(number)
-        enable_nested_virtualization = optional(bool)
+        enable_nested_virtualization = optional(bool, false)
         pool_size                    = optional(number)
         accelerators                 = optional(map(number), {})
       })), {})

--- a/modules/workstation-cluster/variables.tf
+++ b/modules/workstation-cluster/variables.tf
@@ -129,6 +129,16 @@ variable "workstation_configs" {
         type  = optional(string)
         count = optional(number)
       })), [])
+      boost_configs = optional(map(object({
+        machine_type                 = optional(string)
+        boot_disk_size_gb            = optional(number)
+        enable_nested_virtualization = optional(bool)
+        pool_size                    = optional(number)
+        accelerators = optional(list(object({
+          type  = optional(string)
+          count = optional(number)
+        })), [])
+      })), {})
       shielded_instance_config = optional(object({
         enable_secure_boot          = optional(bool, false)
         enable_vtpm                 = optional(bool, false)

--- a/modules/workstation-cluster/variables.tf
+++ b/modules/workstation-cluster/variables.tf
@@ -125,19 +125,13 @@ variable "workstation_configs" {
       service_account              = optional(string)
       service_account_scopes       = optional(list(string), [])
       tags                         = optional(list(string))
-      accelerators = optional(list(object({
-        type  = optional(string)
-        count = optional(number)
-      })), [])
+      accelerators                 = optional(map(number), {})
       boost_configs = optional(map(object({
         machine_type                 = optional(string)
         boot_disk_size_gb            = optional(number)
         enable_nested_virtualization = optional(bool)
         pool_size                    = optional(number)
-        accelerators = optional(list(object({
-          type  = optional(string)
-          count = optional(number)
-        })), [])
+        accelerators                 = optional(map(number), {})
       })), {})
       shielded_instance_config = optional(object({
         enable_secure_boot          = optional(bool, false)

--- a/tests/modules/workstation_cluster/examples/boost-configs.yaml
+++ b/tests/modules/workstation_cluster/examples/boost-configs.yaml
@@ -1,0 +1,107 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values:
+  module.workstation-cluster.google_workstations_workstation.workstations["my-workstation-config-my-workstation"]:
+    annotations: null
+    deletion_policy: DELETE
+    display_name: null
+    effective_labels:
+      goog-terraform-provisioned: 'true'
+      team: my-team
+    env: null
+    labels:
+      team: my-team
+    location: europe-west8
+    project: project-id
+    source_workstation: null
+    terraform_labels:
+      goog-terraform-provisioned: 'true'
+      team: my-team
+    timeouts: null
+    workstation_cluster_id: my-workstation-cluster
+    workstation_config_id: my-workstation-config
+    workstation_id: my-workstation
+  module.workstation-cluster.google_workstations_workstation_cluster.cluster:
+    annotations: null
+    deletion_policy: DELETE
+    display_name: null
+    domain_config: []
+    effective_labels:
+      goog-terraform-provisioned: 'true'
+    labels: null
+    location: europe-west8
+    network: https://www.googleapis.com/compute/v1/projects/xxx/global/networks/aaa
+    private_cluster_config: []
+    project: project-id
+    subnetwork: subnet_self_link
+    tags: null
+    terraform_labels:
+      goog-terraform-provisioned: 'true'
+    timeouts: null
+    workstation_cluster_id: my-workstation-cluster
+    workstation_launch_url: null
+  module.workstation-cluster.google_workstations_workstation_config.configs["my-workstation-config"]:
+    annotations: null
+    deletion_policy: DELETE
+    disable_tcp_connections: null
+    display_name: null
+    effective_labels:
+      goog-terraform-provisioned: 'true'
+    enable_audit_agent: null
+    encryption_key: []
+    host:
+    - gce_instance:
+      - accelerators: []
+        boost_configs:
+        - accelerators:
+          - count: 1
+            type: nvidia-tesla-t4
+          id: boost-1
+          machine_type: n1-standard-2
+        - accelerators: []
+          boot_disk_size_gb: 30
+          enable_nested_virtualization: true
+          id: boost-2
+          machine_type: n1-standard-4
+          pool_size: 2
+        boot_disk_size_gb: 10
+        disable_public_ip_addresses: true
+        disable_ssh: true
+        enable_nested_virtualization: false
+        instance_metadata: null
+        machine_type: n1-standard-2
+        service_account_scopes: []
+        tags: null
+        vm_tags: null
+    idle_timeout: 1200s
+    labels: null
+    location: europe-west8
+    project: project-id
+    readiness_checks: []
+    running_timeout: 43200s
+    terraform_labels:
+      goog-terraform-provisioned: 'true'
+    timeouts: null
+    workstation_cluster_id: my-workstation-cluster
+    workstation_config_id: my-workstation-config
+
+counts:
+  google_workstations_workstation: 1
+  google_workstations_workstation_cluster: 1
+  google_workstations_workstation_config: 1
+  modules: 1
+  resources: 3
+
+outputs: {}

--- a/tests/modules/workstation_cluster/examples/boost-configs.yaml
+++ b/tests/modules/workstation_cluster/examples/boost-configs.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -68,6 +68,7 @@ values:
         - accelerators:
           - count: 1
             type: nvidia-tesla-t4
+          enable_nested_virtualization: false
           id: boost-1
           machine_type: n1-standard-2
         - accelerators: []

--- a/tests/modules/workstation_cluster/examples/boost-configs.yaml
+++ b/tests/modules/workstation_cluster/examples/boost-configs.yaml
@@ -81,7 +81,6 @@ values:
         disable_public_ip_addresses: true
         disable_ssh: true
         enable_nested_virtualization: false
-        instance_metadata: null
         machine_type: n1-standard-2
         service_account_scopes: []
         tags: null


### PR DESCRIPTION
This PR adds support for specifying [boost configurations](https://docs.cloud.google.com/workstations/docs/boost-workstation) for workstation configs to the `workstation-cluster` module by exposing a `boost_configs` parameter within the `gce_instance` parameter of the `workstation_configs` variable.

Fixes #4075

---
**Checklist**

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [x] Made sure all relevant tests pass