### PR TITLE
Fix unknown IAM principals when organization logging settings are created

### DIFF
--- a/fast/stages/0-org-setup/factory.tf
+++ b/fast/stages/0-org-setup/factory.tf
@@ -50,10 +50,12 @@ module "factory" {
         default = try(module.organization[0].id, null)
       }
     )
+    # no null filter here: values are non-null by construction, and filtering
+    # on them would make this map unknown at plan time (cf. organization.tf)
     iam_principals = merge(
       {
         for k, v in local.org_logging_identities :
-        k => "serviceAccount:${v}" if v != null
+        k => "serviceAccount:${v}"
       },
       local.iam_principals
     )

--- a/fast/stages/0-org-setup/organization.tf
+++ b/fast/stages/0-org-setup/organization.tf
@@ -15,6 +15,7 @@
  */
 
 locals {
+  _org_logging_settings = lookup(local.organization, "logging", null)
   ctx_condition_vars = {
     custom_roles = merge(
       local.ctx.custom_roles,
@@ -56,14 +57,6 @@ locals {
   org_access_levels = {
     for k, v in module.organization[0].access_levels : k => v.id
   }
-  # private local: logging settings as defined in yaml, used to derive the
-  # shape of the identities map below from plan-time known values
-  _org_logging_settings = lookup(local.organization, "logging", null)
-  # keys must only depend on the yaml configuration: gating them on the
-  # computed identity attributes makes the ternary condition itself unknown
-  # while the logging settings resource is being created, which turns the
-  # whole map unknown and poisons every principal interpolation downstream
-  # (folder/project IAM, PAM entitlements, ...) in the project factory
   org_logging_identities = merge(
     try(local._org_logging_settings.kms_key_name, null) == null ? {} : {
       "organization/logging/kms" = module.organization[0].logging_identities.kms

--- a/fast/stages/0-org-setup/organization.tf
+++ b/fast/stages/0-org-setup/organization.tf
@@ -56,11 +56,19 @@ locals {
   org_access_levels = {
     for k, v in module.organization[0].access_levels : k => v.id
   }
+  # private local: logging settings as defined in yaml, used to derive the
+  # shape of the identities map below from plan-time known values
+  _org_logging_settings = lookup(local.organization, "logging", null)
+  # keys must only depend on the yaml configuration: gating them on the
+  # computed identity attributes makes the ternary condition itself unknown
+  # while the logging settings resource is being created, which turns the
+  # whole map unknown and poisons every principal interpolation downstream
+  # (folder/project IAM, PAM entitlements, ...) in the project factory
   org_logging_identities = merge(
-    module.organization[0].logging_identities.kms == null ? {} : {
+    try(local._org_logging_settings.kms_key_name, null) == null ? {} : {
       "organization/logging/kms" = module.organization[0].logging_identities.kms
     },
-    module.organization[0].logging_identities.logging == null ? {} : {
+    local._org_logging_settings == null ? {} : {
       "organization/logging/sinks" = module.organization[0].logging_identities.logging
     }
   )

--- a/tests/fast/stages/s0_org_setup/customizations.yaml
+++ b/tests/fast/stages/s0_org_setup/customizations.yaml
@@ -256,28 +256,46 @@ values:
     deletion_policy: DELETE
     project: ft0-dev-net-shared-0
     timeouts: null
+  # NOTE: the `members` assertions below are regression coverage: this dataset
+  # defines org-level `logging.sinks`, and deriving the logging identity map
+  # keys from computed attributes used to make the whole factory
+  # `iam_principals` context unknown at plan time, turning every principal here
+  # into "(known after apply)".
   module.factory.module.projects-iam["iac-0"].google_project_iam_binding.authoritative["roles/cloudbuild.builds.editor"]:
     condition: []
+    members:
+    - serviceAccount:iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
     project: ft0-prod-iac-core-0
     role: roles/cloudbuild.builds.editor
   module.factory.module.projects-iam["iac-0"].google_project_iam_binding.authoritative["roles/iam.serviceAccountAdmin"]:
     condition: []
+    members:
+    - serviceAccount:iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
     project: ft0-prod-iac-core-0
     role: roles/iam.serviceAccountAdmin
   ? module.factory.module.projects-iam["iac-0"].google_project_iam_binding.authoritative["roles/iam.serviceAccountTokenCreator"]
   : condition: []
+    members:
+    - group:fabric-fast-owners@google.com
     project: ft0-prod-iac-core-0
     role: roles/iam.serviceAccountTokenCreator
   ? module.factory.module.projects-iam["iac-0"].google_project_iam_binding.authoritative["roles/iam.workloadIdentityPoolAdmin"]
   : condition: []
+    members:
+    - group:fabric-fast-owners@google.com
+    - serviceAccount:iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
     project: ft0-prod-iac-core-0
     role: roles/iam.workloadIdentityPoolAdmin
   module.factory.module.projects-iam["iac-0"].google_project_iam_binding.authoritative["roles/owner"]:
     condition: []
+    members:
+    - serviceAccount:iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
     project: ft0-prod-iac-core-0
     role: roles/owner
   module.factory.module.projects-iam["iac-0"].google_project_iam_binding.authoritative["roles/storage.admin"]:
     condition: []
+    members:
+    - serviceAccount:iac-org-rw@ft0-prod-iac-core-0.iam.gserviceaccount.com
     project: ft0-prod-iac-core-0
     role: roles/storage.admin
   module.factory.module.projects-iam["prod-app-0"].google_compute_shared_vpc_service_project.shared_vpc_service[0]:


### PR DESCRIPTION
Adding an org-level log sink to `0-org-setup` can produce dozens of spurious `update in-place` diffs on folder/project IAM bindings and PAM entitlements, with every existing principal rendered as `(known after apply)`.

### Root cause

`org_logging_identities` in `fast/stages/0-org-setup/organization.tf` gated its map keys on computed attributes:

```hcl
org_logging_identities = merge(
  module.organization[0].logging_identities.kms == null ? {} : {...},
  module.organization[0].logging_identities.logging == null ? {} : {...}
)
```

`logging_identities.logging` is `google_logging_organization_settings.default[0].logging_service_account_id`, which is unknown while that resource is being created. The ternary **condition** is therefore unknown, so the ternary returns a *wholly unknown map* — not a map containing unknown values.

That map is merged into the `iam_principals` context passed to `module.factory` (`factory.tf`), so every `lookup(local.ctx.iam_principals, m, m)` across `modules/project-factory` (folder IAM, project IAM, bucket/KMS/pubsub/log-bucket IAM, PAM entitlements) returns unknown.

The trigger is the organization `logging:` block going from **absent to present** — `logging_settings` and `logging.sinks` are both driven off that one key, so `count` on the settings resource flips 0→1. It does not depend on which sink is defined. Orgs that have always had the OOTB sink never see it, which makes it easy to miss.

Minimal repro of the mechanism, with an *unrelated* principal lookup:

```
+ buggy_lookup_unrelated_principal = (known after apply)
+ fixed_lookup_unrelated_principal = "group:admins@example.com"
```

### Fix

Derive the map keys from the yaml configuration, which is known at plan time:
- `organization/logging/sinks` — gated on presence of the `logging:` block
- `organization/logging/kms` — gated on `logging.kms_key_name` (schema-backed in `schemas/organization.schema.json`)

Also drop `if v != null` from the `iam_principals` comprehension in `factory.tf`; values are non-null by construction now, and that filter would make the map unknown again.

### Effect

Stage-0 plan with the `customizations` dataset (which defines org-level sinks):

| | resolved principals | unknown |
|---|---|---|
| before | 22 | 8 |
| after | 30 | 0 |

The 8 that flip are `google_project_iam_binding.authoritative` and `google_storage_bucket_iam_binding.authoritative` entries — the same class users report.

### Tests

Added `members` assertions to `tests/fast/stages/s0_org_setup/customizations.yaml`. These fail before the change:

```
AssertionError: ...authoritative["roles/cloudbuild.builds.editor"].members
is not a valid address in the plan
```

Note the inventory previously had *no* `members` key on those bindings at all — the bug was silently baked into the fixtures.

Full stage-0 suite passes (`hardened`, `simple`, `starter-gcd`, `customizations`, `caa`).

### Reviewer note

The KMS identity is now gated on `kms_key_name` rather than on the computed `kms_service_account_id`. The provider docs do not state whether that attribute is populated when no CMEK key is configured, so this preserves the *intent* of the original null check but is a slight behaviour change if the provider returns it unconditionally. No in-repo dataset sets `logging.kms_key_name`, so it is uncovered either way — worth a second opinion.

### Workaround for affected users

Until this lands, importing the settings resource makes the value known at plan time and removes the churn:

```hcl
import {
  to = module.organization[0].google_logging_organization_settings.default[0]
  id = "organizations/ORG_ID/settings"
}
```

---
**Checklist**

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
