### PR TITLE
Fix service agent context interpolation in project factory sub-resources

### DIFF
--- a/modules/project-factory/README.md
+++ b/modules/project-factory/README.md
@@ -281,8 +281,8 @@ Assuming keys of the form `my_folder`, `my_project`, `my_sa`, etc. this is an ex
 - `$folder_ids:my_folder`
 - `$iam_principals:my_principal`
 - `$iam_principals:service_accounts/my_project/my_sa`
-- `$iam_principals:service_agents/_self_/my_api`
-- `$iam_principals:service_agents/my_project/my_api`
+- `$iam_principals:service_agents/_self_/my_api` *only resolves for agents whose API is enabled in the project*
+- `$iam_principals:service_agents/my_project/my_api` *only resolves for agents whose API is enabled in the target project*
 - `$iam_principalsets:service_accounts/all`
 - `$kms_keys:my_key`
 - `$log_buckets:my_project/my_bucket`
@@ -664,7 +664,7 @@ service_accounts:
       roles/iam.serviceAccountUser:
         - $iam_principals:service_accounts/_self_/app-0-fe
         - $iam_principals:service_agents/_self_/compute
-        - $iam_principals:service_agents/dev-tb-app0-0/compute
+        - $iam_principals:service_agents/dev-tb-app0-0/storage
     iam_bindings_additive:
       test:
         role: roles/iam.serviceAccountUser
@@ -697,7 +697,8 @@ buckets:
     iam:
       roles/storage.objectViewer:
         - $iam_principals:service_agents/_self_/compute
-        - $iam_principals:service_agents/dev-tb-app0-0/compute
+      roles/storage.legacyObjectReader:
+        - $iam_principals:service_agents/dev-tb-app0-0/storage
     tag_bindings:
       context: $tag_values:context/gke
   app-0-bucket-b:
@@ -734,6 +735,8 @@ pubsub_topics:
     iam:
       roles/pubsub.subscriber:
         - group:team-a-admins@example.org
+      roles/pubsub.viewer:
+        - $iam_principals:service_agents/_self_/pubsub
   app-0-topic-b:
     subscriptions:
       app-0-topic-b-sub: {}

--- a/modules/project-factory/README.md
+++ b/modules/project-factory/README.md
@@ -694,6 +694,10 @@ billing_budgets:
 buckets:
   app-0-bucket-a:
     location: europe-west8
+    iam:
+      roles/storage.objectViewer:
+        - $iam_principals:service_agents/_self_/compute
+        - $iam_principals:service_agents/dev-tb-app0-0/compute
     tag_bindings:
       context: $tag_values:context/gke
   app-0-bucket-b:

--- a/modules/project-factory/aspect-types.tf
+++ b/modules/project-factory/aspect-types.tf
@@ -33,8 +33,9 @@ module "aspect-types" {
   context = merge(local.ctx, {
     iam_principals = merge(
       local.ctx_iam_principals,
-      lookup(local.self_sas_iam_emails, each.key, {}),
-      local.projects_service_agents
+      local.projects_service_agents,
+      lookup(local.per_project_service_agents, each.key, {}),
+      lookup(local.self_sas_iam_emails, each.key, {})
     )
     project_ids = merge(
       local.ctx.project_ids,

--- a/modules/project-factory/projects-bigquery.tf
+++ b/modules/project-factory/projects-bigquery.tf
@@ -59,6 +59,8 @@ module "bigquery-datasets" {
       local.ctx.iam_principals,
       local.projects_sas_iam_emails,
       local.automation_sas_iam_emails,
+      local.projects_service_agents,
+      lookup(local.per_project_service_agents, each.value.project_key, {}),
       lookup(local.self_sas_iam_emails, each.value.project_key, {})
     )
     kms_keys    = merge(local.ctx.kms_keys, local.kms_keys, local.kms_autokeys)

--- a/modules/project-factory/projects-buckets.tf
+++ b/modules/project-factory/projects-buckets.tf
@@ -81,6 +81,8 @@ module "buckets" {
       local.ctx.iam_principals,
       local.projects_sas_iam_emails,
       local.automation_sas_iam_emails,
+      local.projects_service_agents,
+      lookup(local.per_project_service_agents, each.value.project_key, {}),
       lookup(local.self_sas_iam_emails, each.value.project_key, {})
     )
     kms_keys        = merge(local.ctx.kms_keys, local.kms_keys, local.kms_autokeys)

--- a/modules/project-factory/projects-kms.tf
+++ b/modules/project-factory/projects-kms.tf
@@ -76,8 +76,9 @@ module "kms" {
       local.ctx.iam_principals,
       local.projects_sas_iam_emails,
       local.automation_sas_iam_emails,
-      lookup(local.self_sas_iam_emails, each.value.project_key, {}),
-      local.projects_service_agents
+      local.projects_service_agents,
+      lookup(local.per_project_service_agents, each.value.project_key, {}),
+      lookup(local.self_sas_iam_emails, each.value.project_key, {})
     )
     locations   = local.ctx.locations
     project_ids = local.ctx_project_ids

--- a/modules/project-factory/projects-log-buckets.tf
+++ b/modules/project-factory/projects-log-buckets.tf
@@ -51,6 +51,8 @@ module "log-buckets" {
       local.ctx.iam_principals,
       local.projects_sas_iam_emails,
       local.automation_sas_iam_emails,
+      local.projects_service_agents,
+      lookup(local.per_project_service_agents, each.value.project_key, {}),
       lookup(local.self_sas_iam_emails, each.value.project_key, {})
     )
     kms_keys    = merge(local.ctx.kms_keys, local.kms_keys, local.kms_autokeys)

--- a/modules/project-factory/projects-pubsub.tf
+++ b/modules/project-factory/projects-pubsub.tf
@@ -47,6 +47,8 @@ module "pubsub" {
       local.ctx.iam_principals,
       local.projects_sas_iam_emails,
       local.automation_sas_iam_emails,
+      local.projects_service_agents,
+      lookup(local.per_project_service_agents, each.value.project_key, {}),
       lookup(local.self_sas_iam_emails, each.value.project_key, {})
     )
     kms_keys    = merge(local.ctx.kms_keys, local.kms_keys, local.kms_autokeys)

--- a/modules/project-factory/taxonomies.tf
+++ b/modules/project-factory/taxonomies.tf
@@ -35,8 +35,9 @@ module "taxonomies" {
   context = merge(local.ctx, {
     iam_principals = merge(
       local.ctx_iam_principals,
-      lookup(local.self_sas_iam_emails, each.key, {}),
-      local.projects_service_agents
+      local.projects_service_agents,
+      lookup(local.per_project_service_agents, each.key, {}),
+      lookup(local.self_sas_iam_emails, each.key, {})
     )
     project_ids = merge(
       local.ctx.project_ids,

--- a/tests/modules/project_factory/examples/example.yaml
+++ b/tests/modules/project_factory/examples/example.yaml
@@ -197,6 +197,14 @@ values:
     uniform_bucket_level_access: true
     versioning:
     - enabled: false
+  ? module.project-factory.module.buckets["dev-ta-app0-be/app-0-bucket-a"].google_storage_bucket_iam_binding.authoritative["roles/storage.objectViewer"]
+  : bucket: test-pf-dev-ta-app0-be-app-0-bucket-a
+    condition: []
+    # members are unknown at plan time when service agent references resolve,
+    # as service agent emails embed the project number
+    members: __missing__
+    role: roles/storage.objectViewer
+    timeouts: null
   module.project-factory.module.buckets["dev-ta-app0-be/app-0-bucket-a"].google_tags_location_tag_binding.binding["context"]:
     deletion_policy: DELETE
     location: europe-west8
@@ -1070,7 +1078,7 @@ counts:
   google_service_account_iam_binding: 2
   google_service_account_iam_member: 3
   google_storage_bucket: 3
-  google_storage_bucket_iam_binding: 2
+  google_storage_bucket_iam_binding: 3
   google_storage_project_service_account: 4
   google_tags_location_tag_binding: 2
   google_tags_tag_binding: 3
@@ -1078,7 +1086,7 @@ counts:
   google_tags_tag_value: 2
   google_tags_tag_value_iam_binding: 1
   modules: 39
-  resources: 122
+  resources: 123
   terraform_data: 2
 
 outputs: {}

--- a/tests/modules/project_factory/examples/example.yaml
+++ b/tests/modules/project_factory/examples/example.yaml
@@ -197,11 +197,21 @@ values:
     uniform_bucket_level_access: true
     versioning:
     - enabled: false
+  ? module.project-factory.module.buckets["dev-ta-app0-be/app-0-bucket-a"].google_storage_bucket_iam_binding.authoritative["roles/storage.legacyObjectReader"]
+  : bucket: test-pf-dev-ta-app0-be-app-0-bucket-a
+    condition: []
+    # members must be unknown at plan time: the cross-project service agent
+    # reference resolves to an email embedding the project number, while an
+    # unresolved reference would be passed through as a known literal
+    members: __missing__
+    role: roles/storage.legacyObjectReader
+    timeouts: null
   ? module.project-factory.module.buckets["dev-ta-app0-be/app-0-bucket-a"].google_storage_bucket_iam_binding.authoritative["roles/storage.objectViewer"]
   : bucket: test-pf-dev-ta-app0-be-app-0-bucket-a
     condition: []
-    # members are unknown at plan time when service agent references resolve,
-    # as service agent emails embed the project number
+    # members must be unknown at plan time: the _self_ service agent
+    # reference resolves to an email embedding the project number, while an
+    # unresolved reference would be passed through as a known literal
     members: __missing__
     role: roles/storage.objectViewer
     timeouts: null
@@ -878,6 +888,14 @@ values:
     - group:team-a-admins@example.org
     project: test-pf-dev-ta-app0-be
     role: roles/pubsub.subscriber
+  ? module.project-factory.module.pubsub["dev-ta-app0-be/app-0-topic-a"].google_pubsub_topic_iam_binding.authoritative["roles/pubsub.viewer"]
+  : condition: []
+    # members must be unknown at plan time: the _self_ service agent
+    # reference resolves to an email embedding the project number, while an
+    # unresolved reference would be passed through as a known literal
+    members: __missing__
+    project: test-pf-dev-ta-app0-be
+    role: roles/pubsub.viewer
   ? module.project-factory.module.pubsub["dev-ta-app0-be/app-0-topic-b"].google_pubsub_subscription.default["app-0-topic-b-sub"]
   : bigquery_config: []
     cloud_storage_config: []
@@ -1073,12 +1091,12 @@ counts:
   google_project_service_identity: 5
   google_pubsub_subscription: 1
   google_pubsub_topic: 2
-  google_pubsub_topic_iam_binding: 1
+  google_pubsub_topic_iam_binding: 2
   google_service_account: 6
   google_service_account_iam_binding: 2
   google_service_account_iam_member: 3
   google_storage_bucket: 3
-  google_storage_bucket_iam_binding: 3
+  google_storage_bucket_iam_binding: 4
   google_storage_project_service_account: 4
   google_tags_location_tag_binding: 2
   google_tags_tag_binding: 3
@@ -1086,7 +1104,7 @@ counts:
   google_tags_tag_value: 2
   google_tags_tag_value_iam_binding: 1
   modules: 39
-  resources: 123
+  resources: 125
   terraform_data: 2
 
 outputs: {}


### PR DESCRIPTION
## Description

Fixes #4087.

`context.iam_principals` passed to `module.buckets` in project-factory did not include project service agents, so references like `$iam_principals:service_agents/my-project/storage` (or `service_agents/_self_/storage`) in bucket IAM were silently passed through unresolved. This worked in v42–v43 via the old `try()` resolution cascade and regressed in the v44 context refactor.

The same gap existed in the `bigquery-datasets`, `pubsub`, and `log-buckets` calls; `kms` was missing the `_self_` (`per_project_service_agents`) entries, and `aspect-types`/`taxonomies` were missing `_self_` as well. This PR aligns all of them with the merge already used by `projects-iam` and `service-accounts`. The automation and folder IAM call sites are deliberately left out of scope.

Also fixes a pre-existing README example referencing a service agent (`compute`) of a project that does not enable its API — service agent references only resolve for enabled APIs — and documents that constraint in the interpolation list.

## Testing

- Live E2E verification in test folder: confirmed bucket IAM (`_self_` storage and cross-project storage service agents) and Pub/Sub topic IAM (`_self_` pubsub service agent) resolve and grant IAM roles to the expected `service-<project_number>@...` principals. Cleanly destroyed after test.
- The main README example now exercises three independent resolution paths: bucket IAM with a `_self_` agent, bucket IAM with a cross-project agent, and pubsub topic IAM with a `_self_` agent.
- Each corresponding inventory binding asserts `members: __missing__`: resolved agent emails embed the project number and are unknown at plan time, while unresolved references would appear as known literals. Each assertion was verified to fail independently when its merge entry is removed.
- Full project-factory example suite (17 tests) and FAST `s0_org_setup` tests (5) pass; `tools/lint.sh` and `check_documentation.py` clean.
- The change set was additionally reviewed adversarially (two independent model reviews) covering merge precedence, dependency-graph cycles, `for_each` unknown-key risk (none: principals only appear in attribute values), and namespace collisions (none: `service_agents/` vs `service_accounts/` are disjoint).
