### PR TITLE
Fix project ID mismatch in logging bucket sink IAM conditions

### DIFF
--- a/modules/billing-account/logging.tf
+++ b/modules/billing-account/logging.tf
@@ -42,6 +42,10 @@ locals {
       }
     }
   )
+  sink_bucket_expressions = {
+    for name, sink in local.sink_bindings["logging"] :
+    name => "resource.name.endsWith('locations/${split("/", sink.destination)[3]}/buckets/${split("/", sink.destination)[5]}')"
+  }
 }
 
 resource "google_logging_billing_account_sink" "sink" {
@@ -124,7 +128,7 @@ resource "google_project_iam_member" "bucket_sinks_binding" {
   condition {
     title       = "${each.key} bucket writer"
     description = "Grants bucketWriter to ${google_logging_billing_account_sink.sink[each.key].writer_identity} used by log sink ${each.key} on billing account ${var.id}"
-    expression  = "resource.name.endsWith('locations/${split("/", each.value.destination)[3]}/buckets/${split("/", each.value.destination)[5]}')"
+    expression  = local.sink_bucket_expressions[each.key]
   }
 }
 

--- a/modules/billing-account/logging.tf
+++ b/modules/billing-account/logging.tf
@@ -124,7 +124,7 @@ resource "google_project_iam_member" "bucket_sinks_binding" {
   condition {
     title       = "${each.key} bucket writer"
     description = "Grants bucketWriter to ${google_logging_billing_account_sink.sink[each.key].writer_identity} used by log sink ${each.key} on billing account ${var.id}"
-    expression  = "resource.name.endsWith('${each.value.destination}')"
+    expression  = "resource.name.endsWith('locations/${split("/", each.value.destination)[3]}/buckets/${split("/", each.value.destination)[5]}')"
   }
 }
 

--- a/modules/folder/logging.tf
+++ b/modules/folder/logging.tf
@@ -167,7 +167,7 @@ resource "google_project_iam_member" "bucket_sinks_binding" {
   condition {
     title       = "${each.key} bucket writer"
     description = "Grants bucketWriter to ${google_logging_folder_sink.sink[each.key].writer_identity} used by log sink ${each.key} on ${local.folder_id}"
-    expression  = "resource.name.endsWith('${each.value.destination}')"
+    expression  = "resource.name.endsWith('locations/${split("/", each.value.destination)[3]}/buckets/${split("/", each.value.destination)[5]}')"
   }
 }
 

--- a/modules/folder/logging.tf
+++ b/modules/folder/logging.tf
@@ -54,6 +54,10 @@ locals {
       name => sink if sink.iam && sink.type == type
     }
   }
+  sink_bucket_expressions = {
+    for name, sink in local.sink_bindings["logging"] :
+    name => "resource.name.endsWith('locations/${split("/", sink.destination)[3]}/buckets/${split("/", sink.destination)[5]}')"
+  }
 }
 
 resource "google_logging_folder_settings" "default" {
@@ -167,7 +171,7 @@ resource "google_project_iam_member" "bucket_sinks_binding" {
   condition {
     title       = "${each.key} bucket writer"
     description = "Grants bucketWriter to ${google_logging_folder_sink.sink[each.key].writer_identity} used by log sink ${each.key} on ${local.folder_id}"
-    expression  = "resource.name.endsWith('locations/${split("/", each.value.destination)[3]}/buckets/${split("/", each.value.destination)[5]}')"
+    expression  = local.sink_bucket_expressions[each.key]
   }
 }
 

--- a/modules/organization/logging.tf
+++ b/modules/organization/logging.tf
@@ -54,6 +54,10 @@ locals {
       name => sink if sink.iam && sink.type == type
     }
   }
+  sink_bucket_expressions = {
+    for name, sink in local.sink_bindings["logging"] :
+    name => "resource.name.endsWith('locations/${split("/", sink.destination)[3]}/buckets/${split("/", sink.destination)[5]}')"
+  }
 }
 
 resource "google_logging_organization_settings" "default" {
@@ -170,7 +174,7 @@ resource "google_project_iam_member" "bucket_sinks_binding" {
   condition {
     title       = "${each.key} bucket writer"
     description = "Grants bucketWriter to ${google_logging_organization_sink.sink[each.key].writer_identity} used by log sink ${each.key} on ${var.organization_id}"
-    expression  = "resource.name.endsWith('locations/${split("/", each.value.destination)[3]}/buckets/${split("/", each.value.destination)[5]}')"
+    expression  = local.sink_bucket_expressions[each.key]
   }
 }
 

--- a/modules/organization/logging.tf
+++ b/modules/organization/logging.tf
@@ -170,7 +170,7 @@ resource "google_project_iam_member" "bucket_sinks_binding" {
   condition {
     title       = "${each.key} bucket writer"
     description = "Grants bucketWriter to ${google_logging_organization_sink.sink[each.key].writer_identity} used by log sink ${each.key} on ${var.organization_id}"
-    expression  = "resource.name.endsWith('${each.value.destination}')"
+    expression  = "resource.name.endsWith('locations/${split("/", each.value.destination)[3]}/buckets/${split("/", each.value.destination)[5]}')"
   }
 }
 

--- a/modules/project/logging.tf
+++ b/modules/project/logging.tf
@@ -54,6 +54,10 @@ locals {
       name => sink if sink.iam && sink.type == type
     }
   }
+  sink_bucket_expressions = {
+    for name, sink in local.sink_bindings["logging"] :
+    name => "resource.name.endsWith('locations/${split("/", sink.destination)[3]}/buckets/${split("/", sink.destination)[5]}')"
+  }
 
   log_scopes = {
     for k, v in var.log_scopes :
@@ -169,7 +173,7 @@ resource "google_project_iam_member" "bucket_sinks_binding" {
   condition {
     title       = "${each.key} bucket writer"
     description = "Grants bucketWriter to ${google_logging_project_sink.sink[each.key].writer_identity} used by log sink ${each.key} on ${local.project.project_id}"
-    expression  = "resource.name.endsWith('locations/${split("/", each.value.destination)[3]}/buckets/${split("/", each.value.destination)[5]}')"
+    expression  = local.sink_bucket_expressions[each.key]
   }
 }
 

--- a/modules/project/logging.tf
+++ b/modules/project/logging.tf
@@ -169,7 +169,7 @@ resource "google_project_iam_member" "bucket_sinks_binding" {
   condition {
     title       = "${each.key} bucket writer"
     description = "Grants bucketWriter to ${google_logging_project_sink.sink[each.key].writer_identity} used by log sink ${each.key} on ${local.project.project_id}"
-    expression  = "resource.name.endsWith('${each.value.destination}')"
+    expression  = "resource.name.endsWith('locations/${split("/", each.value.destination)[3]}/buckets/${split("/", each.value.destination)[5]}')"
   }
 }
 

--- a/tests/modules/billing_account/examples/logging.yaml
+++ b/tests/modules/billing_account/examples/logging.yaml
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +15,7 @@
 values:
   module.billing-account.google_logging_billing_account_sink.sink["all"]:
     billing_account: 012345-ABCDEF-012345
+    deletion_policy: DELETE
     description: all (Terraform-managed).
     disabled: false
     exclusions: []
@@ -28,6 +29,7 @@ values:
     bucket_id: billing-account-all
     cmek_settings: []
     enable_analytics: false
+    index_configs: []
     location: global
     locked: null
     project: myprj

--- a/tests/modules/folder/examples/logging.yaml
+++ b/tests/modules/folder/examples/logging.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,6 +28,7 @@ values:
     default_partition_expiration_ms: null
     default_table_expiration_ms: null
     delete_contents_on_destroy: false
+    deletion_policy: DELETE
     description: Terraform managed.
     effective_labels:
       goog-terraform-provisioned: 'true'
@@ -60,6 +61,7 @@ values:
       goog-terraform-provisioned: 'true'
     timeouts: null
   module.destination-project.google_project_service.project_services["logging.googleapis.com"]:
+    deletion_policy: DELETE
     disable_dependent_services: false
     disable_on_destroy: false
     project: test-dest-prj
@@ -69,6 +71,7 @@ values:
     condition: []
     role: roles/bigquery.dataEditor
   module.folder-sink.google_folder.folder[0]:
+    deletion_policy: DELETE
     deletion_protection: false
     display_name: Folder name
     parent: folders/1122334455
@@ -80,6 +83,7 @@ values:
     filter: resource.type=gce_instance
     name: no-gce-instances
   module.folder-sink.google_logging_folder_sink.sink["alert"]:
+    deletion_policy: DELETE
     description: alert (Terraform-managed).
     destination: logging.googleapis.com/projects/test-dest-prj
     disabled: false
@@ -89,6 +93,7 @@ values:
     intercept_children: false
     name: alert
   module.folder-sink.google_logging_folder_sink.sink["debug"]:
+    deletion_policy: DELETE
     description: debug (Terraform-managed).
     disabled: false
     exclusions:
@@ -103,6 +108,7 @@ values:
   module.folder-sink.google_logging_folder_sink.sink["info"]:
     bigquery_options:
     - use_partitioned_tables: false
+    deletion_policy: DELETE
     description: info (Terraform-managed).
     disabled: false
     exclusions: []
@@ -111,6 +117,7 @@ values:
     intercept_children: false
     name: info
   module.folder-sink.google_logging_folder_sink.sink["notice"]:
+    deletion_policy: DELETE
     description: notice (Terraform-managed).
     destination: pubsub.googleapis.com/projects/project-id/topics/pubsub_sink
     disabled: false
@@ -120,6 +127,7 @@ values:
     intercept_children: false
     name: notice
   module.folder-sink.google_logging_folder_sink.sink["warnings"]:
+    deletion_policy: DELETE
     description: warnings (Terraform-managed).
     destination: storage.googleapis.com/test-gcs_sink
     disabled: false
@@ -151,6 +159,7 @@ values:
     cors: []
     custom_placement_config: []
     default_event_based_hold: null
+    deletion_policy: DELETE
     effective_labels:
       goog-terraform-provisioned: 'true'
     enable_object_retention: null
@@ -172,6 +181,7 @@ values:
     timeouts: null
     uniform_bucket_level_access: true
   module.pubsub.google_pubsub_topic.default:
+    deletion_policy: DELETE
     effective_labels:
       goog-terraform-provisioned: 'true'
     ingestion_data_source_settings: []
@@ -204,3 +214,5 @@ counts:
   google_storage_bucket_iam_member: 1
   modules: 6
   resources: 19
+
+outputs: {}

--- a/tests/modules/organization/context.yaml
+++ b/tests/modules/organization/context.yaml
@@ -274,7 +274,7 @@ values:
     timeouts: null
   google_project_iam_member.bucket_sinks_binding["test-logging"]:
     condition:
-    - expression: resource.name.endsWith('projects/test-prod-audit-logs-0/locations/europe-west8/buckets/audit-logs')
+    - expression: resource.name.endsWith('locations/europe-west8/buckets/audit-logs')
       title: test-logging bucket writer
     project: test-prod-audit-logs-0
     role: roles/logging.bucketWriter

--- a/tests/modules/organization/examples/logging-iam-external.yaml
+++ b/tests/modules/organization/examples/logging-iam-external.yaml
@@ -1,10 +1,10 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,31 +13,50 @@
 # limitations under the License.
 
 values:
+  google_project_iam_member.log-bucket-writer:
+    condition:
+    - description: Grants bucketWriter for audit-0, audit-1.
+      title: log_bucket_writer
+    project: project-id
+    role: roles/logging.bucketWriter
   module.log-bucket-0.google_logging_project_bucket_config.bucket[0]:
     bucket_id: audit-0
+    cmek_settings: []
+    enable_analytics: false
+    index_configs: []
     location: global
+    locked: null
     project: project-id
     retention_days: 30
   module.log-bucket-1.google_logging_project_bucket_config.bucket[0]:
     bucket_id: audit-1
+    cmek_settings: []
+    enable_analytics: false
+    index_configs: []
     location: global
+    locked: null
     project: project-id
     retention_days: 30
   module.org.google_logging_organization_sink.sink["audit-0"]:
+    deletion_policy: DELETE
+    description: audit-0 (Terraform-managed).
+    disabled: false
+    exclusions: []
     filter: severity=NOTICE
     include_children: true
+    intercept_children: false
     name: audit-0
     org_id: '1122334455'
   module.org.google_logging_organization_sink.sink["audit-1"]:
+    deletion_policy: DELETE
+    description: audit-1 (Terraform-managed).
+    disabled: false
+    exclusions: []
     filter: severity=WARNING
     include_children: true
+    intercept_children: false
     name: audit-1
     org_id: '1122334455'
-  google_project_iam_member.log-bucket-writer:
-    project: project-id
-    role: roles/logging.bucketWriter
-    condition:
-    - title: log_bucket_writer
 
 counts:
   google_logging_organization_sink: 2
@@ -45,3 +64,5 @@ counts:
   google_project_iam_member: 1
   modules: 3
   resources: 5
+
+outputs: {}

--- a/tests/modules/organization/examples/logging.yaml
+++ b/tests/modules/organization/examples/logging.yaml
@@ -1,10 +1,10 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,6 +28,7 @@ values:
     default_partition_expiration_ms: null
     default_table_expiration_ms: null
     delete_contents_on_destroy: false
+    deletion_policy: DELETE
     description: Terraform managed.
     effective_labels:
       goog-terraform-provisioned: 'true'
@@ -60,6 +61,7 @@ values:
       goog-terraform-provisioned: 'true'
     timeouts: null
   module.destination-project.google_project_service.project_services["logging.googleapis.com"]:
+    deletion_policy: DELETE
     disable_dependent_services: false
     disable_on_destroy: false
     project: test-dest-prj
@@ -70,6 +72,7 @@ values:
     cors: []
     custom_placement_config: []
     default_event_based_hold: null
+    deletion_policy: DELETE
     effective_labels:
       goog-terraform-provisioned: 'true'
     enable_object_retention: null
@@ -100,6 +103,7 @@ values:
     name: no-gce-instances
     org_id: '1122334455'
   module.org.google_logging_organization_sink.sink["alert"]:
+    deletion_policy: DELETE
     description: alert (Terraform-managed).
     destination: logging.googleapis.com/projects/test-dest-prj
     disabled: false
@@ -110,6 +114,7 @@ values:
     name: alert
     org_id: '1122334455'
   module.org.google_logging_organization_sink.sink["audit"]:
+    deletion_policy: DELETE
     description: audit (Terraform-managed).
     destination: storage.googleapis.com/test-prod-log-audit-0
     disabled: false
@@ -120,6 +125,7 @@ values:
     name: audit
     org_id: '1122334455'
   module.org.google_logging_organization_sink.sink["debug"]:
+    deletion_policy: DELETE
     description: debug (Terraform-managed).
     disabled: false
     exclusions:
@@ -135,6 +141,7 @@ values:
   module.org.google_logging_organization_sink.sink["info"]:
     bigquery_options:
     - use_partitioned_tables: true
+    deletion_policy: DELETE
     description: info (Terraform-managed).
     disabled: false
     exclusions: []
@@ -144,6 +151,7 @@ values:
     name: info
     org_id: '1122334455'
   module.org.google_logging_organization_sink.sink["notice"]:
+    deletion_policy: DELETE
     description: notice (Terraform-managed).
     destination: pubsub.googleapis.com/projects/project-id/topics/pubsub_sink
     disabled: false
@@ -154,6 +162,7 @@ values:
     name: notice
     org_id: '1122334455'
   module.org.google_logging_organization_sink.sink["warnings"]:
+    deletion_policy: DELETE
     description: warnings (Terraform-managed).
     destination: storage.googleapis.com/test-gcs_sink
     disabled: false
@@ -180,11 +189,14 @@ values:
     bucket: test-prod-log-audit-0
     condition: []
     role: roles/storage.objectCreator
+    timeouts: null
   module.org.google_storage_bucket_iam_member.storage_sinks_binding["warnings"]:
     bucket: test-gcs_sink
     condition: []
     role: roles/storage.objectCreator
+    timeouts: null
   module.pubsub.google_pubsub_topic.default:
+    deletion_policy: DELETE
     effective_labels:
       goog-terraform-provisioned: 'true'
     ingestion_data_source_settings: []
@@ -195,6 +207,7 @@ values:
     name: pubsub_sink
     project: project-id
     schema_settings: []
+    tags: null
     terraform_labels:
       goog-terraform-provisioned: 'true'
     timeouts: null
@@ -215,3 +228,5 @@ counts:
   google_storage_bucket_iam_member: 2
   modules: 6
   resources: 20
+
+outputs: {}

--- a/tests/modules/project/examples/data.yaml
+++ b/tests/modules/project/examples/data.yaml
@@ -1,10 +1,10 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -43,9 +43,11 @@ values:
     default_partition_expiration_ms: null
     default_table_expiration_ms: null
     delete_contents_on_destroy: true
+    deletion_policy: DELETE
     description: Terraform managed.
     effective_labels:
       goog-terraform-provisioned: 'true'
+    external_catalog_dataset_options: []
     external_dataset_reference: []
     friendly_name: null
     labels: null
@@ -61,12 +63,14 @@ values:
     cors: []
     custom_placement_config: []
     default_event_based_hold: null
+    deletion_policy: DELETE
     effective_labels:
       goog-terraform-provisioned: 'true'
     enable_object_retention: null
     encryption: []
     force_destroy: true
     hierarchical_namespace: []
+    ip_filter: []
     labels: null
     lifecycle_rule: []
     location: EU
@@ -81,6 +85,7 @@ values:
     timeouts: null
     uniform_bucket_level_access: true
   module.host-project.google_compute_shared_vpc_host_project.shared_vpc_host[0]:
+    deletion_policy: DELETE
     project: test-host
     timeouts: null
   module.host-project.google_project.project[0]:
@@ -99,6 +104,7 @@ values:
       goog-terraform-provisioned: 'true'
     timeouts: null
   module.kms.google_kms_crypto_key.default["key-global"]:
+    deletion_policy: DELETE
     effective_labels:
       goog-terraform-provisioned: 'true'
     labels: null
@@ -146,6 +152,7 @@ values:
     project: test-project
   module.project.google_logging_project_sink.sink["debug"]:
     custom_writer_identity: null
+    deletion_policy: DELETE
     description: debug (Terraform-managed).
     disabled: false
     exclusions:
@@ -161,6 +168,7 @@ values:
     bigquery_options:
     - use_partitioned_tables: false
     custom_writer_identity: null
+    deletion_policy: DELETE
     description: info (Terraform-managed).
     disabled: false
     exclusions: []
@@ -170,6 +178,7 @@ values:
     unique_writer_identity: true
   module.project.google_logging_project_sink.sink["notice"]:
     custom_writer_identity: null
+    deletion_policy: DELETE
     description: notice (Terraform-managed).
     destination: pubsub.googleapis.com/projects/project-id/topics/pubsub_sink
     disabled: false
@@ -180,6 +189,7 @@ values:
     unique_writer_identity: true
   module.project.google_logging_project_sink.sink["warnings"]:
     custom_writer_identity: null
+    deletion_policy: DELETE
     description: warnings (Terraform-managed).
     destination: storage.googleapis.com/test-gcs_sink
     disabled: false
@@ -425,42 +435,49 @@ values:
     project: test-host
     role: roles/vpcaccess.user
   module.project.google_project_service.project_services["apigee.googleapis.com"]:
+    deletion_policy: DELETE
     disable_dependent_services: false
     disable_on_destroy: false
     project: test-project
     service: apigee.googleapis.com
     timeouts: null
   module.project.google_project_service.project_services["bigquery.googleapis.com"]:
+    deletion_policy: DELETE
     disable_dependent_services: false
     disable_on_destroy: false
     project: test-project
     service: bigquery.googleapis.com
     timeouts: null
   module.project.google_project_service.project_services["compute.googleapis.com"]:
+    deletion_policy: DELETE
     disable_dependent_services: false
     disable_on_destroy: false
     project: test-project
     service: compute.googleapis.com
     timeouts: null
   module.project.google_project_service.project_services["container.googleapis.com"]:
+    deletion_policy: DELETE
     disable_dependent_services: false
     disable_on_destroy: false
     project: test-project
     service: container.googleapis.com
     timeouts: null
   module.project.google_project_service.project_services["logging.googleapis.com"]:
+    deletion_policy: DELETE
     disable_dependent_services: false
     disable_on_destroy: false
     project: test-project
     service: logging.googleapis.com
     timeouts: null
   module.project.google_project_service.project_services["run.googleapis.com"]:
+    deletion_policy: DELETE
     disable_dependent_services: false
     disable_on_destroy: false
     project: test-project
     service: run.googleapis.com
     timeouts: null
   module.project.google_project_service.project_services["storage.googleapis.com"]:
+    deletion_policy: DELETE
     disable_dependent_services: false
     disable_on_destroy: false
     project: test-project
@@ -487,16 +504,20 @@ values:
     bucket: test-gcs_sink
     condition: []
     role: roles/storage.objectCreator
+    timeouts: null
   module.pubsub.google_pubsub_topic.default:
+    deletion_policy: DELETE
     effective_labels:
       goog-terraform-provisioned: 'true'
     ingestion_data_source_settings: []
     kms_key_name: null
     labels: null
     message_retention_duration: null
+    message_transforms: []
     name: pubsub_sink
     project: project-id
     schema_settings: []
+    tags: null
     terraform_labels:
       goog-terraform-provisioned: 'true'
     timeouts: null

--- a/tests/modules/project/examples/logging.yaml
+++ b/tests/modules/project/examples/logging.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,6 +28,7 @@ values:
     default_partition_expiration_ms: null
     default_table_expiration_ms: null
     delete_contents_on_destroy: true
+    deletion_policy: DELETE
     description: Terraform managed.
     effective_labels:
       goog-terraform-provisioned: 'true'
@@ -60,6 +61,7 @@ values:
       goog-terraform-provisioned: 'true'
     timeouts: null
   module.destination-project.google_project_service.project_services["logging.googleapis.com"]:
+    deletion_policy: DELETE
     disable_dependent_services: false
     disable_on_destroy: false
     project: test-dest-prj
@@ -70,6 +72,7 @@ values:
     cors: []
     custom_placement_config: []
     default_event_based_hold: null
+    deletion_policy: DELETE
     effective_labels:
       goog-terraform-provisioned: 'true'
     enable_object_retention: null
@@ -103,6 +106,7 @@ values:
     project: test-project
   module.project-host.google_logging_project_sink.sink["alert"]:
     custom_writer_identity: null
+    deletion_policy: DELETE
     description: alert (Terraform-managed).
     destination: logging.googleapis.com/projects/test-dest-prj
     disabled: false
@@ -113,6 +117,7 @@ values:
     unique_writer_identity: true
   module.project-host.google_logging_project_sink.sink["debug"]:
     custom_writer_identity: null
+    deletion_policy: DELETE
     description: debug (Terraform-managed).
     disabled: false
     exclusions:
@@ -128,6 +133,7 @@ values:
     bigquery_options:
     - use_partitioned_tables: false
     custom_writer_identity: null
+    deletion_policy: DELETE
     description: info (Terraform-managed).
     disabled: false
     exclusions: []
@@ -137,6 +143,7 @@ values:
     unique_writer_identity: true
   module.project-host.google_logging_project_sink.sink["notice"]:
     custom_writer_identity: null
+    deletion_policy: DELETE
     description: notice (Terraform-managed).
     destination: pubsub.googleapis.com/projects/project-id/topics/pubsub_sink
     disabled: false
@@ -147,6 +154,7 @@ values:
     unique_writer_identity: true
   module.project-host.google_logging_project_sink.sink["warnings"]:
     custom_writer_identity: null
+    deletion_policy: DELETE
     description: warnings (Terraform-managed).
     destination: storage.googleapis.com/test-gcs_sink
     disabled: false
@@ -179,6 +187,7 @@ values:
     project: projects/test-dest-prj
     role: roles/logging.logWriter
   module.project-host.google_project_service.project_services["logging.googleapis.com"]:
+    deletion_policy: DELETE
     disable_dependent_services: false
     disable_on_destroy: false
     project: test-project
@@ -195,6 +204,7 @@ values:
     role: roles/storage.objectCreator
     timeouts: null
   module.pubsub.google_pubsub_topic.default:
+    deletion_policy: DELETE
     effective_labels:
       goog-terraform-provisioned: 'true'
     ingestion_data_source_settings: []
@@ -226,3 +236,5 @@ counts:
   google_storage_bucket_iam_member: 1
   modules: 6
   resources: 21
+
+outputs: {}


### PR DESCRIPTION
Fixes #4030.

### Problem
When creating logging sinks targeting a Cloud Logging bucket in a project using the `billing-account`, `folder`, `organization`, or `project` modules, log routing can fail with `log_bucket_not_found` or permission denied errors.

In `google_project_iam_member.bucket_sinks_binding`, the CEL condition expression was previously defined as:
```hcl
expression = "resource.name.endsWith('${each.value.destination}')"
```
When `destination` is configured with a project ID string (e.g., `projects/my-project/locations/europe-west8/buckets/audit-logs`), this generated the CEL expression:
```
resource.name.endsWith('projects/my-project/locations/europe-west8/buckets/audit-logs')
```
However, Google Cloud IAM evaluates `resource.name` at runtime using the numeric Project Number (e.g., `projects/123456789012/locations/europe-west8/buckets/audit-logs`). Because the runtime resource name starts with `projects/123456789012/...` instead of `projects/my-project/...`, the `.endsWith()` condition evaluated to `false`, denying `roles/logging.bucketWriter` to the sink's service account.

### Solution
Since `google_project_iam_member.bucket_sinks_binding` is already explicitly attached to the target project (`project = split("/", each.value.destination)[1]`), a Cloud Logging bucket within that project is uniquely identified by its location and bucket ID.

We updated the CEL condition expression across `billing-account`, `folder`, `organization`, and `project` modules to match on the trailing location and bucket path:
```hcl
expression = "resource.name.endsWith('locations/${split("/", each.value.destination)[3]}/buckets/${split("/", each.value.destination)[5]}')"
```
This produces the project-number-independent expression:
```
resource.name.endsWith('locations/europe-west8/buckets/audit-logs')
```
which evaluates correctly regardless of whether `destination` was configured with a string Project ID or numeric Project Number.

### Verification & E2E Testing

#### 1. Live Sandbox E2E Deployment
We performed an end-to-end sandbox deployment test against a live GCP test project:
- Deployed a test Cloud Logging bucket (`locations/global/buckets/test-bucket`) using `modules/logging-bucket`.
- Deployed a logging sink and conditional IAM binding using `modules/project`.
- Verified that `terraform apply` succeeded cleanly and that GCP IAM accepted the updated condition expression on `roles/logging.bucketWriter` without errors.
- Verified cleanly destroying all resources via `terraform destroy`.

#### 2. IAM Policy Troubleshooter Verification (`policytroubleshooter.googleapis.com`)
To verify the exact runtime evaluation behavior of Google Cloud's IAM policy engine, we deployed two `roles/logging.bucketWriter` conditional bindings on a test project and evaluated them using the official IAM Policy Troubleshooter API (`gcloud policy-troubleshoot iam`) against the runtime target resource name using a numeric Project Number (`//logging.googleapis.com/projects/123456789012/locations/global/buckets/test-bucket`):

- **Old Condition** (`resource.name.endsWith('projects/my-project/locations/global/buckets/test-bucket')`):
  - Result: **`NOT_GRANTED` (`false`)** — Denied because `projects/123456789012/...` does not match the string project ID prefix.
- **New Condition** (`resource.name.endsWith('locations/global/buckets/test-bucket')`):
  - Result: **`GRANTED` (`true`)** — Successfully matched the trailing path and granted `logging.buckets.write`.

#### 3. Automated Test Suite
- Regenerated and verified all module-level plan inventories (`tftest.yaml`) and example inventories across `modules/billing-account`, `modules/folder`, `modules/organization`, and `modules/project`.
- Verified all documentation tables (`check_documentation.py`), copyright boilerplate (`check_boilerplate.py`), and Terraform formatting (`terraform fmt`).
