### PR TITLE
Add title, description and stage support to custom roles

### DIFF
--- a/fast/stages/0-org-setup/schemas/custom-role.schema.json
+++ b/fast/stages/0-org-setup/schemas/custom-role.schema.json
@@ -7,6 +7,23 @@
     "name": {
       "type": "string"
     },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "stage": {
+      "type": "string",
+      "enum": [
+        "ALPHA",
+        "BETA",
+        "GA",
+        "DEPRECATED",
+        "DISABLED",
+        "EAP"
+      ]
+    },
     "includedPermissions": {
       "type": "array",
       "items": {

--- a/fast/stages/0-org-setup/schemas/custom-role.schema.md
+++ b/fast/stages/0-org-setup/schemas/custom-role.schema.md
@@ -7,6 +7,10 @@
 *additional properties: false*
 
 - **name**: *string*
+- **title**: *string*
+- **description**: *string*
+- **stage**: *string*
+  <br>*enum: ['ALPHA', 'BETA', 'GA', 'DEPRECATED', 'DISABLED', 'EAP']*
 - **includedPermissions**: *array*
   - items: *string*
     <br>*pattern: ^[a-zA-Z-]+\.[a-zA-Z-]+\.[a-zA-Z-]+$*

--- a/fast/stages/3-secops-dev/main.tf
+++ b/fast/stages/3-secops-dev/main.tf
@@ -58,24 +58,28 @@ module "project" {
     project_ids    = merge(var.project_ids, var.context.project_ids)
   }
   custom_roles = {
-    "secopsDashboardViewer" = [
-      "chronicle.dashboardCharts.get",
-      "chronicle.dashboardCharts.list",
-      "chronicle.dashboardQueries.execute",
-      "chronicle.dashboardQueries.get",
-      "chronicle.dashboardQueries.list",
-      "chronicle.dashboards.get",
-      "chronicle.dashboards.list",
-      "chronicle.dashboards.schedule",
-      "chronicle.nativeDashboards.get",
-      "chronicle.nativeDashboards.list"
-    ]
-    "secopsDataViewer" = [
-      "chronicle.legacies.legacyFindRawLogs",
-      "chronicle.legacies.legacySearchRawLogs",
-      "chronicle.referenceLists.get",
-      "chronicle.referenceLists.update"
-    ]
+    "secopsDashboardViewer" = {
+      permissions = [
+        "chronicle.dashboardCharts.get",
+        "chronicle.dashboardCharts.list",
+        "chronicle.dashboardQueries.execute",
+        "chronicle.dashboardQueries.get",
+        "chronicle.dashboardQueries.list",
+        "chronicle.dashboards.get",
+        "chronicle.dashboards.list",
+        "chronicle.dashboards.schedule",
+        "chronicle.nativeDashboards.get",
+        "chronicle.nativeDashboards.list"
+      ]
+    }
+    "secopsDataViewer" = {
+      permissions = [
+        "chronicle.legacies.legacyFindRawLogs",
+        "chronicle.legacies.legacySearchRawLogs",
+        "chronicle.referenceLists.get",
+        "chronicle.referenceLists.update"
+      ]
+    }
   }
   iam = {}
   iam_bindings_additive = merge(

--- a/modules/organization/README.md
+++ b/modules/organization/README.md
@@ -567,9 +567,13 @@ module "org" {
   source          = "./fabric/modules/organization"
   organization_id = var.organization_id
   custom_roles = {
-    "myRole${replace(var.prefix, "/[^a-zA-Z0-9_\\.]/", "")}" = [
-      "compute.instances.list",
-    ]
+    "myRole${replace(var.prefix, "/[^a-zA-Z0-9_\\.]/", "")}" = {
+      title       = "My custom role"
+      description = "Allows listing compute instances."
+      permissions = [
+        "compute.instances.list",
+      ]
+    }
   }
   iam = {
     (module.org.custom_role_id["myRole${replace(var.prefix, "/[^a-zA-Z0-9_\\.]/", "")}"]) = ["group:${var.group_email}"]
@@ -584,6 +588,7 @@ Custom roles can also be specified via a factory in a similar way to organizatio
 
 - the role name defaults to the file name but can be overridden via a `name` attribute in the yaml
 - role permissions are defined in an `includedPermissions` map
+- role title, description and launch stage can optionally be set via the `title`, `description` and `stage` attributes
 
 Custom roles defined via the variable are merged with those coming from the factory, and override them in case of duplicate names.
 
@@ -609,6 +614,9 @@ includedPermissions:
 # tftest-file id=custom-role-2 path=data/custom_roles/test_2.yaml
 
 name: projectViewer
+title: Project viewer
+description: Allows viewing project resources.
+stage: GA
 includedPermissions:
   - resourcemanager.projects.get
   - resourcemanager.projects.getIamPolicy
@@ -1122,7 +1130,7 @@ module "org" {
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [organization_id](variables.tf#L303) | Organization id in organizations/nnnnnn format. | <code>string</code> | ✓ |  |
+| [organization_id](variables.tf#L317) | Organization id in organizations/nnnnnn format. | <code>string</code> | ✓ |  |
 | [access_levels](variables.tf#L18) | Access level definitions. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [access_policy](variables.tf#L118) | Access Policy name or ID, required if creating access levels. | <code>string</code> |  | <code>null</code> |
 | [asset_feeds](variables.tf#L124) | Cloud Asset Inventory feeds. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
@@ -1130,9 +1138,9 @@ module "org" {
 | [contacts](variables.tf#L167) | List of essential contacts for this resource. Must be in the form EMAIL -> [NOTIFICATION_TYPES]. Valid notification types are ALL, SUSPENSION, SECURITY, TECHNICAL, BILLING, LEGAL, PRODUCT_UPDATES. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [context](variables.tf#L185) | Context-specific interpolations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [context_aware_access_bindings](variables.tf#L211) | GCP User Access Bindings for securing Console and APIs. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [custom_roles](variables.tf#L229) | Map of role name => list of permissions to create in this project. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [factories_config](variables.tf#L236) | Paths to data files and folders that enable factory functionality. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [firewall_policy](variables.tf#L252) | Hierarchical firewall policies to associate to the organization. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [custom_roles](variables.tf#L229) | Map of role name => role attributes to create in this organization. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [factories_config](variables.tf#L250) | Paths to data files and folders that enable factory functionality. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [firewall_policy](variables.tf#L266) | Hierarchical firewall policies to associate to the organization. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
 | [iam](variables-iam.tf#L17) | Authoritative IAM bindings in {ROLE => [MEMBERS]} format. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_bindings](variables-iam.tf#L24) | Authoritative IAM bindings in {KEY => {role = ROLE, members = [], condition = {}}}. Keys are arbitrary. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_bindings_additive](variables-iam.tf#L39) | Individual additive IAM bindings. Keys are arbitrary. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
@@ -1145,12 +1153,12 @@ module "org" {
 | [logging_settings](variables-logging.tf#L35) | Default settings for logging resources. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
 | [logging_sinks](variables-logging.tf#L45) | Logging sinks to create for the organization. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [network_tags](variables-tags.tf#L17) | Network tags by key name. If `id` is provided, key creation is skipped. The `iam` attribute behaves like the similarly named one at module level. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [org_policies](variables.tf#L261) | Organization policies applied to this organization keyed by policy name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [org_policy_custom_constraints](variables.tf#L289) | Organization policy custom constraints keyed by constraint name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [org_policies](variables.tf#L275) | Organization policies applied to this organization keyed by policy name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [org_policy_custom_constraints](variables.tf#L303) | Organization policy custom constraints keyed by constraint name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [pam_entitlements](variables-pam.tf#L17) | Privileged Access Manager entitlements for this resource, keyed by entitlement ID. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [scc_mute_configs](variables-scc.tf#L17) | SCC mute configurations keyed by name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [scc_sha_custom_modules](variables-scc.tf#L28) | SCC custom modules keyed by module name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [service_agents_config](variables.tf#L312) | Service agents configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [service_agents_config](variables.tf#L326) | Service agents configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [tag_bindings](variables-tags.tf#L89) | Tag bindings for this organization, in key => tag value id format. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
 | [tags](variables-tags.tf#L96) | Tags by key name. If `id` is provided, key or value creation is skipped. The `iam` attribute behaves like the similarly named one at module level. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [tags_config](variables-tags.tf#L171) | Fine-grained control on tag resource and IAM creation. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |

--- a/modules/organization/iam.tf
+++ b/modules/organization/iam.tf
@@ -45,13 +45,19 @@ locals {
     {
       for k, v in local._custom_roles : k => {
         name        = lookup(v, "name", k)
+        title       = lookup(v, "title", null)
+        description = lookup(v, "description", null)
+        stage       = lookup(v, "stage", null)
         permissions = v["includedPermissions"]
       }
     },
     {
       for k, v in var.custom_roles : k => {
         name        = k
-        permissions = v
+        title       = v.title
+        description = v.description
+        stage       = v.stage
+        permissions = v.permissions
       }
     }
   )
@@ -116,11 +122,16 @@ check "custom_roles" {
 }
 
 resource "google_organization_iam_custom_role" "roles" {
-  for_each    = local.custom_roles
-  org_id      = local.organization_id_numeric
-  role_id     = each.value.name
-  title       = "Custom role ${each.value.name}"
-  description = "Terraform-managed."
+  for_each = local.custom_roles
+  org_id   = local.organization_id_numeric
+  role_id  = each.value.name
+  title = coalesce(
+    each.value.title, "Custom role ${each.value.name}"
+  )
+  description = coalesce(
+    each.value.description, "Terraform-managed."
+  )
+  stage       = each.value.stage
   permissions = each.value.permissions
 }
 

--- a/modules/organization/schemas/custom-role.schema.json
+++ b/modules/organization/schemas/custom-role.schema.json
@@ -7,6 +7,23 @@
     "name": {
       "type": "string"
     },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "stage": {
+      "type": "string",
+      "enum": [
+        "ALPHA",
+        "BETA",
+        "GA",
+        "DEPRECATED",
+        "DISABLED",
+        "EAP"
+      ]
+    },
     "includedPermissions": {
       "type": "array",
       "items": {

--- a/modules/organization/schemas/custom-role.schema.md
+++ b/modules/organization/schemas/custom-role.schema.md
@@ -7,6 +7,10 @@
 *additional properties: false*
 
 - **name**: *string*
+- **title**: *string*
+- **description**: *string*
+- **stage**: *string*
+  <br>*enum: ['ALPHA', 'BETA', 'GA', 'DEPRECATED', 'DISABLED', 'EAP']*
 - **includedPermissions**: *array*
   - items: *string*
     <br>*pattern: ^[a-zA-Z-]+\.[a-zA-Z-]+\.[a-zA-Z-]+$*

--- a/modules/organization/variables.tf
+++ b/modules/organization/variables.tf
@@ -227,10 +227,24 @@ variable "context_aware_access_bindings" {
 }
 
 variable "custom_roles" {
-  description = "Map of role name => list of permissions to create in this project."
-  type        = map(list(string))
-  default     = {}
-  nullable    = false
+  description = "Map of role name => role attributes to create in this organization."
+  type = map(object({
+    permissions = list(string)
+    title       = optional(string)
+    description = optional(string)
+    stage       = optional(string)
+  }))
+  default  = {}
+  nullable = false
+  validation {
+    condition = alltrue([
+      for k, v in var.custom_roles : contains(
+        ["ALPHA", "BETA", "GA", "DEPRECATED", "DISABLED", "EAP"],
+        coalesce(v.stage, "GA")
+      )
+    ])
+    error_message = "Stage must be one of ALPHA, BETA, GA, DEPRECATED, DISABLED, EAP."
+  }
 }
 
 variable "factories_config" {

--- a/modules/project/README.md
+++ b/modules/project/README.md
@@ -1385,9 +1385,13 @@ module "project" {
   source = "./fabric/modules/project"
   name   = "project"
   custom_roles = {
-    "myRole" = [
-      "compute.instances.list",
-    ]
+    "myRole" = {
+      title       = "My custom role"
+      description = "Allows listing compute instances."
+      permissions = [
+        "compute.instances.list",
+      ]
+    }
   }
   context = {
     condition_vars = {
@@ -1428,6 +1432,7 @@ Custom roles can also be specified via a factory in a similar way to organizatio
 
 - the role name defaults to the file name but can be overridden via a `name` attribute in the yaml
 - role permissions are defined in an `includedPermissions` map
+- role title, description and launch stage can optionally be set via the `title`, `description` and `stage` attributes
 
 Custom roles defined via the variable are merged with those coming from the factory, and override them in case of duplicate names.
 
@@ -1451,6 +1456,9 @@ includedPermissions:
 
 ```yaml
 name: projectViewer
+title: Project viewer
+description: Allows viewing project resources.
+stage: GA
 includedPermissions:
   - resourcemanager.projects.get
   - resourcemanager.projects.getIamPolicy
@@ -2360,7 +2368,7 @@ module "project" {
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [name](variables.tf#L252) | Project name and id suffix. | <code>string</code> | ✓ |  |
+| [name](variables.tf#L266) | Project name and id suffix. | <code>string</code> | ✓ |  |
 | [alerts](variables-observability.tf#L17) | Monitoring alerts. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [asset_feeds](variables.tf#L18) | Cloud Asset Inventory feeds. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [asset_search](variables.tf#L51) | Cloud Asset Inventory search configurations. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
@@ -2370,12 +2378,12 @@ module "project" {
 | [compute_metadata](variables.tf#L110) | Optional compute metadata key/values. Only usable if compute API has been enabled. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
 | [contacts](variables.tf#L117) | List of essential contacts for this resource. Must be in the form EMAIL -> [NOTIFICATION_TYPES]. Valid notification types are ALL, SUSPENSION, SECURITY, TECHNICAL, BILLING, LEGAL, PRODUCT_UPDATES. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [context](variables.tf#L135) | Context-specific interpolations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [custom_roles](variables.tf#L162) | Map of role name => list of permissions to create in this project. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [default_network_tier](variables.tf#L169) | Default compute network tier for the project. | <code>string</code> |  | <code>null</code> |
-| [default_service_account](variables.tf#L175) | Project default service account setting: can be one of `delete`, `deprivilege`, `disable`, or `keep`. | <code>string</code> |  | <code>&#34;keep&#34;</code> |
-| [deletion_policy](variables.tf#L188) | Deletion policy setting for this project. | <code>string</code> |  | <code>&#34;DELETE&#34;</code> |
-| [descriptive_name](variables.tf#L199) | Descriptive project name. Set when name differs from project id. | <code>string</code> |  | <code>null</code> |
-| [factories_config](variables.tf#L205) | Paths to data files and folders that enable factory functionality. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [custom_roles](variables.tf#L162) | Map of role name => role attributes to create in this project. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [default_network_tier](variables.tf#L183) | Default compute network tier for the project. | <code>string</code> |  | <code>null</code> |
+| [default_service_account](variables.tf#L189) | Project default service account setting: can be one of `delete`, `deprivilege`, `disable`, or `keep`. | <code>string</code> |  | <code>&#34;keep&#34;</code> |
+| [deletion_policy](variables.tf#L202) | Deletion policy setting for this project. | <code>string</code> |  | <code>&#34;DELETE&#34;</code> |
+| [descriptive_name](variables.tf#L213) | Descriptive project name. Set when name differs from project id. | <code>string</code> |  | <code>null</code> |
+| [factories_config](variables.tf#L219) | Paths to data files and folders that enable factory functionality. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam](variables-iam.tf#L17) | Authoritative IAM bindings in {ROLE => [MEMBERS]} format. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_bindings](variables-iam.tf#L24) | Authoritative IAM bindings in {KEY => {role = ROLE, members = [], condition = {}}}. Keys are arbitrary. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_bindings_additive](variables-iam.tf#L39) | Individual additive IAM bindings. Keys are arbitrary. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
@@ -2383,9 +2391,9 @@ module "project" {
 | [iam_by_principals_additive](variables-iam.tf#L54) | Additive IAM binding in {PRINCIPAL => [ROLES]} format. Principals need to be statically defined to avoid errors. Merged internally with the `iam_bindings_additive` variable. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_by_principals_conditional](variables-iam.tf#L68) | Authoritative IAM binding in {PRINCIPAL => {roles = [roles], condition = {cond}}} format. Principals need to be statically defined to avoid errors. Condition is required. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_deny_policies](variables-iam.tf#L98) | IAM Deny policies to be applied to the project. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [kms_autokeys](variables.tf#L221) | KMS Autokey key handles. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [labels](variables.tf#L239) | Resource labels. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
-| [lien_reason](variables.tf#L246) | If non-empty, creates a project lien with this description. | <code>string</code> |  | <code>null</code> |
+| [kms_autokeys](variables.tf#L235) | KMS Autokey key handles. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [labels](variables.tf#L253) | Resource labels. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [lien_reason](variables.tf#L260) | If non-empty, creates a project lien with this description. | <code>string</code> |  | <code>null</code> |
 | [log_scopes](variables-observability.tf#L117) | Log scopes under this project. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [logging_data_access](variables-observability.tf#L127) | Control activation of data access logs. The special 'allServices' key denotes configuration for all services. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [logging_exclusions](variables-observability.tf#L138) | Logging exclusions for this project in the form {NAME -> FILTER}. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
@@ -2394,26 +2402,26 @@ module "project" {
 | [metric_scopes](variables-observability.tf#L216) | List of projects that will act as metric scopes for this project. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
 | [network_tags](variables-tags.tf#L17) | Network tags by key name. If `id` is provided, key creation is skipped. The `iam` attribute behaves like the similarly named one at module level. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [notification_channels](variables-observability.tf#L223) | Monitoring notification channels. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [org_policies](variables.tf#L257) | Organization policies applied to this project keyed by policy name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [org_policies](variables.tf#L271) | Organization policies applied to this project keyed by policy name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [pam_entitlements](variables-pam.tf#L17) | Privileged Access Manager entitlements for this resource, keyed by entitlement ID. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [parent](variables.tf#L285) | Parent folder or organization in 'folders/folder_id' or 'organizations/org_id' format. | <code>string</code> |  | <code>null</code> |
-| [prefix](variables.tf#L299) | Optional prefix used to generate project id and name. | <code>string</code> |  | <code>null</code> |
-| [project_reuse](variables.tf#L309) | Reuse existing project if not null. If name and number are not passed in, a data source is used. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [parent](variables.tf#L299) | Parent folder or organization in 'folders/folder_id' or 'organizations/org_id' format. | <code>string</code> |  | <code>null</code> |
+| [prefix](variables.tf#L313) | Optional prefix used to generate project id and name. | <code>string</code> |  | <code>null</code> |
+| [project_reuse](variables.tf#L323) | Reuse existing project if not null. If name and number are not passed in, a data source is used. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
 | [quotas](variables-quotas.tf#L17) | Service quota configuration. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [scc_mute_configs](variables-scc.tf#L17) | SCC mute configurations keyed by name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [scc_sha_custom_modules](variables-scc.tf#L28) | SCC custom modules keyed by module name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [service_agents_config](variables.tf#L329) | Automatic service agent configuration options. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [service_config](variables.tf#L341) | Configure service API activation. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#8230;&#125;</code> |
-| [service_encryption_key_ids](variables.tf#L353) | Service Agents to be granted encryption/decryption permissions over Cloud KMS encryption keys. Format {SERVICE_AGENT => [KEY_ID]}. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [services](variables.tf#L360) | Service APIs to enable. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
-| [shared_vpc_host_config](variables.tf#L366) | Configures this project as a Shared VPC host project (mutually exclusive with shared_vpc_service_project). | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [shared_vpc_service_config](variables.tf#L376) | Configures this project as a Shared VPC service project (mutually exclusive with shared_vpc_host_config). | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#8230;&#125;</code> |
-| [skip_delete](variables.tf#L413) | Deprecated. Use deletion_policy. | <code>bool</code> |  | <code>null</code> |
+| [service_agents_config](variables.tf#L343) | Automatic service agent configuration options. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [service_config](variables.tf#L355) | Configure service API activation. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#8230;&#125;</code> |
+| [service_encryption_key_ids](variables.tf#L367) | Service Agents to be granted encryption/decryption permissions over Cloud KMS encryption keys. Format {SERVICE_AGENT => [KEY_ID]}. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [services](variables.tf#L374) | Service APIs to enable. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
+| [shared_vpc_host_config](variables.tf#L380) | Configures this project as a Shared VPC host project (mutually exclusive with shared_vpc_service_project). | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [shared_vpc_service_config](variables.tf#L390) | Configures this project as a Shared VPC service project (mutually exclusive with shared_vpc_host_config). | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#8230;&#125;</code> |
+| [skip_delete](variables.tf#L427) | Deprecated. Use deletion_policy. | <code>bool</code> |  | <code>null</code> |
 | [tag_bindings](variables-tags.tf#L89) | Tag bindings for this project, in key => tag value id format. | <code>map&#40;string&#41;</code> |  | <code>null</code> |
 | [tags](variables-tags.tf#L96) | Tags by key name. If `id` is provided, key or value creation is skipped. The `iam` attribute behaves like the similarly named one at module level. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [tags_config](variables-tags.tf#L171) | Fine-grained control on tag resource and IAM creation. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [universe](variables.tf#L425) | GCP universe where to deploy the project. The prefix will be prepended to the project id. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [vpc_sc](variables.tf#L436) | VPC-SC configuration for the project, use when `ignore_changes` for resources is set in the VPC-SC module. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [universe](variables.tf#L439) | GCP universe where to deploy the project. The prefix will be prepended to the project id. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [vpc_sc](variables.tf#L450) | VPC-SC configuration for the project, use when `ignore_changes` for resources is set in the VPC-SC module. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
 | [workload_identity_pools](variables-identity-providers.tf#L17) | Workload Identity Federation pools and providers. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 
 ## Outputs

--- a/modules/project/iam.tf
+++ b/modules/project/iam.tf
@@ -61,13 +61,19 @@ locals {
     {
       for k, v in local._custom_roles : k => {
         name        = lookup(v, "name", k)
+        title       = lookup(v, "title", null)
+        description = lookup(v, "description", null)
+        stage       = lookup(v, "stage", null)
         permissions = v["includedPermissions"]
       }
     },
     {
       for k, v in var.custom_roles : k => {
         name        = k
-        permissions = v
+        title       = v.title
+        description = v.description
+        stage       = v.stage
+        permissions = v.permissions
       }
     }
   )
@@ -137,11 +143,16 @@ check "custom_roles" {
 }
 
 resource "google_project_iam_custom_role" "roles" {
-  for_each    = local.custom_roles
-  project     = local.project.project_id
-  role_id     = each.value.name
-  title       = "Custom role ${each.value.name}"
-  description = "Terraform-managed."
+  for_each = local.custom_roles
+  project  = local.project.project_id
+  role_id  = each.value.name
+  title = coalesce(
+    each.value.title, "Custom role ${each.value.name}"
+  )
+  description = coalesce(
+    each.value.description, "Terraform-managed."
+  )
+  stage       = each.value.stage
   permissions = each.value.permissions
 }
 

--- a/modules/project/schemas/custom-role.schema.json
+++ b/modules/project/schemas/custom-role.schema.json
@@ -7,6 +7,23 @@
     "name": {
       "type": "string"
     },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "stage": {
+      "type": "string",
+      "enum": [
+        "ALPHA",
+        "BETA",
+        "GA",
+        "DEPRECATED",
+        "DISABLED",
+        "EAP"
+      ]
+    },
     "includedPermissions": {
       "type": "array",
       "items": {

--- a/modules/project/schemas/custom-role.schema.md
+++ b/modules/project/schemas/custom-role.schema.md
@@ -7,6 +7,10 @@
 *additional properties: false*
 
 - **name**: *string*
+- **title**: *string*
+- **description**: *string*
+- **stage**: *string*
+  <br>*enum: ['ALPHA', 'BETA', 'GA', 'DEPRECATED', 'DISABLED', 'EAP']*
 - **includedPermissions**: *array*
   - items: *string*
     <br>*pattern: ^[a-zA-Z-]+\.[a-zA-Z-]+\.[a-zA-Z-]+$*

--- a/modules/project/variables.tf
+++ b/modules/project/variables.tf
@@ -160,10 +160,24 @@ variable "context" {
 }
 
 variable "custom_roles" {
-  description = "Map of role name => list of permissions to create in this project."
-  type        = map(list(string))
-  default     = {}
-  nullable    = false
+  description = "Map of role name => role attributes to create in this project."
+  type = map(object({
+    permissions = list(string)
+    title       = optional(string)
+    description = optional(string)
+    stage       = optional(string)
+  }))
+  default  = {}
+  nullable = false
+  validation {
+    condition = alltrue([
+      for k, v in var.custom_roles : contains(
+        ["ALPHA", "BETA", "GA", "DEPRECATED", "DISABLED", "EAP"],
+        coalesce(v.stage, "GA")
+      )
+    ])
+    error_message = "Stage must be one of ALPHA, BETA, GA, DEPRECATED, DISABLED, EAP."
+  }
 }
 
 variable "default_network_tier" {

--- a/tests/modules/organization/examples/custom-roles.yaml
+++ b/tests/modules/organization/examples/custom-roles.yaml
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,17 +13,8 @@
 # limitations under the License.
 
 values:
-  module.org.google_organization_iam_custom_role.roles["test_2"]:
-    description: Terraform-managed.
-    org_id: '1122334455'
-    permissions:
-    - resourcemanager.projects.get
-    - resourcemanager.projects.getIamPolicy
-    - resourcemanager.projects.list
-    role_id: projectViewer
-    stage: GA
-    title: Custom role projectViewer
   module.org.google_organization_iam_custom_role.roles["test_1"]:
+    deletion_policy: DELETE
     description: Terraform-managed.
     org_id: '1122334455'
     permissions:
@@ -31,6 +22,17 @@ values:
     role_id: test_1
     stage: GA
     title: Custom role test_1
+  module.org.google_organization_iam_custom_role.roles["test_2"]:
+    deletion_policy: DELETE
+    description: Allows viewing project resources.
+    org_id: '1122334455'
+    permissions:
+    - resourcemanager.projects.get
+    - resourcemanager.projects.getIamPolicy
+    - resourcemanager.projects.list
+    role_id: projectViewer
+    stage: GA
+    title: Project viewer
 
 counts:
   google_organization_iam_custom_role: 2

--- a/tests/modules/organization/examples/roles.yaml
+++ b/tests/modules/organization/examples/roles.yaml
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,14 +20,19 @@ values:
     org_id: '1122334455'
     role: organizations/1122334455/roles/myRoletest
   module.org.google_organization_iam_custom_role.roles["myRoletest"]:
-    description: Terraform-managed.
+    deletion_policy: DELETE
+    description: Allows listing compute instances.
     org_id: '1122334455'
     permissions:
     - compute.instances.list
     role_id: myRoletest
     stage: GA
-    title: Custom role myRoletest
+    title: My custom role
 
 counts:
   google_organization_iam_binding: 1
   google_organization_iam_custom_role: 1
+  modules: 1
+  resources: 2
+
+outputs: {}

--- a/tests/modules/project/examples/custom-role-iam.yaml
+++ b/tests/modules/project/examples/custom-role-iam.yaml
@@ -1,10 +1,10 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -46,13 +46,14 @@ values:
     project: project
     role: roles/resourcemanager.projectIamAdmin
   module.project.google_project_iam_custom_role.roles["myRole"]:
-    description: Terraform-managed.
+    deletion_policy: DELETE
+    description: Allows listing compute instances.
     permissions:
     - compute.instances.list
     project: project
     role_id: myRole
     stage: GA
-    title: Custom role myRole
+    title: My custom role
 
 counts:
   google_project: 1


### PR DESCRIPTION
Fixes #4101

This PR enhances custom role management in both `modules/organization` and `modules/project` by adding support for explicit `title`, `description`, and `stage` attributes alongside `permissions`. This
allows cleanly creating or importing existing custom roles with their full metadata.

### Key Changes
- **Module Variables**:
  - Updated `var.custom_roles` type in `modules/organization` and `modules/project` from `map(list(string))` to `map(object({ permissions = list(string), title = optional(string), description =
optional(string), stage = optional(string) }))`.
  - Added plan-time validation ensuring `stage` matches allowed values (`ALPHA`, `BETA`, `GA`, `DEPRECATED`, `DISABLED`, `EAP`).
- **Resource Definitions**:
  - Updated `google_organization_iam_custom_role` and `google_project_iam_custom_role` to use configured `title`, `description`, and `stage`, retaining default fallbacks (`"Custom role <name>"` and
`"Terraform-managed."`) when omitted.
- **Factory Schemas & Documentation**:
  - Updated `custom-role.schema.json` and generated `custom-role.schema.md` in `modules/organization`, `modules/project`, and `fast/stages/0-org-setup`.
- **FAST & Examples**:
  - Updated `fast/stages/3-secops-dev/main.tf` to align with the new `custom_roles` object structure.
  - Updated README examples and corresponding test inventories in `tests/modules/organization` and `tests/modules/project`.

## Verification & Testing

- **FAST Stage 0 Validation**:
  - Initialized and ran `terraform plan` in `fast/stages/0-org-setup` verifying clean execution and backwards compatibility across factory datasets.
- **Module Tests**:
  - Validated test fixtures and examples in `modules/organization` and `modules/project`.

**Breaking Changes**

```upgrade-note
`modules/organization`: `custom_roles` variable type changed from `map(list(string))` to `map(object({ permissions = list(string), title = optional(string), description = optional(string), stage = optional(string) }))`. Existing code passing permission lists directly must be updated to pass `{ permissions = [...] }`.
```
```upgrade-note
`modules/project`: `custom_roles` variable type changed from `map(list(string))` to `map(object({ permissions = list(string), title = optional(string), description = optional(string), stage = optional(string) }))`. Existing code passing permission lists directly must be updated to pass `{ permissions = [...] }`.
```
