### PR TITLE
Support name overrides for routes and policy based routes in net-vpc

### DIFF
--- a/fast/stages/0-org-setup/schemas/vpc-factory.schema.json
+++ b/fast/stages/0-org-setup/schemas/vpc-factory.schema.json
@@ -75,10 +75,10 @@
       "$ref": "#/$defs/ncc_config"
     },
     "routes": {
-      "type": "object"
+      "$ref": "#/$defs/routes"
     },
     "policy_based_routes": {
-      "type": "object"
+      "$ref": "#/$defs/policy_based_routes"
     },
     "vpn_config": {
       "type": "object"
@@ -248,6 +248,72 @@
         }
       }
     },
+    "policy_based_routes": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z0-9-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "filter": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "dest_range": {
+                  "type": "string"
+                },
+                "ip_protocol": {
+                  "type": "string"
+                },
+                "src_range": {
+                  "type": "string"
+                }
+              }
+            },
+            "labels": {
+              "type": "object",
+              "additionalProperties": false,
+              "patternProperties": {
+                "^[a-z][a-z0-9_-]{0,62}$": {
+                  "type": "string",
+                  "pattern": "^[a-z0-9_-]{0,63}$"
+                }
+              }
+            },
+            "name": {
+              "type": "string"
+            },
+            "next_hop_ilb_ip": {
+              "type": "string"
+            },
+            "priority": {
+              "type": "number"
+            },
+            "target": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "interconnect_attachment": {
+                  "type": "string"
+                },
+                "tags": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "use_default_routing": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
     "psa_config": {
       "type": "object",
       "properties": {
@@ -314,6 +380,53 @@
                     }
                   }
                 }
+              }
+            }
+          }
+        }
+      }
+    },
+    "routes": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z0-9-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "dest_range",
+            "next_hop_type",
+            "next_hop"
+          ],
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "dest_range": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "next_hop_type": {
+              "type": "string",
+              "enum": [
+                "gateway",
+                "ilb",
+                "instance",
+                "ip",
+                "vpn_tunnel"
+              ]
+            },
+            "next_hop": {
+              "type": "string"
+            },
+            "priority": {
+              "type": "number"
+            },
+            "tags": {
+              "type": "array",
+              "items": {
+                "type": "string"
               }
             }
           }

--- a/fast/stages/0-org-setup/schemas/vpc-factory.schema.md
+++ b/fast/stages/0-org-setup/schemas/vpc-factory.schema.md
@@ -27,8 +27,8 @@
   - items: *reference([psa_config](#refs-psa_config))*
 - **nat_config**: *reference([nat_config](#refs-nat_config))*
 - **ncc_config**: *reference([ncc_config](#refs-ncc_config))*
-- **routes**: *object*
-- **policy_based_routes**: *object*
+- **routes**: *reference([routes](#refs-routes))*
+- **policy_based_routes**: *reference([policy_based_routes](#refs-policy_based_routes))*
 - **vpn_config**: *object*
 
 ## Definitions
@@ -78,6 +78,28 @@
   - **create_remote_peer**: *boolean*
   - **export_routes**: *boolean*
   - **import_routes**: *boolean*
+- **policy_based_routes**<a name="refs-policy_based_routes"></a>: *object*
+  - **`^[a-z0-9-]+$`**: *object*
+    <br>*additional properties: false*
+    - **description**: *string*
+    - **filter**: *object*
+      <br>*additional properties: false*
+      - **dest_range**: *string*
+      - **ip_protocol**: *string*
+      - **src_range**: *string*
+    - **labels**: *object*
+      <br>*additional properties: false*
+      - **`^[a-z][a-z0-9_-]{0,62}$`**: *string*
+        <br>*pattern: ^[a-z0-9_-]{0,63}$*
+    - **name**: *string*
+    - **next_hop_ilb_ip**: *string*
+    - **priority**: *number*
+    - **target**: *object*
+      <br>*additional properties: false*
+      - **interconnect_attachment**: *string*
+      - **tags**: *array*
+        - items: *string*
+    - **use_default_routing**: *boolean*
 - **psa_config**<a name="refs-psa_config"></a>: *object*
   - **deletion_policy**: *string*
   - **ranges**: *object*
@@ -97,3 +119,15 @@
       - **all_subnets**: *boolean*
       - **ip_ranges**: *object*
         - **`.*`**: *string*
+- **routes**<a name="refs-routes"></a>: *object*
+  - **`^[a-z0-9-]+$`**: *object*
+    <br>*additional properties: false*
+    - **description**: *string*
+    - ⁺**dest_range**: *string*
+    - **name**: *string*
+    - ⁺**next_hop_type**: *string*
+      <br>*enum: ['gateway', 'ilb', 'instance', 'ip', 'vpn_tunnel']*
+    - ⁺**next_hop**: *string*
+    - **priority**: *number*
+    - **tags**: *array*
+      - items: *string*

--- a/fast/stages/2-networking/factory-vpcs.tf
+++ b/fast/stages/2-networking/factory-vpcs.tf
@@ -101,9 +101,15 @@ moved {
 }
 
 module "vpc-factory" {
-  source         = "../../../modules/net-vpc-factory"
-  data_defaults  = local.vpc_defaults.defaults
-  data_overrides = local.vpc_defaults.overrides
+  source        = "../../../modules/net-vpc-factory"
+  data_defaults = local.vpc_defaults.defaults
+  # routes and policy based routes are suppressed here and managed in a
+  # second pass via module.vpc-routes, so that next hops can resolve NVA
+  # ILB addresses created after the VPCs
+  data_overrides = merge(local.vpc_defaults.overrides, {
+    policy_based_routes = {}
+    routes              = {}
+  })
   factories_config = {
     basepath = var.factories_config.dataset
     paths    = var.factories_config.paths
@@ -126,9 +132,10 @@ module "vpc-routes" {
     use_data_source = false
     attributes      = { network_id = module.vpc-factory.vpcs[each.key].network_id }
   }
-  project_id = each.value.project_id
-  name       = each.value.name
-  routes     = try(each.value.routes, {})
+  project_id          = each.value.project_id
+  name                = each.value.name
+  policy_based_routes = try(each.value.policy_based_routes, {})
+  routes              = try(each.value.routes, {})
   context = {
     project_ids = local.ctx_projects.project_ids
     locations   = local.ctx.locations

--- a/fast/stages/2-networking/schemas/vpc.schema.json
+++ b/fast/stages/2-networking/schemas/vpc.schema.json
@@ -302,6 +302,9 @@
                 }
               }
             },
+            "name": {
+              "type": "string"
+            },
             "next_hop_ilb_ip": {
               "type": "string"
             },
@@ -379,6 +382,9 @@
               "type": "string"
             },
             "dest_range": {
+              "type": "string"
+            },
+            "name": {
               "type": "string"
             },
             "next_hop_type": {

--- a/fast/stages/2-networking/schemas/vpc.schema.md
+++ b/fast/stages/2-networking/schemas/vpc.schema.md
@@ -98,6 +98,7 @@
       <br>*additional properties: false*
       - **`^[a-z][a-z0-9_-]{0,62}$`**: *string*
         <br>*pattern: ^[a-z0-9_-]{0,63}$*
+    - **name**: *string*
     - **next_hop_ilb_ip**: *string*
     - **priority**: *number*
     - **target**: *object*
@@ -120,6 +121,7 @@
   - **`^[a-z0-9-]+$`**: *object*
     - **description**: *string*
     - ⁺**dest_range**: *string*
+    - **name**: *string*
     - ⁺**next_hop_type**: *string*
     - ⁺**next_hop**: *string*
     - **priority**: *number*

--- a/modules/net-vpc-factory/README.md
+++ b/modules/net-vpc-factory/README.md
@@ -155,6 +155,24 @@ bgp_config:
   always_compare_med: true
   best_path_selection_mode: STANDARD
   inter_region_cost: ADD_COST_TO_MED
+routes:
+  gateway:
+    dest_range: 8.8.8.8/32
+    next_hop_type: gateway
+    next_hop: default-internet-gateway
+  nva:
+    name: to-nva-route
+    dest_range: 0.0.0.0/0
+    priority: 100
+    next_hop_type: ip
+    next_hop: 10.10.0.253
+policy_based_routes:
+  skip-pbr-for-nva:
+    use_default_routing: true
+    priority: 100
+    target:
+      tags:
+        - nva
 # tftest-file id=vpc path=data/vpcs/data-vpc-0/.config.yaml schema=vpc-factory.schema.json
 ```
 
@@ -185,7 +203,7 @@ ingress:
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [factories_config](variables.tf#L99) | Path to folder with YAML resource description data files. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
+| [factories_config](variables.tf#L125) | Path to folder with YAML resource description data files. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
 | [context](variables.tf#L17) | Context-specific interpolations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [data_defaults](variables.tf#L29) | Optional default values used when corresponding vpc data from files are missing. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [data_overrides](variables.tf#L64) | Optional values that override corresponding data from files. Takes precedence over file data and `data_defaults`. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |

--- a/modules/net-vpc-factory/README.md
+++ b/modules/net-vpc-factory/README.md
@@ -1,10 +1,10 @@
 # Net VPC Factory
 
-This module implements the creation of VPCs, subnets, and firewall rules via YAML configurations. It is designed to be embedded in other factories such as the [FAST networking stage](../../fast/stages/2-networking).
+This module implements the creation of VPCs, subnets, routes, and firewall rules via YAML configurations. It is designed to be embedded in other factories such as the [FAST networking stage](../../fast/stages/2-networking).
 
 It supports:
 
-- **VPCs** and **Subnets** leveraging the [net-vpc](../net-vpc/) module.
+- **VPCs**, **Subnets**, **Routes** and **Policy Based Routes** leveraging the [net-vpc](../net-vpc/) module.
 - **Firewall rules** leveraging the [net-vpc-firewall](../net-vpc-firewall/) module.
 - **Context-based interpolation** for referring to resources dynamically (e.g., project IDs, IAM principals, Locations).
 

--- a/modules/net-vpc-factory/main.tf
+++ b/modules/net-vpc-factory/main.tf
@@ -82,7 +82,9 @@ module "vpcs" {
   ipv6_config                       = try(each.value.ipv6_config, null)
   mtu                               = try(each.value.mtu, null)
   network_attachments               = try(each.value.network_attachments, {})
+  policy_based_routes               = try(each.value.policy_based_routes, {})
   psa_configs                       = try(each.value.psa_configs, [])
+  routes                            = try(each.value.routes, {})
   routing_mode                      = try(each.value.routing_mode, "GLOBAL")
 }
 

--- a/modules/net-vpc-factory/schemas/vpc-factory.schema.json
+++ b/modules/net-vpc-factory/schemas/vpc-factory.schema.json
@@ -75,10 +75,10 @@
       "$ref": "#/$defs/ncc_config"
     },
     "routes": {
-      "type": "object"
+      "$ref": "#/$defs/routes"
     },
     "policy_based_routes": {
-      "type": "object"
+      "$ref": "#/$defs/policy_based_routes"
     },
     "vpn_config": {
       "type": "object"
@@ -248,6 +248,72 @@
         }
       }
     },
+    "policy_based_routes": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z0-9-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "filter": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "dest_range": {
+                  "type": "string"
+                },
+                "ip_protocol": {
+                  "type": "string"
+                },
+                "src_range": {
+                  "type": "string"
+                }
+              }
+            },
+            "labels": {
+              "type": "object",
+              "additionalProperties": false,
+              "patternProperties": {
+                "^[a-z][a-z0-9_-]{0,62}$": {
+                  "type": "string",
+                  "pattern": "^[a-z0-9_-]{0,63}$"
+                }
+              }
+            },
+            "name": {
+              "type": "string"
+            },
+            "next_hop_ilb_ip": {
+              "type": "string"
+            },
+            "priority": {
+              "type": "number"
+            },
+            "target": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "interconnect_attachment": {
+                  "type": "string"
+                },
+                "tags": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "use_default_routing": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
     "psa_config": {
       "type": "object",
       "properties": {
@@ -314,6 +380,53 @@
                     }
                   }
                 }
+              }
+            }
+          }
+        }
+      }
+    },
+    "routes": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z0-9-]+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "dest_range",
+            "next_hop_type",
+            "next_hop"
+          ],
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "dest_range": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "next_hop_type": {
+              "type": "string",
+              "enum": [
+                "gateway",
+                "ilb",
+                "instance",
+                "ip",
+                "vpn_tunnel"
+              ]
+            },
+            "next_hop": {
+              "type": "string"
+            },
+            "priority": {
+              "type": "number"
+            },
+            "tags": {
+              "type": "array",
+              "items": {
+                "type": "string"
               }
             }
           }

--- a/modules/net-vpc-factory/schemas/vpc-factory.schema.md
+++ b/modules/net-vpc-factory/schemas/vpc-factory.schema.md
@@ -27,8 +27,8 @@
   - items: *reference([psa_config](#refs-psa_config))*
 - **nat_config**: *reference([nat_config](#refs-nat_config))*
 - **ncc_config**: *reference([ncc_config](#refs-ncc_config))*
-- **routes**: *object*
-- **policy_based_routes**: *object*
+- **routes**: *reference([routes](#refs-routes))*
+- **policy_based_routes**: *reference([policy_based_routes](#refs-policy_based_routes))*
 - **vpn_config**: *object*
 
 ## Definitions
@@ -78,6 +78,28 @@
   - **create_remote_peer**: *boolean*
   - **export_routes**: *boolean*
   - **import_routes**: *boolean*
+- **policy_based_routes**<a name="refs-policy_based_routes"></a>: *object*
+  - **`^[a-z0-9-]+$`**: *object*
+    <br>*additional properties: false*
+    - **description**: *string*
+    - **filter**: *object*
+      <br>*additional properties: false*
+      - **dest_range**: *string*
+      - **ip_protocol**: *string*
+      - **src_range**: *string*
+    - **labels**: *object*
+      <br>*additional properties: false*
+      - **`^[a-z][a-z0-9_-]{0,62}$`**: *string*
+        <br>*pattern: ^[a-z0-9_-]{0,63}$*
+    - **name**: *string*
+    - **next_hop_ilb_ip**: *string*
+    - **priority**: *number*
+    - **target**: *object*
+      <br>*additional properties: false*
+      - **interconnect_attachment**: *string*
+      - **tags**: *array*
+        - items: *string*
+    - **use_default_routing**: *boolean*
 - **psa_config**<a name="refs-psa_config"></a>: *object*
   - **deletion_policy**: *string*
   - **ranges**: *object*
@@ -97,3 +119,15 @@
       - **all_subnets**: *boolean*
       - **ip_ranges**: *object*
         - **`.*`**: *string*
+- **routes**<a name="refs-routes"></a>: *object*
+  - **`^[a-z0-9-]+$`**: *object*
+    <br>*additional properties: false*
+    - **description**: *string*
+    - ⁺**dest_range**: *string*
+    - **name**: *string*
+    - ⁺**next_hop_type**: *string*
+      <br>*enum: ['gateway', 'ilb', 'instance', 'ip', 'vpn_tunnel']*
+    - ⁺**next_hop**: *string*
+    - **priority**: *number*
+    - **tags**: *array*
+      - items: *string*

--- a/modules/net-vpc-factory/variables.tf
+++ b/modules/net-vpc-factory/variables.tf
@@ -91,6 +91,32 @@ variable "data_overrides" {
       enable_ula_internal = optional(bool)
       internal_range      = optional(string)
     }))
+    policy_based_routes = optional(map(object({
+      name                = optional(string)
+      description         = optional(string, "Terraform-managed.")
+      labels              = optional(map(string))
+      priority            = optional(number)
+      next_hop_ilb_ip     = optional(string)
+      use_default_routing = optional(bool, false)
+      filter = optional(object({
+        ip_protocol = optional(string)
+        dest_range  = optional(string)
+        src_range   = optional(string)
+      }), {})
+      target = optional(object({
+        interconnect_attachment = optional(string)
+        tags                    = optional(list(string))
+      }), {})
+    })))
+    routes = optional(map(object({
+      name          = optional(string)
+      description   = optional(string, "Terraform-managed.")
+      dest_range    = string
+      next_hop_type = string
+      next_hop      = string
+      priority      = optional(number)
+      tags          = optional(list(string))
+    })))
   })
   default  = {}
   nullable = false

--- a/modules/net-vpc/README.md
+++ b/modules/net-vpc/README.md
@@ -613,6 +613,7 @@ module "vpc" {
       next_hop      = each.value
     }
     gateway = {
+      name          = "gateway-route"
       dest_range    = "0.0.0.0/0",
       priority      = 100
       tags          = ["tag-a"]
@@ -646,6 +647,7 @@ module "vpc" {
       }
     }
     send-all-to-nva = {
+      name            = "pbr-nva"
       next_hop_ilb_ip = "10.0.0.253"
       priority        = 101
       filter = {
@@ -961,7 +963,7 @@ secondary_ip_ranges:
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
 | [name](variables.tf#L207) | The name of the network being created. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L284) | The ID of the project where this VPC will be created. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L285) | The ID of the project where this VPC will be created. | <code>string</code> | ✓ |  |
 | [auto_create_subnetworks](variables.tf#L17) | Set to true to create an auto mode subnet, defaults to custom mode. | <code>bool</code> |  | <code>false</code> |
 | [bgp_config](variables.tf#L23) | Optional BGP path selection configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
 | [context](variables.tf#L47) | Context-specific interpolations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
@@ -977,17 +979,17 @@ secondary_ip_ranges:
 | [network_attachments](variables.tf#L212) | PSC network attachments, names as keys. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [peering_config](variables.tf#L225) | VPC peering configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
 | [policy_based_routes](variables.tf#L236) | Policy based routes, keyed by name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [psa_configs](variables.tf#L289) | The Private Service Access configuration. | <code>list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
-| [routes](variables.tf#L321) | Network routes, keyed by name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [routing_mode](variables.tf#L342) | The network routing mode (default 'GLOBAL'). | <code>string</code> |  | <code>&#34;GLOBAL&#34;</code> |
-| [service_connection_policies](variables.tf#L352) | Service connection policies, keyed by name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [shared_vpc_host](variables.tf#L394) | Enable shared VPC for this project. | <code>bool</code> |  | <code>false</code> |
-| [shared_vpc_service_projects](variables.tf#L400) | Shared VPC service projects to register with this host. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
-| [subnets](variables.tf#L406) | Subnet configuration. | <code>list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
-| [subnets_private_nat](variables.tf#L486) | List of private NAT subnets. | <code>list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
-| [subnets_proxy_only](variables.tf#L498) | List of proxy-only subnets for Regional HTTPS or Internal HTTPS load balancers. Note: Only one proxy-only subnet for each VPC network in each region can be active. | <code>list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
-| [subnets_psc](variables.tf#L532) | List of subnets for Private Service Connect service producers. | <code>list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
-| [vpc_reuse](variables.tf#L572) | Reuse existing VPC if not null. If the network_id number is not passed in, a data source is used. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [psa_configs](variables.tf#L290) | The Private Service Access configuration. | <code>list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
+| [routes](variables.tf#L322) | Network routes, keyed by name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [routing_mode](variables.tf#L344) | The network routing mode (default 'GLOBAL'). | <code>string</code> |  | <code>&#34;GLOBAL&#34;</code> |
+| [service_connection_policies](variables.tf#L354) | Service connection policies, keyed by name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [shared_vpc_host](variables.tf#L396) | Enable shared VPC for this project. | <code>bool</code> |  | <code>false</code> |
+| [shared_vpc_service_projects](variables.tf#L402) | Shared VPC service projects to register with this host. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
+| [subnets](variables.tf#L408) | Subnet configuration. | <code>list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
+| [subnets_private_nat](variables.tf#L488) | List of private NAT subnets. | <code>list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
+| [subnets_proxy_only](variables.tf#L500) | List of proxy-only subnets for Regional HTTPS or Internal HTTPS load balancers. Note: Only one proxy-only subnet for each VPC network in each region can be active. | <code>list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
+| [subnets_psc](variables.tf#L534) | List of subnets for Private Service Connect service producers. | <code>list&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#91;&#93;</code> |
+| [vpc_reuse](variables.tf#L574) | Reuse existing VPC if not null. If the network_id number is not passed in, a data source is used. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
 
 ## Outputs
 

--- a/modules/net-vpc/routes.tf
+++ b/modules/net-vpc/routes.tf
@@ -27,6 +27,7 @@ locals {
   }
   _googleapis_routes = {
     for k, v in local._googleapis_ranges : "${k}-googleapis" => {
+      name          = null
       description   = "Terraform-managed."
       dest_range    = v
       next_hop      = "default-internet-gateway"
@@ -53,7 +54,7 @@ resource "google_compute_route" "gateway" {
   for_each    = local.routes.gateway
   project     = local.project_id
   network     = local.network.name
-  name        = "${var.name}-${each.key}"
+  name        = coalesce(each.value.name, "${var.name}-${each.key}")
   description = each.value.description
   dest_range = lookup(
     local.ctx.cidr_ranges, each.value.dest_range, each.value.dest_range
@@ -67,7 +68,7 @@ resource "google_compute_route" "ilb" {
   for_each    = local.routes.ilb
   project     = local.project_id
   network     = local.network.name
-  name        = "${var.name}-${each.key}"
+  name        = coalesce(each.value.name, "${var.name}-${each.key}")
   description = each.value.description
   dest_range = lookup(
     local.ctx.cidr_ranges, each.value.dest_range, each.value.dest_range
@@ -83,7 +84,7 @@ resource "google_compute_route" "instance" {
   for_each    = local.routes.instance
   project     = local.project_id
   network     = local.network.name
-  name        = "${var.name}-${each.key}"
+  name        = coalesce(each.value.name, "${var.name}-${each.key}")
   description = each.value.description
   dest_range = lookup(
     local.ctx.cidr_ranges, each.value.dest_range, each.value.dest_range
@@ -99,7 +100,7 @@ resource "google_compute_route" "ip" {
   for_each    = local.routes.ip
   project     = local.project_id
   network     = local.network.name
-  name        = "${var.name}-${each.key}"
+  name        = coalesce(each.value.name, "${var.name}-${each.key}")
   description = each.value.description
   dest_range = lookup(
     local.ctx.cidr_ranges, each.value.dest_range, each.value.dest_range
@@ -115,7 +116,7 @@ resource "google_compute_route" "vpn_tunnel" {
   for_each    = local.routes.vpn_tunnel
   project     = local.project_id
   network     = local.network.name
-  name        = "${var.name}-${each.key}"
+  name        = coalesce(each.value.name, "${var.name}-${each.key}")
   description = each.value.description
   dest_range = lookup(
     local.ctx.cidr_ranges, each.value.dest_range, each.value.dest_range
@@ -129,12 +130,20 @@ resource "google_network_connectivity_policy_based_route" "default" {
   for_each              = var.policy_based_routes
   project               = local.project_id
   network               = local.network.id
-  name                  = "${var.name}-${each.key}"
+  name                  = coalesce(each.value.name, "${var.name}-${each.key}")
   description           = each.value.description
   labels                = each.value.labels
   priority              = each.value.priority
   next_hop_other_routes = each.value.use_default_routing ? "DEFAULT_ROUTING" : null
-  next_hop_ilb_ip       = each.value.use_default_routing ? null : each.value.next_hop_ilb_ip
+  next_hop_ilb_ip = (
+    each.value.use_default_routing
+    ? null
+    : lookup(
+      local.ctx.addresses,
+      each.value.next_hop_ilb_ip,
+      each.value.next_hop_ilb_ip
+    )
+  )
   filter {
     protocol_version = "IPV4"
     ip_protocol      = each.value.filter.ip_protocol

--- a/modules/net-vpc/variables.tf
+++ b/modules/net-vpc/variables.tf
@@ -236,6 +236,7 @@ variable "peering_config" {
 variable "policy_based_routes" {
   description = "Policy based routes, keyed by name."
   type = map(object({
+    name                = optional(string)
     description         = optional(string, "Terraform-managed.")
     labels              = optional(map(string))
     priority            = optional(number)
@@ -321,6 +322,7 @@ variable "psa_configs" {
 variable "routes" {
   description = "Network routes, keyed by name."
   type = map(object({
+    name          = optional(string)
     description   = optional(string, "Terraform-managed.")
     dest_range    = string
     next_hop_type = string # gateway, instance, ip, vpn_tunnel, ilb

--- a/tests/fast/stages/s2_networking/data-testvlan/vpcs/hub/.config.yaml
+++ b/tests/fast/stages/s2_networking/data-testvlan/vpcs/hub/.config.yaml
@@ -16,3 +16,16 @@ routes:
     dest_range: 0.0.0.0/0
     next_hop_type: "gateway"
     next_hop: "default-internet-gateway"
+  named:
+    name: imported-route
+    dest_range: 172.16.0.0/16
+    next_hop_type: "gateway"
+    next_hop: "default-internet-gateway"
+policy_based_routes:
+  skip-pbr-for-nva:
+    name: imported-pbr
+    use_default_routing: true
+    priority: 100
+    target:
+      tags:
+        - nva

--- a/tests/fast/stages/s2_networking/vlan_attachments.yaml
+++ b/tests/fast/stages/s2_networking/vlan_attachments.yaml
@@ -586,6 +586,41 @@ values:
     project: fast-prod-net-core-0
     tags: null
     timeouts: null
+  module.vpc-routes["hub"].google_compute_route.gateway["named"]:
+    deletion_policy: DELETE
+    description: Terraform-managed.
+    dest_range: 172.16.0.0/16
+    name: imported-route
+    network: hub-0
+    next_hop_gateway: default-internet-gateway
+    next_hop_ilb: null
+    next_hop_instance: null
+    next_hop_vpn_tunnel: null
+    params: []
+    priority: 1000
+    project: fast-prod-net-core-0
+    tags: null
+    timeouts: null
+  module.vpc-routes["hub"].google_network_connectivity_policy_based_route.default["skip-pbr-for-nva"]:
+    deletion_policy: DELETE
+    description: Terraform-managed.
+    filter:
+    - dest_range: 0.0.0.0/0
+      ip_protocol: ALL
+      protocol_version: IPV4
+      src_range: 0.0.0.0/0
+    interconnect_attachment: []
+    labels: null
+    name: imported-pbr
+    network: projects/fast-prod-net-core-0/global/networks/hub-0
+    next_hop_ilb_ip: null
+    next_hop_other_routes: DEFAULT_ROUTING
+    priority: 100
+    project: fast-prod-net-core-0
+    timeouts: null
+    virtual_machine:
+    - tags:
+      - nva
   module.vpn-ha["hub/to-onprem"].google_compute_external_vpn_gateway.external_gateway["default"]:
     deletion_policy: DELETE
     description: Terraform managed external VPN gateway
@@ -740,7 +775,7 @@ counts:
   google_compute_interconnect_attachment: 2
   google_compute_interconnect_attachment_group: 1
   google_compute_network: 1
-  google_compute_route: 4
+  google_compute_route: 5
   google_compute_router: 1
   google_compute_router_interface: 4
   google_compute_router_peer: 4
@@ -750,6 +785,7 @@ counts:
   google_logging_project_settings: 1
   google_network_connectivity_group: 1
   google_network_connectivity_hub: 1
+  google_network_connectivity_policy_based_route: 1
   google_network_connectivity_spoke: 3
   google_project: 1
   google_project_iam_member: 8
@@ -758,7 +794,7 @@ counts:
   google_storage_bucket_object: 2
   modules: 9
   random_id: 5
-  resources: 65
+  resources: 67
   terraform_data: 2
 
 outputs:

--- a/tests/modules/net_vpc/examples/pbr.yaml
+++ b/tests/modules/net_vpc/examples/pbr.yaml
@@ -34,7 +34,7 @@ values:
       - region: europe-west8
     labels:
       environment: prod
-    name: my-vpc-send-all-to-nva
+    name: pbr-nva
     next_hop_ilb_ip: 10.0.0.253
     next_hop_other_routes: null
     priority: 101

--- a/tests/modules/net_vpc/examples/routes.yaml
+++ b/tests/modules/net_vpc/examples/routes.yaml
@@ -20,7 +20,7 @@ values:
   module.vpc["gateway"].google_compute_route.gateway["gateway"]:
     description: Terraform-managed.
     dest_range: 0.0.0.0/0
-    name: my-network-with-route-gateway-gateway
+    name: gateway-route
     next_hop_gateway: default-internet-gateway
     next_hop_ilb: null
     next_hop_instance: null
@@ -47,7 +47,7 @@ values:
   module.vpc["ilb"].google_compute_route.gateway["gateway"]:
     description: Terraform-managed.
     dest_range: 0.0.0.0/0
-    name: my-network-with-route-ilb-gateway
+    name: gateway-route
     next_hop_gateway: default-internet-gateway
     next_hop_ilb: null
     next_hop_instance: null
@@ -74,7 +74,7 @@ values:
   module.vpc["instance"].google_compute_route.gateway["gateway"]:
     description: Terraform-managed.
     dest_range: 0.0.0.0/0
-    name: my-network-with-route-instance-gateway
+    name: gateway-route
     next_hop_gateway: default-internet-gateway
     next_hop_ilb: null
     next_hop_instance: null
@@ -102,7 +102,7 @@ values:
   module.vpc["ip"].google_compute_route.gateway["gateway"]:
     description: Terraform-managed.
     dest_range: 0.0.0.0/0
-    name: my-network-with-route-ip-gateway
+    name: gateway-route
     next_hop_gateway: default-internet-gateway
     next_hop_ilb: null
     next_hop_instance: null
@@ -130,7 +130,7 @@ values:
   module.vpc["vpn_tunnel"].google_compute_route.gateway["gateway"]:
     description: Terraform-managed.
     dest_range: 0.0.0.0/0
-    name: my-network-with-route-vpn-tunnel-gateway
+    name: gateway-route
     next_hop_gateway: default-internet-gateway
     next_hop_ilb: null
     next_hop_instance: null

--- a/tests/modules/net_vpc_factory/examples/example.yaml
+++ b/tests/modules/net_vpc_factory/examples/example.yaml
@@ -67,6 +67,20 @@ values:
     project: my-host-project-id
     tags: null
     timeouts: null
+  module.net-vpc-factory.module.vpcs["data-vpc-0"].google_compute_route.gateway["gateway"]:
+    description: Terraform-managed.
+    dest_range: 8.8.8.8/32
+    name: data-vpc-0-gateway
+    network: data-vpc-0
+    next_hop_gateway: default-internet-gateway
+    next_hop_ilb: null
+    next_hop_instance: null
+    next_hop_vpn_tunnel: null
+    params: []
+    priority: 1000
+    project: my-host-project-id
+    tags: null
+    timeouts: null
   module.net-vpc-factory.module.vpcs["data-vpc-0"].google_compute_route.gateway["private-googleapis"]:
     description: Terraform-managed.
     dest_range: 199.36.153.8/30
@@ -95,6 +109,39 @@ values:
     project: my-host-project-id
     tags: null
     timeouts: null
+  module.net-vpc-factory.module.vpcs["data-vpc-0"].google_compute_route.ip["nva"]:
+    description: Terraform-managed.
+    dest_range: 0.0.0.0/0
+    name: to-nva-route
+    network: data-vpc-0
+    next_hop_gateway: null
+    next_hop_ilb: null
+    next_hop_instance: null
+    next_hop_ip: 10.10.0.253
+    next_hop_vpn_tunnel: null
+    params: []
+    priority: 100
+    project: my-host-project-id
+    tags: null
+    timeouts: null
+  ? module.net-vpc-factory.module.vpcs["data-vpc-0"].google_network_connectivity_policy_based_route.default["skip-pbr-for-nva"]
+  : description: Terraform-managed.
+    filter:
+    - dest_range: 0.0.0.0/0
+      ip_protocol: ALL
+      protocol_version: IPV4
+      src_range: 0.0.0.0/0
+    interconnect_attachment: []
+    labels: null
+    name: data-vpc-0-skip-pbr-for-nva
+    next_hop_ilb_ip: null
+    next_hop_other_routes: DEFAULT_ROUTING
+    priority: 100
+    project: my-host-project-id
+    timeouts: null
+    virtual_machine:
+    - tags:
+      - nva
   module.net-vpc-factory.module.vpcs["data-vpc-0"].google_compute_subnetwork.subnetwork["europe-west1/primary-subnet"]:
     description: Primary subnet for data-vpc-0
     ip_cidr_range: 10.10.0.0/24
@@ -116,9 +163,10 @@ values:
 counts:
   google_compute_firewall: 1
   google_compute_network: 1
-  google_compute_route: 3
+  google_compute_route: 5
   google_compute_subnetwork: 1
+  google_network_connectivity_policy_based_route: 1
   modules: 3
-  resources: 6
+  resources: 9
 
 outputs: {}


### PR DESCRIPTION
Fixes #4103

## Problem

`modules/net-vpc` derives route and policy based route names as
`"${var.name}-${key}"` with no way to override them, which prevents matching
the names of preexisting resources (e.g. when importing routes or using
`vpc_reuse`).

While addressing this, two related gaps surfaced:

- `modules/net-vpc-factory` advertised `routes` and `policy_based_routes` in
  its schema but never passed them to the underlying `net-vpc` module, so
  factory YAML definitions were silently dropped. The module originally
  supported routes (#2982) but lost them in the minimal rewrite (#3696).
- `fast/stages/2-networking` read `policy_based_routes` from VPC YAML files
  into locals but never passed them to any module.

## Changes

### modules/net-vpc

- New optional `name` attribute on `routes` and `policy_based_routes`
  entries, resolved via `coalesce(each.value.name, "${var.name}-${each.key}")`
  — fully backward compatible, mirroring the existing subnets pattern.
- `next_hop_ilb_ip` on policy based routes now supports `$addresses:`
  context interpolation, consistent with `ilb`/`ip` routes.

### modules/net-vpc-factory

- `routes` and `policy_based_routes` are now wired through to `net-vpc`.
- `data_overrides` gains typed `routes` / `policy_based_routes` attributes so
  embedding stages can centrally override or suppress them. This is
  load-bearing: Terraform silently drops undeclared object attributes, so
  suppression only works with the attributes declared in the variable type.
- Schema: `routes` / `policy_based_routes` are now fully specified (previously
  free-form objects), including the new `name` attribute; duplicate synced to
  `fast/stages/0-org-setup` and schema docs regenerated.

### fast/stages/2-networking

- The factory call suppresses `routes` and `policy_based_routes` via
  `data_overrides`, preserving the deliberate two-pass design where routes
  are created after NVAs so next hops can resolve NVA ILB addresses.
  Verified no double-creation.
- The second-pass `vpc-routes` module now also passes `policy_based_routes`,
  fixing the dead-ended YAML definitions.
- `vpc.schema.json` extended with the `name` attribute for both defs.

## Upgrade considerations

No state moves, renames, or destroys for configs whose YAML matched actual
behavior; all pre-existing test inventories pass unchanged. Three cases of
previously silently-ignored YAML now take effect:

1. `policy_based_routes` in 2-networking VPC YAML files are now created
  (additive; if equivalent PBRs were created manually out-of-band, they need
  to be imported first).
2. `routes` / `policy_based_routes` in 0-org-setup and 2-project-factory VPC
  YAML files are now created (same additive caveat).
3. A stray `name:` field on route entries in existing YAML now takes effect,
  causing a route replacement (name is ForceNew; same routing semantics).

## Testing

- Before/after plan comparison on a factory dataset with 2 routes and 1 PBR:
  before, both were silently ignored; after, all are created with `name`
  overrides honored and default naming preserved for unnamed entries.
- Before/after plan comparison on the 2-networking `data-testvlan` scenario:
  the stage-managed route is still created exactly once (no double-creation
  from the factory), and a new named route + PBR are created via the second
  pass with overridden names.
- Extended tests: `net-vpc` README examples demonstrate `name` on a route and
  a PBR; `net-vpc-factory` README example adds routes and a PBR (schema
  validated); `data-testvlan` adds a named route and PBR with inventory
  assertions.
- Full suites green: `tests/modules/net_vpc`, `tests/modules/net_vpc_factory`,
  `tests/fast/stages/s2_networking`, `tests/fast/stages/s0_org_setup`,
  `tests/fast/stages/s2_project_factory`, plus all README example tests for
  both modules. Linting, docs, and schema duplication checks pass.