### PR TITLE
Exclude default log sinks, buckets, and PAM grants in fabric-importer

### DIFF
--- a/skills/fabric-importer/README.md
+++ b/skills/fabric-importer/README.md
@@ -373,10 +373,10 @@ to the current working directory.
 
 | Script | Purpose | Flags |
 |---|---|---|
-| `inventory.py survey` | Enumerate everything in scope, to draft a manifest from | `--scope` (required), `--out`, `--verbose` |
+| `inventory.py survey` | Enumerate everything in scope, to draft a manifest from | `--scope` (required), `--out`, `--verbose`, `--include-deleted`, `--include-logging-defaults`, `--include-pam-grants` |
 | `manifest_init.py` | Draft a manifest from a survey (Mode B) | `--survey` (required), `--scope` (required), `--out` |
 | `manifest_from_state.py` | Infer a manifest from existing `.tfstate` (Mode A) | `--state` (1+, required), `--out` (`-` for stdout), `--force` to overwrite an existing manifest |
-| `inventory.py collect` | Build the denominator from CAI | `--manifest` (required), `--out`, `--verbose` |
+| `inventory.py collect` | Build the denominator from CAI | `--manifest` (required), `--out`, `--verbose`, `--include-deleted`, `--include-logging-defaults`, `--include-pam-grants` |
 | `coverage.py` | Gate 1 — completeness | `--inventory` (required), `--workspace` (required), `--coverage-map`, `--waivers`, `--require-signed-waivers`, `--allow-empty-inventory`, `--worklist-out` |
 | `verify_plan.py` | Gate 2 — plan convergence | positional plan JSON (default stdin), `--rules`, `--allow-empty-plan` |
 | `integrity.py` | Print the frozen-tools provenance digest | `--verbose` for per-file digests |

--- a/skills/fabric-importer/SKILL.md
+++ b/skills/fabric-importer/SKILL.md
@@ -204,6 +204,12 @@ projects) and their child resources, matching what is active in the GCP Console.
 Pass `--include-deleted` if you explicitly need to capture soft-deleted assets in
 the denominator (e.g. to audit or waive them).
 
+Similarly, Google-managed default log sinks and log buckets (`_Default` and
+`_Required`) as well as Privileged Access Manager (PAM) grants
+(`privilegedaccessmanager.googleapis.com/Grant`) are automatically excluded from
+the denominator. Pass `--include-logging-defaults` or `--include-pam-grants` if
+you explicitly need to capture them in the denominator.
+
 **CAI is the default source of the denominator, never the boundary of
 it.** Cloud Asset Inventory does not model every GCP resource. A type it
 does not support must be enumerated by other means and merged into the

--- a/skills/fabric-importer/references/mapping-cookbook.md
+++ b/skills/fabric-importer/references/mapping-cookbook.md
@@ -653,7 +653,7 @@ let plan tell you: it errors loudly and safely on a wrong ID.
 
 ### Log sinks (org/folder level)
 
-- Never import `_Default` / `_Required` (Google-managed; waive).
+- Never import `_Default` / `_Required` (Google-managed; automatically excluded from the denominator by `inventory.py`).
 - The module `type` enum is `gcs` (not `storage`), `bigquery`,
   `logging`, `pubsub`, `project` — map the destination API prefix
   accordingly; fail on an unknown prefix, never rewrite (r7).
@@ -669,7 +669,7 @@ let plan tell you: it errors loudly and safely on a wrong ID.
 ### Logging buckets (`modules/logging-bucket`) — verified r10
 
 - Manifest: `logging.googleapis.com/LogBucket`, `levels: [project]`.
-- Waive the `_Default` and `_Required` buckets (Google-managed).
+- `_Default` and `_Required` buckets are Google-managed and automatically excluded from the denominator by `inventory.py`.
 - ForceNew parent trap: the provider stores
   `project = "projects/<id>"` on import; a bare project id in `parent`
   plans a ForceNew recreation. Always pass
@@ -863,8 +863,18 @@ let plan tell you: it errors loudly and safely on a wrong ID.
 - **Org Policy Constraints & Traps**:
   - `constraints/iam.workloadIdentityPoolProviders`: Restricts allowed external identity provider issuer URLs.
   - Providers (such as GitHub Actions OIDC) require CEL `attribute_condition` referencing provider claims (e.g. `assertion.repository == '...'`).
-- **Residue Accounting**:
-  - Workload Identity Pools are soft-deleted by GCP with a 30-day purge window. A deleted pool ID cannot be reused immediately. Seeded pools during test runs must use round-specific unique IDs.
+### Privileged Access Manager (PAM)
+
+- **Canonical Module**: `modules/organization`, `modules/folder`, `modules/project` via `pam_entitlements` map or `factories_config.pam_entitlements` factory path.
+- **Resource Address**:
+  - `module.<container>.google_privileged_access_manager_entitlement.default["<entitlement_id>"]`
+- **Import ID Formats**:
+  - Entitlement: `{{parent}}/locations/{{location}}/entitlements/{{entitlement_id}}` (e.g., `organizations/123/locations/global/entitlements/my-entitlement` or `projects/my-project/locations/global/entitlements/my-entitlement`)
+- **CAI Types**:
+  - `privilegedaccessmanager.googleapis.com/Entitlement` (levels: `organization`, `folder`, `project`)
+  - `privilegedaccessmanager.googleapis.com/Grant`: Ephemeral runtime access requests generated upon JIT access activation. Excluded from survey and collection by default; retained only with `--include-pam-grants`.
+- **Traps**:
+  - Grants represent transient workflow state with short TTLs and should **not** be managed in Terraform baseline IaC.
 
 ### Root module
 

--- a/skills/fabric-importer/scripts/inventory.py
+++ b/skills/fabric-importer/scripts/inventory.py
@@ -286,6 +286,31 @@ def _has_deleted_ancestor(asset, deleted_containers):
   return False
 
 
+def _is_google_managed_logging_asset(asset):
+  """Checks if an asset is a Google-managed default log sink or log bucket (_Default / _Required)."""
+  t = asset.get('assetType', '')
+  name = asset.get('name', '')
+  if t == 'logging.googleapis.com/LogSink':
+    if name.endswith('/sinks/_Default') or name.endswith('/sinks/_Required'):
+      return True
+  elif t == 'logging.googleapis.com/LogBucket':
+    if name.endswith('/buckets/_Default') or name.endswith(
+        '/buckets/_Required'):
+      return True
+  return False
+
+
+def _is_pam_grant_asset(asset):
+  """Checks if an asset is a Privileged Access Manager (PAM) Grant."""
+  t = asset.get('assetType', '') or asset.get('asset_type', '')
+  if t == 'privilegedaccessmanager.googleapis.com/Grant':
+    return True
+  name = asset.get('name', '') or asset.get('key', '')
+  if '//privilegedaccessmanager.googleapis.com/' in name and '/grants/' in name:
+    return True
+  return False
+
+
 class ProjectRegistry:
   """Maintains bidirectional mapping between Project IDs and Project Numbers, and tracks deleted containers."""
 
@@ -1159,7 +1184,8 @@ def api_call_summary():
           f'{f", {failed} not ok" if failed else ""}: {families}')
 
 
-def collect(manifest, include_deleted=False):
+def collect(manifest, include_deleted=False, include_logging_defaults=False,
+            include_pam_grants=False):
   # Module-level accumulators: reset so a second collect() in the same
   # process cannot inherit the first run's failures (or hide behind
   # them).
@@ -1209,6 +1235,8 @@ def collect(manifest, include_deleted=False):
 
   all_entries = []
   scope_summaries = []
+  excluded_defaults_count = 0
+  excluded_pam_grants_count = 0
 
   for s in scopes:
     root = s['root']
@@ -1307,13 +1335,20 @@ def collect(manifest, include_deleted=False):
                 '--format=json', f'--page-size={CAI_SEARCH_PAGE_SIZE}'
             ], ignore_errors=True)
       registry.ingest_assets(assets)
-      filtered_res = [
-          a for a in assets
-          if (include_deleted or
-              (not _is_deleted_container(a) and
-               not _has_deleted_ancestor(a, registry.deleted_containers))) and
-          in_subtree(a, include, exclude, registry)
-      ]
+      filtered_res = []
+      for a in assets:
+        if not include_deleted and (_is_deleted_container(a) or
+                                    _has_deleted_ancestor(
+                                        a, registry.deleted_containers)):
+          continue
+        if not include_logging_defaults and _is_google_managed_logging_asset(a):
+          excluded_defaults_count += 1
+          continue
+        if not include_pam_grants and _is_pam_grant_asset(a):
+          excluded_pam_grants_count += 1
+          continue
+        if in_subtree(a, include, exclude, registry):
+          filtered_res.append(a)
       scope_entries += _normalize_resources(filtered_res)
 
     if ('iam' in effective_levels_by_type and
@@ -1322,6 +1357,8 @@ def collect(manifest, include_deleted=False):
           a for a in run_gcloud_json([scope_arg, '--content-type=iam-policy'])
           if (include_deleted or
               not _has_deleted_ancestor(a, registry.deleted_containers)) and
+          (include_logging_defaults or not _is_google_managed_logging_asset(a)
+          ) and (include_pam_grants or not _is_pam_grant_asset(a)) and
           in_subtree(a, include, exclude, registry)
       ]
       registry.ingest_assets(assets)
@@ -1413,6 +1450,20 @@ def collect(manifest, include_deleted=False):
         'state; never mapped, never waived). Details in '
         '_meta.pam_grant_exclusions.', file=sys.stderr)
 
+  if excluded_defaults_count and not include_logging_defaults:
+    print(
+        f'\nNOTICE: excluded {excluded_defaults_count} Google-managed default log sink(s)/bucket(s) (_Default, _Required).',
+        file=sys.stderr)
+    print('Use --include-logging-defaults to retain them in the denominator.',
+          file=sys.stderr)
+
+  if excluded_pam_grants_count and not include_pam_grants:
+    print(
+        f'\nNOTICE: excluded {excluded_pam_grants_count} Privileged Access Manager (PAM) grant(s).',
+        file=sys.stderr)
+    print('Use --include-pam-grants to retain them in the denominator.',
+          file=sys.stderr)
+
   if NATIVE_SWEEPS:
     by_type = {}
     for sw in NATIVE_SWEEPS:
@@ -1490,7 +1541,8 @@ def collect(manifest, include_deleted=False):
   return entries, registry, scope_summaries
 
 
-def survey(scope_root, include_deleted=False):
+def survey(scope_root, include_deleted=False, include_logging_defaults=False,
+           include_pam_grants=False):
   if '/' not in scope_root:
     scope_root = f'projects/{scope_root}'
   scope_flag = {
@@ -1510,6 +1562,10 @@ def survey(scope_root, include_deleted=False):
         a for a in assets if not _is_deleted_container(a) and
         not _has_deleted_ancestor(a, registry.deleted_containers)
     ]
+  if not include_logging_defaults:
+    assets = [a for a in assets if not _is_google_managed_logging_asset(a)]
+  if not include_pam_grants:
+    assets = [a for a in assets if not _is_pam_grant_asset(a)]
   return _normalize_resources(assets)
 
 
@@ -1529,6 +1585,14 @@ def main():
       '--include-deleted', action='store_true', help=
       'include soft-deleted / pending-deletion folders and projects (default: active only)'
   )
+  common.add_argument(
+      '--include-logging-defaults', action='store_true', help=
+      'include Google-managed default log sinks and log buckets (_Default, _Required)'
+  )
+  common.add_argument(
+      '--include-pam-grants', action='store_true', help=
+      'include Privileged Access Manager (PAM) grants (default: excluded as ephemeral runtime state)'
+  )
   sub = p.add_subparsers(dest='mode', required=True)
   ps = sub.add_parser('survey', parents=[common])
   ps.add_argument('--scope', required=True,
@@ -1541,20 +1605,27 @@ def main():
   VERBOSE = args.verbose
 
   if args.mode == 'survey':
+    kwargs = {}
     if args.include_deleted:
-      entries = survey(args.scope, include_deleted=True)
-    else:
-      entries = survey(args.scope)
+      kwargs['include_deleted'] = True
+    if args.include_logging_defaults:
+      kwargs['include_logging_defaults'] = True
+    if args.include_pam_grants:
+      kwargs['include_pam_grants'] = True
+    entries = survey(args.scope, **kwargs)
     payload = json.dumps(entries, indent=2)
   else:
     with open(args.manifest, 'rb') as f:
       manifest_raw = f.read()
     manifest = yaml.safe_load(manifest_raw)
+    kwargs = {}
     if args.include_deleted:
-      entries, registry, scope_summaries = collect(manifest,
-                                                   include_deleted=True)
-    else:
-      entries, registry, scope_summaries = collect(manifest)
+      kwargs['include_deleted'] = True
+    if args.include_logging_defaults:
+      kwargs['include_logging_defaults'] = True
+    if args.include_pam_grants:
+      kwargs['include_pam_grants'] = True
+    entries, registry, scope_summaries = collect(manifest, **kwargs)
 
     # Per-declared-type yield table.
     declared = [t['type'] for t in manifest.get('types') or []]

--- a/skills/fabric-importer/tests/test_scripts.py
+++ b/skills/fabric-importer/tests/test_scripts.py
@@ -2736,6 +2736,178 @@ class TestDeletedContainersFilter(unittest.TestCase):
     finally:
       inventory.run_json = real
 
+  def test_inventory_google_managed_logging_defaults_filtering(self):
+    real = inventory.run_json
+    fake_assets = [
+        {
+            'assetType':
+                'logging.googleapis.com/LogSink',
+            'name':
+                '//logging.googleapis.com/organizations/1/sinks/custom-sink',
+            'ancestors': ['organizations/1'],
+        },
+        {
+            'assetType': 'logging.googleapis.com/LogSink',
+            'name': '//logging.googleapis.com/organizations/1/sinks/_Default',
+            'ancestors': ['organizations/1'],
+        },
+        {
+            'assetType': 'logging.googleapis.com/LogSink',
+            'name': '//logging.googleapis.com/organizations/1/sinks/_Required',
+            'ancestors': ['organizations/1'],
+        },
+        {
+            'assetType':
+                'logging.googleapis.com/LogBucket',
+            'name':
+                '//logging.googleapis.com/projects/12345/locations/global/buckets/custom-bucket',
+            'ancestors': ['projects/12345', 'organizations/1'],
+        },
+        {
+            'assetType':
+                'logging.googleapis.com/LogBucket',
+            'name':
+                '//logging.googleapis.com/projects/12345/locations/global/buckets/_Default',
+            'ancestors': ['projects/12345', 'organizations/1'],
+        },
+        {
+            'assetType':
+                'logging.googleapis.com/LogBucket',
+            'name':
+                '//logging.googleapis.com/projects/12345/locations/global/buckets/_Required',
+            'ancestors': ['projects/12345', 'organizations/1'],
+        },
+    ]
+
+    def fake(cmd, **kwargs):
+      del cmd, kwargs
+      return list(fake_assets)
+
+    inventory.run_json = fake
+    try:
+      manifest = {
+          'scope': {
+              'root': 'organizations/1'
+          },
+          'types': [
+              {
+                  'type': 'logging.googleapis.com/LogSink'
+              },
+              {
+                  'type': 'logging.googleapis.com/LogBucket'
+              },
+          ]
+      }
+      # Default: excludes _Default and _Required sinks and buckets
+      entries_default, _, _ = inventory.collect(manifest,
+                                                include_logging_defaults=False)
+      keys_default = [e['key'] for e in entries_default]
+      self.assertIn(
+          '//logging.googleapis.com/organizations/1/sinks/custom-sink',
+          keys_default)
+      self.assertIn(
+          '//logging.googleapis.com/projects/12345/locations/global/buckets/custom-bucket',
+          keys_default)
+      self.assertNotIn(
+          '//logging.googleapis.com/organizations/1/sinks/_Default',
+          keys_default)
+      self.assertNotIn(
+          '//logging.googleapis.com/organizations/1/sinks/_Required',
+          keys_default)
+      self.assertNotIn(
+          '//logging.googleapis.com/projects/12345/locations/global/buckets/_Default',
+          keys_default)
+      self.assertNotIn(
+          '//logging.googleapis.com/projects/12345/locations/global/buckets/_Required',
+          keys_default)
+
+      # Opt-in: include_logging_defaults=True retains all
+      entries_all, _, _ = inventory.collect(manifest,
+                                            include_logging_defaults=True)
+      keys_all = [e['key'] for e in entries_all]
+      self.assertEqual(len(keys_all), 6)
+      self.assertIn('//logging.googleapis.com/organizations/1/sinks/_Default',
+                    keys_all)
+      self.assertIn(
+          '//logging.googleapis.com/projects/12345/locations/global/buckets/_Required',
+          keys_all)
+    finally:
+      inventory.run_json = real
+
+  def test_survey_google_managed_logging_defaults_filtering(self):
+    real = inventory.run_json
+    fake_assets = [
+        {
+            'assetType':
+                'logging.googleapis.com/LogSink',
+            'name':
+                '//logging.googleapis.com/organizations/1/sinks/custom-sink',
+            'ancestors': ['organizations/1'],
+        },
+        {
+            'assetType': 'logging.googleapis.com/LogSink',
+            'name': '//logging.googleapis.com/organizations/1/sinks/_Default',
+            'ancestors': ['organizations/1'],
+        },
+    ]
+
+    def fake(cmd, **kwargs):
+      del cmd, kwargs
+      return list(fake_assets)
+
+    inventory.run_json = fake
+    try:
+      entries_default = inventory.survey('organizations/1',
+                                         include_logging_defaults=False)
+      self.assertEqual(len(entries_default), 1)
+      self.assertEqual(
+          entries_default[0]['key'],
+          '//logging.googleapis.com/organizations/1/sinks/custom-sink')
+
+      entries_all = inventory.survey('organizations/1',
+                                     include_logging_defaults=True)
+      self.assertEqual(len(entries_all), 2)
+    finally:
+      inventory.run_json = real
+
+  def test_survey_pam_grants_filtering(self):
+    real = inventory.run_json
+    fake_assets = [
+        {
+            'assetType':
+                'privilegedaccessmanager.googleapis.com/Entitlement',
+            'name':
+                '//privilegedaccessmanager.googleapis.com/organizations/1/locations/global/entitlements/org-admin',
+            'ancestors': ['organizations/1'],
+        },
+        {
+            'assetType':
+                'privilegedaccessmanager.googleapis.com/Grant',
+            'name':
+                '//privilegedaccessmanager.googleapis.com/organizations/1/locations/global/entitlements/org-admin/grants/grant-123',
+            'ancestors': ['organizations/1'],
+        },
+    ]
+
+    def fake(cmd, **kwargs):
+      del cmd, kwargs
+      return list(fake_assets)
+
+    inventory.run_json = fake
+    try:
+      entries_default = inventory.survey('organizations/1',
+                                         include_pam_grants=False)
+      self.assertEqual(len(entries_default), 1)
+      self.assertEqual(
+          entries_default[0]['key'],
+          '//privilegedaccessmanager.googleapis.com/organizations/1/locations/global/entitlements/org-admin'
+      )
+
+      entries_all = inventory.survey('organizations/1', include_pam_grants=True)
+      self.assertEqual(len(entries_all), 2)
+    finally:
+      inventory.run_json = real
+
 
 def _parse_state(state_content):
   """Runs parse_state_files over one in-memory state document."""


### PR DESCRIPTION
### Description

This PR excludes Google-managed default logging assets and ephemeral Privileged Access Manager (PAM) grants by default from the inventory denominator and survey discovery in `skills/fabric-importer`, providing opt-in CLI flags when they need to be retained:

1. **Logging Defaults Exclusions**:
   - Google-managed default log sinks and buckets (`_Default`, `_Required`) across organizations, folders, and projects are filtered out by default.
   - Retainable via `--include-logging-defaults`.
   - Eliminates dozens/hundreds of boilerplate waivers on real estates while preserving complete coverage verification.

2. **Privileged Access Manager (PAM) Grants Exclusions**:
   - Ephemeral PAM grants (`privilegedaccessmanager.googleapis.com/Grant`) generated upon JIT access requests are filtered out by default in both `survey` and `collect` modes.
   - Retainable via `--include-pam-grants`.
   - Distinguishes declarative static IaC (`Entitlement`) from transient runtime audit state (`Grant`).

3. **Documentation & Tests**:
   - Unit tests added in `skills/fabric-importer/tests/test_scripts.py` for both features.
   - Updated `SKILL.md`, `README.md`, and added Privileged Access Manager (PAM) recipe section to `references/mapping-cookbook.md`.