### PR TITLE
Sweep CAI list-surface split types in fabric-importer inventory

### DIFF
--- a/skills/fabric-importer/README.md
+++ b/skills/fabric-importer/README.md
@@ -291,6 +291,32 @@ the same inventory (this also overrides a built-in):
       key: '//iam.googleapis.com/{container}/denypolicies/{item.name}'
 ```
 
+CAI is also not one taxonomy but two, and they disagree. For a few
+Compute families the list surface (`asset list`, the primary sweep)
+splits the family by scope into separate asset types, while
+`search-all-resources` unifies them:
+`compute.googleapis.com/GlobalAddress`, `.../GlobalForwardingRule`,
+`.../RegionBackendService` and `.../RegionDisk` exist only on the list
+surface. Declaring the unified type therefore used to collect only part
+of the family — with no error, no failed sweep, and a non-zero yield, so
+every guard stayed quiet. The tool now sweeps the known siblings
+alongside the declared type at no extra API cost and accounts them under
+it, preserving the real type per entry (`cai_list_type`) and in
+`_meta.split_type_sweeps`.
+
+That table is a frozen snapshot of a document Google changes, so check
+it against live CAI at least once per engagement:
+
+```bash
+uv run scripts/inventory.py collect --manifest import-manifest.yaml \
+  --out inventory.json --verify-search-parity
+```
+
+It costs one extra `search-all-resources` call per scope and fails the
+run if the search surface returns an asset the list sweep did not.
+`_meta.split_parity` is absent when the probe did not run, which is not
+the same as clean.
+
 Every run closes with a one-line cost summary on stderr:
 
 ```
@@ -376,7 +402,7 @@ to the current working directory.
 | `inventory.py survey` | Enumerate everything in scope, to draft a manifest from | `--scope` (required), `--out`, `--verbose`, `--include-deleted`, `--include-logging-defaults`, `--include-pam-grants` |
 | `manifest_init.py` | Draft a manifest from a survey (Mode B) | `--survey` (required), `--scope` (required), `--out` |
 | `manifest_from_state.py` | Infer a manifest from existing `.tfstate` (Mode A) | `--state` (1+, required), `--out` (`-` for stdout), `--force` to overwrite an existing manifest |
-| `inventory.py collect` | Build the denominator from CAI | `--manifest` (required), `--out`, `--verbose`, `--include-deleted`, `--include-logging-defaults`, `--include-pam-grants` |
+| `inventory.py collect` | Build the denominator from CAI | `--manifest` (required), `--out`, `--verbose`, `--include-deleted`, `--include-logging-defaults`, `--include-pam-grants`, `--verify-search-parity` |
 | `coverage.py` | Gate 1 — completeness | `--inventory` (required), `--workspace` (required), `--coverage-map`, `--waivers`, `--require-signed-waivers`, `--allow-empty-inventory`, `--worklist-out` |
 | `verify_plan.py` | Gate 2 — plan convergence | positional plan JSON (default stdin), `--rules`, `--allow-empty-plan` |
 | `integrity.py` | Print the frozen-tools provenance digest | `--verbose` for per-file digests |

--- a/skills/fabric-importer/README.md
+++ b/skills/fabric-importer/README.md
@@ -314,8 +314,9 @@ uv run scripts/inventory.py collect --manifest import-manifest.yaml \
 
 It costs one extra `search-all-resources` call per scope and fails the
 run if the search surface returns an asset the list sweep did not.
-`_meta.split_parity` is absent when the probe did not run, which is not
-the same as clean.
+`_meta.split_parity` is EMPTY when the probe did not run; a probe that
+ran and found nothing is a record whose `only_in_search` is empty. Read
+the record, not the key — the two are not the same claim.
 
 Every run closes with a one-line cost summary on stderr:
 

--- a/skills/fabric-importer/SKILL.md
+++ b/skills/fabric-importer/SKILL.md
@@ -223,12 +223,35 @@ enumerators for types known to be absent from the CAI catalogue
 (`NATIVE_ENUMERATORS`), so declaring the type in the manifest is enough
 — the tool skips CAI, sweeps with gcloud, and says so. Where no
 enumerator exists it refuses to proceed rather than guess, and it
-separates that case from a permission failure. Two remedies, in order:
+separates that case from a permission failure. Three remedies, in order:
 
 - **The type string is wrong.** The common case. Check it against the
   [supported types list](https://cloud.google.com/asset-inventory/docs/supported-asset-types)
   — CAI calls the Logs Router settings singleton
   `logging.googleapis.com/Settings`, not `.../OrganizationSettings`.
+- **The type string is right, but only for the other CAI surface.** CAI
+  has TWO asset-type taxonomies. For a few Compute families the
+  list surface (`asset list`, the primary sweep) splits the family by
+  scope into separate types — `compute.googleapis.com/GlobalAddress`,
+  `.../GlobalForwardingRule`, `.../RegionBackendService`,
+  `.../RegionDisk` — while `search-all-resources` unifies them. This
+  one does not raise: the declared type is supported, the sweep
+  succeeds, the yield is non-zero, and the split-off assets are simply
+  never asked for. `inventory.py` sweeps the known siblings
+  automatically and accounts them under the declared type (stamped in
+  `_meta.split_type_sweeps`, and per entry as `cai_list_type`). The
+  table is a frozen snapshot of a doc that changes, so check it against
+  live CAI at least once per engagement:
+
+  ```bash
+  uv run scripts/inventory.py collect --manifest import-manifest.yaml \
+    --out inventory.json --verify-search-parity
+  ```
+
+  One extra call per scope; fatal if the search surface returns an asset
+  the list sweep did not. `_meta.split_parity` absent means NOT CHECKED,
+  which is not the same as clean — say which in the report. See
+  [references/cai-blind-spots.md](./references/cai-blind-spots.md).
 - **CAI genuinely does not model the type, and no built-in covers it.**
   Give it a native enumerator in the manifest — a read-only gcloud
   command run per in-scope container, normalized into inventory
@@ -254,7 +277,9 @@ separates that case from a permission failure. Two remedies, in order:
 
 Every entry that did not come from CAI is stamped into
 `inventory.json`'s `_meta.native_sweeps` with the verbatim command, and
-belongs in the step-5 report.
+belongs in the step-5 report. Entries that came from CAI under a
+different asset type than the one declared are stamped into
+`_meta.split_type_sweeps` and belong there too.
 
 Collection closes with a one-line cost summary (`N gcloud call(s) in
 Xs: …`) and records every command it ran in `_meta.api_calls`. Add
@@ -374,6 +399,12 @@ The loop:
    `gcloud asset list` output before trusting it. Type strings taken
    from module knowledge have been wrong before. Record what CAI
    actually returns, including which enumeration path had to be used.
+   A non-zero yield is NOT confirmation that the type is complete: for
+   split families the list surface answers happily with only part of
+   the family (see step 1's second remedy). Where the type has any
+   global/regional/zonal distinction, census it on BOTH surfaces —
+   `asset list --asset-types=T` against `asset search-all-resources
+   --asset-types=T` — and reconcile the counts before trusting either.
    If CAI does not model the type at all, that is not a dead end and
    not a reason to narrow the manifest: enumerate it with `gcloud` (or
    the REST API) and merge it into the same denominator — see step 1 and
@@ -438,6 +469,17 @@ of completeness**, and a reconciled coverage report is not evidence of
 correctness. Never report one as if it covered the other, and never
 skip a gate because the other one is green.
 
+**An orphan import block is evidence about the DENOMINATOR, not just
+about the coverage map.** When gate 1 reports an `import {}` block
+targeting a resource that is not in `inventory.json`, and you know that
+resource is live, the first hypothesis is that enumeration missed it —
+not that the mapping is spurious. This is the only signal that fires for
+a silently short denominator, and it has been mistaken for a coverage-map
+problem and waived away in a live run. Investigate the enumeration path
+for that type (step 1, and `references/cai-blind-spots.md`) BEFORE
+proposing a waiver: a waiver over a short denominator makes the gap
+permanent and puts a human's name on it.
+
 ```bash
 terraform -chdir=tf fmt -recursive   # generated code is ALWAYS fmt-ed
 uv run scripts/coverage.py --inventory inventory.json --workspace tf \
@@ -485,7 +527,10 @@ module fell short, which attribute, and whether it is
 upstream-Fabric-issue material — plus
 benign diffs relied on, waivers in effect, proposed waivers/benign rules
 awaiting human review, and anything the manifest excludes that you
-believe deserves attention. Plain facts; no "100%" claims beyond what the
+believe deserves attention. State whether `--verify-search-parity` was
+run and what it found; `_meta.split_parity` absent means NOT CHECKED,
+and reporting an unchecked table as clean is exactly the kind of claim
+this section exists to prevent. Plain facts; no "100%" claims beyond what the
 gates literally verified.
 
 The report MUST include the verbatim stdout of both final gate runs —

--- a/skills/fabric-importer/SKILL.md
+++ b/skills/fabric-importer/SKILL.md
@@ -249,8 +249,10 @@ separates that case from a permission failure. Three remedies, in order:
   ```
 
   One extra call per scope; fatal if the search surface returns an asset
-  the list sweep did not. `_meta.split_parity` absent means NOT CHECKED,
-  which is not the same as clean — say which in the report. See
+  the list sweep did not. `_meta.split_parity` EMPTY means the probe did
+  not run; a probe that ran and found nothing is a record whose
+  `only_in_search` is empty. Read the record, not the key — and say
+  which in the report. See
   [references/cai-blind-spots.md](./references/cai-blind-spots.md).
 - **CAI genuinely does not model the type, and no built-in covers it.**
   Give it a native enumerator in the manifest — a read-only gcloud
@@ -528,9 +530,10 @@ upstream-Fabric-issue material — plus
 benign diffs relied on, waivers in effect, proposed waivers/benign rules
 awaiting human review, and anything the manifest excludes that you
 believe deserves attention. State whether `--verify-search-parity` was
-run and what it found; `_meta.split_parity` absent means NOT CHECKED,
-and reporting an unchecked table as clean is exactly the kind of claim
-this section exists to prevent. Plain facts; no "100%" claims beyond what the
+run and what it found. An empty `_meta.split_parity` means the probe did
+not run; a clean probe is a record whose `only_in_search` is empty.
+Reporting an unchecked table as clean is exactly the kind of claim this
+section exists to prevent. Plain facts; no "100%" claims beyond what the
 gates literally verified.
 
 The report MUST include the verbatim stdout of both final gate runs —

--- a/skills/fabric-importer/references/cai-blind-spots.md
+++ b/skills/fabric-importer/references/cai-blind-spots.md
@@ -133,8 +133,13 @@ Nothing is laundered by the retyping:
 - each retyped entry carries `cai_list_type` with the type CAI actually
   returned it as, and that field travels into `coverage.py`'s worklist;
 - `_meta.split_type_sweeps` records declared type, list-surface type,
-  scope and yield;
-- collection prints a NOTICE naming every sibling that contributed.
+  scope and the RAW swept count — what CAI returned, before the
+  subtree/deleted/level filters;
+- collection prints a NOTICE naming every sibling that contributed, and
+  reconciles swept against in-the-denominator itself (e.g. `3 swept …,
+  2 in the denominator (1 excluded by scope/level/deleted filters)`) —
+  the filters apply to retyped entries like to any other asset, and the
+  subtraction is the tool's to show, not the reader's to derive.
 
 A sibling the manifest declares **in its own right** is not remapped: an
 operator who names `compute.googleapis.com/GlobalAddress` explicitly

--- a/skills/fabric-importer/references/cai-blind-spots.md
+++ b/skills/fabric-importer/references/cai-blind-spots.md
@@ -82,6 +82,17 @@ The documented pairs:
 | `compute.googleapis.com/Disk` | `compute.googleapis.com/RegionDisk` |
 | `compute.googleapis.com/ForwardingRule` | `compute.googleapis.com/GlobalForwardingRule` |
 
+### Reproducing it, if you ever need to
+
+The silent-gap condition needs a family whose declared type yields
+**non-zero** while still being incomplete: at least one REGIONAL address
+and at least one GLOBAL address, in the same in-scope project. With only
+global addresses present the declared type yields zero, the pre-existing
+zero-yield warning fires, and the tool is loud — a real bug, but not
+THIS bug. A test estate built only from a freshly created global address
+therefore validates that siblings are swept, and validates nothing about
+the silence.
+
 ### Why this one is worse than an unsupported type
 
 An unsupported type fails loudly. This one fails **silently, past every
@@ -151,8 +162,10 @@ table is stale and the denominator is incomplete.
 The probe is opt-in, for two reasons: it costs a call per scope, and it
 imports the search index's propagation lag as a possible false positive.
 Run it at least once per engagement, and quote the result in the run
-report. `_meta.split_parity` is absent when the probe did not run —
-which is **not** the same as clean.
+report. `_meta.split_parity` is **empty** when the probe did not run; a
+probe that ran and found nothing is a RECORD whose `only_in_search` is
+empty. Read the record, not the key — "not checked" and "checked, clean"
+are different claims and must not be reported as the same one.
 
 If the probe fires, identify the list-surface type of the missing assets
 (`gcloud asset list` with no `--asset-types`, then match on name) and

--- a/skills/fabric-importer/references/cai-blind-spots.md
+++ b/skills/fabric-importer/references/cai-blind-spots.md
@@ -6,6 +6,16 @@ simultaneously (not enumerated → not required by coverage; not emitted →
 not diffed by plan). Treat this list as living documentation: verify and
 extend it per engagement.
 
+There are two distinct blind spots, and they need different remedies:
+
+1. **CAI does not model the type at all.** The classic case, and what
+   most of this document is about. Remedy: enumerate it by other means
+   and merge it into the same denominator.
+2. **CAI models the type under a different NAME on the surface you
+   queried.** Rarer, much quieter, and not a blind spot in CAI at all —
+   a blind spot in the question. See
+   [Surface-dependent type taxonomies](#surface-dependent-type-taxonomies).
+
 ## The rule
 
 **CAI is the DEFAULT source of the denominator, never the boundary of
@@ -38,6 +48,122 @@ tool announces that it took the gcloud route. A declared type that CAI
 rejects and no enumerator covers fails the run with the remedy, instead
 of a generic enumeration failure. Steps 3 and 4 it cannot enforce — that
 is the operator's honesty, and the run report is where it is spent.
+
+## Surface-dependent type taxonomies
+
+CAI does not have one asset-type taxonomy. It has two, and for a handful
+of Compute families they disagree:
+
+- the **list / export / query / monitor** surface (`gcloud asset list`,
+  this tool's primary sweep) splits a family by scope into **separate
+  asset types**;
+- the **search / analysis** surface (`gcloud asset
+  search-all-resources`) folds those same resources into a **single
+  unified type**.
+
+Google documents this per type on the
+[supported types list](https://cloud.google.com/asset-inventory/docs/supported-asset-types),
+but only in the per-type prose, which is easy to read past:
+
+> `compute.googleapis.com/Address` — Returns global and regional
+> addresses in the search and analysis APIs, and only regional addresses
+> in the list, export, query, and monitor APIs.
+>
+> `compute.googleapis.com/GlobalAddress` — Not available in the analysis
+> and search APIs. Use `compute.googleapis.com/Address` instead in the
+> search and analysis APIs.
+
+The documented pairs:
+
+| Declared (search taxonomy) | List-surface sibling swept alongside it |
+|---|---|
+| `compute.googleapis.com/Address` | `compute.googleapis.com/GlobalAddress` |
+| `compute.googleapis.com/BackendService` | `compute.googleapis.com/RegionBackendService` |
+| `compute.googleapis.com/Disk` | `compute.googleapis.com/RegionDisk` |
+| `compute.googleapis.com/ForwardingRule` | `compute.googleapis.com/GlobalForwardingRule` |
+
+### Why this one is worse than an unsupported type
+
+An unsupported type fails loudly. This one fails **silently, past every
+guard the tool has** — which is why it needed a mechanism rather than a
+sharper error message. Live-run finding: a global Private Service
+Connect address never entered the denominator, because
+
+- the declared type IS supported by `asset list`, so the
+  unsupported-type fallback to `search-all-resources` never fired;
+- the sweep SUCCEEDED, so nothing landed in `SWEEP_FAILURES`;
+- it returned 33 regional addresses, so the zero-yield warning stayed
+  quiet;
+- the asset was never collected, so `apply_level_filter`'s `unknown`
+  safety net never saw it either.
+
+The operator had already hand-written the correct `import {}` block, so
+the only signal that fired was `coverage.py` reporting it as an **orphan
+import block** — and an orphan was read as a coverage-map problem and
+waived, rather than as evidence that the denominator was short.
+
+**An orphan import block for a resource you know is live is evidence the
+denominator is short.** Investigate the enumeration before waiving it;
+a waiver signed over a short denominator makes the gap permanent and
+attributed to a human.
+
+### What `inventory.py` does
+
+`CAI_SPLIT_TYPES` is a frozen table of the pairs above. Declaring the
+unified type sweeps its list-surface siblings too, and the siblings'
+entries are **retyped back to the declared type**, so one manifest line
+means "all addresses" — which is what an operator reading the
+supported-types page will believe it means. This costs **zero extra API
+calls**: `asset list` takes a comma-separated `--asset-types`, so the
+siblings ride along in the existing sweep.
+
+Nothing is laundered by the retyping:
+
+- each retyped entry carries `cai_list_type` with the type CAI actually
+  returned it as, and that field travels into `coverage.py`'s worklist;
+- `_meta.split_type_sweeps` records declared type, list-surface type,
+  scope and yield;
+- collection prints a NOTICE naming every sibling that contributed.
+
+A sibling the manifest declares **in its own right** is not remapped: an
+operator who names `compute.googleapis.com/GlobalAddress` explicitly
+wants it accounted as itself, and remapping would make their
+per-declared-type yield read zero.
+
+### Checking the table against live CAI
+
+The table is a frozen snapshot of a document Google changes. A new split
+— or a renamed pairing — would put the tool straight back into the
+failure mode the table closes, so there is a probe:
+
+```bash
+uv run scripts/inventory.py collect --manifest import-manifest.yaml \
+  --out inventory.json --verify-search-parity
+```
+
+One extra `search-all-resources` call per scope, restricted to declared
+split types. It compares against the **raw** sweep output, before the
+manifest's subtree filters, because the question under test is taxonomy
+and not scope. Anything the search surface returns that the list sweep
+did not is **fatal** (exit 3) with the offending resource names: the
+table is stale and the denominator is incomplete.
+
+The probe is opt-in, for two reasons: it costs a call per scope, and it
+imports the search index's propagation lag as a possible false positive.
+Run it at least once per engagement, and quote the result in the run
+report. `_meta.split_parity` is absent when the probe did not run —
+which is **not** the same as clean.
+
+If the probe fires, identify the list-surface type of the missing assets
+(`gcloud asset list` with no `--asset-types`, then match on name) and
+report it: `CAI_SPLIT_TYPES` needs a new entry, which is a reviewed
+change to a frozen file, not a local patch.
+
+CAI **retiring** a split is the convergence this table is waiting for.
+A sibling type that `asset list` no longer recognises is therefore
+reported as a possibly-stale table, not as a failed run — a sibling is
+tool-supplied, not operator-declared, so it must never fail someone
+else's collection.
 
 ## Built-in enumerators
 
@@ -133,6 +259,7 @@ agent may draft one; a human signs it, exactly as with waivers.
 |---|---|---|
 | Service coverage | CAI supports several hundred asset types but not every GCP service/resource; niche or very new resources may be absent | Check the [CAI supported types list](https://cloud.google.com/asset-inventory/docs/supported-asset-types) for every service the user cares about; for uncovered types, declare a native enumerator (above) so they still enter the denominator |
 | Wrong type string | A type string that does not exist in the catalogue is not a blind spot but a typo, and it presents as one. `gcloud asset list` answers `INVALID_ARGUMENT: No supported asset type matches: <type>` | `inventory.py` classifies that error separately from a permission failure and stops with instructions. Live example: `logging.googleapis.com/OrganizationSettings` does not exist — CAI models the Logs Router settings singleton as `logging.googleapis.com/Settings` at every container level |
+| Right type string, wrong surface | A type that is correct for `search-all-resources` can cover only PART of its family under `asset list`, which splits some Compute families by scope into separate types. No error, non-zero yield, silent gap. Live example: a global PSC address typed `compute.googleapis.com/GlobalAddress` by the list surface, absent from a `compute.googleapis.com/Address` sweep | **Handled automatically** for the documented pairs — `CAI_SPLIT_TYPES` sweeps the siblings and accounts them under the declared type. Run `--verify-search-parity` once per engagement to check the frozen table against live CAI; see [Surface-dependent type taxonomies](#surface-dependent-type-taxonomies) |
 | IAM deny policies | `iam.googleapis.com/DenyPolicy` is not a CAI asset type. Fabric manages deny policies at all three container levels (`iam_deny_policies`) | **Handled automatically** — built-in enumerator; just declare the type |
 | Log exclusions | `logging.googleapis.com/LogExclusion` is not a CAI asset type, and current `gcloud` has no `logging exclusions` group either — the ladder falls through to the REST API (`v2/{parent}/exclusions`). Fabric manages exclusions in `modules/organization`, `modules/folder` and `modules/project` | Enumerate out of band, map them, and record the enumeration method in the run report; do not let their absence from CAI read as absence from the estate |
 | Org-policy content-type lag | `--content-type=org-policy` can lag behind newly introduced v2 constraints; the `orgpolicy.googleapis.com/Policy` resource asset stream is more complete | `inventory.py` merges both CAI streams; keep cross-checking counts with `gcloud org-policies list` |
@@ -155,10 +282,19 @@ agent may draft one; a human signs it, exactly as with waivers.
    out-of-band enumeration recorded in the report, or a signed waiver —
    one of the three, always. Never a quiet removal from the manifest.
 2. Any count mismatch between CAI and a service API is a **failure to
-   investigate**, never noise to average over.
-3. Every entry that did not come from CAI is named in the run report,
+   investigate**, never noise to average over. The same applies between
+   CAI's own two surfaces: `asset list` and `search-all-resources`
+   disagreeing about a type is a taxonomy split to identify, not a
+   discrepancy to pick a winner from.
+3. An **orphan import block** reported by `coverage.py` for a resource
+   you know is live is evidence the denominator is short. Investigate
+   the enumeration first; a waiver over a short denominator makes the
+   gap permanent and signs a human's name to it.
+4. Every entry that did not come from CAI is named in the run report,
    with the command that produced it. `_meta.native_sweeps` in
-   `inventory.json` carries this for declared enumerators; out-of-band
-   enumeration is on you to quote.
-4. New blind spots discovered during an engagement get added here (this
+   `inventory.json` carries this for declared enumerators;
+   `_meta.split_type_sweeps` carries entries that came from CAI under a
+   different type than the one declared; out-of-band enumeration is on
+   you to quote.
+5. New blind spots discovered during an engagement get added here (this
    file is reference documentation, not a frozen tool).

--- a/skills/fabric-importer/references/mapping-cookbook.md
+++ b/skills/fabric-importer/references/mapping-cookbook.md
@@ -729,6 +729,52 @@ let plan tell you: it errors loudly and safely on a wrong ID.
 - Coverage map: CAI models only `compute.googleapis.com/Router` (the NAT is a sub-resource with no independent CAI asset type). In `coverage-map.yaml`, the single router key claims both addresses: `[module.<instance>.google_compute_router.router[0], module.<instance>.google_compute_router_nat.nat]`.
 - Lives in `project-<key>.tf`.
 
+### Compute addresses (`modules/net-address`) — verified r19 (global PSC, global PSA, regional internal)
+
+- Manifest: `compute.googleapis.com/Address`, `levels: [project]`.
+- **CAI split-type note**: CAI's list surface types GLOBAL addresses as
+  `compute.googleapis.com/GlobalAddress`; only the search surface
+  unifies them under `.../Address`. `inventory.py` sweeps the sibling
+  automatically and accounts it under the declared type — such entries
+  carry `cai_list_type` in the inventory and worklist, and
+  `_meta.split_type_sweeps` records the raw swept count. Do NOT declare
+  `GlobalAddress` yourself unless you deliberately want it accounted as
+  its own type. Run `--verify-search-parity` at least once per
+  engagement (see `cai-blind-spots.md`).
+- **Global PSC addresses** (`addressType: INTERNAL`,
+  `purpose: PRIVATE_SERVICE_CONNECT`, `global/` in the self link):
+  - Variable: `psc_addresses` with `region = null` (routes the entry
+    through `local.global_psc`). The paired consumer forwarding rule is
+    created only when `service_attachment != null`; an address-only
+    entry is legitimate.
+  - **Trap**: do NOT use `global_addresses` — it sets only
+    name/description/ip_version and cannot express `address_type`,
+    `purpose`, `network` or `address`, all ForceNew: the plan shows a
+    destroy/create, which on an import is always a mapping error.
+  - Address: `module.<instance>.google_compute_global_address.psc["<key>"]`;
+    import ID `projects/<project_id>/global/addresses/<name>`.
+  - **ForceNew trap — empty live description**: `psc_addresses.*.
+    description` defaults to `"Terraform managed."`, and `description`
+    is ForceNew on `google_compute_global_address`. A live address with
+    an empty description must set `description = ""` explicitly or the
+    plan shows a replacement.
+- **Global PSA addresses** (`purpose: VPC_PEERING`):
+  - Variable: `psa_addresses` with `address`, `network` and
+    `prefix_length` mirrored to live values.
+  - Address: `module.<instance>.google_compute_global_address.psa["<key>"]`;
+    import ID `projects/<project_id>/global/addresses/<name>`.
+- **Regional internal addresses** (`purpose: GCE_ENDPOINT` or
+  `SHARED_LOADBALANCER_VIP`):
+  - Variable: `internal_addresses` with `region`, `subnetwork` and
+    `purpose` mirrored to live values.
+  - Address: `module.<instance>.google_compute_address.internal["<key>"]`;
+    import ID `projects/<project_id>/regions/<region>/addresses/<name>`.
+- External, IPsec-interconnect and network-attachment variants:
+  unverified (not exercised by the validation runs).
+- **Reference rule**: `project_id = module.project_<key>.project_id`;
+  networks via `module.net_vpc_<key>.self_link`.
+- Lives in `project-<key>.tf`.
+
 ### NCC spokes — raw resource, documented capability gap (r12)
 
 - Manifest: `networkconnectivity.googleapis.com/Spoke`,

--- a/skills/fabric-importer/scripts/inventory.py
+++ b/skills/fabric-importer/scripts/inventory.py
@@ -97,6 +97,18 @@ UNSUPPORTED_CAI_TYPES = []
 # provenance block: a denominator built partly outside CAI must say so.
 NATIVE_SWEEPS = []
 
+# Which CAI list-surface sibling types were swept for a declared unified
+# type, and how many entries each contributed (see CAI_SPLIT_TYPES).
+# Part of the denominator that would not exist under a literal reading of
+# the manifest, so it is stamped rather than assumed.
+SPLIT_TYPE_SWEEPS = []
+
+# Results of the optional --verify-search-parity probe: assets the search
+# surface returns for a split type that the list sweep did not produce.
+# Non-empty means CAI_SPLIT_TYPES is stale against live CAI, and is
+# FATAL — the whole point is that this class of gap must never be quiet.
+SPLIT_PARITY_FINDINGS = []
+
 # Privileged Access Manager grant bindings are machine-managed runtime
 # state: PAM injects a temporary conditional role binding on grant
 # activation and revokes it itself when the grant ends. They are NEVER
@@ -130,6 +142,105 @@ _CAI_UNSUPPORTED_MARKERS = (
 def _is_unsupported_type_error(text):
   low = (text or '').lower()
   return any(m in low for m in _CAI_UNSUPPORTED_MARKERS)
+
+
+# ---------------------------------------------------------------------------
+# Surface-dependent asset-type taxonomies
+# ---------------------------------------------------------------------------
+# Cloud Asset Inventory does not have ONE asset-type taxonomy; it has
+# two, and they disagree. For a handful of Compute types the
+# list/export/query/monitor surface (`gcloud asset list`, which is this
+# tool's primary sweep) splits a family by scope into SEPARATE asset
+# types, while the search/analysis surface (`asset search-all-resources`)
+# folds them into a single unified type. Google documents this per type
+# on the supported-asset-types page, e.g.:
+#
+#   compute.googleapis.com/Address
+#     "Returns global and regional addresses in the search and analysis
+#      APIs, and only regional addresses in the list, export, query, and
+#      monitor APIs."
+#   compute.googleapis.com/GlobalAddress
+#     "Not available in the analysis and search APIs. Use
+#      compute.googleapis.com/Address instead in the search and analysis
+#      APIs."
+#
+# The failure this causes is the one this tool exists to prevent, and
+# every existing guard misses it (live-run finding, global PSC address):
+# the declared type is SUPPORTED by `asset list`, so the
+# unsupported-type fallback to `search-all-resources` never fires; the
+# sweep succeeds, so nothing lands in SWEEP_FAILURES; and it returns a
+# non-zero count, so the zero-yield warning stays quiet. The global
+# addresses are simply never asked for, and an asset absent from the
+# denominator is invisible to BOTH gates at once.
+#
+# So: declaring the unified (search-taxonomy) type ALSO sweeps its
+# list-taxonomy siblings, and the siblings' entries are retyped back to
+# the declared type — one manifest line means "all addresses", which is
+# what an operator reading the supported-types page will believe it
+# means. The list-surface type is preserved per entry as `cai_list_type`
+# and stamped into _meta.split_type_sweeps, so nothing is laundered.
+#
+# This costs ZERO extra API calls: `asset list` takes a comma-separated
+# --asset-types, so the siblings ride along in the existing sweep.
+#
+# This table is frozen, like NATIVE_ENUMERATORS and for the same reason:
+# it decides part of what the denominator contains. It is a snapshot of
+# a Google doc that changes, which is why --verify-search-parity exists
+# to check it against the search surface rather than trusting it
+# forever.
+#
+# Note on the source doc: the prose for BackendService says the list
+# surface returns "only regional backend services" while naming
+# RegionBackendService as the list-only sibling, which is
+# self-contradictory and is almost certainly an upstream error. The
+# PAIRING is what matters here and is unambiguous; the direction of the
+# split is not something this table has to decide.
+CAI_SPLIT_TYPES = {
+    'compute.googleapis.com/Address': ('compute.googleapis.com/GlobalAddress',),
+    'compute.googleapis.com/BackendService':
+        ('compute.googleapis.com/RegionBackendService',),
+    'compute.googleapis.com/Disk': ('compute.googleapis.com/RegionDisk',),
+    'compute.googleapis.com/ForwardingRule':
+        ('compute.googleapis.com/GlobalForwardingRule',),
+}
+
+
+def split_sibling_map(declared):
+  """Maps list-surface sibling type -> declared unified type.
+
+  A sibling the manifest declares in its own right is NOT remapped: an
+  operator who names `compute.googleapis.com/GlobalAddress` explicitly
+  wants it accounted as itself, and remapping would make their
+  per-declared-type yield read zero.
+  """
+  declared = set(declared)
+  return {
+      sibling: unified for unified, siblings in CAI_SPLIT_TYPES.items()
+      if unified in declared for sibling in siblings if sibling not in declared
+  }
+
+
+def retype_split_assets(assets, sibling_map):
+  """Retypes split-off siblings to their declared unified type in place.
+
+  Retyping happens BEFORE normalization so that apply_level_filter(),
+  which keys off `asset_type`, applies the DECLARED type's `levels`. A
+  sibling left under its own type would match no manifest entry and be
+  filtered by the permissive default instead of by user intent.
+
+  Returns a {declared_type: {sibling_type: count}} tally for provenance.
+  """
+  tally = {}
+  for a in assets:
+    unified = sibling_map.get(a.get('assetType', ''))
+    if not unified:
+      continue
+    sibling = a['assetType']
+    a['_cai_list_type'] = sibling
+    a['assetType'] = unified
+    tally.setdefault(unified, {})
+    tally[unified][sibling] = tally[unified].get(sibling, 0) + 1
+  return tally
 
 
 # Page sizes. gcloud passes these straight through to the API, and each
@@ -569,12 +680,19 @@ def _normalize_resources(assets):
       c = a['organization']
     elif a.get('project'):
       c = a['project']
-    out.append({
+    entry = {
         'key': a['name'],
         'asset_type': a.get('assetType', ''),
         'level': asset_level(a),
         'container': c,
-    })
+    }
+    # Retyped split-surface sibling (see CAI_SPLIT_TYPES): the entry is
+    # accounted under the declared unified type, but the type CAI's list
+    # surface actually returned travels with it into the worklist, so a
+    # reader never has to guess where it came from.
+    if a.get('_cai_list_type'):
+      entry['cai_list_type'] = a['_cai_list_type']
+    out.append(entry)
   return out
 
 
@@ -1041,6 +1159,50 @@ def sweep_native(asset_type, spec, containers, source='manifest'):
   return entries
 
 
+def _verify_split_parity(assets, declared_types, sibling_map, scope,
+                         search_scope):
+  """Checks CAI_SPLIT_TYPES against the live search surface.
+
+  CAI_SPLIT_TYPES is a frozen snapshot of a Google doc that changes. If
+  a new split appears — or an existing pairing is renamed — the table
+  goes quietly incomplete, which puts us back in the failure mode it was
+  added to close. This probe asks the OTHER surface, which by
+  construction unifies the families, and reports anything it returns
+  that the list sweep did not.
+
+  One call per scope, restricted to declared split types, so the cost is
+  bounded and does not scale with the type list. Comparison is against
+  the RAW sweep output, before the manifest's subtree filters: the
+  question under test is taxonomy, not scope, and mixing the two would
+  make every excluded subtree look like a parity failure.
+  """
+  split_declared = sorted(t for t in declared_types if t in CAI_SPLIT_TYPES)
+  if not split_declared:
+    return
+  family = set(split_declared) | set(sibling_map)
+  listed = {
+      a['name']
+      for a in assets
+      if a.get('assetType', '') in family and a.get('name')
+  }
+  found = run_json([
+      'gcloud', '--quiet', 'asset', 'search-all-resources',
+      f'--scope={search_scope}', f'--asset-types={",".join(split_declared)}',
+      '--format=json', f'--page-size={CAI_SEARCH_PAGE_SIZE}'
+  ], ignore_errors=True)
+  searched = {r['name'] for r in found if r.get('name')}
+  # Recorded even when clean: a probe that ran and found nothing is
+  # evidence, and its absence from the provenance block is how a reader
+  # tells "checked" from "not checked".
+  SPLIT_PARITY_FINDINGS.append({
+      'scope': scope,
+      'asset_types': split_declared,
+      'listed_count': len(listed),
+      'searched_count': len(searched),
+      'only_in_search': sorted(searched - listed),
+  })
+
+
 def validate_manifest_types(types):
   """Fails closed on manifest mistakes that silently shrink the
   denominator.
@@ -1185,7 +1347,7 @@ def api_call_summary():
 
 
 def collect(manifest, include_deleted=False, include_logging_defaults=False,
-            include_pam_grants=False):
+            include_pam_grants=False, verify_search_parity=False):
   # Module-level accumulators: reset so a second collect() in the same
   # process cannot inherit the first run's failures (or hide behind
   # them).
@@ -1193,6 +1355,8 @@ def collect(manifest, include_deleted=False, include_logging_defaults=False,
   del SUPPRESSED_SWEEPS[:]
   del UNSUPPORTED_CAI_TYPES[:]
   del NATIVE_SWEEPS[:]
+  del SPLIT_TYPE_SWEEPS[:]
+  del SPLIT_PARITY_FINDINGS[:]
   del API_CALLS[:]
   del PAM_EXCLUSIONS[:]
   registry = ProjectRegistry()
@@ -1263,6 +1427,14 @@ def collect(manifest, include_deleted=False, include_logging_defaults=False,
             t['type']] or 'unknown' in manifest_levels_by_type[t['type']])
     })
 
+    # CAI's list surface splits some Compute families by scope into
+    # separate asset types that its search surface unifies (see
+    # CAI_SPLIT_TYPES). Declaring the unified type must sweep the
+    # siblings too, or the split-off assets never enter the denominator
+    # and are invisible to BOTH gates.
+    sibling_map = split_sibling_map(active_resource_types)
+    sweep_resource_types = sorted(set(active_resource_types) | set(sibling_map))
+
     scope_entries = []
 
     # In-scope containers at a given set of levels, resolved once per
@@ -1305,15 +1477,20 @@ def collect(manifest, include_deleted=False, include_logging_defaults=False,
       _cache[ck] = out
       return out
 
-    if active_resource_types:
+    search_scope = scope_arg.replace(
+        '--organization=',
+        'organizations/').replace('--folder=',
+                                  'folders/').replace('--project=', 'projects/')
+
+    if sweep_resource_types:
       try:
         assets = run_gcloud_json([
             scope_arg, '--content-type=resource',
-            f'--asset-types={",".join(active_resource_types)}'
+            f'--asset-types={",".join(sweep_resource_types)}'
         ])
       except SystemExit:
         assets = []
-        for rt in active_resource_types:
+        for rt in sweep_resource_types:
           try:
             assets += run_gcloud_json(
                 [scope_arg, '--content-type=resource', f'--asset-types={rt}'])
@@ -1323,18 +1500,41 @@ def collect(manifest, include_deleted=False, include_logging_defaults=False,
               # model this type at all. `search-all-resources` would
               # fail identically, so skip it and raise the real issue —
               # the type needs a native enumerator.
-              if rt not in UNSUPPORTED_CAI_TYPES:
+              #
+              # A SIBLING is tool-supplied, not operator-declared, so it
+              # is not fatal: CAI retiring a split type is exactly the
+              # convergence CAI_SPLIT_TYPES is waiting for. It is still
+              # reported, because a stale frozen table is a fact about
+              # the denominator.
+              if rt in sibling_map:
+                msg = (f'{rt} (list-surface sibling of '
+                       f'{sibling_map[rt]}) is no longer a CAI type; '
+                       'CAI_SPLIT_TYPES may be stale')
+                if msg not in SUPPRESSED_SWEEPS:
+                  SUPPRESSED_SWEEPS.append(msg)
+              elif rt not in UNSUPPORTED_CAI_TYPES:
                 UNSUPPORTED_CAI_TYPES.append(rt)
               continue
-            search_scope = scope_arg.replace(
-                '--organization=', 'organizations/').replace(
-                    '--folder=', 'folders/').replace('--project=', 'projects/')
             assets += run_json([
                 'gcloud', '--quiet', 'asset', 'search-all-resources',
                 f'--scope={search_scope}', f'--asset-types={rt}',
                 '--format=json', f'--page-size={CAI_SEARCH_PAGE_SIZE}'
             ], ignore_errors=True)
       registry.ingest_assets(assets)
+      # Account split-off siblings under the DECLARED type, before the
+      # level filter (which keys off asset_type) ever sees them.
+      for unified, per_sibling in sorted(
+          retype_split_assets(assets, sibling_map).items()):
+        for sibling, n in sorted(per_sibling.items()):
+          SPLIT_TYPE_SWEEPS.append({
+              'declared_type': unified,
+              'cai_list_type': sibling,
+              'scope': root,
+              'yield_count': n,
+          })
+      if verify_search_parity:
+        _verify_split_parity(assets, active_resource_types, sibling_map, root,
+                             search_scope)
       filtered_res = []
       for a in assets:
         if not include_deleted and (_is_deleted_container(a) or
@@ -1483,6 +1683,55 @@ def collect(manifest, include_deleted=False, include_logging_defaults=False,
           f'  - {t}: {agg["yield_count"]} entr(ies) over '
           f'{agg["containers"]} container(s)', file=sys.stderr)
 
+  if SPLIT_TYPE_SWEEPS:
+    by_declared = {}
+    for sw in SPLIT_TYPE_SWEEPS:
+      agg = by_declared.setdefault(sw['declared_type'], {})
+      agg[sw['cai_list_type']] = (agg.get(sw['cai_list_type'], 0) +
+                                  sw['yield_count'])
+    print(
+        f'\nNOTICE: {len(by_declared)} declared type(s) are split by '
+        "scope in Cloud Asset Inventory's list surface but\nunified in "
+        'its search surface. The list-only sibling type(s) were swept '
+        'too and are\naccounted under the declared type; they are IN '
+        'the denominator and must be mapped or\nwaived like any other '
+        'asset (details in _meta.split_type_sweeps):', file=sys.stderr)
+    for t, agg in sorted(by_declared.items()):
+      for sibling, n in sorted(agg.items()):
+        print(f'  - {t}: +{n} entr(ies) from {sibling}', file=sys.stderr)
+    if not SPLIT_PARITY_FINDINGS:
+      print(
+          'The split-type table is a frozen snapshot of a Google doc '
+          'that changes. Pass\n--verify-search-parity to check it '
+          'against the live search surface (one extra call\nper scope).',
+          file=sys.stderr)
+
+  parity_gaps = [f for f in SPLIT_PARITY_FINDINGS if f['only_in_search']]
+  if parity_gaps:
+    total = sum(len(f['only_in_search']) for f in parity_gaps)
+    print(
+        f'\nERROR: --verify-search-parity found {total} asset(s) that '
+        "Cloud Asset Inventory's search\nsurface returns and the list "
+        'sweep did not. The frozen split-type table is stale '
+        'against\nlive CAI, so the denominator is INCOMPLETE and cannot '
+        'be trusted:', file=sys.stderr)
+    for f in parity_gaps:
+      print(
+          f'  - scope {f["scope"]}: listed {f["listed_count"]}, '
+          f'searched {f["searched_count"]}', file=sys.stderr)
+      for name in f['only_in_search'][:10]:
+        print(f'      {name}', file=sys.stderr)
+      if len(f['only_in_search']) > 10:
+        print(f'      ... and {len(f["only_in_search"]) - 10} more',
+              file=sys.stderr)
+    print(
+        'Identify the list-surface asset type of the missing asset(s) '
+        '(`gcloud asset list` with\nno --asset-types, then match on '
+        'name) and report it: CAI_SPLIT_TYPES needs a new\nentry, which '
+        'is a reviewed change to a frozen file. Never proceed on a '
+        'partial\ndenominator.', file=sys.stderr)
+    raise SystemExit(3)
+
   if UNSUPPORTED_CAI_TYPES:
     print(
         f'\nERROR: {len(UNSUPPORTED_CAI_TYPES)} declared type(s) are not '
@@ -1601,6 +1850,12 @@ def main():
   pc = sub.add_parser('collect', parents=[common])
   pc.add_argument('--manifest', required=True)
   pc.add_argument('--out', default='-')
+  pc.add_argument(
+      '--verify-search-parity', action='store_true',
+      help="check the frozen split-type table against Cloud Asset Inventory's "
+      'search surface (one extra call per scope). Fails the run if search '
+      'returns an asset the list sweep did not — i.e. if CAI_SPLIT_TYPES '
+      'has gone stale')
   args = p.parse_args()
   VERBOSE = args.verbose
 
@@ -1625,6 +1880,8 @@ def main():
       kwargs['include_logging_defaults'] = True
     if args.include_pam_grants:
       kwargs['include_pam_grants'] = True
+    if args.verify_search_parity:
+      kwargs['verify_search_parity'] = True
     entries, registry, scope_summaries = collect(manifest, **kwargs)
 
     # Per-declared-type yield table.
@@ -1669,6 +1926,18 @@ def main():
                 # re-run these by hand.
                 'native_sweeps':
                     list(NATIVE_SWEEPS),
+                # Entries that entered the denominator because a
+                # declared type is split by scope in CAI's list surface
+                # (see CAI_SPLIT_TYPES). They are accounted under the
+                # declared type, so this block is the only place the
+                # list-surface type they were actually returned as is
+                # aggregated.
+                'split_type_sweeps':
+                    list(SPLIT_TYPE_SWEEPS),
+                # Result of --verify-search-parity, when it ran. Absent
+                # means NOT CHECKED, which is not the same as clean.
+                'split_parity':
+                    list(SPLIT_PARITY_FINDINGS),
                 # Every command this collection ran, in order, with its
                 # outcome and duration. Makes the cost of a scope
                 # auditable after the fact, and a slow or failing sweep

--- a/skills/fabric-importer/scripts/inventory.py
+++ b/skills/fabric-importer/scripts/inventory.py
@@ -229,6 +229,10 @@ def retype_split_assets(assets, sibling_map):
   filtered by the permissive default instead of by user intent.
 
   Returns a {declared_type: {sibling_type: count}} tally for provenance.
+  The tally counts the RAW sweep — before the subtree/deleted/level
+  filters — because its job is to record what CAI returned; how many of
+  those survive into the denominator is a separate number, reconciled in
+  the end-of-run NOTICE.
   """
   tally = {}
   for a in assets:
@@ -1530,7 +1534,7 @@ def collect(manifest, include_deleted=False, include_logging_defaults=False,
               'declared_type': unified,
               'cai_list_type': sibling,
               'scope': root,
-              'yield_count': n,
+              'swept_count': n,
           })
       if verify_search_parity:
         _verify_split_parity(assets, active_resource_types, sibling_map, root,
@@ -1688,17 +1692,34 @@ def collect(manifest, include_deleted=False, include_logging_defaults=False,
     for sw in SPLIT_TYPE_SWEEPS:
       agg = by_declared.setdefault(sw['declared_type'], {})
       agg[sw['cai_list_type']] = (agg.get(sw['cai_list_type'], 0) +
-                                  sw['yield_count'])
+                                  sw['swept_count'])
+    # Swept and in-the-denominator are DIFFERENT numbers: the sweep is
+    # raw, and the subtree/deleted/level filters apply to retyped
+    # entries like to any other asset. Reconcile the two here rather
+    # than leaving the subtraction to the reader (a live validation run
+    # had to do exactly that by hand).
+    in_denom = {}
+    for e in entries:
+      lt = e.get('cai_list_type')
+      if lt:
+        key = (e['asset_type'], lt)
+        in_denom[key] = in_denom.get(key, 0) + 1
     print(
         f'\nNOTICE: {len(by_declared)} declared type(s) are split by '
         "scope in Cloud Asset Inventory's list surface but\nunified in "
         'its search surface. The list-only sibling type(s) were swept '
-        'too and are\naccounted under the declared type; they are IN '
-        'the denominator and must be mapped or\nwaived like any other '
-        'asset (details in _meta.split_type_sweeps):', file=sys.stderr)
+        'too and are\naccounted under the declared type; the ones in '
+        'scope are IN the denominator and\nmust be mapped or waived '
+        'like any other asset (details in _meta.split_type_sweeps):',
+        file=sys.stderr)
     for t, agg in sorted(by_declared.items()):
       for sibling, n in sorted(agg.items()):
-        print(f'  - {t}: +{n} entr(ies) from {sibling}', file=sys.stderr)
+        kept = in_denom.get((t, sibling), 0)
+        excluded = ('' if kept == n else
+                    f' ({n - kept} excluded by scope/level/deleted filters)')
+        print(
+            f'  - {t}: {n} swept from {sibling}, {kept} in the '
+            f'denominator{excluded}', file=sys.stderr)
     if not SPLIT_PARITY_FINDINGS:
       print(
           'The split-type table is a frozen snapshot of a Google doc '

--- a/skills/fabric-importer/scripts/inventory.py
+++ b/skills/fabric-importer/scripts/inventory.py
@@ -1934,8 +1934,11 @@ def main():
                 # aggregated.
                 'split_type_sweeps':
                     list(SPLIT_TYPE_SWEEPS),
-                # Result of --verify-search-parity, when it ran. Absent
-                # means NOT CHECKED, which is not the same as clean.
+                # Result of --verify-search-parity. EMPTY means the
+                # probe did not run, which is not the same as clean: a
+                # probe that ran and found nothing appears here as a
+                # record whose `only_in_search` is empty. Read the
+                # record, not the key.
                 'split_parity':
                     list(SPLIT_PARITY_FINDINGS),
                 # Every command this collection ran, in order, with its

--- a/skills/fabric-importer/tests/test_scripts.py
+++ b/skills/fabric-importer/tests/test_scripts.py
@@ -3597,8 +3597,61 @@ class TestCaiSplitTypes(unittest.TestCase):
             'declared_type': 'compute.googleapis.com/Address',
             'cai_list_type': 'compute.googleapis.com/GlobalAddress',
             'scope': 'projects/my-prj',
-            'yield_count': 1,
+            'swept_count': 1,
         })
+    # Swept == kept here, so no exclusion note.
+    self.assertIn('1 swept from', err)
+    self.assertIn('1 in the denominator', err)
+    self.assertNotIn('excluded by scope/level/deleted', err)
+
+  def test_notice_reconciles_swept_against_denominator(self):
+    """Live-run finding (validation round 2): three siblings swept
+    org-wide, one dropped by the manifest's subtree filter — and the
+    NOTICE claimed all swept entries were IN the denominator. The
+    reader had to reconcile 3 against 2 by hand. The NOTICE must do
+    that subtraction itself."""
+    out_of_scope = {
+        'name': ('//compute.googleapis.com/projects/other-prj/'
+                 'global/addresses/psc-elsewhere'),
+        'assetType': 'compute.googleapis.com/GlobalAddress',
+        'ancestors': ['projects/999', 'organizations/1'],
+    }
+
+    def handler(cmd, **kwargs):
+      joined = ' '.join(cmd)
+      resolved = self._resolve_project(joined)
+      if resolved is not None:
+        return resolved
+      if '--content-type=resource' in joined and 'Address' in joined:
+        return [
+            self._addr(self._REGIONAL, 'compute.googleapis.com/Address'),
+            self._addr(self._GLOBAL, 'compute.googleapis.com/GlobalAddress'),
+            out_of_scope,
+        ]
+      return []
+
+    manifest = {
+        'scope': {
+            'root': 'organizations/1',
+            'include': ['projects/111'],
+        },
+        'types': [{
+            'type': 'compute.googleapis.com/Address',
+            'levels': ['project']
+        }],
+    }
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+      entries, _, _ = self._collect(handler, manifest)
+    err = buf.getvalue()
+    keys = {e['key'] for e in entries}
+    self.assertNotIn(out_of_scope['name'], keys)
+    # Raw sweep is stamped raw...
+    self.assertEqual(inventory.SPLIT_TYPE_SWEEPS[0]['swept_count'], 2)
+    # ...and the NOTICE reconciles it against what actually survived.
+    self.assertIn('2 swept from', err)
+    self.assertIn('1 in the denominator', err)
+    self.assertIn('(1 excluded by scope/level/deleted filters)', err)
 
   def test_no_parity_call_unless_asked(self):
     calls = []

--- a/skills/fabric-importer/tests/test_scripts.py
+++ b/skills/fabric-importer/tests/test_scripts.py
@@ -3426,5 +3426,270 @@ class TestCoverageEdgeCases(unittest.TestCase):
     self.assertEqual(unsigned, ['k2', 'k3', 'k4'])
 
 
+class TestCaiSplitTypes(unittest.TestCase):
+  """CAI's list and search surfaces use DIFFERENT asset-type taxonomies.
+
+  Live-run finding: a global Private Service Connect address was absent
+  from the denominator. `gcloud asset list --asset-types=
+  compute.googleapis.com/Address` returned 33 regional addresses;
+  `search-all-resources` for the same type returned 34, including the
+  global one. The cause is not a disagreement between the surfaces but a
+  documented taxonomy split: the list surface types global addresses as
+  `compute.googleapis.com/GlobalAddress`, which the manifest never
+  declared and the tool therefore never asked for.
+
+  Every existing guard missed it — the declared type is supported (no
+  unsupported-type fallback), the sweep succeeded (no SWEEP_FAILURES),
+  and it yielded 33 (no zero-yield warning) — which is why this needs
+  its own mechanism rather than a sharper error message.
+  """
+
+  _MANIFEST = {
+      'scope': {
+          'root': 'projects/my-prj'
+      },
+      'types': [{
+          'type': 'compute.googleapis.com/Address',
+          'levels': ['project']
+      }],
+  }
+
+  @staticmethod
+  def _addr(name, atype):
+    return {
+        'name': f'//compute.googleapis.com/projects/my-prj/{name}',
+        'assetType': atype,
+        'ancestors': ['projects/111', 'organizations/1'],
+    }
+
+  _REGIONAL = 'regions/europe-west1/addresses/regional-one'
+  _GLOBAL = 'global/addresses/psc-endpoint'
+
+  def _collect(self, handler, manifest=None, **kwargs):
+    real = inventory.run_json
+    inventory.run_json = handler
+    try:
+      return inventory.collect(manifest or self._MANIFEST, **kwargs)
+    finally:
+      inventory.run_json = real
+
+  @staticmethod
+  def _resolve_project(joined):
+    """CAI ancestors are project NUMBERS, so collect() resolves the scope
+    id first; unresolved, in_subtree() matches nothing."""
+    if 'projects describe' in joined:
+      return {
+          'projectNumber': '111',
+          'projectId': 'my-prj',
+          'lifecycleState': 'ACTIVE'
+      }
+    return None
+
+  def _list_handler(self, calls):
+
+    def handler(cmd, **kwargs):
+      joined = ' '.join(cmd)
+      calls.append(joined)
+      resolved = self._resolve_project(joined)
+      if resolved is not None:
+        return resolved
+      if 'search-all-resources' in joined:
+        return [
+            {
+                'name': self._addr(self._REGIONAL, '')['name']
+            },
+            {
+                'name': self._addr(self._GLOBAL, '')['name']
+            },
+        ]
+      if '--content-type=resource' in joined and 'Address' in joined:
+        out = [self._addr(self._REGIONAL, 'compute.googleapis.com/Address')]
+        if 'GlobalAddress' in joined:
+          out.append(
+              self._addr(self._GLOBAL, 'compute.googleapis.com/GlobalAddress'))
+        return out
+      return []
+
+    return handler
+
+  def test_split_sibling_map_only_covers_declared_unified_types(self):
+    self.assertEqual(
+        inventory.split_sibling_map(['compute.googleapis.com/Address']), {
+            'compute.googleapis.com/GlobalAddress':
+                'compute.googleapis.com/Address'
+        })
+    # Nothing declared, nothing swept: the table never widens a sweep on
+    # its own.
+    self.assertEqual(
+        inventory.split_sibling_map(['storage.googleapis.com/Bucket']), {})
+
+  def test_explicitly_declared_sibling_is_not_remapped(self):
+    """An operator who names the list-surface type wants it accounted as
+    itself; remapping would make their per-declared-type yield read 0."""
+    self.assertEqual(
+        inventory.split_sibling_map([
+            'compute.googleapis.com/Address',
+            'compute.googleapis.com/GlobalAddress',
+        ]), {})
+
+  def test_global_address_enters_the_denominator(self):
+    calls = []
+    with contextlib.redirect_stderr(io.StringIO()):
+      entries, _, _ = self._collect(self._list_handler(calls))
+    keys = {e['key'] for e in entries}
+    self.assertIn(self._addr(self._GLOBAL, '')['name'], keys)
+    self.assertIn(self._addr(self._REGIONAL, '')['name'], keys)
+
+  def test_sibling_rides_along_in_the_existing_call(self):
+    """The fix must cost zero extra API calls: `asset list` takes a
+    comma-separated --asset-types."""
+    calls = []
+    with contextlib.redirect_stderr(io.StringIO()):
+      self._collect(self._list_handler(calls))
+    sweeps = [c for c in calls if '--content-type=resource' in c]
+    self.assertEqual(len(sweeps), 1, calls)
+    self.assertIn('compute.googleapis.com/Address', sweeps[0])
+    self.assertIn('compute.googleapis.com/GlobalAddress', sweeps[0])
+
+  def test_sibling_is_accounted_under_the_declared_type(self):
+    calls = []
+    with contextlib.redirect_stderr(io.StringIO()):
+      entries, _, _ = self._collect(self._list_handler(calls))
+    glob = [
+        e for e in entries if e['key'].endswith('global/addresses/psc-endpoint')
+    ][0]
+    self.assertEqual(glob['asset_type'], 'compute.googleapis.com/Address')
+    # ...but the list-surface type is preserved, not laundered.
+    self.assertEqual(glob['cai_list_type'],
+                     'compute.googleapis.com/GlobalAddress')
+
+  def test_sibling_survives_the_level_filter(self):
+    """apply_level_filter() keys off asset_type. A sibling left under its
+    own type would match no manifest entry and be filtered by the
+    permissive default instead of by the operator's `levels`."""
+    manifest = {
+        'scope': {
+            'root': 'projects/my-prj'
+        },
+        'types': [{
+            'type': 'compute.googleapis.com/Address',
+            'levels': ['project']
+        }],
+    }
+    calls = []
+    with contextlib.redirect_stderr(io.StringIO()):
+      entries, _, _ = self._collect(self._list_handler(calls), manifest)
+    self.assertEqual(len(entries), 2)
+    self.assertTrue(all(e['level'] == 'project' for e in entries))
+
+  def test_split_sweep_is_announced_and_stamped(self):
+    calls = []
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+      self._collect(self._list_handler(calls))
+    err = buf.getvalue()
+    self.assertIn('split by scope', err)
+    self.assertIn('compute.googleapis.com/GlobalAddress', err)
+    self.assertIn('--verify-search-parity', err)
+    self.assertEqual(len(inventory.SPLIT_TYPE_SWEEPS), 1)
+    self.assertEqual(
+        inventory.SPLIT_TYPE_SWEEPS[0], {
+            'declared_type': 'compute.googleapis.com/Address',
+            'cai_list_type': 'compute.googleapis.com/GlobalAddress',
+            'scope': 'projects/my-prj',
+            'yield_count': 1,
+        })
+
+  def test_no_parity_call_unless_asked(self):
+    calls = []
+    with contextlib.redirect_stderr(io.StringIO()):
+      self._collect(self._list_handler(calls))
+    self.assertFalse([c for c in calls if 'search-all-resources' in c])
+    self.assertEqual(inventory.SPLIT_PARITY_FINDINGS, [])
+
+  def test_parity_probe_is_clean_when_the_table_is_current(self):
+    calls = []
+    with contextlib.redirect_stderr(io.StringIO()):
+      self._collect(self._list_handler(calls), verify_search_parity=True)
+    probes = [c for c in calls if 'search-all-resources' in c]
+    self.assertEqual(len(probes), 1, calls)
+    # Bounded cost: the probe asks only for declared SPLIT types.
+    self.assertIn('--asset-types=compute.googleapis.com/Address', probes[0])
+    self.assertEqual(len(inventory.SPLIT_PARITY_FINDINGS), 1)
+    self.assertEqual(inventory.SPLIT_PARITY_FINDINGS[0]['only_in_search'], [])
+
+  def test_parity_probe_fails_loud_on_a_stale_table(self):
+    """The regression the whole table is exposed to: CAI adds a split
+    this frozen snapshot does not know about."""
+    unknown = ('//compute.googleapis.com/projects/my-prj/'
+               'global/addresses/some-future-split')
+
+    def handler(cmd, **kwargs):
+      joined = ' '.join(cmd)
+      resolved = self._resolve_project(joined)
+      if resolved is not None:
+        return resolved
+      if 'search-all-resources' in joined:
+        return [{
+            'name': self._addr(self._REGIONAL, '')['name']
+        }, {
+            'name': unknown
+        }]
+      if '--content-type=resource' in joined and 'Address' in joined:
+        return [self._addr(self._REGIONAL, 'compute.googleapis.com/Address')]
+      return []
+
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+      with self.assertRaises(SystemExit) as ctx:
+        self._collect(handler, verify_search_parity=True)
+    self.assertEqual(ctx.exception.code, 3)
+    err = buf.getvalue()
+    self.assertIn('search', err)
+    self.assertIn(unknown, err)
+    self.assertIn('CAI_SPLIT_TYPES', err)
+
+  def test_retired_sibling_type_is_reported_not_fatal(self):
+    """A sibling is tool-supplied, not operator-declared. CAI retiring a
+    split type is the convergence the table is waiting for, so it must
+    not fail the operator's run — but a stale frozen table is still a
+    fact about the denominator."""
+    err_text = ('command failed: gcloud --quiet asset list\n'
+                'ERROR: (gcloud.asset.list) INVALID_ARGUMENT: No '
+                'supported asset type matches: '
+                'compute.googleapis.com/GlobalAddress.')
+
+    def handler(cmd, **kwargs):
+      joined = ' '.join(cmd)
+      resolved = self._resolve_project(joined)
+      if resolved is not None:
+        return resolved
+      if kwargs.get('ignore_errors'):
+        return []
+      if 'GlobalAddress' in joined:
+        raise SystemExit(err_text)
+      if '--content-type=resource' in joined and 'Address' in joined:
+        return [self._addr(self._REGIONAL, 'compute.googleapis.com/Address')]
+      return []
+
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+      entries, _, _ = self._collect(handler)
+    self.assertEqual(len(entries), 1)
+    self.assertEqual(inventory.UNSUPPORTED_CAI_TYPES, [])
+    self.assertTrue(
+        any('CAI_SPLIT_TYPES may be stale' in m
+            for m in inventory.SUPPRESSED_SWEEPS), inventory.SUPPRESSED_SWEEPS)
+
+  def test_table_pairs_are_distinct_and_well_formed(self):
+    for unified, siblings in inventory.CAI_SPLIT_TYPES.items():
+      self.assertIsInstance(siblings, tuple, unified)
+      self.assertTrue(siblings, unified)
+      for s in siblings:
+        self.assertNotEqual(s, unified)
+        self.assertNotIn(s, inventory.CAI_SPLIT_TYPES,
+                         f'{s} is both a unified type and a sibling')
+
+
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
This PR fixes a bug in `inventory.py collect`: global compute addresses never entered the denominator, silently. It adds a frozen table that sweeps the missing asset types automatically, a probe that checks the table against live CAI, and the documentation and cookbook entries earned by two live validation runs.

## The problem

A live test reported a global Private Service Connect address missing from `inventory.json`. The address was real, live and indexed by Cloud Asset Inventory. Because it was missing from the denominator, `coverage.py` could not require it to be mapped. The operator had already written a correct `import {}` block for it, which the tool flagged only as an orphan. They read the orphan as a coverage-map problem and covered it with a signed waiver. An asset invisible to both gates at once is the exact failure this tool exists to prevent.

## What caused it

The bug report blamed `gcloud asset list` for under-reporting and suggested merging results from `search-all-resources`. That diagnosis was wrong, and the difference matters.

CAI has 2 asset-type taxonomies, not one. For some Compute families, the list surface (`gcloud asset list`, our primary sweep) splits the family by scope into separate types. The search surface unifies them. Google documents this in the [supported asset types list](https://cloud.google.com/asset-inventory/docs/supported-asset-types):

> `compute.googleapis.com/Address` — Returns global and regional addresses in the search and analysis APIs, and only regional addresses in the list, export, query, and monitor APIs.
>
> `compute.googleapis.com/GlobalAddress` — Not available in the analysis and search APIs. Use `compute.googleapis.com/Address` instead in the search and analysis APIs.

So `asset list` reported the global address correctly — under a type the manifest never declared. The tool never asked for it. Four documented pairs behave this way:

| Declared type (search taxonomy) | List-surface sibling that was dropped |
|---|---|
| `compute.googleapis.com/Address` | `compute.googleapis.com/GlobalAddress` |
| `compute.googleapis.com/BackendService` | `compute.googleapis.com/RegionBackendService` |
| `compute.googleapis.com/Disk` | `compute.googleapis.com/RegionDisk` |
| `compute.googleapis.com/ForwardingRule` | `compute.googleapis.com/GlobalForwardingRule` |

## Why the tool did not catch it

This is a new failure class, different from "CAI does not model the type". Every existing guard stayed quiet:

- the declared type is supported, so the unsupported-type fallback to `search-all-resources` never ran
- the sweep succeeded, so nothing landed in `SWEEP_FAILURES`
- the type returned the regional addresses, so the zero-yield warning did not fire
- the asset was never collected, so the level-filter safety net never saw it

## What this PR changes

A new frozen table, `CAI_SPLIT_TYPES`, lists the 4 pairs. It is frozen for the same reason as `NATIVE_ENUMERATORS`: it decides part of what the denominator contains. Declaring the unified type now sweeps its list-surface siblings too:

- it costs no extra API calls — `asset list` takes a comma-separated `--asset-types`, so the siblings join the existing sweep
- sibling entries are retyped to the declared type before the level filter runs, so one manifest line means "all addresses" and the operator's `levels:` intent applies
- nothing is hidden: each retyped entry carries `cai_list_type` into the worklist, `_meta.split_type_sweeps` records the raw swept count, and a stderr NOTICE reconciles swept against kept (for example: "3 swept, 2 in the denominator, 1 excluded by scope filters")
- a sibling the manifest declares in its own right is not remapped
- if CAI retires a sibling type, the run warns instead of failing — the sibling is tool-supplied, not operator-declared

The table is a snapshot of a document Google changes, so there is also a new opt-in flag, `--verify-search-parity`. It runs one `search-all-resources` call per scope, restricted to declared split types, and compares against the raw sweep. If search returns an asset the list sweep did not, the run fails with the names (exit 3). `_meta.split_parity` records the probe even when clean. Empty means the probe did not run, which is not the same claim as clean.

## How we validated it

We ran 2 live rounds against a test estate. Round 1 proved the mechanics but its negative control was degenerate: with no regional addresses the yield was zero and the existing zero-yield warning fired, so the run was loud, not silent. Round 2 provisioned a regional address and a global PSC address in the same in-scope project, then reproduced the real failure on the pre-fix build (digest `52a19017eb419867`, the same build as the bug report): non-zero yield, no warnings, global address absent, list count below search count.

On this branch the same estate gives: list count equal to search count, the sibling swept in the same `asset list` call, a clean parity probe, both gates green with verbatim provenance, and the previously orphaned import block reported as a covered asset.

Validation found 2 defects in the first version of the fix. Both are corrected in this PR:

1. Four documentation locations said `_meta.split_parity` is absent when the probe does not run. The key is always present and empty. Readers would have mistaken "not checked" for "checked, clean". Fixed in 13953992f.
2. The NOTICE claimed every swept sibling was in the denominator. With a subtree filter that is false, and the validation agent had to reconcile the counts by hand. The NOTICE now shows the subtraction itself, and `yield_count` is renamed `swept_count` to say what it measures. Fixed in f67a8849d, with a regression test pinning the live scenario.

## Documentation changes

- `references/cai-blind-spots.md` gains a "Surface-dependent type taxonomies" section. The document now separates the 2 blind-spot classes: CAI does not model the type, and CAI models it under a different name on the surface you queried. It also records how to reproduce the silent gap.
- `SKILL.md` step 1 grows from 2 remedies to 3. Step 3b now requires checking both CAI surfaces for any type with a global, regional or zonal split — the old instruction ("confirm against `asset list` output") is exactly what fails here. A new step 4 note tells the agent to treat an orphan import block for a live resource as evidence of a short denominator, and to investigate before proposing a waiver.
- `references/mapping-cookbook.md` gains a verified `modules/net-address` entry from the validation runs: global PSC addresses map through `psc_addresses` with `region = null`, never through `global_addresses` (which cannot express `address_type`, `purpose`, `network` or `address`, all ForceNew). It also records the empty-description ForceNew trap and the global PSA and regional internal shapes. Unexercised variants are marked unverified.
- `README.md` describes the split taxonomy and the parity probe for human users.

## Tests

`tests/test_scripts.py` gains `TestCaiSplitTypes` with 13 cases: sibling mapping, explicit-declaration override, retype-before-level-filter ordering, zero-extra-call behaviour, provenance stamping, swept-versus-kept reconciliation, the parity probe (clean, stale-table-fatal and not-run), retired-sibling tolerance, and table well-formedness. The full suite passes: 187 tests.

## Frozen-tool digests

Gate transcripts pin these values. Reviewers compare them against a clean checkout.

| Digest | Commit | State |
|---|---|---|
| `52a19017eb419867` | 62c608464 | before the fix (the bug report's build) |
| `0222f4a777164176` | 6c2435904 | split-type fix |
| `edeeb30885d8e29e` | 13953992f | split_parity documentation correction |
| `2981b25646a9a74a` | f67a8849d | this PR's head |

## Action for operators

If you carry an interim waiver for a split-type asset, retire it when you upgrade. The asset re-enters the denominator, and a stale signed waiver would hide a real gap under a human signature.
