### PR TITLE
Add traffic splitting and revision tagging to modules/cloud-run-v2

### DIFF
--- a/modules/cloud-run-v2/README.md
+++ b/modules/cloud-run-v2/README.md
@@ -22,6 +22,7 @@ Cloud Run Services and Jobs, with support for IAM roles and Eventarc trigger cre
 - [IAP Configuration](#iap-configuration)
 - [Adding GPUs](#adding-gpus)
 - [Multi-Region Service](#multi-region-service)
+- [Traffic Splitting and Revision Tagging](#traffic-splitting-and-revision-tagging)
 - [Variables](#variables)
 - [Outputs](#outputs)
 - [Fixtures](#fixtures)
@@ -1001,6 +1002,39 @@ module "cloud_run" {
 }
 # tftest inventory=multiregion.yaml
 ```
+
+## Traffic Splitting and Revision Tagging
+
+```hcl
+module "cloud_run" {
+  source     = "./fabric/modules/cloud-run-v2"
+  project_id = var.project_id
+  region     = var.region
+  name       = "example-traffic"
+  containers = {
+    hello = {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+    }
+  }
+  service_config = {
+    traffic = [
+      {
+        percent  = 90
+        revision = "example-traffic-v1"
+        type     = "TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION"
+      },
+      {
+        percent  = 10
+        revision = "example-traffic-v2"
+        tag      = "candidate"
+        type     = "TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION"
+      }
+    ]
+  }
+  deletion_protection = false
+}
+# tftest inventory=traffic.yaml
+```
 <!-- BEGIN TFDOC -->
 ## Variables
 
@@ -1021,11 +1055,11 @@ module "cloud_run" {
 | [revision](variables.tf#L197) | Revision template configurations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [service_account_config](variables-serviceaccount.tf#L17) | Service account configurations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [service_config](variables.tf#L264) | Cloud Run service specific configuration options. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [tag_bindings](variables.tf#L330) | Tag bindings for this service, in key => tag value id format. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
-| [type](variables.tf#L337) | Type of Cloud Run resource to deploy: JOB, SERVICE or WORKERPOOL. | <code>string</code> |  | <code>&#34;SERVICE&#34;</code> |
-| [volumes](variables.tf#L347) | Named volumes in containers in name => attributes format. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [tag_bindings](variables.tf#L363) | Tag bindings for this service, in key => tag value id format. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [type](variables.tf#L370) | Type of Cloud Run resource to deploy: JOB, SERVICE or WORKERPOOL. | <code>string</code> |  | <code>&#34;SERVICE&#34;</code> |
+| [volumes](variables.tf#L380) | Named volumes in containers in name => attributes format. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [vpc_connector_create](variables-vpcconnector.tf#L17) | VPC connector network configuration. Must be provided if new VPC connector is being created. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [workerpool_config](variables.tf#L381) | Cloud Run Worker Pool specific configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [workerpool_config](variables.tf#L414) | Cloud Run Worker Pool specific configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 
 ## Outputs
 

--- a/modules/cloud-run-v2/service-managed.tf
+++ b/modules/cloud-run-v2/service-managed.tf
@@ -35,6 +35,16 @@ resource "google_cloud_run_v2_service" "service" {
     }
   }
 
+  dynamic "traffic" {
+    for_each = var.service_config.traffic == null ? [] : var.service_config.traffic
+    content {
+      percent  = traffic.value.percent
+      revision = traffic.value.revision
+      tag      = traffic.value.tag
+      type     = traffic.value.type
+    }
+  }
+
   template {
     labels         = var.revision.labels
     encryption_key = var.encryption_key

--- a/modules/cloud-run-v2/service-unmanaged.tf
+++ b/modules/cloud-run-v2/service-unmanaged.tf
@@ -35,6 +35,16 @@ resource "google_cloud_run_v2_service" "service_unmanaged" {
     }
   }
 
+  dynamic "traffic" {
+    for_each = var.service_config.traffic == null ? [] : var.service_config.traffic
+    content {
+      percent  = traffic.value.percent
+      revision = traffic.value.revision
+      tag      = traffic.value.tag
+      type     = traffic.value.type
+    }
+  }
+
   template {
     labels         = var.revision.labels
     encryption_key = var.encryption_key

--- a/modules/cloud-run-v2/variables.tf
+++ b/modules/cloud-run-v2/variables.tf
@@ -294,6 +294,12 @@ variable "service_config" {
       min_instance_count = optional(number)
     }))
     timeout = optional(string)
+    traffic = optional(list(object({
+      percent  = optional(number)
+      revision = optional(string)
+      tag      = optional(string)
+      type     = optional(string)
+    })))
   })
   default  = {}
   nullable = false
@@ -323,6 +329,33 @@ variable "service_config" {
     Ingress should be one of INGRESS_TRAFFIC_ALL, INGRESS_TRAFFIC_INTERNAL_ONLY,
     INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER.
     EOF
+  }
+
+  validation {
+    condition = var.service_config.traffic == null ? true : alltrue([
+      for t in var.service_config.traffic :
+      t.type == null ? true : contains([
+        "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST",
+        "TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION"
+      ], t.type)
+    ])
+    error_message = "Traffic type should be one of TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST, TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION."
+  }
+
+  validation {
+    condition = var.service_config.traffic == null ? true : alltrue([
+      for t in var.service_config.traffic :
+      t.percent == null ? true : (t.percent >= 0 && t.percent <= 100)
+    ])
+    error_message = "Traffic percent must be between 0 and 100."
+  }
+
+  validation {
+    condition = var.service_config.traffic == null ? true : alltrue([
+      for t in var.service_config.traffic :
+      t.tag == null ? true : (length(t.tag) >= 3 && length(t.tag) <= 47)
+    ])
+    error_message = "Traffic tag length must be between 3 and 47 characters."
   }
 }
 

--- a/tests/modules/cloud_run_v2/examples/traffic.yaml
+++ b/tests/modules/cloud_run_v2/examples/traffic.yaml
@@ -1,0 +1,106 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values:
+  module.cloud_run.google_cloud_run_v2_service.service[0]:
+    annotations: null
+    binary_authorization: []
+    build_config: []
+    client: null
+    client_version: null
+    custom_audiences: null
+    default_uri_disabled: null
+    deletion_policy: DELETE
+    deletion_protection: false
+    description: null
+    effective_labels:
+      goog-terraform-provisioned: 'true'
+    iap_enabled: false
+    invoker_iam_disabled: false
+    labels: null
+    location: europe-west8
+    multi_region_settings: []
+    name: example-traffic
+    project: project-id
+    tags: null
+    template:
+    - annotations: null
+      containers:
+      - args: null
+        base_image_uri: null
+        command: null
+        depends_on: null
+        env: []
+        image: us-docker.pkg.dev/cloudrun/container/hello
+        liveness_probe: []
+        name: hello
+        readiness_probe: []
+        sandbox_launcher: null
+        source_code: []
+        volume_mounts: []
+        working_dir: null
+      encryption_key: null
+      execution_environment: EXECUTION_ENVIRONMENT_GEN1
+      gpu_zonal_redundancy_disabled: null
+      health_check_disabled: null
+      labels: null
+      node_selector: []
+      revision: null
+      service_account: example-traffic@project-id.iam.gserviceaccount.com
+      service_mesh: []
+      session_affinity: null
+      volumes: []
+      vpc_access: []
+    terraform_labels:
+      goog-terraform-provisioned: 'true'
+    timeouts: null
+    traffic:
+    - percent: 90
+      revision: example-traffic-v1
+      tag: null
+      type: TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION
+    - percent: 10
+      revision: example-traffic-v2
+      tag: candidate
+      type: TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION
+  module.cloud_run.google_project_iam_member.default["roles/logging.logWriter"]:
+    condition: []
+    member: serviceAccount:example-traffic@project-id.iam.gserviceaccount.com
+    project: project-id
+    role: roles/logging.logWriter
+  module.cloud_run.google_project_iam_member.default["roles/monitoring.metricWriter"]:
+    condition: []
+    member: serviceAccount:example-traffic@project-id.iam.gserviceaccount.com
+    project: project-id
+    role: roles/monitoring.metricWriter
+  module.cloud_run.google_service_account.service_account[0]:
+    account_id: example-traffic
+    create_ignore_already_exists: null
+    deletion_policy: DELETE
+    description: null
+    disabled: false
+    display_name: example-traffic
+    email: example-traffic@project-id.iam.gserviceaccount.com
+    member: serviceAccount:example-traffic@project-id.iam.gserviceaccount.com
+    project: project-id
+    timeouts: null
+
+counts:
+  google_cloud_run_v2_service: 1
+  google_project_iam_member: 2
+  google_service_account: 1
+  modules: 1
+  resources: 4
+
+outputs: {}

--- a/tests/modules/cloud_run_v2/examples/traffic.yaml
+++ b/tests/modules/cloud_run_v2/examples/traffic.yaml
@@ -14,57 +14,9 @@
 
 values:
   module.cloud_run.google_cloud_run_v2_service.service[0]:
-    annotations: null
-    binary_authorization: []
-    build_config: []
-    client: null
-    client_version: null
-    custom_audiences: null
-    default_uri_disabled: null
-    deletion_policy: DELETE
-    deletion_protection: false
-    description: null
-    effective_labels:
-      goog-terraform-provisioned: 'true'
-    iap_enabled: false
-    invoker_iam_disabled: false
-    labels: null
     location: europe-west8
-    multi_region_settings: []
     name: example-traffic
     project: project-id
-    tags: null
-    template:
-    - annotations: null
-      containers:
-      - args: null
-        base_image_uri: null
-        command: null
-        depends_on: null
-        env: []
-        image: us-docker.pkg.dev/cloudrun/container/hello
-        liveness_probe: []
-        name: hello
-        readiness_probe: []
-        sandbox_launcher: null
-        source_code: []
-        volume_mounts: []
-        working_dir: null
-      encryption_key: null
-      execution_environment: EXECUTION_ENVIRONMENT_GEN1
-      gpu_zonal_redundancy_disabled: null
-      health_check_disabled: null
-      labels: null
-      node_selector: []
-      revision: null
-      service_account: example-traffic@project-id.iam.gserviceaccount.com
-      service_mesh: []
-      session_affinity: null
-      volumes: []
-      vpc_access: []
-    terraform_labels:
-      goog-terraform-provisioned: 'true'
-    timeouts: null
     traffic:
     - percent: 90
       revision: example-traffic-v1
@@ -74,27 +26,6 @@ values:
       revision: example-traffic-v2
       tag: candidate
       type: TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION
-  module.cloud_run.google_project_iam_member.default["roles/logging.logWriter"]:
-    condition: []
-    member: serviceAccount:example-traffic@project-id.iam.gserviceaccount.com
-    project: project-id
-    role: roles/logging.logWriter
-  module.cloud_run.google_project_iam_member.default["roles/monitoring.metricWriter"]:
-    condition: []
-    member: serviceAccount:example-traffic@project-id.iam.gserviceaccount.com
-    project: project-id
-    role: roles/monitoring.metricWriter
-  module.cloud_run.google_service_account.service_account[0]:
-    account_id: example-traffic
-    create_ignore_already_exists: null
-    deletion_policy: DELETE
-    description: null
-    disabled: false
-    display_name: example-traffic
-    email: example-traffic@project-id.iam.gserviceaccount.com
-    member: serviceAccount:example-traffic@project-id.iam.gserviceaccount.com
-    project: project-id
-    timeouts: null
 
 counts:
   google_cloud_run_v2_service: 1
@@ -102,5 +33,3 @@ counts:
   google_service_account: 1
   modules: 1
   resources: 4
-
-outputs: {}

--- a/tests/modules/cloud_run_v2/tftest.yaml
+++ b/tests/modules/cloud_run_v2/tftest.yaml
@@ -19,4 +19,4 @@ tests:
   context-subnet-project:
   vpcconnector:
   multiregion:
-
+  traffic:

--- a/tests/modules/cloud_run_v2/traffic.tfvars
+++ b/tests/modules/cloud_run_v2/traffic.tfvars
@@ -1,0 +1,25 @@
+name       = "test-run-traffic"
+project_id = "test-project"
+region     = "europe-west8"
+
+containers = {
+  first = {
+    image = "gcr.io/cloudrun/hello"
+  }
+}
+
+service_config = {
+  traffic = [
+    {
+      percent  = 90
+      revision = "test-run-traffic-v1"
+      type     = "TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION"
+    },
+    {
+      percent  = 10
+      revision = "test-run-traffic-v2"
+      tag      = "candidate"
+      type     = "TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION"
+    }
+  ]
+}

--- a/tests/modules/cloud_run_v2/traffic.yaml
+++ b/tests/modules/cloud_run_v2/traffic.yaml
@@ -1,0 +1,118 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values:
+  google_cloud_run_v2_service.service[0]:
+    annotations: null
+    binary_authorization: []
+    build_config: []
+    client: null
+    client_version: null
+    custom_audiences: null
+    default_uri_disabled: null
+    deletion_policy: DELETE
+    deletion_protection: true
+    description: null
+    effective_labels:
+      goog-terraform-provisioned: 'true'
+    iap_enabled: false
+    invoker_iam_disabled: false
+    labels: null
+    location: europe-west8
+    multi_region_settings: []
+    name: test-run-traffic
+    project: test-project
+    tags: null
+    template:
+    - annotations: null
+      containers:
+      - args: null
+        base_image_uri: null
+        command: null
+        depends_on: null
+        env: []
+        image: gcr.io/cloudrun/hello
+        liveness_probe: []
+        name: first
+        readiness_probe: []
+        sandbox_launcher: null
+        source_code: []
+        volume_mounts: []
+        working_dir: null
+      encryption_key: null
+      execution_environment: EXECUTION_ENVIRONMENT_GEN1
+      gpu_zonal_redundancy_disabled: null
+      health_check_disabled: null
+      labels: null
+      node_selector: []
+      revision: null
+      service_account: test-run-traffic@test-project.iam.gserviceaccount.com
+      service_mesh: []
+      session_affinity: null
+      volumes: []
+      vpc_access: []
+    terraform_labels:
+      goog-terraform-provisioned: 'true'
+    timeouts: null
+    traffic:
+    - percent: 90
+      revision: test-run-traffic-v1
+      tag: null
+      type: TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION
+    - percent: 10
+      revision: test-run-traffic-v2
+      tag: candidate
+      type: TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION
+  google_project_iam_member.default["roles/logging.logWriter"]:
+    condition: []
+    member: serviceAccount:test-run-traffic@test-project.iam.gserviceaccount.com
+    project: test-project
+    role: roles/logging.logWriter
+  google_project_iam_member.default["roles/monitoring.metricWriter"]:
+    condition: []
+    member: serviceAccount:test-run-traffic@test-project.iam.gserviceaccount.com
+    project: test-project
+    role: roles/monitoring.metricWriter
+  google_service_account.service_account[0]:
+    account_id: test-run-traffic
+    create_ignore_already_exists: null
+    deletion_policy: DELETE
+    description: null
+    disabled: false
+    display_name: test-run-traffic
+    email: test-run-traffic@test-project.iam.gserviceaccount.com
+    member: serviceAccount:test-run-traffic@test-project.iam.gserviceaccount.com
+    project: test-project
+    timeouts: null
+
+counts:
+  google_cloud_run_v2_service: 1
+  google_project_iam_member: 2
+  google_service_account: 1
+  modules: 0
+  resources: 4
+
+outputs:
+  id: __missing__
+  invoke_command: __missing__
+  job: null
+  resource: __missing__
+  resource_name: __missing__
+  service: __missing__
+  service_account: __missing__
+  service_account_email: test-run-traffic@test-project.iam.gserviceaccount.com
+  service_account_iam_email: serviceAccount:test-run-traffic@test-project.iam.gserviceaccount.com
+  service_name: __missing__
+  service_uri: __missing__
+  vpc_connector: null

--- a/tests/modules/cloud_run_v2/traffic.yaml
+++ b/tests/modules/cloud_run_v2/traffic.yaml
@@ -14,57 +14,9 @@
 
 values:
   google_cloud_run_v2_service.service[0]:
-    annotations: null
-    binary_authorization: []
-    build_config: []
-    client: null
-    client_version: null
-    custom_audiences: null
-    default_uri_disabled: null
-    deletion_policy: DELETE
-    deletion_protection: true
-    description: null
-    effective_labels:
-      goog-terraform-provisioned: 'true'
-    iap_enabled: false
-    invoker_iam_disabled: false
-    labels: null
     location: europe-west8
-    multi_region_settings: []
     name: test-run-traffic
     project: test-project
-    tags: null
-    template:
-    - annotations: null
-      containers:
-      - args: null
-        base_image_uri: null
-        command: null
-        depends_on: null
-        env: []
-        image: gcr.io/cloudrun/hello
-        liveness_probe: []
-        name: first
-        readiness_probe: []
-        sandbox_launcher: null
-        source_code: []
-        volume_mounts: []
-        working_dir: null
-      encryption_key: null
-      execution_environment: EXECUTION_ENVIRONMENT_GEN1
-      gpu_zonal_redundancy_disabled: null
-      health_check_disabled: null
-      labels: null
-      node_selector: []
-      revision: null
-      service_account: test-run-traffic@test-project.iam.gserviceaccount.com
-      service_mesh: []
-      session_affinity: null
-      volumes: []
-      vpc_access: []
-    terraform_labels:
-      goog-terraform-provisioned: 'true'
-    timeouts: null
     traffic:
     - percent: 90
       revision: test-run-traffic-v1
@@ -74,27 +26,6 @@ values:
       revision: test-run-traffic-v2
       tag: candidate
       type: TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION
-  google_project_iam_member.default["roles/logging.logWriter"]:
-    condition: []
-    member: serviceAccount:test-run-traffic@test-project.iam.gserviceaccount.com
-    project: test-project
-    role: roles/logging.logWriter
-  google_project_iam_member.default["roles/monitoring.metricWriter"]:
-    condition: []
-    member: serviceAccount:test-run-traffic@test-project.iam.gserviceaccount.com
-    project: test-project
-    role: roles/monitoring.metricWriter
-  google_service_account.service_account[0]:
-    account_id: test-run-traffic
-    create_ignore_already_exists: null
-    deletion_policy: DELETE
-    description: null
-    disabled: false
-    display_name: test-run-traffic
-    email: test-run-traffic@test-project.iam.gserviceaccount.com
-    member: serviceAccount:test-run-traffic@test-project.iam.gserviceaccount.com
-    project: test-project
-    timeouts: null
 
 counts:
   google_cloud_run_v2_service: 1
@@ -102,17 +33,3 @@ counts:
   google_service_account: 1
   modules: 0
   resources: 4
-
-outputs:
-  id: __missing__
-  invoke_command: __missing__
-  job: null
-  resource: __missing__
-  resource_name: __missing__
-  service: __missing__
-  service_account: __missing__
-  service_account_email: test-run-traffic@test-project.iam.gserviceaccount.com
-  service_account_iam_email: serviceAccount:test-run-traffic@test-project.iam.gserviceaccount.com
-  service_name: __missing__
-  service_uri: __missing__
-  vpc_connector: null


### PR DESCRIPTION
### Description

This PR adds support for configuring `traffic` blocks on Cloud Run services within the `cloud-run-v2` module (`google_cloud_run_v2_service` for both managed and unmanaged revision configurations). This enables scenarios such as canary deployments, blue/green traffic splitting, and revision tagging for dedicated URIs.

Closes #4089

### Key Changes
- Added optional `traffic` list attribute and validations (for allocation type, percent bounds, and tag length constraints) to `var.service_config` in `modules/cloud-run-v2/variables.tf`.
- Added dynamic `traffic` block to `google_cloud_run_v2_service` in `modules/cloud-run-v2/service-managed.tf` and `modules/cloud-run-v2/service-unmanaged.tf`.
- Added a `Traffic Splitting and Revision Tagging` example to `modules/cloud-run-v2/README.md` and a `traffic` test scenario to `tests/modules/cloud_run_v2/tftest.yaml`.
- Regenerated documentation and test inventories.

### Testing & Verification
- **Linting & Documentation**: Verified with `tools/lint.sh`, `tools/tfdoc.py`, and `tools/check_documentation.py`.
- **Unit & Example Tests**: Ran `pytest tests/modules/cloud_run_v2` (6/6 passed) and `pytest -k 'modules and cloud-run-v2:' tests/examples` (24/24 passed).
- **Live E2E Sandbox Verification**:
  1. Deployed service with revision `v1` (tag `tag-v1`) serving 100% traffic.
  2. Applied an update deploying revision `v2` (tag `tag-v2`) with a 50/50 traffic split between `v1` and `v2`.
  3. Curled the revision-tagged URLs (`https://tag-v1---...` and `https://tag-v2---...`) and confirmed they consistently routed to `1.0.0` and `2.0.0` respectively.
  4. Curled the main service URL across 20 sequential requests and verified balanced routing (9 requests to v1, 11 requests to v2).
