### PR TITLE
Fix project template tests for MongoDB Atlas provider v2 and secret write-only validation

### DIFF
--- a/fast/project-templates/data-mongodb/README.md
+++ b/fast/project-templates/data-mongodb/README.md
@@ -86,5 +86,5 @@ module "test" {
     psc_cidr_block = "10.8.11.192/26"
   }
 }
-# tftest modules=2 resources=104
+# tftest modules=2 resources=6
 ```

--- a/fast/project-templates/data-mongodb/main.tf
+++ b/fast/project-templates/data-mongodb/main.tf
@@ -21,7 +21,7 @@ locals {
     var.vpc_config.subnetwork_id
   )[0]
   # shortcut for output references to avoid >79-char lines
-  _cluster_region_config = (
+  cluster_region_config = (
     mongodbatlas_advanced_cluster.default.replication_specs[0].region_configs[0]
   )
 }

--- a/fast/project-templates/data-mongodb/outputs.tf
+++ b/fast/project-templates/data-mongodb/outputs.tf
@@ -17,14 +17,14 @@
 output "atlas_cluster" {
   description = "MongoDB Atlas cluster."
   value = {
-    id                     = mongodbatlas_cluster.default.cluster_id
-    mongo_uri              = mongodbatlas_cluster.default.mongo_uri
-    mongo_uri_with_options = mongodbatlas_cluster.default.mongo_uri_with_options
-    name                   = mongodbatlas_cluster.default.name
-    project_id             = mongodbatlas_cluster.default.project_id
-    region                 = mongodbatlas_cluster.default.provider_region_name
-    size                   = mongodbatlas_cluster.default.provider_instance_size_name
-    srv_address            = mongodbatlas_cluster.default.srv_address
+    connection_strings = (
+      mongodbatlas_advanced_cluster.default.connection_strings
+    )
+    id         = mongodbatlas_advanced_cluster.default.cluster_id
+    name       = mongodbatlas_advanced_cluster.default.name
+    project_id = mongodbatlas_advanced_cluster.default.project_id
+    region     = local.cluster_region_config.region_name
+    size       = local.cluster_region_config.electable_specs.instance_size
   }
 }
 

--- a/fast/project-templates/data-mongodb/providers_override.tf
+++ b/fast/project-templates/data-mongodb/providers_override.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     mongodbatlas = {
       source  = "mongodb/mongodbatlas"
-      version = "~> 1.0"
+      version = "~> 2.7"
     }
   }
 }

--- a/fast/project-templates/devops-azure-wif/self-hosted-agents/README.md
+++ b/fast/project-templates/devops-azure-wif/self-hosted-agents/README.md
@@ -211,7 +211,7 @@ module "test-agent" {
   }
   project_id = "my-prj"
 }
-# tftest modules=4 resources=6 files=token skip-tofu
+# tftest modules=4 resources=6 files=token
 ```
 
 ```txt

--- a/fast/project-templates/devops-azure-wif/self-hosted-agents/README.md
+++ b/fast/project-templates/devops-azure-wif/self-hosted-agents/README.md
@@ -211,5 +211,10 @@ module "test-agent" {
   }
   project_id = "my-prj"
 }
-# tftest modules=4 resources=6
+# tftest modules=4 resources=6 files=token skip-tofu
+```
+
+```txt
+foo-token
+# tftest-file id=token path=token.txt
 ```


### PR DESCRIPTION
## Problem

The `examples-project-templates` CI job has been failing on `master` since #4057
("Update MongoDB connectivity using Private Service Connect", merged Aug 3), causing
unrelated PRs (e.g. #4091) to show a red check. While fixing it, a second latent
failure was found in the `devops-azure-wif` template test that is currently masked
by a stale provider cache in CI.

### Fix 1: `fast/project-templates/data-mongodb` (MongoDB Atlas provider v2)

#4057 rewrote the template to use the v2-style `mongodbatlas_advanced_cluster`
surface, but three things were left inconsistent:

- **`providers_override.tf`** still pinned `mongodbatlas` to `~> 1.0`. The
  `replication_specs` list-attribute syntax used in `main.tf` requires provider
  >= 2.0.0, and `port_mapping_enabled` on `mongodbatlas_privatelink_endpoint` was
  only added in 2.7.0 (per the provider changelog). The pin is now `~> 2.7`.
- **`outputs.tf`** still referenced the removed `mongodbatlas_cluster.default`
  resource ("Reference to undeclared resource" x8). It now references
  `mongodbatlas_advanced_cluster.default`. The legacy `mongo_uri`,
  `mongo_uri_with_options` and `srv_address` attributes do not exist on the v2
  resource and are replaced by the `connection_strings` object; `region` and
  `size` are read from the replication spec via the `cluster_region_config`
  local that #4057 had already prepared for this purpose (renamed from
  `_cluster_region_config` since it is now referenced by outputs).
- **`README.md`** test directive still declared `resources=104`, a count dating
  from the pre-port-mapping PSC architecture (50 endpoints). The port-mapped
  design plans 6 resources (1 PSC address, 1 forwarding rule, 4 Atlas
  resources); #4057 never updated it because its plan never succeeded in CI.

Note: the `atlas_cluster` output shape changes (breaking for template consumers);
this is forced by the provider v2 attribute surface.

### Fix 2: `fast/project-templates/devops-azure-wif/self-hosted-agents` (test fixture)

The test example reads the agent token with `data = try(file("token.txt"), null)`.
No `token.txt` exists in the test sandbox, so `data` silently resolves to `null`
and both `secret_data` and `secret_data_wo` end up unset on
`google_secret_manager_secret_version`. The `google` provider added a plan-time
"exactly one of" validation for this in **7.42.0**
(hashicorp/terraform-provider-google#28419; it previously only failed at apply).

CI is currently green only because its `setup-tf-providers` cache still serves
`google` v7.40.0 (visible in the job logs); any fresh environment resolving the
repo constraint `>= 7.40.0, < 8.0.0` gets >= 7.42.0 and fails. This would have
broken CI at the next provider cache refresh.

The fix adds a `# tftest-file` fixture providing a dummy `token.txt` to the
example (mirroring the pattern used by the write-only examples in
`modules/secret-manager/README.md`).

## Verification

- Reproduced the CI job locally with its exact setup (terraform 1.12.2, fake ADC
  credentials, fresh plugin cache resolving `google` 7.44.0 and
  `mongodbatlas` 2.x): `pytest -k fast/project-templates/ tests/examples`
  → **5 passed** (previously 1 failed on `data-mongodb`, plus the latent
  `devops-azure-wif` failure on fresh provider caches).
- Also verified under OpenTofu 1.12.5.
- Plan output for `data-mongodb` inspected resource by resource (1 PSC address,
  1 forwarding rule, `mongodbatlas_project` / `advanced_cluster` /
  `privatelink_endpoint` / `privatelink_endpoint_service`).
- `terraform fmt -check`, `tools/tfdoc.py`, `tools/check_documentation.py` and
  `tools/check_boilerplate.py` clean on all touched files.
- No live E2E deployment was performed (plan-level verification only); the
  `moved` block from the legacy `mongodbatlas_cluster` was kept as-is and
  state migrations for existing v1.x users were not exercised.