### PR TITLE
deletion_policy for service account module

### DIFF
--- a/modules/iam-service-account/README.md
+++ b/modules/iam-service-account/README.md
@@ -230,11 +230,12 @@ module "service-account-with-tags" {
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [name](variables.tf#L62) | Name of the service account to create. | <code>string</code> | ✓ |  |
+| [name](variables.tf#L72) | Name of the service account to create. | <code>string</code> | ✓ |  |
 | [context](variables.tf#L17) | External context used in replacements. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [create_ignore_already_exists](variables.tf#L37) | If set to true, skip service account creation if a service account with the same email already exists. | <code>bool</code> |  | <code>null</code> |
-| [description](variables.tf#L48) | Optional description. | <code>string</code> |  | <code>null</code> |
-| [display_name](variables.tf#L55) | Display name of the service account to create. | <code>string</code> |  | <code>&#34;Terraform-managed.&#34;</code> |
+| [deletion_policy](variables.tf#L48) | Deletion policy: DELETE, ABANDON, or PREVENT. | <code>string</code> |  | <code>null</code> |
+| [description](variables.tf#L58) | Optional description. | <code>string</code> |  | <code>null</code> |
+| [display_name](variables.tf#L65) | Display name of the service account to create. | <code>string</code> |  | <code>&#34;Terraform-managed.&#34;</code> |
 | [iam](variables-iam.tf#L17) | IAM bindings in {ROLE => [MEMBERS]} format. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_billing_bindings](variables-iam.tf#L24) | Billing account role bindings granted to this service account, by arbitrary key. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_billing_roles](variables-iam.tf#L39) | Billing account roles granted to this service account, by billing account id. Non-authoritative. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
@@ -252,11 +253,11 @@ module "service-account-with-tags" {
 | [iam_sa_roles](variables-iam.tf#L171) | Service account roles granted to this service account, by service account name. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_storage_bindings](variables-iam.tf#L178) | Storage role bindings granted to this service account, by arbitrary key. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_storage_roles](variables-iam.tf#L193) | Storage roles granted to this service account, by bucket name. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [prefix](variables.tf#L68) | Prefix applied to service account names. | <code>string</code> |  | <code>null</code> |
-| [project_id](variables.tf#L79) | Project id where service account will be created. This can be left null when reusing service accounts. | <code>string</code> |  | <code>null</code> |
-| [project_number](variables.tf#L93) | Project number of var.project_id. Set this to avoid permadiffs when creating tag bindings. This can be left null when reusing service accounts and tags are not used. | <code>string</code> |  | <code>null</code> |
-| [service_account_reuse](variables.tf#L100) | Reuse existing service account if not null. Data source can be forced disabled if tag bindings are not used, or unique id is set. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [tag_bindings](variables.tf#L116) | Tag bindings for this service accounts, in key => tag value id format. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [prefix](variables.tf#L78) | Prefix applied to service account names. | <code>string</code> |  | <code>null</code> |
+| [project_id](variables.tf#L89) | Project id where service account will be created. This can be left null when reusing service accounts. | <code>string</code> |  | <code>null</code> |
+| [project_number](variables.tf#L103) | Project number of var.project_id. Set this to avoid permadiffs when creating tag bindings. This can be left null when reusing service accounts and tags are not used. | <code>string</code> |  | <code>null</code> |
+| [service_account_reuse](variables.tf#L110) | Reuse existing service account if not null. Data source can be forced disabled if tag bindings are not used, or unique id is set. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [tag_bindings](variables.tf#L126) | Tag bindings for this service accounts, in key => tag value id format. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
 
 ## Outputs
 

--- a/modules/iam-service-account/main.tf
+++ b/modules/iam-service-account/main.tf
@@ -97,6 +97,7 @@ resource "google_service_account" "service_account" {
   display_name                 = var.display_name
   description                  = var.description
   create_ignore_already_exists = var.create_ignore_already_exists
+  deletion_policy              = var.deletion_policy
 }
 
 resource "google_tags_tag_binding" "binding" {

--- a/modules/iam-service-account/variables.tf
+++ b/modules/iam-service-account/variables.tf
@@ -45,6 +45,16 @@ variable "create_ignore_already_exists" {
   }
 }
 
+variable "deletion_policy" {
+  description = "Deletion policy: DELETE, ABANDON, or PREVENT."
+  type        = string
+  default     = null
+  validation {
+    condition     = var.deletion_policy == null || contains(["ABANDON", "DELETE", "PREVENT"], var.deletion_policy)
+    error_message = "deletion_policy must be one of 'ABANDON', 'DELETE', 'PREVENT'."
+  }
+}
+
 variable "description" {
   description = "Optional description."
   type        = string

--- a/tests/modules/iam_service_account/context.yaml
+++ b/tests/modules/iam_service_account/context.yaml
@@ -1,10 +1,10 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,6 +24,7 @@ values:
   google_service_account.service_account[0]:
     account_id: prefix-test-sa
     create_ignore_already_exists: null
+    deletion_policy: DELETE
     description: null
     disabled: false
     display_name: Terraform-managed.
@@ -67,6 +68,7 @@ values:
     bucket: gcs-test-0
     condition: []
     role: roles/storage.admin
+    timeouts: null
   google_tags_tag_binding.binding["foo"]:
     tag_value: tagValues/1234567890
     timeouts: null
@@ -81,3 +83,11 @@ counts:
   google_tags_tag_binding: 1
   modules: 0
   resources: 11
+
+outputs:
+  email: prefix-test-sa@my-project-id.iam.gserviceaccount.com
+  iam_email: serviceAccount:prefix-test-sa@my-project-id.iam.gserviceaccount.com
+  id: projects/my-project-id/serviceAccounts/prefix-test-sa@my-project-id.iam.gserviceaccount.com
+  name: prefix-test-sa@my-project-id.iam.gserviceaccount.com
+  service_account: __missing__
+  unique_id: __missing__


### PR DESCRIPTION
Added support for deletion_policy for the service account module.

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
