### PR TITLE
Supplementing project.schema.json with 'logging_sinks' element

### DIFF
--- a/fast/stages/0-org-setup/schemas/project.schema.json
+++ b/fast/stages/0-org-setup/schemas/project.schema.json
@@ -578,6 +578,15 @@
         }
       }
     },
+    "logging_sinks": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-zA-Z0-9_-]+$": {
+          "$ref": "#/$defs/logging_sink"
+        }
+      }
+    },
     "metric_scopes": {
       "type": "array",
       "items": {
@@ -1975,6 +1984,57 @@
         },
         "retention": {
           "type": "number"
+        }
+      }
+    },
+    "logging_sink": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "destination",
+        "type"
+      ],
+      "properties": {
+        "bq_partitioned_table": {
+          "type": "boolean",
+          "default": false
+        },
+        "description": {
+          "type": "string"
+        },
+        "destination": {
+          "type": "string"
+        },
+        "disabled": {
+          "type": "boolean",
+          "default": false
+        },
+        "exclusions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "filter": {
+          "type": "string"
+        },
+        "iam": {
+          "type": "boolean",
+          "default": true
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "bigquery",
+            "logging",
+            "project",
+            "pubsub",
+            "storage"
+          ]
+        },
+        "unique_writer": {
+          "type": "boolean",
+          "default": true
         }
       }
     },

--- a/fast/stages/0-org-setup/schemas/project.schema.md
+++ b/fast/stages/0-org-setup/schemas/project.schema.md
@@ -178,6 +178,9 @@
 - **log_buckets**: *object*
   <br>*additional properties: false*
   - **`^[a-zA-Z0-9_-]+$`**: *reference([log_bucket](#refs-log_bucket))*
+- **logging_sinks**: *object*
+  <br>*additional properties: false*
+  - **`^[a-zA-Z0-9_-]+$`**: *reference([logging_sink](#refs-logging_sink))*
 - **metric_scopes**: *array*
   - items: *string*
 - **name**: *string*
@@ -570,6 +573,19 @@
     - **dataset_link_id**: *string*
     - **description**: *string*
   - **retention**: *number*
+- **logging_sink**<a name="refs-logging_sink"></a>: *object*
+  <br>*additional properties: false*
+  - **bq_partitioned_table**: *boolean*
+  - **description**: *string*
+  - ⁺**destination**: *string*
+  - **disabled**: *boolean*
+  - **exclusions**: *object*
+    <br>*additional properties: string*
+  - **filter**: *string*
+  - **iam**: *boolean*
+  - ⁺**type**: *string*
+    <br>*enum: ['bigquery', 'logging', 'project', 'pubsub', 'storage']*
+  - **unique_writer**: *boolean*
 - **pam_entitlements**<a name="refs-pam_entitlements"></a>: *object*
   <br>*additional properties: false*
   - **`^[a-z][a-z0-9-]{0,61}[a-z0-9]$`**: *object*

--- a/fast/stages/2-networking/schemas/project.schema.json
+++ b/fast/stages/2-networking/schemas/project.schema.json
@@ -578,6 +578,15 @@
         }
       }
     },
+    "logging_sinks": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-zA-Z0-9_-]+$": {
+          "$ref": "#/$defs/logging_sink"
+        }
+      }
+    },
     "metric_scopes": {
       "type": "array",
       "items": {
@@ -1975,6 +1984,57 @@
         },
         "retention": {
           "type": "number"
+        }
+      }
+    },
+    "logging_sink": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "destination",
+        "type"
+      ],
+      "properties": {
+        "bq_partitioned_table": {
+          "type": "boolean",
+          "default": false
+        },
+        "description": {
+          "type": "string"
+        },
+        "destination": {
+          "type": "string"
+        },
+        "disabled": {
+          "type": "boolean",
+          "default": false
+        },
+        "exclusions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "filter": {
+          "type": "string"
+        },
+        "iam": {
+          "type": "boolean",
+          "default": true
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "bigquery",
+            "logging",
+            "project",
+            "pubsub",
+            "storage"
+          ]
+        },
+        "unique_writer": {
+          "type": "boolean",
+          "default": true
         }
       }
     },

--- a/fast/stages/2-networking/schemas/project.schema.md
+++ b/fast/stages/2-networking/schemas/project.schema.md
@@ -178,6 +178,9 @@
 - **log_buckets**: *object*
   <br>*additional properties: false*
   - **`^[a-zA-Z0-9_-]+$`**: *reference([log_bucket](#refs-log_bucket))*
+- **logging_sinks**: *object*
+  <br>*additional properties: false*
+  - **`^[a-zA-Z0-9_-]+$`**: *reference([logging_sink](#refs-logging_sink))*
 - **metric_scopes**: *array*
   - items: *string*
 - **name**: *string*
@@ -570,6 +573,19 @@
     - **dataset_link_id**: *string*
     - **description**: *string*
   - **retention**: *number*
+- **logging_sink**<a name="refs-logging_sink"></a>: *object*
+  <br>*additional properties: false*
+  - **bq_partitioned_table**: *boolean*
+  - **description**: *string*
+  - ⁺**destination**: *string*
+  - **disabled**: *boolean*
+  - **exclusions**: *object*
+    <br>*additional properties: string*
+  - **filter**: *string*
+  - **iam**: *boolean*
+  - ⁺**type**: *string*
+    <br>*enum: ['bigquery', 'logging', 'project', 'pubsub', 'storage']*
+  - **unique_writer**: *boolean*
 - **pam_entitlements**<a name="refs-pam_entitlements"></a>: *object*
   <br>*additional properties: false*
   - **`^[a-z][a-z0-9-]{0,61}[a-z0-9]$`**: *object*

--- a/fast/stages/2-project-factory/schemas/project.schema.json
+++ b/fast/stages/2-project-factory/schemas/project.schema.json
@@ -578,6 +578,15 @@
         }
       }
     },
+    "logging_sinks": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-zA-Z0-9_-]+$": {
+          "$ref": "#/$defs/logging_sink"
+        }
+      }
+    },
     "metric_scopes": {
       "type": "array",
       "items": {
@@ -1975,6 +1984,57 @@
         },
         "retention": {
           "type": "number"
+        }
+      }
+    },
+    "logging_sink": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "destination",
+        "type"
+      ],
+      "properties": {
+        "bq_partitioned_table": {
+          "type": "boolean",
+          "default": false
+        },
+        "description": {
+          "type": "string"
+        },
+        "destination": {
+          "type": "string"
+        },
+        "disabled": {
+          "type": "boolean",
+          "default": false
+        },
+        "exclusions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "filter": {
+          "type": "string"
+        },
+        "iam": {
+          "type": "boolean",
+          "default": true
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "bigquery",
+            "logging",
+            "project",
+            "pubsub",
+            "storage"
+          ]
+        },
+        "unique_writer": {
+          "type": "boolean",
+          "default": true
         }
       }
     },

--- a/fast/stages/2-project-factory/schemas/project.schema.md
+++ b/fast/stages/2-project-factory/schemas/project.schema.md
@@ -178,6 +178,9 @@
 - **log_buckets**: *object*
   <br>*additional properties: false*
   - **`^[a-zA-Z0-9_-]+$`**: *reference([log_bucket](#refs-log_bucket))*
+- **logging_sinks**: *object*
+  <br>*additional properties: false*
+  - **`^[a-zA-Z0-9_-]+$`**: *reference([logging_sink](#refs-logging_sink))*
 - **metric_scopes**: *array*
   - items: *string*
 - **name**: *string*
@@ -570,6 +573,19 @@
     - **dataset_link_id**: *string*
     - **description**: *string*
   - **retention**: *number*
+- **logging_sink**<a name="refs-logging_sink"></a>: *object*
+  <br>*additional properties: false*
+  - **bq_partitioned_table**: *boolean*
+  - **description**: *string*
+  - ⁺**destination**: *string*
+  - **disabled**: *boolean*
+  - **exclusions**: *object*
+    <br>*additional properties: string*
+  - **filter**: *string*
+  - **iam**: *boolean*
+  - ⁺**type**: *string*
+    <br>*enum: ['bigquery', 'logging', 'project', 'pubsub', 'storage']*
+  - **unique_writer**: *boolean*
 - **pam_entitlements**<a name="refs-pam_entitlements"></a>: *object*
   <br>*additional properties: false*
   - **`^[a-z][a-z0-9-]{0,61}[a-z0-9]$`**: *object*

--- a/fast/stages/2-security/schemas/project.schema.json
+++ b/fast/stages/2-security/schemas/project.schema.json
@@ -578,6 +578,15 @@
         }
       }
     },
+    "logging_sinks": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-zA-Z0-9_-]+$": {
+          "$ref": "#/$defs/logging_sink"
+        }
+      }
+    },
     "metric_scopes": {
       "type": "array",
       "items": {
@@ -1975,6 +1984,57 @@
         },
         "retention": {
           "type": "number"
+        }
+      }
+    },
+    "logging_sink": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "destination",
+        "type"
+      ],
+      "properties": {
+        "bq_partitioned_table": {
+          "type": "boolean",
+          "default": false
+        },
+        "description": {
+          "type": "string"
+        },
+        "destination": {
+          "type": "string"
+        },
+        "disabled": {
+          "type": "boolean",
+          "default": false
+        },
+        "exclusions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "filter": {
+          "type": "string"
+        },
+        "iam": {
+          "type": "boolean",
+          "default": true
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "bigquery",
+            "logging",
+            "project",
+            "pubsub",
+            "storage"
+          ]
+        },
+        "unique_writer": {
+          "type": "boolean",
+          "default": true
         }
       }
     },

--- a/fast/stages/2-security/schemas/project.schema.md
+++ b/fast/stages/2-security/schemas/project.schema.md
@@ -178,6 +178,9 @@
 - **log_buckets**: *object*
   <br>*additional properties: false*
   - **`^[a-zA-Z0-9_-]+$`**: *reference([log_bucket](#refs-log_bucket))*
+- **logging_sinks**: *object*
+  <br>*additional properties: false*
+  - **`^[a-zA-Z0-9_-]+$`**: *reference([logging_sink](#refs-logging_sink))*
 - **metric_scopes**: *array*
   - items: *string*
 - **name**: *string*
@@ -570,6 +573,19 @@
     - **dataset_link_id**: *string*
     - **description**: *string*
   - **retention**: *number*
+- **logging_sink**<a name="refs-logging_sink"></a>: *object*
+  <br>*additional properties: false*
+  - **bq_partitioned_table**: *boolean*
+  - **description**: *string*
+  - ⁺**destination**: *string*
+  - **disabled**: *boolean*
+  - **exclusions**: *object*
+    <br>*additional properties: string*
+  - **filter**: *string*
+  - **iam**: *boolean*
+  - ⁺**type**: *string*
+    <br>*enum: ['bigquery', 'logging', 'project', 'pubsub', 'storage']*
+  - **unique_writer**: *boolean*
 - **pam_entitlements**<a name="refs-pam_entitlements"></a>: *object*
   <br>*additional properties: false*
   - **`^[a-z][a-z0-9-]{0,61}[a-z0-9]$`**: *object*

--- a/modules/project-factory/schemas/project.schema.json
+++ b/modules/project-factory/schemas/project.schema.json
@@ -578,6 +578,15 @@
         }
       }
     },
+    "logging_sinks": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-zA-Z0-9_-]+$": {
+          "$ref": "#/$defs/logging_sink"
+        }
+      }
+    },
     "metric_scopes": {
       "type": "array",
       "items": {
@@ -1975,6 +1984,57 @@
         },
         "retention": {
           "type": "number"
+        }
+      }
+    },
+    "logging_sink": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "destination",
+        "type"
+      ],
+      "properties": {
+        "bq_partitioned_table": {
+          "type": "boolean",
+          "default": false
+        },
+        "description": {
+          "type": "string"
+        },
+        "destination": {
+          "type": "string"
+        },
+        "disabled": {
+          "type": "boolean",
+          "default": false
+        },
+        "exclusions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "filter": {
+          "type": "string"
+        },
+        "iam": {
+          "type": "boolean",
+          "default": true
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "bigquery",
+            "logging",
+            "project",
+            "pubsub",
+            "storage"
+          ]
+        },
+        "unique_writer": {
+          "type": "boolean",
+          "default": true
         }
       }
     },

--- a/modules/project-factory/schemas/project.schema.md
+++ b/modules/project-factory/schemas/project.schema.md
@@ -178,6 +178,9 @@
 - **log_buckets**: *object*
   <br>*additional properties: false*
   - **`^[a-zA-Z0-9_-]+$`**: *reference([log_bucket](#refs-log_bucket))*
+- **logging_sinks**: *object*
+  <br>*additional properties: false*
+  - **`^[a-zA-Z0-9_-]+$`**: *reference([logging_sink](#refs-logging_sink))*
 - **metric_scopes**: *array*
   - items: *string*
 - **name**: *string*
@@ -570,6 +573,19 @@
     - **dataset_link_id**: *string*
     - **description**: *string*
   - **retention**: *number*
+- **logging_sink**<a name="refs-logging_sink"></a>: *object*
+  <br>*additional properties: false*
+  - **bq_partitioned_table**: *boolean*
+  - **description**: *string*
+  - ⁺**destination**: *string*
+  - **disabled**: *boolean*
+  - **exclusions**: *object*
+    <br>*additional properties: string*
+  - **filter**: *string*
+  - **iam**: *boolean*
+  - ⁺**type**: *string*
+    <br>*enum: ['bigquery', 'logging', 'project', 'pubsub', 'storage']*
+  - **unique_writer**: *boolean*
 - **pam_entitlements**<a name="refs-pam_entitlements"></a>: *object*
   <br>*additional properties: false*
   - **`^[a-z][a-z0-9-]{0,61}[a-z0-9]$`**: *object*


### PR DESCRIPTION
Supplementing project.schema.json with 'logging_sinks' element across all the codebase. Logging_sinks variable was already exposed in project module and correctly passed along the chain [0-org-setup|2-networking|2-security|2-project-factory] stage --> project-factory module --> project module but was missing in project.schema.json in both: stages and project-factory module what might have led to confusion.

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
