### PR TITLE
Make factory emission a per-family manifest choice in fabric-importer skill

### DIFF
--- a/skills/fabric-importer/COVERAGE.md
+++ b/skills/fabric-importer/COVERAGE.md
@@ -47,6 +47,13 @@ Fabric ref it was verified against; re-verify on bumps (see
 
 ## Verification Notes & Caveats
 
+- **Factory emission (opt-in)**: all matrix levels above are for the
+  default per-instance emission. The `factory` emission mode (manifest
+  `emission:` block; cookbook "Factory emission (opt-in)") is at **C**
+  across all carriers — address shapes and layout rules derived from
+  module source in-repo, no live import exercised yet. First verified
+  run graduates the exercised carrier and stamps it here.
+
 - **CAS & Custom Roles**: CAS `publishing_options` requires Fabric PR #4106 (`a153861aae`). Custom roles title/description convergence requires Fabric PR #4102.
 - **Non-CAI types**: CAI is the default source of the denominator, not its boundary. Types it does not model are enumerated with `gcloud` — automatically where `inventory.py` ships a built-in enumerator, otherwise via a manifest `enumerate:` block — or, where gcloud has no container-scoped surface, out of band against the REST API. All of it merges into the same denominator, and `inventory.py` stops the run rather than proceeding without a type it cannot enumerate. See `references/cai-blind-spots.md`.
 - **Provider Label Inheritance**: Provider v5/v6/v7 generates computed `terraform_labels: {} -> {...}` diffs for resources with inherited provider labels. These are accounted for via scoped rules in `scripts/benign-drift.yaml`.

--- a/skills/fabric-importer/SKILL.md
+++ b/skills/fabric-importer/SKILL.md
@@ -263,10 +263,18 @@ First run: everything is missing. Re-runs: only the delta.
 **Fabric modules are the product, not an optimization.** Every resource
 maps to its canonical Fabric module (the cookbook's "Canonical module
 map" is normative): `modules/organization` for everything org-level,
-one `modules/folder` instance per folder, one `modules/project`
-instance per project — each carrying its own IAM, org policies, and
-sinks. Do NOT use `project-factory` for imports: per-instance modules
-give stable, chosen addresses.
+and — by default — one `modules/folder` instance per folder and one
+`modules/project` instance per project, each carrying its own IAM, org
+policies, and sinks. For families where Fabric also offers a factory
+carrier (e.g. `project-factory` for the folder hierarchy,
+`net-firewall-policy` rule factories), the manifest may opt into
+`factory` emission per resource family via `emission:` — a human call,
+made when the imported workspace is meant to become the day-2
+operating model (e.g. foundational folders + org policies + IAM as
+YAML data). The default stays per-instance: shallow, chosen addresses
+with no coupling to factory internals. The cookbook's "Factory
+emission (opt-in)" section is normative for how, and for the
+tradeoffs.
 
 For each worklist entry, emit module config (factory YAML or module
 inputs, per the cookbook) + a paired import block targeting the

--- a/skills/fabric-importer/examples/import-manifest.org-foundation.yaml
+++ b/skills/fabric-importer/examples/import-manifest.org-foundation.yaml
@@ -85,6 +85,28 @@ scope:
   # only the new assets appear in the worklist. Types' `levels` still
   # apply on top of scope.
 
+# ---------------------------------------------------------------------
+# Optional: emission style, per resource family. This is YOUR call —
+# the scripts do not consume it; it directs step-3 mapping (see the
+# cookbook's "Factory emission (opt-in)" section, normative).
+#
+#   per-instance (default) : one module instance per container, HCL
+#                            inputs, shallow chosen addresses.
+#   factory                : data-driven YAML via the family's Fabric
+#                            factory carrier (canonical map names it;
+#                            FACTORIES.md is the full catalog).
+#
+# An org foundation is the canonical factory case: folder tree, folder
+# IAM and org policies maintained as hierarchical data/ YAML via
+# project-factory — the imported workspace doubles as the day-2
+# operating model. Mind the tradeoffs (4-level nesting cap, data-path =
+# key so directory moves re-key the subtree, deeper import addresses).
+# Per-scope override: scopes[].emission, same enum.
+#
+# emission:
+#   folder: factory
+#   project: per-instance
+
 types:
   # -------------------------------------------------------------------
   # IAM policies (pseudo-type). CAI models IAM as a content type attached

--- a/skills/fabric-importer/references/mapping-cookbook.md
+++ b/skills/fabric-importer/references/mapping-cookbook.md
@@ -29,10 +29,11 @@ ID format, the ForceNew inputs that must mirror live values, and every
 trap that cost a cycle. Mark surfaces you did not exercise as unverified
 — an honest gap is worth more than an implied guarantee.
 
-Contents: canonical module map · universal rules · workspace layout ·
-scaffolding scripts · import-ID table · per-type rules (organization,
-folders, projects, service accounts, log sinks, logging buckets, VPC
-networks, root module) · fallback and accelerator.
+Contents: canonical module map · factory emission (opt-in) · universal
+rules · workspace layout · scaffolding scripts · import-ID table ·
+per-type rules (organization, folders, projects, service accounts, log
+sinks, logging buckets, VPC networks, root module) · fallback and
+accelerator.
 
 ## Canonical module map (normative)
 
@@ -40,24 +41,110 @@ Fabric modules are the product — this table is the default mapping, not
 a suggestion. Raw resources require a documented module capability gap
 (see "Fallback" at the end).
 
-| Scope / resource family | Module | Carries |
-|---|---|---|
-| Organization | `modules/organization` (single instance) | org IAM + audit configs, org policies (factory), custom roles (factory), org sinks |
-| Folder | `modules/folder` — one instance per folder | the folder itself, folder IAM, folder org policies (factory), folder sinks |
-| Project | `modules/project` — one instance per project | the project, services, project IAM, project org policies, metadata |
-| Service accounts | `modules/iam-service-account` | SA + its IAM |
-| Log buckets | `modules/logging-bucket` | bucket config (sink destinations) |
-| VPC networks | `modules/net-vpc` | network, subnets (incl. proxy-only), routes |
-| Other | nearest Fabric module for the family; check `modules/` in-repo | — |
+Emission has two modes — `per-instance` (the default: one module
+instance per container, inputs as HCL) and `factory` (data-driven YAML
+consumed by a Fabric factory carrier). The mode is chosen per resource
+family in the manifest's `emission:` block (see "Factory emission
+(opt-in)" below); families with `—` in the factory column have exactly
+one mode and ignore the knob. Some sub-resources are factory-only by
+Fabric convention regardless of the knob: org policies, custom roles
+and custom constraints are carried as `data/` YAML inside their owning
+`organization` / `folder` / `project` instance.
 
-Never use `project-factory` for imports: per-instance `folder` /
-`project` modules give addresses derived from instance keys you choose
-once, instead of display-name-derived factory keys.
+| Scope / resource family | Default (`per-instance`) | `factory` emission — carrier | Carries |
+|---|---|---|---|
+| Organization | `modules/organization` (single instance) | — | org IAM + audit configs, org policies (factory), custom roles (factory), org sinks |
+| Folder | `modules/folder` — one instance per folder | `project-factory` — hierarchy `data/`, one YAML dir per folder, path = key | the folder itself, folder IAM, folder org policies (factory), folder sinks |
+| Project | `modules/project` — one instance per project | `project-factory` — one project YAML per project | the project, services, project IAM, project org policies, metadata |
+| Service accounts | `modules/iam-service-account` | `project-factory` — `service_accounts:` block in the owning project's YAML (only when that project is factory-emitted) | SA + its IAM |
+| Log buckets | `modules/logging-bucket` | — | bucket config (sink destinations) |
+| VPC networks | `modules/net-vpc` | subnets only: `net-vpc` `factories_config.subnets_folder` | network, subnets (incl. proxy-only), routes |
+| Firewall policy rules | `modules/net-firewall-policy` inputs | `net-firewall-policy` `factories_config` rule files | ingress/egress rules |
+| Other | nearest Fabric module for the family; check `modules/` in-repo | see `FACTORIES.md` at the repo root — the authoritative factory catalog (every module factory flows through `factories_config`) | — |
 
 Instance keys: pick short stable slugs at first import (record them in
 `coverage-map.yaml`); keys are immutable afterwards. Because the key —
 not the display name — defines the address, a console rename plans as
 an in-place `name` update, not destroy/create (verified r6).
+
+## Factory emission (opt-in)
+
+**Status: cookbook-level (C) — rules below are derived from module
+source in this repository, not yet exercised against live imports.**
+Everything in this section meets that standard and no higher; treat
+unmarked claims as unverified.
+
+The manifest owns the choice, per resource family:
+
+```yaml
+# Values: per-instance (default) | factory. Family names are the
+# canonical-map rows; families without a factory carrier reject
+# `factory`. Resolution: scopes[].emission.<family> → top-level
+# emission.<family> → per-instance.
+emission:
+  folder: factory          # -> project-factory hierarchy data/
+  project: per-instance
+
+scopes:
+  - name: org-foundation
+    levels: [organization, folder]
+    emission:
+      folder: factory      # per-scope override, same enum
+```
+
+When to opt in: the imported workspace is the intended day-2 operating
+model and the family's ongoing management is data-shaped — the
+canonical case is foundational infrastructure, with the folder tree,
+folder IAM and org policies maintained as hierarchical YAML. When in
+doubt, stay per-instance; graduating a family to factory emission later
+is a `moved {}` exercise, per instance, at a time of your choosing.
+
+### Tradeoffs (why per-instance stays the default)
+
+- **Key = data path, blast radius = subtree.** In `project-factory` the
+  hierarchy directory path IS the instance key: renaming or moving a
+  directory re-keys every folder and project below it — a
+  destroy/create plan across the subtree. The same immutability rule as
+  instance keys applies (choose the `data/` layout once, record it in
+  `coverage-map.yaml`), but the coupling is structural, not per-key.
+  D-04 recovery applies unchanged if it ever happens.
+- **Deeper, internal addresses.** Import blocks target factory
+  internals — these are not a stable interface across Fabric refs, so
+  "read the module source in this repository, do not trust memory" does
+  double duty here. Re-verify address shapes on every Fabric ref bump.
+- **Nesting depth.** `project-factory` supports at most 4 folder
+  levels (hardcoded `module.folder-1` … `module.folder-4`); the
+  per-instance `modules/folder` chain has no limit. A hierarchy deeper
+  than 4 cannot be factory-emitted.
+- **The reference rule changes carrier.** Inside factory YAML,
+  references are context interpolations (`$folder_ids:<path>`,
+  `$iam_principals:…`), not module outputs. The rule itself is
+  unchanged — no literals for managed resources — only its spelling.
+
+### project-factory: addresses and layout (from module source)
+
+- Folders: `module.<pf>.module.folder-<level>["<path>"]` where
+  `<level>` is 1-based directory depth and `<path>` the `data/`-relative
+  directory path. Folder IAM lives on a **separate** paired instance,
+  `module.<pf>.module.folder-<level>-iam["<path>"]` — both must appear
+  in `coverage-map.yaml` for a folder with IAM.
+- Projects: `module.<pf>.module.projects["<key>"]`; service accounts:
+  see `projects-service-accounts.tf` for the key format.
+- Cross-emission references: the factory outputs `folder_ids` /
+  `project_ids` / `iam_principals` keyed by hierarchy path, so mixed
+  mode composes without literals — a per-instance project under a
+  factory folder takes `parent = module.<pf>.folder_ids["<path>"]`.
+  The inverse (factory projects under per-instance folders) goes
+  through the factory's `context.folder_ids` input.
+- Escaping: the factory-YAML rows of the escaping table below apply
+  wholesale; check `templatestring` usage per field with the same
+  `grep -rn templatestring modules/project-factory/` discipline.
+
+Other carriers (`net-vpc` subnet factory, `net-firewall-policy` rule
+files, …): same method — read the carrier's `factories_config` source,
+derive address + key formats, and add a subsection here as part of the
+run report, marking what was exercised. `FACTORIES.md` at the repo root
+is the authoritative catalog of factory carriers.
 
 ## Universal rules
 
@@ -370,8 +457,8 @@ let plan tell you: it errors loudly and safely on a wrong ID.
 
 - Chain parents by module reference
   (`parent = module.folder-<parent-key>.id`; top-level folders point at
-  the org). No nesting-depth limit — that was a project-factory
-  constraint.
+  the org). No nesting-depth limit — unlike factory emission, which
+  caps at 4 levels (see "Factory emission (opt-in)").
 - Set `deletion_protection = true` (imported provider default; avoids a
   spurious in-place change — verified r2).
 - Folder-level org policies, sinks and IAM live on the same instance as


### PR DESCRIPTION
## Motivation

The skill was prescriptive about never using `project-factory` for imports. There are scenarios where factory emission is the better call — e.g. foundational infrastructure, where maintaining folders, their org policies and IAM bindings as hierarchical YAML is exactly the day-2 operating model the customer wants. The call belongs to the user, in the manifest (which is already framed as the user-owned contract).

## Design

- **Generic axis, not a project-factory switch**: emission is `per-instance` (default) | `factory`, keyed **per resource family** (canonical-map rows), since other families have factory carriers too (net-vpc subnet factory, net-firewall-policy rule files, …). `FACTORIES.md` is the authoritative carrier catalog — verified that every module factory flows through `factories_config`.
- **Per-scope override**: `scopes[].emission.<family>` → top-level `emission.<family>` → `per-instance`, so e.g. factory folders + per-instance projects is expressible. Mixed mode composes without literals via factory outputs (`folder_ids`/`project_ids` keyed by hierarchy path).
- **Canonical map** gains a factory-carrier column; org policies / custom roles are now honestly stated as factory-only rather than buried in the Carries column.
- **Tradeoffs documented** instead of banned: data-path = instance key (directory moves re-key the subtree → D-04), deeper module-internal import addresses, **4-level folder nesting cap** (hardcoded `module.folder-1..4` — also fixes the stale claim that this 'was' a constraint), context-interpolation reference carrier.
- **Honesty preserved**: scripts untouched (`emission` is documentary; coverage.py is emission-agnostic), and COVERAGE.md stamps factory emission at **C** — address shapes derived from module source in-repo, no live import exercised yet.

## Files

- `SKILL.md` — step-3 prohibition → default + manifest opt-in
- `references/mapping-cookbook.md` — map columns + new normative *Factory emission (opt-in)* section
- `examples/import-manifest.org-foundation.yaml` — commented `emission:` block in the canonical use case
- `COVERAGE.md` — maturity note

`yamllint` and `check_boilerplate.py` pass on the touched YAML.