### PR TITLE
Support CA pool publishing_options in modules/certificate-authority-service

### DIFF
--- a/fast/stages/2-security/factory-cas.tf
+++ b/fast/stages/2-security/factory-cas.tf
@@ -38,6 +38,9 @@ locals {
           enterprise_tier = try(
             v.ca_pool_config.create_pool.enterprise_tier, false
           )
+          publishing_options = try(
+            v.ca_pool_config.create_pool.publishing_options, null
+          )
         }
         use_pool = try(v.ca_pool_config.use_pool.id, null) == null ? null : {
           id = v.ca_pool_config.use_pool.id

--- a/fast/stages/2-security/schemas/certificate-authority.schema.json
+++ b/fast/stages/2-security/schemas/certificate-authority.schema.json
@@ -57,6 +57,29 @@
             "enterprise_tier": {
               "type": "boolean",
               "default": false
+            },
+            "publishing_options": {
+              "type": "object",
+              "required": [
+                "publish_ca_cert",
+                "publish_crl"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "encoding_format": {
+                  "type": "string",
+                  "enum": [
+                    "PEM",
+                    "DER"
+                  ]
+                },
+                "publish_ca_cert": {
+                  "type": "boolean"
+                },
+                "publish_crl": {
+                  "type": "boolean"
+                }
+              }
             }
           }
         },

--- a/fast/stages/2-security/schemas/certificate-authority.schema.md
+++ b/fast/stages/2-security/schemas/certificate-authority.schema.md
@@ -18,6 +18,12 @@
     <br>*additional properties: false*
     - **name**: *string*
     - **enterprise_tier**: *boolean*
+    - **publishing_options**: *object*
+      <br>*additional properties: false*
+      - **encoding_format**: *string*
+        <br>*enum: ['PEM', 'DER']*
+      - ⁺**publish_ca_cert**: *boolean*
+      - ⁺**publish_crl**: *boolean*
   - **use_pool**: *object*
     <br>*additional properties: false*
     - ⁺**id**: *string*

--- a/modules/certificate-authority-service/README.md
+++ b/modules/certificate-authority-service/README.md
@@ -43,7 +43,12 @@ module "cas" {
   location   = "europe-west1"
   ca_pool_config = {
     create_pool = {
-      name = "test-ca"
+      name            = "test-ca"
+      enterprise_tier = true
+      publishing_options = {
+        publish_ca_cert = true
+        publish_crl     = true
+      }
     }
   }
   ca_configs = {
@@ -114,10 +119,10 @@ module "cas" {
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
 | [ca_pool_config](variables.tf#L105) | The CA pool config. Either use_pool or create_pool need to be used. Use pool takes precedence if both are defined. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
-| [location](variables.tf#L134) | The location of the CAs. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L139) | Project id. | <code>string</code> | ✓ |  |
+| [location](variables.tf#L149) | The location of the CAs. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L154) | Project id. | <code>string</code> | ✓ |  |
 | [ca_configs](variables.tf#L17) | The CA configurations. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#8230;&#125;</code> |
-| [context](variables.tf#L119) | Context-specific interpolations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [context](variables.tf#L134) | Context-specific interpolations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam](variables-iam.tf#L17) | IAM bindings in {ROLE => [MEMBERS]} format. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_bindings](variables-iam.tf#L24) | Authoritative IAM bindings in {KEY => {role = ROLE, members = [], condition = {}}}. Keys are arbitrary. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_bindings_additive](variables-iam.tf#L39) | Individual additive IAM bindings. Keys are arbitrary. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |

--- a/modules/certificate-authority-service/main.tf
+++ b/modules/certificate-authority-service/main.tf
@@ -28,6 +28,9 @@ locals {
   )
   pool_name  = reverse(split("/", local.pool_id))[0]
   project_id = lookup(local.ctx.project_ids, var.project_id, var.project_id)
+  publishing_options = try(
+    var.ca_pool_config.create_pool.publishing_options, null
+  )
 }
 
 resource "google_privateca_ca_pool" "default" {
@@ -41,6 +44,16 @@ resource "google_privateca_ca_pool" "default" {
     ? "ENTERPRISE"
     : "DEVOPS"
   )
+  dynamic "publishing_options" {
+    for_each = (
+      local.publishing_options == null ? [] : [local.publishing_options]
+    )
+    content {
+      encoding_format = publishing_options.value.encoding_format
+      publish_ca_cert = publishing_options.value.publish_ca_cert
+      publish_crl     = publishing_options.value.publish_crl
+    }
+  }
 }
 
 resource "google_privateca_certificate_authority" "default" {

--- a/modules/certificate-authority-service/variables.tf
+++ b/modules/certificate-authority-service/variables.tf
@@ -106,14 +106,29 @@ variable "ca_pool_config" {
   description = "The CA pool config. Either use_pool or create_pool need to be used. Use pool takes precedence if both are defined."
   type = object({
     create_pool = optional(object({
-      name            = string
       enterprise_tier = optional(bool, false)
+      name            = string
+      publishing_options = optional(object({
+        encoding_format = optional(string)
+        publish_ca_cert = bool
+        publish_crl     = bool
+      }))
     }))
     use_pool = optional(object({
       id = string
     }))
   })
   nullable = false
+  validation {
+    condition = contains(
+      ["PEM", "DER"],
+      coalesce(
+        try(var.ca_pool_config.create_pool.publishing_options.encoding_format, null),
+        "PEM"
+      )
+    )
+    error_message = "Encoding format must be one of PEM or DER."
+  }
 }
 
 variable "context" {

--- a/tests/fast/stages/s2_security/data-simple/certificate-authorities/prod-ca-0.yaml
+++ b/tests/fast/stages/s2_security/data-simple/certificate-authorities/prod-ca-0.yaml
@@ -17,6 +17,11 @@
 location: $locations:primary
 project_id: $project_ids:prod-sec-core-0
 ca_pool_config:
-  create_pool: {}
+  create_pool:
+    enterprise_tier: true
+    publishing_options:
+      encoding_format: PEM
+      publish_ca_cert: true
+      publish_crl: true
 ca_configs:
   prod-ca-0-0: {}

--- a/tests/fast/stages/s2_security/simple.yaml
+++ b/tests/fast/stages/s2_security/simple.yaml
@@ -59,10 +59,13 @@ values:
     location: europe-west1
     name: prod-ca-0
     project: fast-prod-sec-core-0
-    publishing_options: []
+    publishing_options:
+    - encoding_format: PEM
+      publish_ca_cert: true
+      publish_crl: true
     terraform_labels:
       goog-terraform-provisioned: 'true'
-    tier: DEVOPS
+    tier: ENTERPRISE
     timeouts: null
   module.cas["prod-ca-0"].google_privateca_certificate_authority.default["prod-ca-0-0"]:
     certificate_authority_id: prod-ca-0-0

--- a/tests/modules/certificate_authority_service/context.tfvars
+++ b/tests/modules/certificate_authority_service/context.tfvars
@@ -31,6 +31,11 @@ location   = "$locations:ew8"
 ca_pool_config = {
   create_pool = {
     name = "test-ca"
+    publishing_options = {
+      encoding_format = "PEM"
+      publish_ca_cert = true
+      publish_crl     = true
+    }
   }
 }
 ca_configs = {

--- a/tests/modules/certificate_authority_service/context.yaml
+++ b/tests/modules/certificate_authority_service/context.yaml
@@ -1,10 +1,10 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,14 +14,19 @@
 
 values:
   google_privateca_ca_pool.default[0]:
+    deletion_policy: DELETE
     effective_labels:
       goog-terraform-provisioned: 'true'
+    encryption_spec: []
     issuance_policy: []
     labels: null
     location: europe-west8
     name: test-ca
     project: test-0
-    publishing_options: []
+    publishing_options:
+    - encoding_format: PEM
+      publish_ca_cert: true
+      publish_crl: true
     terraform_labels:
       goog-terraform-provisioned: 'true'
     tier: DEVOPS
@@ -107,6 +112,7 @@ values:
           unknown_extended_key_usages: []
         name_constraints: []
         policy_ids: []
+    deletion_policy: DELETE
     deletion_protection: true
     desired_state: null
     effective_labels:
@@ -136,3 +142,10 @@ counts:
   google_privateca_certificate_authority: 1
   modules: 0
   resources: 9
+
+outputs:
+  ca_chains: __missing__
+  ca_ids: __missing__
+  ca_pool: __missing__
+  ca_pool_id: __missing__
+  cas: __missing__

--- a/tests/modules/certificate_authority_service/examples/custom_cas.yaml
+++ b/tests/modules/certificate_authority_service/examples/custom_cas.yaml
@@ -12,8 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+values:
+  module.cas.google_privateca_ca_pool.default[0]:
+    location: europe-west1
+    name: test-ca
+    publishing_options:
+    - encoding_format: null
+      publish_ca_cert: true
+      publish_crl: true
+    tier: ENTERPRISE
+
 counts:
   google_privateca_ca_pool: 1
   google_privateca_certificate_authority: 2
   modules: 1
   resources: 3
+


### PR DESCRIPTION
Expose the `publishing_options` block of `google_privateca_ca_pool` within `modules/certificate-authority-service` and propagate support to `fast/stages/2-security`.

### Rationale
The `publishing_options` block configures publication of CA certificates and CRLs to Cloud Storage for Authority Information Access (AIA) and CRL Distribution Points. Previously, `ca_pool_config.create_pool` only supported `name` and `enterprise_tier`, omitting `publishing_options`. This prevented configuring CA cert and CRL publication and resulted in unwanted diffs when managing pre-existing pools.

### Changes
- Added `publishing_options` object with required `publish_ca_cert` and `publish_crl` booleans and optional `encoding_format` (with enum validation) to `ca_pool_config.create_pool` in `modules/certificate-authority-service/variables.tf`.
- Added dynamic `publishing_options` block to `google_privateca_ca_pool.default` in `modules/certificate-authority-service/main.tf` using the standard Fabric `local.publishing_options` idiom.
- Updated `fast/stages/2-security/factory-cas.tf` and its JSON schema/docs to support `publishing_options`.
- Updated `Create custom CAs` example in `modules/certificate-authority-service/README.md` and added values assertions in `tests/modules/certificate_authority_service/examples/custom_cas.yaml`.
- Extended FAST stage 2-security test fixture `tests/fast/stages/s2_security/data-simple/certificate-authorities/prod-ca-0.yaml` and regenerated `tests/fast/stages/s2_security/simple.yaml` to verify the FAST integration path.

### Verification
- **Unit & Plan Tests**: All module and FAST stage tests pass (`tests/modules/certificate_authority_service`, `tests/examples`, `tests/fast/stages/s2_security`).
- **Linters**: All repository linters passed (`tools/lint.sh`, `terraform fmt`, `check_documentation`, `check_schema_docs`, `duplicate-diff`).
- **E2E Sandbox Verification**: Deployed live to a sandbox project:
  - Created `google_privateca_ca_pool` with `publishing_options` (`publish_ca_cert = true`, `publish_crl = true`, `encoding_format = "PEM"`) and a self-signed root CA.
  - **Read-Back Verification**: Verified via `gcloud privateca pools describe` that `publishingOptions` was set on the live resource.
  - **Behavioral Verification**: Verified published CA certificate retrieval from the storage bucket AIA URL (`accessUrls.caCertificateAccessUrl`).


Closes #4106
