### PR TITLE
Split the Mapping Cookbook Into Fielded Data and Prose

### DIFF
--- a/skills/fabric-importer/README.md
+++ b/skills/fabric-importer/README.md
@@ -465,6 +465,7 @@ Three human-owned files govern the process. The agent may propose edits, but onl
 | `import-manifest.yaml` | Declares in-scope resource types, container levels, and subtree filters. |
 | `waivers.yaml` | Written waivers for resources deliberately excluded from management (e.g. `_Default` log sinks, default compute service accounts). Requires a `signed_by` attribute. |
 | `scripts/benign-drift.yaml` | Scoped provider quirks accepted as cosmetic diffs (e.g., computed provider labels or default timeouts). |
+| `references/address-map.yaml` | The fielded subset of the mapping cookbook: asset type, module, address pattern, import ID, verification round. Advisory, not a gate input — see below. |
 
 ---
 
@@ -482,6 +483,7 @@ skills/fabric-importer/
 │   ├── manifest_from_state.py   #   Terraform state-driven manifest inference
 │   ├── manifest_init.py         #   Starter manifest drafting assistant
 │   ├── integrity.py             #   Input binding & runtime provenance stamping
+│   ├── address_map.py           #   Address-map validator, cookbook linter, table renderer
 │   └── benign-drift.yaml        #   Human-reviewed provider quirk ruleset
 ├── examples/                    # Manifest and waiver templates
 │   ├── import-manifest.org-foundation.yaml
@@ -491,9 +493,45 @@ skills/fabric-importer/
 │   ├── import-manifest.fast-networking.yaml
 │   └── waivers.example.yaml
 ├── references/                  # Normative mapping rules & technical gotchas
-│   ├── mapping-cookbook.md      #   Module map, escaping rules, import IDs
+│   ├── mapping-cookbook.md      #   Traps, reasoning, capability gaps (prose)
+│   ├── address-map.yaml         #   Addresses, import IDs, asset types (data)
 │   ├── inferring-manifests-from-state.md # State-driven manifest inference workflow
 │   ├── cai-blind-spots.md       #   Known CAI gaps and service API mitigations
 │   └── operating-contract.md    #   Safety invariants and trust boundaries
 └── tests/                       # Unit test suite
 ```
+
+### Where mapping knowledge lives
+
+The cookbook carries two different kinds of knowledge, and they are now
+stored differently because they fail differently.
+
+**Fielded tuples** — asset type, module, address pattern, import ID,
+verification round — live in `references/address-map.yaml`. They are
+uniform and mechanically checkable, and they were the part that kept
+being duplicated: the same address appeared in per-type prose and again
+in a hand-maintained markdown table, and three families were once
+documented twice because nothing could detect it. Two invariants are now
+enforced:
+
+- an address pattern is claimed by exactly one entry;
+- a CAI asset type serviced by more than one module (the live case:
+  `compute.googleapis.com/Router`, created by both `net-cloudnat` and
+  `net-vpn-ha`) must say how to tell the carriers apart.
+
+**Reasoning** — ForceNew traps, provider quirks, waiver postures,
+capability gaps — stays in `references/mapping-cookbook.md`, in prose,
+on purpose. It is causal and only degrades when squeezed into a schema.
+
+```bash
+uv run scripts/address_map.py                      # validate + lint
+uv run scripts/address_map.py --render-cookbook    # regenerate the table
+uv run scripts/address_map.py --check-workspace tf/  # advisory, always exits 0
+```
+
+`address_map.py` is a linter, **not a gate**. `coverage.py` and
+`verify_plan.py` never read the address map, and a test enforces that.
+A wrong entry is caught by `terraform plan` erroring loudly, unlike a
+wrong `benign-drift.yaml` entry which would silently pass a gate. The
+map is also deliberately incomplete: an address it does not recognise is
+a type nobody has mapped yet, which SKILL.md calls the normal case.

--- a/skills/fabric-importer/SKILL.md
+++ b/skills/fabric-importer/SKILL.md
@@ -595,6 +595,10 @@ missing permission when one is needed.
 - [COVERAGE.md](./COVERAGE.md) — resource maturity matrix
 - [references/mapping-cookbook.md](./references/mapping-cookbook.md) —
   Fabric mapping rules, escaping, import-ID table, known traps
+- [references/address-map.yaml](./references/address-map.yaml) — the
+  fielded subset of the cookbook (asset type, module, address, import
+  ID, verification round); validated and rendered by
+  `scripts/address_map.py`, never read by the gates
 - [references/inferring-manifests-from-state.md](./references/inferring-manifests-from-state.md)
   — inferring import manifests from existing Terraform states
 - [references/cai-blind-spots.md](./references/cai-blind-spots.md) —

--- a/skills/fabric-importer/references/address-map.yaml
+++ b/skills/fabric-importer/references/address-map.yaml
@@ -1,0 +1,782 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Address and import-ID map — the FIELDED subset of the mapping cookbook.
+#
+# WHY THIS FILE EXISTS
+#
+# `mapping-cookbook.md` carries two different kinds of knowledge:
+#
+#   1. Fielded tuples — (asset type, module, address pattern, import ID,
+#      verification round). Uniform across every entry, mechanically
+#      checkable, and the part that kept being duplicated: the same
+#      address appeared once in the per-type prose and again in a
+#      hand-maintained markdown table, and three families were added
+#      twice because nothing could detect it.
+#
+#   2. Reasoning — ForceNew traps, provider quirks, waiver postures,
+#      capability gaps. Causal prose that becomes strictly worse when
+#      squeezed into a `notes:` string.
+#
+# Only (1) lives here. (2) stays in the cookbook, in prose, on purpose.
+# This file is NOT a specification of what the skill supports and NOT a
+# closed world: a type absent from it is a type nobody has run the
+# method on yet. See "Step 3b" in SKILL.md. Never treat a miss here as
+# a reason to stop, and never treat a hit here as a substitute for
+# reading the module source.
+#
+# NOT FROZEN. This file is advisory input to `address_map.py`, which is
+# a linter, not a gate. It is deliberately outside the trust boundary in
+# `integrity.py`: a wrong entry here makes `terraform plan` error
+# loudly, unlike a wrong `benign-drift.yaml` entry which silently passes
+# a gate. Different blast radius, different rigour budget.
+#
+# SCHEMA (enforced by `scripts/address_map.py --validate`)
+#
+#   version: 1
+#   entries:
+#     <slug>:                # stable, kebab-case, immutable once used
+#       resource:      str   # human label, used for the rendered table
+#       module:        str   # 'modules/<name>', or 'raw' for a gap
+#       address:       str   # Terraform address pattern, <placeholder>s
+#       import_id:     str   # provider import ID pattern
+#       asset_type:    str   # CAI asset type, or null when not CAI-modelled
+#       verified:      str   # 'r<N>' round that proved it, or false
+#       note:          str   # optional, ONE line; prose belongs in the cookbook
+#       disambiguation: str  # REQUIRED when an asset_type maps to >1 module
+#
+# INVARIANTS (all machine-enforced)
+#   - `address` is globally unique: no two entries may claim it.
+#   - when one `asset_type` maps to more than one `module`, EVERY entry
+#     sharing that type must carry a non-empty `disambiguation`.
+#   - `verified` is false or matches `r<digits>`.
+#   - `note` is a single line (multi-line reasoning goes in the cookbook).
+#
+# Regenerate the cookbook's rendered table after editing:
+#   uv run scripts/address_map.py --render-cookbook
+
+version: 1
+
+entries:
+
+  # --- organization -------------------------------------------------
+
+  org-custom-role:
+    resource: Custom role
+    module: modules/organization
+    address: 'module.organization.google_organization_iam_custom_role.roles["<id>"]'
+    import_id: 'organizations/<org>/roles/<id>'
+    asset_type: iam.googleapis.com/Role
+    verified: r3
+
+  org-iam-member:
+    resource: Org IAM member (additive, default)
+    module: modules/organization
+    address: 'module.organization.google_organization_iam_member.bindings["<key>"]'
+    import_id: '<org> <role> <member>'
+    asset_type: null
+    verified: false
+    note: 'conditional bindings append <condition_title> to the import ID'
+
+  org-iam-binding-authoritative:
+    resource: Org IAM binding (authoritative opt-in)
+    module: modules/organization
+    address: 'module.organization.google_organization_iam_binding.authoritative["<role>"]'
+    import_id: '<org> <role>'
+    asset_type: null
+    verified: r3
+
+  org-iam-binding-conditional:
+    resource: Org IAM binding (cond.)
+    module: modules/organization
+    address: 'module.organization.google_organization_iam_binding.bindings["<key>"]'
+    import_id: '<org> <role> <condition_title>'
+    asset_type: null
+    verified: r3
+
+  org-audit-config:
+    resource: Org audit config
+    module: modules/organization
+    address: 'module.organization.google_organization_iam_audit_config.default["<service>"]'
+    import_id: '<org> <service>'
+    asset_type: null
+    verified: r3
+
+  org-policy:
+    resource: Org policy
+    module: modules/organization
+    address: 'module.organization.google_org_policy_policy.default["<constraint>"]'
+    import_id: 'organizations/<org>/policies/<constraint>'
+    asset_type: orgpolicy.googleapis.com/Policy
+    verified: r5
+    disambiguation: 'org-level constraints; folder and project scopes have their own entries'
+
+  org-log-sink:
+    resource: Org log sink
+    module: modules/organization
+    address: 'module.organization.google_logging_organization_sink.sink["<name>"]'
+    import_id: 'organizations/<org>/sinks/<name>'
+    asset_type: logging.googleapis.com/LogSink
+    verified: r3
+    disambiguation: 'org-level sinks; folder sinks are carried by modules/folder'
+
+  org-tag-key:
+    resource: Tag Key
+    module: modules/organization
+    address: 'module.organization.google_tags_tag_key.default["<short_name>"]'
+    import_id: 'tagKeys/<id>'
+    asset_type: cloudresourcemanager.googleapis.com/TagKey
+    verified: r18
+
+  org-tag-value:
+    resource: Tag Value
+    module: modules/organization
+    address: 'module.organization.google_tags_tag_value.default["<key_short_name>/<value_short_name>"]'
+    import_id: 'tagValues/<id>'
+    asset_type: cloudresourcemanager.googleapis.com/TagValue
+    verified: r18
+
+  tag-binding:
+    resource: Tag Binding
+    module: modules/organization
+    address: 'module.<instance>.google_tags_tag_binding.binding["<key>"]'
+    import_id: 'tagBindings/<url-encoded-parent-and-value>'
+    asset_type: cloudresourcemanager.googleapis.com/TagBinding
+    verified: r18
+    note: 'emitted on the container module that owns the bound resource'
+
+  # --- folders ------------------------------------------------------
+
+  folder:
+    resource: Folder
+    module: modules/folder
+    address: 'module.folder-<key>.google_folder.folder[0]'
+    import_id: 'folders/<id>'
+    asset_type: cloudresourcemanager.googleapis.com/Folder
+    verified: r6
+
+  folder-iam-member:
+    resource: Folder IAM member (additive, default)
+    module: modules/folder
+    address: 'module.folder-<key>.google_folder_iam_member.bindings["<key>"]'
+    import_id: 'folders/<id> <role> <member>'
+    asset_type: null
+    verified: false
+    note: 'conditional bindings append <condition_title> to the import ID'
+
+  folder-iam-binding-authoritative:
+    resource: Folder IAM
+    module: modules/folder
+    address: 'module.folder-<key>.google_folder_iam_binding.authoritative["<role>"]'
+    import_id: 'folders/<id> <role>'
+    asset_type: null
+    verified: r6
+
+  folder-iam-binding-conditional:
+    resource: Folder IAM (cond.)
+    module: modules/folder
+    address: 'module.folder-<key>.google_folder_iam_binding.bindings["<key>"]'
+    import_id: 'folders/<id> <role> <condition_title>'
+    asset_type: null
+    verified: r6
+
+  folder-org-policy:
+    resource: Folder org policy
+    module: modules/folder
+    address: 'module.folder-<key>.google_org_policy_policy.default["<constraint>"]'
+    import_id: 'folders/<id>/policies/<constraint>'
+    asset_type: orgpolicy.googleapis.com/Policy
+    verified: r6
+    disambiguation: 'folder-scoped constraints; org and project scopes have their own entries'
+
+  folder-log-sink:
+    resource: Folder sink
+    module: modules/folder
+    address: 'module.folder-<key>.google_logging_folder_sink.sink["<name>"]'
+    import_id: 'folders/<id>/sinks/<name>'
+    asset_type: logging.googleapis.com/LogSink
+    verified: r6
+    disambiguation: 'folder-level sinks; org sinks are carried by modules/organization'
+
+  # --- projects -----------------------------------------------------
+
+  project:
+    resource: Project
+    module: modules/project
+    address: 'module.project-<key>.google_project.project[0]'
+    import_id: 'projects/<project_id>'
+    asset_type: cloudresourcemanager.googleapis.com/Project
+    verified: r4
+
+  project-service:
+    resource: Project service
+    module: modules/project
+    address: 'module.project-<key>.google_project_service.project_services["<api>"]'
+    import_id: '<project_id>/<api>'
+    asset_type: serviceusage.googleapis.com/Service
+    verified: r4
+
+  project-service-orgpolicy:
+    resource: Project service (orgpolicy)
+    module: modules/project
+    address: 'module.project-<key>.google_project_service.org_policy_service[0]'
+    import_id: '<project_id>/orgpolicy.googleapis.com'
+    asset_type: serviceusage.googleapis.com/Service
+    verified: r4
+
+  project-iam-member:
+    resource: Project IAM member (additive, default)
+    module: modules/project
+    address: 'module.project-<key>.google_project_iam_member.bindings["<key>"]'
+    import_id: '<project_id> <role> <member>'
+    asset_type: null
+    verified: false
+    note: 'conditional bindings append <condition_title> to the import ID'
+
+  project-iam-binding-authoritative:
+    resource: Project IAM
+    module: modules/project
+    address: 'module.project-<key>.google_project_iam_binding.authoritative["<role>"]'
+    import_id: '<project_id> <role>'
+    asset_type: null
+    verified: r4
+
+  project-iam-binding-conditional:
+    resource: Project IAM (cond.)
+    module: modules/project
+    address: 'module.project-<key>.google_project_iam_binding.bindings["<key>"]'
+    import_id: '<project_id> <role> <condition_title>'
+    asset_type: null
+    verified: r4
+
+  project-org-policy:
+    resource: Project org policy
+    module: modules/project
+    address: 'module.project-<key>.google_org_policy_policy.default["<constraint>"]'
+    import_id: 'projects/<project_id>/policies/<constraint>'
+    asset_type: orgpolicy.googleapis.com/Policy
+    verified: false
+    disambiguation: 'project-scoped constraints; org and folder scopes have their own entries'
+
+  workload-identity-pool:
+    resource: Workload Identity Pool
+    module: modules/project
+    address: 'module.project-<key>.google_iam_workload_identity_pool.default["<pool_id>"]'
+    import_id: 'projects/<project_id>/locations/global/workloadIdentityPools/<pool_id>'
+    asset_type: iam.googleapis.com/WorkloadIdentityPool
+    verified: r18
+
+  workload-identity-pool-provider:
+    resource: Workload Identity Pool Provider
+    module: modules/project
+    address: 'module.project-<key>.google_iam_workload_identity_pool_provider.default["<pool_id>/<provider_id>"]'
+    import_id: 'projects/<project_id>/locations/global/workloadIdentityPools/<pool_id>/providers/<provider_id>'
+    asset_type: iam.googleapis.com/WorkloadIdentityPoolProvider
+    verified: r18
+
+  pam-entitlement:
+    resource: PAM entitlement
+    module: modules/project
+    address: 'module.<container>.google_privileged_access_manager_entitlement.default["<entitlement_id>"]'
+    import_id: '<parent>/locations/<location>/entitlements/<entitlement_id>'
+    asset_type: privilegedaccessmanager.googleapis.com/Entitlement
+    verified: false
+    note: '<parent> is organizations/<org>, folders/<id> or projects/<project_id>; grants are excluded, never imported'
+
+  # --- service accounts ---------------------------------------------
+
+  service-account:
+    resource: Service account
+    module: modules/iam-service-account
+    address: 'module.sa-<key>.google_service_account.service_account[0]'
+    import_id: 'projects/<project_id>/serviceAccounts/<email>'
+    asset_type: iam.googleapis.com/ServiceAccount
+    verified: r8
+
+  service-account-iam-member:
+    resource: SA IAM member (additive, default)
+    module: modules/iam-service-account
+    address: 'module.sa-<key>.google_service_account_iam_member.bindings["<key>"]'
+    import_id: 'projects/<project_id>/serviceAccounts/<email> <role> <member>'
+    asset_type: null
+    verified: false
+    note: 'conditional bindings append <condition_title> to the import ID'
+
+  service-account-iam-binding-authoritative:
+    resource: SA IAM binding
+    module: modules/iam-service-account
+    address: 'module.sa-<key>.google_service_account_iam_binding.authoritative["<role>"]'
+    import_id: 'projects/<project_id>/serviceAccounts/<email> <role>'
+    asset_type: null
+    verified: r8
+
+  service-account-iam-binding-conditional:
+    resource: SA IAM binding (cond.)
+    module: modules/iam-service-account
+    address: 'module.sa-<key>.google_service_account_iam_binding.bindings["<key>"]'
+    import_id: 'projects/<project_id>/serviceAccounts/<email> <role> <condition_title>'
+    asset_type: null
+    verified: r8
+
+  # --- logging and storage ------------------------------------------
+
+  log-bucket:
+    resource: Log bucket
+    module: modules/logging-bucket
+    address: 'module.logging_bucket_<key>.google_logging_project_bucket_config.bucket[0]'
+    import_id: 'projects/<project_id>/locations/<location>/buckets/<name>'
+    asset_type: logging.googleapis.com/LogBucket
+    verified: r10
+
+  gcs-bucket:
+    resource: GCS bucket
+    module: modules/gcs
+    address: 'module.<instance>.google_storage_bucket.bucket[0]'
+    import_id: '<project_id>/<bucket_name>'
+    asset_type: storage.googleapis.com/Bucket
+    verified: r12
+    note: 'never import bare <bucket_name> — the project qualifier is a ForceNew trap'
+
+  bigquery-dataset:
+    resource: BigQuery Dataset
+    module: modules/bigquery-dataset
+    address: 'module.<instance>.google_bigquery_dataset.default'
+    import_id: 'projects/<project_id>/datasets/<dataset_id>'
+    asset_type: bigquery.googleapis.com/Dataset
+    verified: r17
+
+  pubsub-topic:
+    resource: Pub/Sub Topic
+    module: modules/pubsub
+    address: 'module.<instance>.google_pubsub_topic.default'
+    import_id: 'projects/<project_id>/topics/<topic_name>'
+    asset_type: pubsub.googleapis.com/Topic
+    verified: r17
+
+  # --- VPC networking -----------------------------------------------
+
+  vpc-network:
+    resource: VPC network
+    module: modules/net-vpc
+    address: 'module.net_vpc_<key>.google_compute_network.network[0]'
+    import_id: 'projects/<project_id>/global/networks/<name>'
+    asset_type: compute.googleapis.com/Network
+    verified: r3
+
+  vpc-subnet:
+    resource: VPC subnet
+    module: modules/net-vpc
+    address: 'module.net_vpc_<key>.google_compute_subnetwork.subnetwork["<region>/<name>"]'
+    import_id: 'projects/<project_id>/regions/<region>/subnetworks/<name>'
+    asset_type: compute.googleapis.com/Subnetwork
+    verified: r3
+    disambiguation: 'ordinary subnets; proxy-only and private-NAT subnets have their own entries'
+
+  vpc-subnet-proxy-only:
+    resource: VPC subnet (proxy-only)
+    module: modules/net-vpc
+    address: 'module.net_vpc_<key>.google_compute_subnetwork.proxy_only["<region>/<name>"]'
+    import_id: 'projects/<project_id>/regions/<region>/subnetworks/<name>'
+    asset_type: compute.googleapis.com/Subnetwork
+    verified: r9
+    disambiguation: 'purpose REGIONAL_MANAGED_PROXY or GLOBAL_MANAGED_PROXY on the live subnet'
+
+  vpc-subnet-private-nat:
+    resource: VPC subnet (private NAT)
+    module: modules/net-vpc
+    address: 'module.net_vpc_<key>.google_compute_subnetwork.private_nat["<region>/<name>"]'
+    import_id: 'projects/<project_id>/regions/<region>/subnetworks/<name>'
+    asset_type: compute.googleapis.com/Subnetwork
+    verified: false
+    disambiguation: 'purpose PRIVATE_NAT on the live subnet'
+
+  vpc-route-gateway:
+    resource: VPC route (gateway)
+    module: modules/net-vpc
+    address: 'module.net_vpc_<key>.google_compute_route.gateway["<key>"]'
+    import_id: 'projects/<project_id>/global/routes/<net>-<key>'
+    asset_type: compute.googleapis.com/Route
+    verified: r9
+    disambiguation: 'next_hop_gateway on the live route'
+
+  vpc-route-ilb:
+    resource: VPC route (ilb)
+    module: modules/net-vpc
+    address: 'module.net_vpc_<key>.google_compute_route.ilb["<key>"]'
+    import_id: 'projects/<project_id>/global/routes/<net>-<key>'
+    asset_type: compute.googleapis.com/Route
+    verified: r9
+    disambiguation: 'next_hop_ilb on the live route'
+
+  vpc-route-instance:
+    resource: VPC route (instance)
+    module: modules/net-vpc
+    address: 'module.net_vpc_<key>.google_compute_route.instance["<key>"]'
+    import_id: 'projects/<project_id>/global/routes/<net>-<key>'
+    asset_type: compute.googleapis.com/Route
+    verified: r9
+    disambiguation: 'next_hop_instance on the live route'
+
+  vpc-route-ip:
+    resource: VPC route (ip)
+    module: modules/net-vpc
+    address: 'module.net_vpc_<key>.google_compute_route.ip["<key>"]'
+    import_id: 'projects/<project_id>/global/routes/<net>-<key>'
+    asset_type: compute.googleapis.com/Route
+    verified: r9
+    disambiguation: 'next_hop_ip on the live route'
+
+  vpc-route-vpn-tunnel:
+    resource: VPC route (vpn tunnel)
+    module: modules/net-vpc
+    address: 'module.net_vpc_<key>.google_compute_route.vpn_tunnel["<key>"]'
+    import_id: 'projects/<project_id>/global/routes/<net>-<key>'
+    asset_type: compute.googleapis.com/Route
+    verified: r9
+    disambiguation: 'next_hop_vpn_tunnel on the live route'
+
+  # --- VPC firewall rules (legacy) ----------------------------------
+
+  vpc-firewall-custom-rule:
+    resource: VPC firewall rule (custom)
+    module: modules/net-vpc-firewall
+    address: 'module.<instance>.google_compute_firewall.custom_rules["<rule_name>"]'
+    import_id: 'projects/<project_id>/global/firewalls/<rule_name>'
+    asset_type: compute.googleapis.com/Firewall
+    verified: false
+    disambiguation: 'every rule not generated by the module default-rule toggles'
+
+  vpc-firewall-default-admins:
+    resource: VPC firewall rule (default, admins)
+    module: modules/net-vpc-firewall
+    address: 'module.<instance>.google_compute_firewall.allow_admins[0]'
+    import_id: 'projects/<project_id>/global/firewalls/<network_name>-ingress-admins'
+    asset_type: compute.googleapis.com/Firewall
+    verified: false
+    disambiguation: 'generated by default_rules_config.admin_ranges, not by custom_rules'
+
+  vpc-firewall-default-http:
+    resource: VPC firewall rule (default, http)
+    module: modules/net-vpc-firewall
+    address: 'module.<instance>.google_compute_firewall.allow_tag_http[0]'
+    import_id: 'projects/<project_id>/global/firewalls/<network_name>-ingress-tag-http'
+    asset_type: compute.googleapis.com/Firewall
+    verified: false
+    disambiguation: 'generated by default_rules_config.http_ranges, not by custom_rules'
+
+  vpc-firewall-default-https:
+    resource: VPC firewall rule (default, https)
+    module: modules/net-vpc-firewall
+    address: 'module.<instance>.google_compute_firewall.allow_tag_https[0]'
+    import_id: 'projects/<project_id>/global/firewalls/<network_name>-ingress-tag-https'
+    asset_type: compute.googleapis.com/Firewall
+    verified: false
+    disambiguation: 'generated by default_rules_config.https_ranges, not by custom_rules'
+
+  vpc-firewall-default-ssh:
+    resource: VPC firewall rule (default, ssh)
+    module: modules/net-vpc-firewall
+    address: 'module.<instance>.google_compute_firewall.allow_tag_ssh[0]'
+    import_id: 'projects/<project_id>/global/firewalls/<network_name>-ingress-tag-ssh'
+    asset_type: compute.googleapis.com/Firewall
+    verified: false
+    disambiguation: 'generated by default_rules_config.ssh_ranges, not by custom_rules'
+
+  # --- firewall policies --------------------------------------------
+
+  firewall-policy-hierarchical:
+    resource: Hierarchical Firewall Policy
+    module: modules/net-firewall-policy
+    address: 'module.<instance>.google_compute_firewall_policy.hierarchical[0]'
+    import_id: 'locations/global/firewallPolicies/<id>'
+    asset_type: compute.googleapis.com/FirewallPolicy
+    verified: r7
+    disambiguation: 'org- or folder-attached policy'
+
+  firewall-policy-network-global:
+    resource: Global Network Firewall Policy
+    module: modules/net-firewall-policy
+    address: 'module.<instance>.google_compute_network_firewall_policy.net_global[0]'
+    import_id: 'projects/<project_id>/global/firewallPolicies/<name>'
+    asset_type: compute.googleapis.com/FirewallPolicy
+    verified: r7
+    disambiguation: 'project-scoped, global'
+
+  firewall-policy-network-regional:
+    resource: Regional Network Firewall Policy
+    module: modules/net-firewall-policy
+    address: 'module.<instance>.google_compute_region_network_firewall_policy.net_regional[0]'
+    import_id: 'projects/<project_id>/regions/<region>/firewallPolicies/<name>'
+    asset_type: compute.googleapis.com/FirewallPolicy
+    verified: r7
+    disambiguation: 'project-scoped, regional'
+
+  # --- compute addresses --------------------------------------------
+
+  address-global-psc:
+    resource: Compute address (global PSC)
+    module: modules/net-address
+    address: 'module.<instance>.google_compute_global_address.psc["<key>"]'
+    import_id: 'projects/<project_id>/global/addresses/<name>'
+    asset_type: compute.googleapis.com/Address
+    verified: r19
+    disambiguation: 'addressType INTERNAL with purpose PRIVATE_SERVICE_CONNECT'
+
+  address-global-psa:
+    resource: Compute address (global PSA)
+    module: modules/net-address
+    address: 'module.<instance>.google_compute_global_address.psa["<key>"]'
+    import_id: 'projects/<project_id>/global/addresses/<name>'
+    asset_type: compute.googleapis.com/Address
+    verified: r19
+    disambiguation: 'purpose VPC_PEERING'
+
+  address-regional-internal:
+    resource: Compute address (regional internal)
+    module: modules/net-address
+    address: 'module.<instance>.google_compute_address.internal["<key>"]'
+    import_id: 'projects/<project_id>/regions/<region>/addresses/<name>'
+    asset_type: compute.googleapis.com/Address
+    verified: r19
+    disambiguation: 'purpose GCE_ENDPOINT or SHARED_LOADBALANCER_VIP'
+
+  # --- routers, NAT, VPN, interconnect ------------------------------
+
+  cloud-router:
+    resource: Cloud Router
+    module: modules/net-cloudnat
+    address: 'module.<nat_instance>.google_compute_router.router[0]'
+    import_id: 'projects/<project_id>/regions/<region>/routers/<name>'
+    asset_type: compute.googleapis.com/Router
+    verified: r12
+    disambiguation: 'router whose only attached function is Cloud NAT; a router that also terminates VPN tunnels belongs to modules/net-vpn-ha'
+
+  cloud-nat:
+    resource: Cloud NAT
+    module: modules/net-cloudnat
+    address: 'module.<nat_instance>.google_compute_router_nat.nat'
+    import_id: 'projects/<project_id>/regions/<region>/routers/<router>/<nat>'
+    asset_type: compute.googleapis.com/Router
+    verified: r12
+    disambiguation: 'sub-resource with no CAI asset of its own; claimed by the parent Router key'
+
+  vpn-ha-gateway:
+    resource: HA VPN Gateway
+    module: modules/net-vpn-ha
+    address: 'module.<vpn_instance>.google_compute_ha_vpn_gateway.ha_gateway[0]'
+    import_id: 'projects/<project_id>/regions/<region>/vpnGateways/<name>'
+    asset_type: compute.googleapis.com/VpnGateway
+    verified: false
+
+  vpn-external-gateway:
+    resource: External VPN Gateway
+    module: modules/net-vpn-ha
+    address: 'module.<vpn_instance>.google_compute_external_vpn_gateway.external_gateway["<peer_key>"]'
+    import_id: 'projects/<project_id>/global/externalVpnGateways/<name>'
+    asset_type: compute.googleapis.com/ExternalVpnGateway
+    verified: false
+
+  vpn-tunnel:
+    resource: VPN Tunnel
+    module: modules/net-vpn-ha
+    address: 'module.<vpn_instance>.google_compute_vpn_tunnel.tunnels["<tunnel_key>"]'
+    import_id: 'projects/<project_id>/regions/<region>/vpnTunnels/<name>'
+    asset_type: compute.googleapis.com/VpnTunnel
+    verified: false
+    note: 'shared_secret is ForceNew and unreadable — see the cookbook section before emitting'
+
+  vpn-router:
+    resource: Cloud Router (VPN)
+    module: modules/net-vpn-ha
+    address: 'module.<vpn_instance>.google_compute_router.router[0]'
+    import_id: 'projects/<project_id>/regions/<region>/routers/<name>'
+    asset_type: compute.googleapis.com/Router
+    verified: false
+    disambiguation: 'router that terminates VPN tunnels; a NAT-only router belongs to modules/net-cloudnat'
+
+  vpn-router-interface:
+    resource: Cloud Router interface (VPN)
+    module: modules/net-vpn-ha
+    address: 'module.<vpn_instance>.google_compute_router_interface.router_interface["<tunnel_key>"]'
+    import_id: '<project_id>/<region>/<router_name>/<interface_name>'
+    asset_type: compute.googleapis.com/Router
+    verified: false
+    disambiguation: 'sub-resource with no CAI asset of its own; claimed by the parent Router key'
+
+  vpn-router-peer:
+    resource: Cloud Router BGP peer (VPN)
+    module: modules/net-vpn-ha
+    address: 'module.<vpn_instance>.google_compute_router_peer.bgp_peer["<tunnel_key>"]'
+    import_id: 'projects/<project_id>/regions/<region>/routers/<router_name>/<peer_name>'
+    asset_type: compute.googleapis.com/Router
+    verified: false
+    disambiguation: 'sub-resource with no CAI asset of its own; claimed by the parent Router key'
+
+  interconnect-attachment:
+    resource: Interconnect Attachment
+    module: modules/net-vlan-attachment
+    address: 'module.<instance>.google_compute_interconnect_attachment.default["<key>"]'
+    import_id: 'projects/<project_id>/regions/<region>/interconnectAttachments/<name>'
+    asset_type: compute.googleapis.com/InterconnectAttachment
+    verified: false
+
+  # --- Cloud DNS ----------------------------------------------------
+
+  dns-managed-zone:
+    resource: DNS zone
+    module: modules/dns
+    address: 'module.<instance>.google_dns_managed_zone.dns_managed_zone[0]'
+    import_id: 'projects/<project_id>/managedZones/<zone>'
+    asset_type: dns.googleapis.com/ManagedZone
+    verified: r12
+
+  dns-record-set:
+    resource: DNS recordset
+    module: modules/dns
+    address: 'module.<instance>.google_dns_record_set.dns_record_set["<type> <name>"]'
+    import_id: 'projects/<project_id>/managedZones/<zone>/rrsets/<record_name>/<type>'
+    asset_type: dns.googleapis.com/ResourceRecordSet
+    verified: false
+    note: 'for_each key is "<type> <name>" — type first, single space, trailing dot on <name>'
+
+  dns-response-policy:
+    resource: DNS Response Policy
+    module: modules/dns-response-policy
+    address: 'module.<instance>.google_dns_response_policy.default[0]'
+    import_id: 'projects/<project_id>/responsePolicies/<response_policy_name>'
+    asset_type: dns.googleapis.com/ResponsePolicy
+    verified: false
+
+  dns-response-policy-rule:
+    resource: DNS Response Policy rule
+    module: modules/dns-response-policy
+    address: 'module.<instance>.google_dns_response_policy_rule.default["<rule_name>"]'
+    import_id: 'projects/<project_id>/responsePolicies/<response_policy_name>/rules/<rule_name>'
+    asset_type: dns.googleapis.com/ResponsePolicyRule
+    verified: false
+
+  # --- KMS ----------------------------------------------------------
+
+  kms-keyring:
+    resource: KMS KeyRing
+    module: modules/kms
+    address: 'module.<instance>.google_kms_key_ring.default[0]'
+    import_id: 'projects/<project_id>/locations/<location>/keyRings/<name>'
+    asset_type: cloudkms.googleapis.com/KeyRing
+    verified: r13
+
+  kms-crypto-key:
+    resource: KMS CryptoKey
+    module: modules/kms
+    address: 'module.<instance>.google_kms_crypto_key.default["<key>"]'
+    import_id: 'projects/<project_id>/locations/<location>/keyRings/<name>/cryptoKeys/<key>'
+    asset_type: cloudkms.googleapis.com/CryptoKey
+    verified: r13
+
+  kms-crypto-key-iam:
+    resource: KMS CryptoKey IAM
+    module: modules/kms
+    address: 'module.<instance>.google_kms_crypto_key_iam_binding.authoritative["<key>.<role>"]'
+    import_id: 'projects/<project_id>/locations/<location>/keyRings/<name>/cryptoKeys/<key> <role>'
+    asset_type: null
+    verified: r13
+
+  # --- Certificate Authority Service --------------------------------
+
+  cas-ca-pool:
+    resource: CAS CA Pool
+    module: modules/certificate-authority-service
+    address: 'module.<instance>.google_privateca_ca_pool.default[0]'
+    import_id: 'projects/<project_id>/locations/<location>/caPools/<name>'
+    asset_type: privateca.googleapis.com/CaPool
+    verified: r14
+
+  cas-ca-pool-iam:
+    resource: CAS CA Pool IAM
+    module: modules/certificate-authority-service
+    address: 'module.<instance>.google_privateca_ca_pool_iam_binding.authoritative["<role>"]'
+    import_id: 'projects/<project_id>/locations/<location>/caPools/<name> <role>'
+    asset_type: null
+    verified: false
+
+  cas-ca-pool-iam-conditional:
+    resource: CAS CA Pool IAM (cond.)
+    module: modules/certificate-authority-service
+    address: 'module.<instance>.google_privateca_ca_pool_iam_binding.bindings["<key>"]'
+    import_id: 'projects/<project_id>/locations/<location>/caPools/<name> <role> <condition_title>'
+    asset_type: null
+    verified: false
+
+  cas-certificate-authority:
+    resource: Certificate Authority
+    module: modules/certificate-authority-service
+    address: 'module.<instance>.google_privateca_certificate_authority.default["<id>"]'
+    import_id: 'projects/<project_id>/locations/<location>/caPools/<pool>/certificateAuthorities/<id>'
+    asset_type: privateca.googleapis.com/CertificateAuthority
+    verified: false
+
+  # --- VPC Service Controls -----------------------------------------
+
+  vpcsc-access-policy:
+    resource: VPC-SC Access Policy
+    module: modules/vpc-sc
+    address: 'module.<instance>.google_access_context_manager_access_policy.default[0]'
+    import_id: '<policy_id>'
+    asset_type: identity.accesscontextmanager.googleapis.com/AccessPolicy
+    verified: r15
+    note: 'import ID is the bare numeric policy id, with no accessPolicies/ prefix'
+
+  vpcsc-access-level:
+    resource: VPC-SC Access Level
+    module: modules/vpc-sc
+    address: 'module.<instance>.google_access_context_manager_access_level.basic["<key>"]'
+    import_id: 'accessPolicies/<policy_id>/accessLevels/<level_name>'
+    asset_type: identity.accesscontextmanager.googleapis.com/AccessLevel
+    verified: r15
+
+  vpcsc-service-perimeter:
+    resource: VPC-SC Service Perimeter
+    module: modules/vpc-sc
+    address: 'module.<instance>.google_access_context_manager_service_perimeter.regular["<key>"]'
+    import_id: 'accessPolicies/<policy_id>/servicePerimeters/<perimeter_name>'
+    asset_type: identity.accesscontextmanager.googleapis.com/ServicePerimeter
+    verified: r15
+
+  # --- Network Connectivity Center ----------------------------------
+
+  ncc-hub:
+    resource: NCC Hub
+    module: modules/ncc-spoke-ra
+    address: 'module.<instance>.google_network_connectivity_hub.hub[0]'
+    import_id: 'projects/<project_id>/locations/global/hubs/<hub_name>'
+    asset_type: networkconnectivity.googleapis.com/Hub
+    verified: false
+
+  ncc-spoke-ra:
+    resource: NCC spoke (router appliance)
+    module: modules/ncc-spoke-ra
+    address: 'module.<instance>.google_network_connectivity_spoke.spoke_ra'
+    import_id: 'projects/<project_id>/locations/<location>/spokes/<spoke_name>'
+    asset_type: networkconnectivity.googleapis.com/Spoke
+    verified: false
+    disambiguation: 'linked_router_appliance_instances spokes only'
+
+  ncc-spoke-raw:
+    resource: NCC spoke (raw — capability gap)
+    module: raw
+    address: 'google_network_connectivity_spoke.<instance>'
+    import_id: 'projects/<project_id>/locations/<location>/spokes/<spoke_name>'
+    asset_type: networkconnectivity.googleapis.com/Spoke
+    verified: r12
+    disambiguation: 'linked-VPC and linked-VPN spokes, which no Fabric module carries'

--- a/skills/fabric-importer/references/mapping-cookbook.md
+++ b/skills/fabric-importer/references/mapping-cookbook.md
@@ -59,8 +59,14 @@ and custom constraints are carried as `data/` YAML inside their owning
 | Service accounts | `modules/iam-service-account` | `project-factory` — `service_accounts:` block in the owning project's YAML (only when that project is factory-emitted) | SA + its IAM |
 | Log buckets | `modules/logging-bucket` | — | bucket config (sink destinations) |
 | VPC networks | `modules/net-vpc` | subnets only: `net-vpc` `factories_config.subnets_folder` | network, subnets (incl. proxy-only), routes |
+| VPC Firewall Rules | `modules/net-vpc-firewall` | `net-vpc-firewall` `factories_config.rules_folder` | legacy VPC firewall rules |
+| Cloud NAT & Routers | `modules/net-cloudnat` | — | Cloud NAT & Cloud Router |
+| HA VPN | `modules/net-vpn-ha` | — | HA VPN gateway, external gateway, tunnels, BGP peers |
+| Cloud DNS | `modules/dns` | `dns` `factories_config.recordsets_file` | managed zones, recordsets |
+| DNS Response Policy | `modules/dns-response-policy` | `dns-response-policy` `factories_config.rules` | response policies & rules |
 | Firewall policy rules | `modules/net-firewall-policy` inputs | `net-firewall-policy` `factories_config` rule files | ingress/egress rules |
 | Other | nearest Fabric module for the family; check `modules/` in-repo | see `FACTORIES.md` at the repo root — the authoritative factory catalog (every module factory flows through `factories_config`) | — |
+
 
 Instance keys: pick short stable slugs at first import (record them in
 `coverage-map.yaml`); keys are immutable afterwards. Because the key —
@@ -959,7 +965,85 @@ let plan tell you: it errors loudly and safely on a wrong ID.
 - **Traps**:
   - Grants represent transient workflow state with short TTLs and should **not** be managed in Terraform baseline IaC.
 
+### VPC Firewall Rules (`modules/net-vpc-firewall`)
+
+- **Manifest**: `compute.googleapis.com/Firewall`, `levels: [project]`.
+- **Carrier Distinction & Boundary Rule**: `modules/net-vpc` deliberately does not manage firewall rules directly to maintain module boundaries. `modules/net-vpc-firewall` is the dedicated Fabric carrier for legacy VPC firewall rules, distinct from `modules/net-firewall-policy` (which manages hierarchical and network firewall policies).
+- **Resource Addresses**:
+  - `module.<instance>.google_compute_firewall.custom_rules["<rule_name>"]` (or `rules["<rule_name>"]`)
+- **Import IDs**:
+  - `projects/<project_id>/global/firewalls/<rule_name>` (or `<project_id>/<rule_name>`)
+- **Inputs**: `project_id`, `network`, and `custom_rules` (or `factories_config.rules_folder`).
+- Lives in `project-<key>.tf`.
+
+### Cloud NAT & Routers (`modules/net-cloudnat`)
+
+- **Manifest**: `compute.googleapis.com/Router`, `levels: [project]`.
+- **Resource Addresses**:
+  - Router: `module.<instance>.google_compute_router.router[0]`
+  - NAT: `module.<instance>.google_compute_router_nat.nat`
+- **Import IDs**:
+  - Router: `projects/<project_id>/regions/<region>/routers/<router_name>`
+  - NAT: `projects/<project_id>/regions/<region>/routers/<router_name>/<nat_name>`
+- **Coverage Mapping Rule**: A single CAI `compute.googleapis.com/Router` key claims both `google_compute_router.router[0]` and `google_compute_router_nat.nat` in `coverage-map.yaml`.
+- Lives in `project-<key>.tf`.
+
+### Cloud DNS & Recordsets (`modules/dns`)
+
+- **Manifest**: `dns.googleapis.com/ManagedZone` and `dns.googleapis.com/ResourceRecordSet`, `levels: [project]`.
+- **Resource Addresses**:
+  - Managed Zone: `module.<instance>.google_dns_managed_zone.dns_managed_zone[0]`
+  - Recordsets: `module.<instance>.google_dns_record_set.dns_record_set["<type> <name>"]`
+- **Import IDs**:
+  - Zone: `projects/<project_id>/managedZones/<zone_name>`
+  - Recordset: `projects/<project_id>/managedZones/<zone_name>/rrsets/<record_name>/<type>`
+- **Coverage Mapping Rule**: In `coverage-map.yaml`, the `dns.googleapis.com/ManagedZone` key claims both the managed zone address and its child `google_dns_record_set` addresses.
+- **Default Description Trap**: Fabric's `modules/dns` defaults `description = "Terraform managed."` (with space), whereas FAST stages use `"Terraform-managed."` (with hyphen). Set `description = "Terraform-managed."` explicitly to prevent description drift.
+- Lives in `project-<key>.tf`.
+
+### DNS Response Policies (`modules/dns-response-policy`)
+
+- **Manifest**: `dns.googleapis.com/ResponsePolicy`, `levels: [project]`.
+- **Resource Addresses**:
+  - Response Policy: `module.<instance>.google_dns_response_policy.default[0]`
+  - Rules: `module.<instance>.google_dns_response_policy_rule.default["<rule_name>"]`
+- **Import IDs**:
+  - Policy: `projects/<project_id>/responsePolicies/<response_policy_name>`
+  - Rule: `projects/<project_id>/responsePolicies/<response_policy_name>/rules/<rule_name>`
+- **Input Schema Trap**: `networks` is `map(string)` (`name => self_link`), not a list of strings.
+- Lives in `project-<key>.tf`.
+
+### HA VPN & VPN Tunnels (`modules/net-vpn-ha`)
+
+- **Manifest**: `compute.googleapis.com/VpnGateway`, `compute.googleapis.com/ExternalVpnGateway`, `compute.googleapis.com/VpnTunnel`, and `compute.googleapis.com/Router`, `levels: [project]`.
+- **Resource Addresses**:
+  - HA VPN Gateway: `module.<instance>.google_compute_ha_vpn_gateway.ha_gateway[0]` (or external gateway resource)
+  - External VPN Gateway: `module.<instance>.google_compute_external_vpn_gateway.external_gateway["<peer_key>"]`
+  - VPN Tunnels: `module.<instance>.google_compute_vpn_tunnel.tunnels["<tunnel_key>"]`
+  - Router Interfaces: `module.<instance>.google_compute_router_interface.router_interface["<tunnel_key>"]`
+  - BGP Peers: `module.<instance>.google_compute_router_peer.bgp_peer["<tunnel_key>"]`
+- **Import IDs**:
+  - HA Gateway: `projects/<project_id>/regions/<region>/vpnGateways/<name>`
+  - External Gateway: `projects/<project_id>/global/externalVpnGateways/<name>`
+  - Tunnel: `projects/<project_id>/regions/<region>/vpnTunnels/<name>`
+  - Router Interface: `<project_id>/<region>/<router_name>/<interface_name>` *(provider format: no `projects/` prefix)*
+  - BGP Peer: `projects/<project_id>/regions/<region>/routers/<router_name>/<peer_name>`
+- **Secret Handling & Waiver Pattern**:
+  - Provider constraint: `google_compute_vpn_tunnel` marks `shared_secret` as `ForceNew: true`. The GCP Compute API only returns `shared_secret_hash` (not plaintext `shared_secret`) on import/read, leaving `shared_secret = null` in imported state. When configuration specifies `shared_secret`, Terraform plans a resource replacement (`destroy / re-create`).
+  - Recommended posture: Emit `modules/net-vpn-ha` with standard configuration, document/comment the secret requirement in HCL with instructions for the operator to provide the secret on day-2 mutation, and record a signed waiver for the preview diff.
+  - Alternative standalone fallback: Declare standalone `google_compute_vpn_tunnel` with `lifecycle { ignore_changes = [shared_secret] }`.
+- Lives in `project-<key>.tf`.
+
+### Network Connectivity Center (NCC)
+
+- **Manifest**: `networkconnectivity.googleapis.com/Hub`, `networkconnectivity.googleapis.com/Spoke`, `levels: [project]`.
+- **Capability Gap & Fallback**: Fabric provides `modules/ncc-spoke-ra` for router appliance spokes. Generic linked-VPC and linked-VPN spokes have no dedicated module carrier and are emitted as native `google_network_connectivity_spoke.<name>` resources.
+- **Import IDs**:
+  - Hub: `projects/<project_id>/locations/global/hubs/<hub_name>`
+  - Spoke: `projects/<project_id>/locations/<location>/spokes/<spoke_name>`
+
 ### Root module
+
 
 - Emit `versions.tf` (terraform >= 1.5, google + google-beta
   `>= 7.40, < 8`, `backend "local"`) and the module wiring yourself;

--- a/skills/fabric-importer/references/mapping-cookbook.md
+++ b/skills/fabric-importer/references/mapping-cookbook.md
@@ -35,6 +35,14 @@ per-type rules (organization, folders, projects, service accounts, log
 sinks, logging buckets, VPC networks, root module) · fallback and
 accelerator.
 
+**Where the fielded data lives.** Address patterns, import IDs, CAI
+asset types and verification rounds are held in
+[`address-map.yaml`](./address-map.yaml) and rendered into the
+import-ID table below; the prose here owns everything else — the traps,
+the causal reasoning and the capability gaps. Add a new address to the
+YAML, not to the table, and run
+`uv run scripts/address_map.py` to check both.
+
 ## Canonical module map (normative)
 
 Fabric modules are the product — this table is the default mapping, not
@@ -59,14 +67,14 @@ and custom constraints are carried as `data/` YAML inside their owning
 | Service accounts | `modules/iam-service-account` | `project-factory` — `service_accounts:` block in the owning project's YAML (only when that project is factory-emitted) | SA + its IAM |
 | Log buckets | `modules/logging-bucket` | — | bucket config (sink destinations) |
 | VPC networks | `modules/net-vpc` | subnets only: `net-vpc` `factories_config.subnets_folder` | network, subnets (incl. proxy-only), routes |
-| VPC Firewall Rules | `modules/net-vpc-firewall` | `net-vpc-firewall` `factories_config.rules_folder` | legacy VPC firewall rules |
-| Cloud NAT & Routers | `modules/net-cloudnat` | — | Cloud NAT & Cloud Router |
-| HA VPN | `modules/net-vpn-ha` | — | HA VPN gateway, external gateway, tunnels, BGP peers |
-| Cloud DNS | `modules/dns` | `dns` `factories_config.recordsets_file` | managed zones, recordsets |
+| VPC firewall rules (legacy) | `modules/net-vpc-firewall` | `net-vpc-firewall` `factories_config.rules_folder` | custom rules + the four `default_rules_config` rules |
+| Cloud NAT & Routers | `modules/net-cloudnat` | — | Cloud NAT + its Cloud Router (NAT-only routers) |
+| HA VPN | `modules/net-vpn-ha` | — | HA VPN gateway, external gateway, tunnels, its own Cloud Router, interfaces, BGP peers |
+| Cloud DNS | `modules/dns` | — (no factory: recordsets are the `recordsets` input, keyed `"<type> <name>"`) | managed zones, recordsets |
 | DNS Response Policy | `modules/dns-response-policy` | `dns-response-policy` `factories_config.rules` | response policies & rules |
+| NCC | `modules/ncc-spoke-ra` (hub + router-appliance spokes only) | — | hub; linked-VPC/VPN spokes are a capability gap |
 | Firewall policy rules | `modules/net-firewall-policy` inputs | `net-firewall-policy` `factories_config` rule files | ingress/egress rules |
 | Other | nearest Fabric module for the family; check `modules/` in-repo | see `FACTORIES.md` at the repo root — the authoritative factory catalog (every module factory flows through `factories_config`) | — |
-
 
 Instance keys: pick short stable slugs at first import (record them in
 `coverage-map.yaml`); keys are immutable afterwards. Because the key —
@@ -417,75 +425,111 @@ governance:
 
 ## Import-ID quick table
 
-All rows verified live except where noted. `module.organization.` is
-shortened to `…` after the first row.
+**Generated — do not edit by hand.** The rows below are rendered from
+[`address-map.yaml`](./address-map.yaml), which owns the fielded subset
+of this cookbook: asset type, module, address pattern, import ID and the
+round that verified it. Edit the YAML and re-render:
 
-| Resource | Address pattern | Import ID |
-|---|---|---|
-| Custom role | `module.organization.google_organization_iam_custom_role.roles["<id>"]` | `organizations/<org>/roles/<id>` |
-| Org IAM member (additive, default) | `…google_organization_iam_member.bindings["<key>"]` | `<org> <role> <member>` (unverified; cond. appends `<condition_title>`) |
-| Org IAM binding (authoritative opt-in) | `…google_organization_iam_binding.authoritative["<role>"]` | `<org> <role>` |
-| Org IAM binding (cond.) | `…google_organization_iam_binding.bindings["<key>"]` | `<org> <role> <condition_title>` |
-| Org audit config | `…google_organization_iam_audit_config.default["<service>"]` | `<org> <service>` (verified r3) |
-| Org policy | `…google_org_policy_policy.default["<constraint>"]` | `organizations/<org>/policies/<constraint>` |
-| Org log sink | `…google_logging_organization_sink.sink["<name>"]` | `organizations/<org>/sinks/<name>` |
-| Folder | `module.folder-<key>.google_folder.folder[0]` | `folders/<id>` |
-| Folder IAM member (additive, default) | `module.folder-<key>.google_folder_iam_member.bindings["<key>"]` | `folders/<id> <role> <member>` (unverified; cond. appends `<condition_title>`) |
-| Folder IAM | `module.folder-<key>.google_folder_iam_binding.authoritative["<role>"]` | `folders/<id> <role>` |
-| Folder IAM (cond.) | `module.folder-<key>.google_folder_iam_binding.bindings["<key>"]` | `folders/<id> <role> <condition_title>` |
-| Folder org policy | `module.folder-<key>.google_org_policy_policy.default["<constraint>"]` | `folders/<id>/policies/<constraint>` |
-| Folder sink | `module.folder-<key>.google_logging_folder_sink.sink["<name>"]` | `folders/<id>/sinks/<name>` |
-| Project | `module.project-<key>.google_project.project[0]` | `projects/<project_id>` |
-| Project service | `module.project-<key>.google_project_service.project_services["<api>"]` | `<project_id>/<api>` |
-| Project service (orgpolicy) | `module.project-<key>.google_project_service.org_policy_service[0]` | `<project_id>/orgpolicy.googleapis.com` |
-| Project IAM member (additive, default) | `module.project-<key>.google_project_iam_member.bindings["<key>"]` | `<project_id> <role> <member>` (unverified; cond. appends `<condition_title>`) |
-| Project IAM | `module.project-<key>.google_project_iam_binding.authoritative["<role>"]` | `<project_id> <role>` |
-| Project IAM (cond.) | `module.project-<key>.google_project_iam_binding.bindings["<key>"]` | `<project_id> <role> <condition_title>` |
-| Service account | `module.sa-<key>.google_service_account.service_account[0]` | `projects/<project_id>/serviceAccounts/<email>` |
-| SA IAM member (additive, default) | `module.sa-<key>.google_service_account_iam_member.bindings["<key>"]` | `projects/<project_id>/serviceAccounts/<email> <role> <member>` (unverified; cond. appends `<condition_title>`) |
-| SA IAM binding | `module.sa-<key>.google_service_account_iam_binding.authoritative["<role>"]` | `projects/<project_id>/serviceAccounts/<email> <role>` |
-| SA IAM binding (cond.) | `module.sa-<key>.google_service_account_iam_binding.bindings["<key>"]` | `projects/<project_id>/serviceAccounts/<email> <role> <condition_title>` |
-| VPC network | `module.net_vpc_<key>.google_compute_network.network[0]` | `projects/<project_id>/global/networks/<name>` |
-| VPC subnet | `module.net_vpc_<key>.google_compute_subnetwork.subnetwork["<region>/<name>"]` | `projects/<project_id>/regions/<region>/subnetworks/<name>` |
-| VPC subnet (proxy-only) | `module.net_vpc_<key>.google_compute_subnetwork.proxy_only["<region>/<name>"]` | `projects/<project_id>/regions/<region>/subnetworks/<name>` |
-| VPC subnet (private NAT) | `module.net_vpc_<key>.google_compute_subnetwork.private_nat["<region>/<name>"]` | `projects/<project_id>/regions/<region>/subnetworks/<name>` (unverified) |
-| VPC route (gateway) | `module.net_vpc_<key>.google_compute_route.gateway["<key>"]` | `projects/<project_id>/global/routes/<net>-<key>` |
-| VPC route (ilb) | `module.net_vpc_<key>.google_compute_route.ilb["<key>"]` | `projects/<project_id>/global/routes/<net>-<key>` |
-| VPC route (instance) | `module.net_vpc_<key>.google_compute_route.instance["<key>"]` | `projects/<project_id>/global/routes/<net>-<key>` |
-| VPC route (ip) | `module.net_vpc_<key>.google_compute_route.ip["<key>"]` | `projects/<project_id>/global/routes/<net>-<key>` |
-| VPC route (vpn tunnel) | `module.net_vpc_<key>.google_compute_route.vpn_tunnel["<key>"]` | `projects/<project_id>/global/routes/<net>-<key>` |
-| Hierarchical Firewall Policy | `module.<instance>.google_compute_firewall_policy.hierarchical[0]` | `locations/global/firewallPolicies/<id>` |
-| Global Network Firewall Policy | `module.<instance>.google_compute_network_firewall_policy.net_global[0]` | `projects/<project_id>/global/firewallPolicies/<name>` |
-| Regional Network Firewall Policy | `module.<instance>.google_compute_region_network_firewall_policy.net_regional[0]` | `projects/<project_id>/regions/<region>/firewallPolicies/<name>` |
-| Interconnect Attachment | `module.<instance>.google_compute_interconnect_attachment.default["<key>"]` | `projects/<project_id>/regions/<region>/interconnectAttachments/<name>` |
-| HA VPN Gateway | `module.<instance>.google_compute_ha_vpn_gateway.ha_gateway[0]` | `projects/<project_id>/regions/<region>/vpnGateways/<name>` |
-| Log bucket | `module.logging_bucket_<key>.google_logging_project_bucket_config.bucket[0]` | `projects/<project_id>/locations/<location>/buckets/<name>` |
-| GCS bucket | `module.<instance>.google_storage_bucket.bucket[0]` | `<project_id>/<bucket_name>` (never bare — ForceNew trap) |
-| DNS zone | `module.<instance>.google_dns_managed_zone.dns_managed_zone[0]` | `projects/<project_id>/managedZones/<zone>` |
-| Cloud Router | `module.<instance>.google_compute_router.router[0]` | `projects/<project_id>/regions/<region>/routers/<name>` |
-| Cloud NAT | `module.<instance>.google_compute_router_nat.nat` | `projects/<project_id>/regions/<region>/routers/<router>/<nat>` |
-| KMS KeyRing | `module.<instance>.google_kms_key_ring.default[0]` | `projects/<project_id>/locations/<location>/keyRings/<name>` |
-| KMS CryptoKey | `module.<instance>.google_kms_crypto_key.default["<key>"]` | `projects/<project_id>/locations/<location>/keyRings/<name>/cryptoKeys/<key>` |
-| KMS CryptoKey IAM | `module.<instance>.google_kms_crypto_key_iam_binding.authoritative["<key>.<role>"]` | `projects/<project_id>/locations/<location>/keyRings/<name>/cryptoKeys/<key> <role>` |
-| BigQuery Dataset | `module.<instance>.google_bigquery_dataset.default` | `projects/<project_id>/datasets/<dataset_id>` (verified r17) |
-| Pub/Sub Topic | `module.<instance>.google_pubsub_topic.default` | `projects/<project_id>/topics/<topic_name>` (verified r17) |
-| CAS CA Pool | `module.<instance>.google_privateca_ca_pool.default[0]` | `projects/<project_id>/locations/<location>/caPools/<name>` (verified r14) |
-| CAS CA Pool IAM | `module.<instance>.google_privateca_ca_pool_iam_binding.authoritative["<role>"]` | `projects/<project_id>/locations/<location>/caPools/<name> <role>` (unverified) |
-| CAS CA Pool IAM (cond.) | `module.<instance>.google_privateca_ca_pool_iam_binding.bindings["<key>"]` | `projects/<project_id>/locations/<location>/caPools/<name> <role> <condition_title>` (unverified) |
-| Certificate Authority | `module.<instance>.google_privateca_certificate_authority.default["<id>"]` | `projects/<project_id>/locations/<location>/caPools/<pool>/certificateAuthorities/<id>` (unverified) |
-| VPC-SC Access Policy | `module.<instance>.google_access_context_manager_access_policy.default[0]` | `<policy_id>` (bare numeric string; verified r15) |
-| VPC-SC Access Level | `module.<instance>.google_access_context_manager_access_level.basic["<key>"]` | `accessPolicies/<policy_id>/accessLevels/<level_name>` (verified r15) |
-| VPC-SC Service Perimeter | `module.<instance>.google_access_context_manager_service_perimeter.regular["<key>"]` | `accessPolicies/<policy_id>/servicePerimeters/<perimeter_name>` (verified r15) |
-| Tag Key | `module.organization.google_tags_tag_key.default["<short_name>"]` | `tagKeys/<id>` (verified r18) |
-| Tag Value | `module.organization.google_tags_tag_value.default["<key_short_name>/<value_short_name>"]` | `tagValues/<id>` (verified r18) |
-| Tag Binding | `module.<instance>.google_tags_tag_binding.binding["<key>"]` | `tagBindings/<url-encoded-parent-and-value>` (verified r18) |
-| Workload Identity Pool | `module.project-<key>.google_iam_workload_identity_pool.default["<pool_id>"]` | `projects/<project_id>/locations/global/workloadIdentityPools/<pool_id>` (verified r18) |
-| Workload Identity Pool Provider | `module.project-<key>.google_iam_workload_identity_pool_provider.default["<pool_id>/<provider_id>"]` | `projects/<project_id>/locations/global/workloadIdentityPools/<pool_id>/providers/<provider_id>` (verified r18) |
-| NCC spoke (raw — gap) | `google_network_connectivity_spoke.<instance>` | `projects/<project_id>/locations/<location>/spokes/<name>` |
+```bash
+uv run scripts/address_map.py --render-cookbook
+```
 
-Verified across r2–r18 (see COVERAGE.md for the per-family evidence). For
+Two invariants are machine-enforced there and cannot be restated here by
+accident: an address pattern is claimed by exactly one entry, and a CAI
+asset type serviced by more than one module must say how to tell the
+carriers apart. `<placeholder>` segments are chosen per engagement.
+A blank `Verified` cell means the surface was never exercised live —
+an honest gap, not an implied guarantee.
 
-anything else: check the provider documentation's import section, or
+<!-- BEGIN ADDRESS-MAP (generated) -->
+
+| Resource | Module | Address pattern | Import ID | Verified |
+|---|---|---|---|---|
+| BigQuery Dataset | `modules/bigquery-dataset` | `module.<instance>.google_bigquery_dataset.default` | `projects/<project_id>/datasets/<dataset_id>` | r17 |
+| CAS CA Pool | `modules/certificate-authority-service` | `module.<instance>.google_privateca_ca_pool.default[0]` | `projects/<project_id>/locations/<location>/caPools/<name>` | r14 |
+| CAS CA Pool IAM | `modules/certificate-authority-service` | `module.<instance>.google_privateca_ca_pool_iam_binding.authoritative["<role>"]` | `projects/<project_id>/locations/<location>/caPools/<name> <role>` | — |
+| CAS CA Pool IAM (cond.) | `modules/certificate-authority-service` | `module.<instance>.google_privateca_ca_pool_iam_binding.bindings["<key>"]` | `projects/<project_id>/locations/<location>/caPools/<name> <role> <condition_title>` | — |
+| Certificate Authority | `modules/certificate-authority-service` | `module.<instance>.google_privateca_certificate_authority.default["<id>"]` | `projects/<project_id>/locations/<location>/caPools/<pool>/certificateAuthorities/<id>` | — |
+| DNS zone | `modules/dns` | `module.<instance>.google_dns_managed_zone.dns_managed_zone[0]` | `projects/<project_id>/managedZones/<zone>` | r12 |
+| DNS recordset | `modules/dns` | `module.<instance>.google_dns_record_set.dns_record_set["<type> <name>"]` | `projects/<project_id>/managedZones/<zone>/rrsets/<record_name>/<type>` | — |
+| DNS Response Policy | `modules/dns-response-policy` | `module.<instance>.google_dns_response_policy.default[0]` | `projects/<project_id>/responsePolicies/<response_policy_name>` | — |
+| DNS Response Policy rule | `modules/dns-response-policy` | `module.<instance>.google_dns_response_policy_rule.default["<rule_name>"]` | `projects/<project_id>/responsePolicies/<response_policy_name>/rules/<rule_name>` | — |
+| Folder | `modules/folder` | `module.folder-<key>.google_folder.folder[0]` | `folders/<id>` | r6 |
+| Folder IAM | `modules/folder` | `module.folder-<key>.google_folder_iam_binding.authoritative["<role>"]` | `folders/<id> <role>` | r6 |
+| Folder IAM (cond.) | `modules/folder` | `module.folder-<key>.google_folder_iam_binding.bindings["<key>"]` | `folders/<id> <role> <condition_title>` | r6 |
+| Folder IAM member (additive, default) | `modules/folder` | `module.folder-<key>.google_folder_iam_member.bindings["<key>"]` | `folders/<id> <role> <member>` | — |
+| Folder sink | `modules/folder` | `module.folder-<key>.google_logging_folder_sink.sink["<name>"]` | `folders/<id>/sinks/<name>` | r6 |
+| Folder org policy | `modules/folder` | `module.folder-<key>.google_org_policy_policy.default["<constraint>"]` | `folders/<id>/policies/<constraint>` | r6 |
+| GCS bucket | `modules/gcs` | `module.<instance>.google_storage_bucket.bucket[0]` | `<project_id>/<bucket_name>` | r12 |
+| Service account | `modules/iam-service-account` | `module.sa-<key>.google_service_account.service_account[0]` | `projects/<project_id>/serviceAccounts/<email>` | r8 |
+| SA IAM binding | `modules/iam-service-account` | `module.sa-<key>.google_service_account_iam_binding.authoritative["<role>"]` | `projects/<project_id>/serviceAccounts/<email> <role>` | r8 |
+| SA IAM binding (cond.) | `modules/iam-service-account` | `module.sa-<key>.google_service_account_iam_binding.bindings["<key>"]` | `projects/<project_id>/serviceAccounts/<email> <role> <condition_title>` | r8 |
+| SA IAM member (additive, default) | `modules/iam-service-account` | `module.sa-<key>.google_service_account_iam_member.bindings["<key>"]` | `projects/<project_id>/serviceAccounts/<email> <role> <member>` | — |
+| KMS CryptoKey | `modules/kms` | `module.<instance>.google_kms_crypto_key.default["<key>"]` | `projects/<project_id>/locations/<location>/keyRings/<name>/cryptoKeys/<key>` | r13 |
+| KMS CryptoKey IAM | `modules/kms` | `module.<instance>.google_kms_crypto_key_iam_binding.authoritative["<key>.<role>"]` | `projects/<project_id>/locations/<location>/keyRings/<name>/cryptoKeys/<key> <role>` | r13 |
+| KMS KeyRing | `modules/kms` | `module.<instance>.google_kms_key_ring.default[0]` | `projects/<project_id>/locations/<location>/keyRings/<name>` | r13 |
+| Log bucket | `modules/logging-bucket` | `module.logging_bucket_<key>.google_logging_project_bucket_config.bucket[0]` | `projects/<project_id>/locations/<location>/buckets/<name>` | r10 |
+| NCC Hub | `modules/ncc-spoke-ra` | `module.<instance>.google_network_connectivity_hub.hub[0]` | `projects/<project_id>/locations/global/hubs/<hub_name>` | — |
+| NCC spoke (router appliance) | `modules/ncc-spoke-ra` | `module.<instance>.google_network_connectivity_spoke.spoke_ra` | `projects/<project_id>/locations/<location>/spokes/<spoke_name>` | — |
+| Compute address (global PSA) | `modules/net-address` | `module.<instance>.google_compute_global_address.psa["<key>"]` | `projects/<project_id>/global/addresses/<name>` | r19 |
+| Compute address (global PSC) | `modules/net-address` | `module.<instance>.google_compute_global_address.psc["<key>"]` | `projects/<project_id>/global/addresses/<name>` | r19 |
+| Compute address (regional internal) | `modules/net-address` | `module.<instance>.google_compute_address.internal["<key>"]` | `projects/<project_id>/regions/<region>/addresses/<name>` | r19 |
+| Cloud NAT | `modules/net-cloudnat` | `module.<nat_instance>.google_compute_router_nat.nat` | `projects/<project_id>/regions/<region>/routers/<router>/<nat>` | r12 |
+| Cloud Router | `modules/net-cloudnat` | `module.<nat_instance>.google_compute_router.router[0]` | `projects/<project_id>/regions/<region>/routers/<name>` | r12 |
+| Hierarchical Firewall Policy | `modules/net-firewall-policy` | `module.<instance>.google_compute_firewall_policy.hierarchical[0]` | `locations/global/firewallPolicies/<id>` | r7 |
+| Global Network Firewall Policy | `modules/net-firewall-policy` | `module.<instance>.google_compute_network_firewall_policy.net_global[0]` | `projects/<project_id>/global/firewallPolicies/<name>` | r7 |
+| Regional Network Firewall Policy | `modules/net-firewall-policy` | `module.<instance>.google_compute_region_network_firewall_policy.net_regional[0]` | `projects/<project_id>/regions/<region>/firewallPolicies/<name>` | r7 |
+| Interconnect Attachment | `modules/net-vlan-attachment` | `module.<instance>.google_compute_interconnect_attachment.default["<key>"]` | `projects/<project_id>/regions/<region>/interconnectAttachments/<name>` | — |
+| VPC network | `modules/net-vpc` | `module.net_vpc_<key>.google_compute_network.network[0]` | `projects/<project_id>/global/networks/<name>` | r3 |
+| VPC route (gateway) | `modules/net-vpc` | `module.net_vpc_<key>.google_compute_route.gateway["<key>"]` | `projects/<project_id>/global/routes/<net>-<key>` | r9 |
+| VPC route (ilb) | `modules/net-vpc` | `module.net_vpc_<key>.google_compute_route.ilb["<key>"]` | `projects/<project_id>/global/routes/<net>-<key>` | r9 |
+| VPC route (instance) | `modules/net-vpc` | `module.net_vpc_<key>.google_compute_route.instance["<key>"]` | `projects/<project_id>/global/routes/<net>-<key>` | r9 |
+| VPC route (ip) | `modules/net-vpc` | `module.net_vpc_<key>.google_compute_route.ip["<key>"]` | `projects/<project_id>/global/routes/<net>-<key>` | r9 |
+| VPC route (vpn tunnel) | `modules/net-vpc` | `module.net_vpc_<key>.google_compute_route.vpn_tunnel["<key>"]` | `projects/<project_id>/global/routes/<net>-<key>` | r9 |
+| VPC subnet | `modules/net-vpc` | `module.net_vpc_<key>.google_compute_subnetwork.subnetwork["<region>/<name>"]` | `projects/<project_id>/regions/<region>/subnetworks/<name>` | r3 |
+| VPC subnet (private NAT) | `modules/net-vpc` | `module.net_vpc_<key>.google_compute_subnetwork.private_nat["<region>/<name>"]` | `projects/<project_id>/regions/<region>/subnetworks/<name>` | — |
+| VPC subnet (proxy-only) | `modules/net-vpc` | `module.net_vpc_<key>.google_compute_subnetwork.proxy_only["<region>/<name>"]` | `projects/<project_id>/regions/<region>/subnetworks/<name>` | r9 |
+| VPC firewall rule (custom) | `modules/net-vpc-firewall` | `module.<instance>.google_compute_firewall.custom_rules["<rule_name>"]` | `projects/<project_id>/global/firewalls/<rule_name>` | — |
+| VPC firewall rule (default, admins) | `modules/net-vpc-firewall` | `module.<instance>.google_compute_firewall.allow_admins[0]` | `projects/<project_id>/global/firewalls/<network_name>-ingress-admins` | — |
+| VPC firewall rule (default, http) | `modules/net-vpc-firewall` | `module.<instance>.google_compute_firewall.allow_tag_http[0]` | `projects/<project_id>/global/firewalls/<network_name>-ingress-tag-http` | — |
+| VPC firewall rule (default, https) | `modules/net-vpc-firewall` | `module.<instance>.google_compute_firewall.allow_tag_https[0]` | `projects/<project_id>/global/firewalls/<network_name>-ingress-tag-https` | — |
+| VPC firewall rule (default, ssh) | `modules/net-vpc-firewall` | `module.<instance>.google_compute_firewall.allow_tag_ssh[0]` | `projects/<project_id>/global/firewalls/<network_name>-ingress-tag-ssh` | — |
+| External VPN Gateway | `modules/net-vpn-ha` | `module.<vpn_instance>.google_compute_external_vpn_gateway.external_gateway["<peer_key>"]` | `projects/<project_id>/global/externalVpnGateways/<name>` | — |
+| HA VPN Gateway | `modules/net-vpn-ha` | `module.<vpn_instance>.google_compute_ha_vpn_gateway.ha_gateway[0]` | `projects/<project_id>/regions/<region>/vpnGateways/<name>` | — |
+| Cloud Router (VPN) | `modules/net-vpn-ha` | `module.<vpn_instance>.google_compute_router.router[0]` | `projects/<project_id>/regions/<region>/routers/<name>` | — |
+| Cloud Router interface (VPN) | `modules/net-vpn-ha` | `module.<vpn_instance>.google_compute_router_interface.router_interface["<tunnel_key>"]` | `<project_id>/<region>/<router_name>/<interface_name>` | — |
+| Cloud Router BGP peer (VPN) | `modules/net-vpn-ha` | `module.<vpn_instance>.google_compute_router_peer.bgp_peer["<tunnel_key>"]` | `projects/<project_id>/regions/<region>/routers/<router_name>/<peer_name>` | — |
+| VPN Tunnel | `modules/net-vpn-ha` | `module.<vpn_instance>.google_compute_vpn_tunnel.tunnels["<tunnel_key>"]` | `projects/<project_id>/regions/<region>/vpnTunnels/<name>` | — |
+| Org audit config | `modules/organization` | `module.organization.google_organization_iam_audit_config.default["<service>"]` | `<org> <service>` | r3 |
+| Custom role | `modules/organization` | `module.organization.google_organization_iam_custom_role.roles["<id>"]` | `organizations/<org>/roles/<id>` | r3 |
+| Org IAM binding (authoritative opt-in) | `modules/organization` | `module.organization.google_organization_iam_binding.authoritative["<role>"]` | `<org> <role>` | r3 |
+| Org IAM binding (cond.) | `modules/organization` | `module.organization.google_organization_iam_binding.bindings["<key>"]` | `<org> <role> <condition_title>` | r3 |
+| Org IAM member (additive, default) | `modules/organization` | `module.organization.google_organization_iam_member.bindings["<key>"]` | `<org> <role> <member>` | — |
+| Org log sink | `modules/organization` | `module.organization.google_logging_organization_sink.sink["<name>"]` | `organizations/<org>/sinks/<name>` | r3 |
+| Org policy | `modules/organization` | `module.organization.google_org_policy_policy.default["<constraint>"]` | `organizations/<org>/policies/<constraint>` | r5 |
+| Tag Key | `modules/organization` | `module.organization.google_tags_tag_key.default["<short_name>"]` | `tagKeys/<id>` | r18 |
+| Tag Value | `modules/organization` | `module.organization.google_tags_tag_value.default["<key_short_name>/<value_short_name>"]` | `tagValues/<id>` | r18 |
+| Tag Binding | `modules/organization` | `module.<instance>.google_tags_tag_binding.binding["<key>"]` | `tagBindings/<url-encoded-parent-and-value>` | r18 |
+| PAM entitlement | `modules/project` | `module.<container>.google_privileged_access_manager_entitlement.default["<entitlement_id>"]` | `<parent>/locations/<location>/entitlements/<entitlement_id>` | — |
+| Project | `modules/project` | `module.project-<key>.google_project.project[0]` | `projects/<project_id>` | r4 |
+| Project IAM | `modules/project` | `module.project-<key>.google_project_iam_binding.authoritative["<role>"]` | `<project_id> <role>` | r4 |
+| Project IAM (cond.) | `modules/project` | `module.project-<key>.google_project_iam_binding.bindings["<key>"]` | `<project_id> <role> <condition_title>` | r4 |
+| Project IAM member (additive, default) | `modules/project` | `module.project-<key>.google_project_iam_member.bindings["<key>"]` | `<project_id> <role> <member>` | — |
+| Project org policy | `modules/project` | `module.project-<key>.google_org_policy_policy.default["<constraint>"]` | `projects/<project_id>/policies/<constraint>` | — |
+| Project service | `modules/project` | `module.project-<key>.google_project_service.project_services["<api>"]` | `<project_id>/<api>` | r4 |
+| Project service (orgpolicy) | `modules/project` | `module.project-<key>.google_project_service.org_policy_service[0]` | `<project_id>/orgpolicy.googleapis.com` | r4 |
+| Workload Identity Pool | `modules/project` | `module.project-<key>.google_iam_workload_identity_pool.default["<pool_id>"]` | `projects/<project_id>/locations/global/workloadIdentityPools/<pool_id>` | r18 |
+| Workload Identity Pool Provider | `modules/project` | `module.project-<key>.google_iam_workload_identity_pool_provider.default["<pool_id>/<provider_id>"]` | `projects/<project_id>/locations/global/workloadIdentityPools/<pool_id>/providers/<provider_id>` | r18 |
+| Pub/Sub Topic | `modules/pubsub` | `module.<instance>.google_pubsub_topic.default` | `projects/<project_id>/topics/<topic_name>` | r17 |
+| VPC-SC Access Level | `modules/vpc-sc` | `module.<instance>.google_access_context_manager_access_level.basic["<key>"]` | `accessPolicies/<policy_id>/accessLevels/<level_name>` | r15 |
+| VPC-SC Access Policy | `modules/vpc-sc` | `module.<instance>.google_access_context_manager_access_policy.default[0]` | `<policy_id>` | r15 |
+| VPC-SC Service Perimeter | `modules/vpc-sc` | `module.<instance>.google_access_context_manager_service_perimeter.regular["<key>"]` | `accessPolicies/<policy_id>/servicePerimeters/<perimeter_name>` | r15 |
+| NCC spoke (raw — capability gap) | raw | `google_network_connectivity_spoke.<instance>` | `projects/<project_id>/locations/<location>/spokes/<spoke_name>` | r12 |
+
+<!-- END ADDRESS-MAP -->
+
+Verified across r2–r19 (see COVERAGE.md for the per-family evidence).
+For anything else: check the provider documentation's import section, or
 emit the import block with the CAI asset name minus the
 `//<service>.googleapis.com/` prefix — verified to match the provider
 import ID byte-for-byte on every family tested (r5 oracle, 100%) — and
@@ -713,26 +757,49 @@ let plan tell you: it errors loudly and safely on a wrong ID.
 - Lives in `project-<key>.tf`.
 
 
-### DNS managed zones (`modules/dns`) — verified r12
+### DNS zones and recordsets (`modules/dns`) — verified r12 (zones)
 
-- Manifest: `dns.googleapis.com/ManagedZone`, `levels: [project]`.
-- Address: `module.<instance>.google_dns_managed_zone.dns_managed_zone[0]`;
-  import ID `projects/<project_id>/managedZones/<zone_name>`.
+- Manifest: `dns.googleapis.com/ManagedZone` and, for recordsets,
+  `dns.googleapis.com/ResourceRecordSet`; `levels: [project]`.
+- Addresses and import IDs: see the generated table.
 - Private-zone client networks reference
   `module.net_vpc_<key>.self_link`.
+- **Recordset `for_each` key**: `"<type> <name>"` — type first, one
+  space, and `<name>` carries the trailing dot exactly as the API
+  returns it (`"A www.example.com."`). Getting the order or the dot
+  wrong produces a create/destroy pair rather than an import.
+- **Coverage map**: the `ManagedZone` key claims the zone address; each
+  recordset is its own CAI asset and claims its own address. Do not
+  fold recordsets under the zone key — that hides a per-record gap
+  behind a covered parent.
+- **CAI surface trap**: `ResourceRecordSet` is a supported asset type
+  for `gcloud asset list`, but it is "not available in the analysis
+  APIs". `--verify-search-parity` compares against
+  `search-all-resources`, so recordsets can be reported as
+  `only_in_list`. That is the documented API taxonomy, not a collection
+  bug — do not "fix" it by dropping the type.
+- **Description default trap**: `modules/dns` defaults `description` to
+  `"Terraform managed."` (with a space). FAST stages write
+  `"Terraform-managed."` (with a hyphen), and live zones created by
+  other tooling may carry anything at all. Mirror the live value
+  explicitly; an unset `description` silently plans the module default
+  over whatever is there.
 - Lives in `project-<key>.tf`.
 
 ### Cloud Routers and NAT (`modules/net-cloudnat`) — verified r12
 
 - Manifest: `compute.googleapis.com/Router`, `levels: [project]`.
-- Addresses: router `module.<instance>.google_compute_router.router[0]`,
-  NAT `module.<instance>.google_compute_router_nat.nat`.
-- Import IDs: router
-  `projects/<project_id>/regions/<region>/routers/<router_name>`, NAT
-  `.../routers/<router_name>/<nat_name>`.
+- Addresses and import IDs: see the generated table.
 - Inputs: `router_create = true`,
   `router_network = module.net_vpc_<key>.name`.
-- Coverage map: CAI models only `compute.googleapis.com/Router` (the NAT is a sub-resource with no independent CAI asset type). In `coverage-map.yaml`, the single router key claims both addresses: `[module.<instance>.google_compute_router.router[0], module.<instance>.google_compute_router_nat.nat]`.
+- **Carrier disambiguation — read before mapping any Router.**
+  `compute.googleapis.com/Router` is the one CAI type in this cookbook
+  that two modules legitimately create. A router whose only attached
+  function is NAT belongs here. A router that terminates VPN tunnels is
+  created by `modules/net-vpn-ha` and belongs in that section; mapping
+  it here strands the tunnels, interfaces and BGP peers with no
+  carrier. Decide from the live router's attachments, not its name.
+- Coverage map: CAI models only `compute.googleapis.com/Router` (the NAT is a sub-resource with no independent CAI asset type). In `coverage-map.yaml`, the single router key claims both addresses: `[module.<nat_instance>.google_compute_router.router[0], module.<nat_instance>.google_compute_router_nat.nat]`.
 - Lives in `project-<key>.tf`.
 
 ### Compute addresses (`modules/net-address`) — verified r19 (global PSC, global PSA, regional internal)
@@ -781,19 +848,24 @@ let plan tell you: it errors loudly and safely on a wrong ID.
   networks via `module.net_vpc_<key>.self_link`.
 - Lives in `project-<key>.tf`.
 
-### NCC spokes — raw resource, documented capability gap (r12)
+### Network Connectivity Center — hub, and spokes as a capability gap (r12)
 
-- Manifest: `networkconnectivity.googleapis.com/Spoke`,
-  `levels: [project]`.
-- Capability gap: Fabric has no module for linked-VPC spokes —
-  `modules/ncc-spoke-ra` covers router-appliance spokes only. Per the
-  fallback doctrine this imports as a raw
-  `google_network_connectivity_spoke.<instance>` and MUST appear in the
-  run report's capability-gaps section (upstream-Fabric-issue
-  material). Revisit and lift with `moved {}` blocks if a module
-  appears.
-- Import ID:
-  `projects/<project_id>/locations/<location>/spokes/<spoke_name>`.
+- Manifest: `networkconnectivity.googleapis.com/Hub` and
+  `networkconnectivity.googleapis.com/Spoke`, `levels: [project]`.
+- **Hub**: `modules/ncc-spoke-ra` does carry the hub
+  (`google_network_connectivity_hub.hub[0]`, created when
+  `hub.create` is true), so a hub is NOT a capability gap. Import it
+  into that module rather than raw.
+- **Spoke capability gap**: `modules/ncc-spoke-ra` covers
+  router-appliance spokes only
+  (`google_network_connectivity_spoke.spoke_ra`, keyed on
+  `linked_router_appliance_instances`). Linked-VPC and linked-VPN
+  spokes have no Fabric carrier. Per the fallback doctrine these import
+  as a raw `google_network_connectivity_spoke.<instance>` and MUST
+  appear in the run report's capability-gaps section
+  (upstream-Fabric-issue material). Revisit and lift with `moved {}`
+  blocks if a module appears.
+- Import IDs: see the generated table.
 - `linked_vpc_network.uri = module.net_vpc_<key>.self_link`.
 - Lives in `project-<key>.tf`.
 
@@ -952,6 +1024,7 @@ let plan tell you: it errors loudly and safely on a wrong ID.
 - **Org Policy Constraints & Traps**:
   - `constraints/iam.workloadIdentityPoolProviders`: Restricts allowed external identity provider issuer URLs.
   - Providers (such as GitHub Actions OIDC) require CEL `attribute_condition` referencing provider claims (e.g. `assertion.repository == '...'`).
+
 ### Privileged Access Manager (PAM)
 
 - **Canonical Module**: `modules/organization`, `modules/folder`, `modules/project` via `pam_entitlements` map or `factories_config.pam_entitlements` factory path.
@@ -965,85 +1038,93 @@ let plan tell you: it errors loudly and safely on a wrong ID.
 - **Traps**:
   - Grants represent transient workflow state with short TTLs and should **not** be managed in Terraform baseline IaC.
 
-### VPC Firewall Rules (`modules/net-vpc-firewall`)
+### VPC firewall rules (`modules/net-vpc-firewall`)
 
-- **Manifest**: `compute.googleapis.com/Firewall`, `levels: [project]`.
-- **Carrier Distinction & Boundary Rule**: `modules/net-vpc` deliberately does not manage firewall rules directly to maintain module boundaries. `modules/net-vpc-firewall` is the dedicated Fabric carrier for legacy VPC firewall rules, distinct from `modules/net-firewall-policy` (which manages hierarchical and network firewall policies).
-- **Resource Addresses**:
-  - `module.<instance>.google_compute_firewall.custom_rules["<rule_name>"]` (or `rules["<rule_name>"]`)
-- **Import IDs**:
-  - `projects/<project_id>/global/firewalls/<rule_name>` (or `<project_id>/<rule_name>`)
-- **Inputs**: `project_id`, `network`, and `custom_rules` (or `factories_config.rules_folder`).
+- Manifest: `compute.googleapis.com/Firewall`, `levels: [project]`.
+- **Carrier boundary**: `modules/net-vpc` deliberately does not manage
+  firewall rules — that is a module-boundary decision, not an omission.
+  `modules/net-vpc-firewall` is the carrier for legacy VPC firewall
+  rules; `modules/net-firewall-policy` carries hierarchical and network
+  firewall policies. They are different CAI types
+  (`.../Firewall` vs `.../FirewallPolicy`) and never substitute for
+  each other.
+- Addresses and import IDs: see the generated table.
+- **Five distinct addresses, not one.** The module emits custom rules
+  under `google_compute_firewall.custom_rules["<rule_name>"]`
+  (`for_each`, keyed on the rule name), *and* up to four `count`-based
+  default rules from `default_rules_config`:
+  `allow_admins[0]`, `allow_tag_http[0]`, `allow_tag_https[0]`,
+  `allow_tag_ssh[0]`, named `<network_name>-ingress-admins`,
+  `-ingress-tag-http`, `-ingress-tag-https` and `-ingress-tag-ssh`.
+  A live estate that was built with FAST already has these. Match a
+  live rule to the default-rule address when its name matches that
+  pattern, and to `custom_rules` otherwise — routing a default rule
+  through `custom_rules` plans a create/destroy pair against the same
+  live name.
+- **There is no `google_compute_firewall.rules` resource.** Verify the
+  resource label against `modules/net-vpc-firewall/main.tf` and
+  `default-rules.tf` before writing an import block.
+- Inputs: `project_id`, `network`, and `custom_rules` (or
+  `factories_config.rules_folder`).
 - Lives in `project-<key>.tf`.
 
-### Cloud NAT & Routers (`modules/net-cloudnat`)
+### DNS response policies (`modules/dns-response-policy`)
 
-- **Manifest**: `compute.googleapis.com/Router`, `levels: [project]`.
-- **Resource Addresses**:
-  - Router: `module.<instance>.google_compute_router.router[0]`
-  - NAT: `module.<instance>.google_compute_router_nat.nat`
-- **Import IDs**:
-  - Router: `projects/<project_id>/regions/<region>/routers/<router_name>`
-  - NAT: `projects/<project_id>/regions/<region>/routers/<router_name>/<nat_name>`
-- **Coverage Mapping Rule**: A single CAI `compute.googleapis.com/Router` key claims both `google_compute_router.router[0]` and `google_compute_router_nat.nat` in `coverage-map.yaml`.
+- Manifest: `dns.googleapis.com/ResponsePolicy` and, for rules,
+  `dns.googleapis.com/ResponsePolicyRule`; `levels: [project]`.
+  Rules are a separate CAI asset type, not a sub-resource — declare
+  both or the rules never enter the denominator.
+- Addresses and import IDs: see the generated table.
+- **Input schema trap**: `networks` is `map(string)`
+  (`name => self_link`), not a list of strings
+  (`modules/dns-response-policy/variables.tf`).
+- **CAI surface trap**: both types are "not available in the analysis
+  APIs", so `--verify-search-parity` may report them as `only_in_list`.
+  Expected; see the DNS zones section.
 - Lives in `project-<key>.tf`.
 
-### Cloud DNS & Recordsets (`modules/dns`)
+### HA VPN and VPN tunnels (`modules/net-vpn-ha`)
 
-- **Manifest**: `dns.googleapis.com/ManagedZone` and `dns.googleapis.com/ResourceRecordSet`, `levels: [project]`.
-- **Resource Addresses**:
-  - Managed Zone: `module.<instance>.google_dns_managed_zone.dns_managed_zone[0]`
-  - Recordsets: `module.<instance>.google_dns_record_set.dns_record_set["<type> <name>"]`
-- **Import IDs**:
-  - Zone: `projects/<project_id>/managedZones/<zone_name>`
-  - Recordset: `projects/<project_id>/managedZones/<zone_name>/rrsets/<record_name>/<type>`
-- **Coverage Mapping Rule**: In `coverage-map.yaml`, the `dns.googleapis.com/ManagedZone` key claims both the managed zone address and its child `google_dns_record_set` addresses.
-- **Default Description Trap**: Fabric's `modules/dns` defaults `description = "Terraform managed."` (with space), whereas FAST stages use `"Terraform-managed."` (with hyphen). Set `description = "Terraform-managed."` explicitly to prevent description drift.
+- Manifest: `compute.googleapis.com/VpnGateway`,
+  `compute.googleapis.com/ExternalVpnGateway`,
+  `compute.googleapis.com/VpnTunnel` and
+  `compute.googleapis.com/Router`; `levels: [project]`.
+- Addresses and import IDs: see the generated table. Note the router
+  interface import ID has **no** `projects/` prefix
+  (`<project_id>/<region>/<router_name>/<interface_name>`) — it is the
+  one irregular form in this family.
+- **Carrier disambiguation**: this module creates its own
+  `google_compute_router.router[0]`, so a VPN-terminating router is
+  mapped here and NOT through `modules/net-cloudnat`. See the Cloud
+  Routers and NAT section for the rule.
+- **`shared_secret` cannot be imported, and cannot be waived.**
+  - Provider constraint: `google_compute_vpn_tunnel.shared_secret` is
+    `ForceNew`, and the Compute API returns only `shared_secret_hash`
+    on read. An imported tunnel therefore holds no plaintext secret.
+  - Fabric constraint: `modules/net-vpn-ha` sets
+    `shared_secret = coalesce(each.value.shared_secret, local.secret)`
+    where `local.secret` is `random_id.secret.b64_url`
+    (`modules/net-vpn-ha/main.tf`). **You cannot leave it unset.**
+    Omitting it does not produce a no-op — it produces an
+    unknown-at-plan-time value on a ForceNew attribute, which plans a
+    tunnel *replacement*, non-deterministically.
+  - **A waiver does not help.** `verify_plan.py` classifies anything
+    other than a clean import or a no-op — including `replace` — as
+    RESIDUAL and fails. `benign-drift.yaml` covers cosmetic attribute
+    diffs, not replacements. A run that "waives" a tunnel replacement
+    is a run that would destroy a live tunnel on apply. Do not do this.
+  - **Correct posture**: obtain the plaintext secret from the operator
+    out of band and set it explicitly. It is the only way the module
+    converges.
+  - **When the secret is genuinely unavailable**, this is a module
+    capability gap, and it is handled the way every other gap is: emit
+    a raw `google_compute_vpn_tunnel` with
+    `lifecycle { ignore_changes = [shared_secret] }`, and record it in
+    the run report's capability-gaps section with that reason. This is
+    a documented fallback, not a shortcut — and not the default.
 - Lives in `project-<key>.tf`.
-
-### DNS Response Policies (`modules/dns-response-policy`)
-
-- **Manifest**: `dns.googleapis.com/ResponsePolicy`, `levels: [project]`.
-- **Resource Addresses**:
-  - Response Policy: `module.<instance>.google_dns_response_policy.default[0]`
-  - Rules: `module.<instance>.google_dns_response_policy_rule.default["<rule_name>"]`
-- **Import IDs**:
-  - Policy: `projects/<project_id>/responsePolicies/<response_policy_name>`
-  - Rule: `projects/<project_id>/responsePolicies/<response_policy_name>/rules/<rule_name>`
-- **Input Schema Trap**: `networks` is `map(string)` (`name => self_link`), not a list of strings.
-- Lives in `project-<key>.tf`.
-
-### HA VPN & VPN Tunnels (`modules/net-vpn-ha`)
-
-- **Manifest**: `compute.googleapis.com/VpnGateway`, `compute.googleapis.com/ExternalVpnGateway`, `compute.googleapis.com/VpnTunnel`, and `compute.googleapis.com/Router`, `levels: [project]`.
-- **Resource Addresses**:
-  - HA VPN Gateway: `module.<instance>.google_compute_ha_vpn_gateway.ha_gateway[0]` (or external gateway resource)
-  - External VPN Gateway: `module.<instance>.google_compute_external_vpn_gateway.external_gateway["<peer_key>"]`
-  - VPN Tunnels: `module.<instance>.google_compute_vpn_tunnel.tunnels["<tunnel_key>"]`
-  - Router Interfaces: `module.<instance>.google_compute_router_interface.router_interface["<tunnel_key>"]`
-  - BGP Peers: `module.<instance>.google_compute_router_peer.bgp_peer["<tunnel_key>"]`
-- **Import IDs**:
-  - HA Gateway: `projects/<project_id>/regions/<region>/vpnGateways/<name>`
-  - External Gateway: `projects/<project_id>/global/externalVpnGateways/<name>`
-  - Tunnel: `projects/<project_id>/regions/<region>/vpnTunnels/<name>`
-  - Router Interface: `<project_id>/<region>/<router_name>/<interface_name>` *(provider format: no `projects/` prefix)*
-  - BGP Peer: `projects/<project_id>/regions/<region>/routers/<router_name>/<peer_name>`
-- **Secret Handling & Waiver Pattern**:
-  - Provider constraint: `google_compute_vpn_tunnel` marks `shared_secret` as `ForceNew: true`. The GCP Compute API only returns `shared_secret_hash` (not plaintext `shared_secret`) on import/read, leaving `shared_secret = null` in imported state. When configuration specifies `shared_secret`, Terraform plans a resource replacement (`destroy / re-create`).
-  - Recommended posture: Emit `modules/net-vpn-ha` with standard configuration, document/comment the secret requirement in HCL with instructions for the operator to provide the secret on day-2 mutation, and record a signed waiver for the preview diff.
-  - Alternative standalone fallback: Declare standalone `google_compute_vpn_tunnel` with `lifecycle { ignore_changes = [shared_secret] }`.
-- Lives in `project-<key>.tf`.
-
-### Network Connectivity Center (NCC)
-
-- **Manifest**: `networkconnectivity.googleapis.com/Hub`, `networkconnectivity.googleapis.com/Spoke`, `levels: [project]`.
-- **Capability Gap & Fallback**: Fabric provides `modules/ncc-spoke-ra` for router appliance spokes. Generic linked-VPC and linked-VPN spokes have no dedicated module carrier and are emitted as native `google_network_connectivity_spoke.<name>` resources.
-- **Import IDs**:
-  - Hub: `projects/<project_id>/locations/global/hubs/<hub_name>`
-  - Spoke: `projects/<project_id>/locations/<location>/spokes/<spoke_name>`
 
 ### Root module
-
 
 - Emit `versions.tf` (terraform >= 1.5, google + google-beta
   `>= 7.40, < 8`, `backend "local"`) and the module wiring yourself;

--- a/skills/fabric-importer/scripts/address_map.py
+++ b/skills/fabric-importer/scripts/address_map.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#    "pyyaml",
+# ]
+# ///
+"""Linter and renderer for the address map — NOT a gate.
+
+`mapping-cookbook.md` mixes two kinds of knowledge. The fielded tuples
+(asset type, module, address, import ID, verification round) are uniform
+and mechanically checkable. The reasoning around them — ForceNew traps,
+provider quirks, waiver postures — is causal prose that only degrades
+when squeezed into a schema. This tool owns the first kind and touches
+nothing of the second.
+
+It exists because the first kind kept being duplicated. Addresses lived
+both in per-type prose and in a hand-maintained markdown table, and
+three families were once documented twice because no check could see it.
+`--lint-cookbook` makes that class of drift a CI failure instead of a
+reviewer's lucky catch.
+
+THIS IS NOT A GATE, and it is deliberately not wired into `coverage.py`
+or `verify_plan.py`. The gates judge a workspace against live reality.
+A wrong entry in the address map is caught by `terraform plan` erroring
+loudly, unlike a wrong `benign-drift.yaml` entry which would silently
+pass a gate. Different blast radius, different rigour budget.
+
+So the split is:
+
+  - THIS FILE is in `integrity.FROZEN_FILES`. Everything executable
+    that ships in `scripts/` is tamper-evident, with no exceptions to
+    reason about — a reader cannot tell a gate from a linter by
+    looking, so the invariant stays unqualified.
+  - `references/address-map.yaml` is NOT frozen, and must not become
+    so. It is human-owned data that grows every time someone maps a new
+    type; putting it behind the digest would add gate ceremony to
+    routine note-taking and would imply the map is authoritative, which
+    it is not.
+
+`--check-workspace` is an ADVISORY reader for the same reason: it
+reports unrecognised addresses and always exits 0. The cookbook is
+deliberately incomplete; an unknown address is a normal finding, not an
+error.
+
+Usage:
+
+    uv run scripts/address_map.py --validate
+    uv run scripts/address_map.py --lint-cookbook
+    uv run scripts/address_map.py --render-cookbook [--check]
+    uv run scripts/address_map.py --check-workspace tf/
+"""
+
+import argparse
+import os
+import re
+import sys
+
+import yaml
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SKILL = os.path.dirname(_HERE)
+
+DEFAULT_MAP = os.path.join(_SKILL, 'references', 'address-map.yaml')
+DEFAULT_COOKBOOK = os.path.join(_SKILL, 'references', 'mapping-cookbook.md')
+
+BEGIN_MARKER = '<!-- BEGIN ADDRESS-MAP (generated) -->'
+END_MARKER = '<!-- END ADDRESS-MAP -->'
+
+REQUIRED = ('resource', 'module', 'address', 'import_id')
+OPTIONAL = ('asset_type', 'verified', 'note', 'disambiguation')
+SLUG_RE = re.compile(r'^[a-z0-9]+(-[a-z0-9]+)*$')
+VERIFIED_RE = re.compile(r'^r\d+$')
+# `### Heading (`modules/x`)` — the per-type section convention.
+SECTION_RE = re.compile(r'^###\s+(?P<title>.+?)\s*$')
+MODULE_IN_TITLE_RE = re.compile(r'`(modules/[a-z0-9-]+)`')
+
+
+def load(path=DEFAULT_MAP):
+  """Reads and shallowly type-checks the address map."""
+  with open(path, encoding='utf-8') as f:
+    doc = yaml.safe_load(f)
+  if not isinstance(doc, dict):
+    raise SystemExit(f'{path}: top level must be a mapping')
+  if doc.get('version') != 1:
+    raise SystemExit(f'{path}: unsupported version {doc.get("version")!r}')
+  entries = doc.get('entries')
+  if not isinstance(entries, dict) or not entries:
+    raise SystemExit(f'{path}: `entries` must be a non-empty mapping')
+  return entries
+
+
+def validate(entries):
+  """Returns a list of human-readable schema and invariant violations."""
+  errors = []
+  by_address = {}
+  by_asset_type = {}
+
+  for slug, entry in entries.items():
+    where = f'entries.{slug}'
+    if not SLUG_RE.match(slug):
+      errors.append(f'{where}: slug must be kebab-case')
+    if not isinstance(entry, dict):
+      errors.append(f'{where}: must be a mapping')
+      continue
+
+    unknown = set(entry) - set(REQUIRED) - set(OPTIONAL)
+    if unknown:
+      errors.append(f'{where}: unknown keys {sorted(unknown)}')
+    for key in REQUIRED:
+      value = entry.get(key)
+      if not isinstance(value, str) or not value.strip():
+        errors.append(
+            f'{where}: `{key}` is required and must be a non-empty string')
+
+    verified = entry.get('verified', False)
+    if verified is not False and not (isinstance(verified, str) and
+                                      VERIFIED_RE.match(verified)):
+      errors.append(f'{where}: `verified` must be false or match r<digits>, '
+                    f'got {verified!r}')
+
+    for key in ('note', 'disambiguation'):
+      value = entry.get(key)
+      if value is None:
+        continue
+      if not isinstance(value, str):
+        errors.append(f'{where}: `{key}` must be a string')
+      elif '\n' in value.strip():
+        errors.append(f'{where}: `{key}` must be a single line — multi-line '
+                      f'reasoning belongs in mapping-cookbook.md')
+
+    address = entry.get('address')
+    if isinstance(address, str):
+      by_address.setdefault(address, []).append(slug)
+
+    asset_type = entry.get('asset_type')
+    if isinstance(asset_type, str) and asset_type.strip():
+      by_asset_type.setdefault(asset_type, []).append(slug)
+
+  # Invariant: an address pattern is claimed exactly once. This is the
+  # check that would have caught the duplicated DNS/NAT/NCC sections.
+  for address, slugs in sorted(by_address.items()):
+    if len(slugs) > 1:
+      errors.append(f'duplicate address {address!r} claimed by {sorted(slugs)}')
+
+  # Invariant: a CAI type serviced by more than one module is ambiguous
+  # for whoever is mapping, so every entry sharing it must say how to
+  # tell them apart. `compute.googleapis.com/Router` is the live case:
+  # net-cloudnat and net-vpn-ha both create one.
+  for asset_type, slugs in sorted(by_asset_type.items()):
+    modules = {entries[s].get('module') for s in slugs}
+    if len(modules) < 2:
+      continue
+    for slug in sorted(slugs):
+      value = entries[slug].get('disambiguation')
+      if not (isinstance(value, str) and value.strip()):
+        errors.append(
+            f'entries.{slug}: asset_type {asset_type!r} maps to modules '
+            f'{sorted(m for m in modules if m)} — `disambiguation` is required')
+  return errors
+
+
+def lint_cookbook(path=DEFAULT_COOKBOOK):
+  """Flags per-type sections that name a module already documented.
+
+  The concrete failure this prevents: a contributor appends a section
+  for a module that already has one further up, and the two silently
+  disagree. Duplicate advice is worse than no advice, because the reader
+  has no way to know which copy is current.
+  """
+  errors = []
+  seen = {}
+  with open(path, encoding='utf-8') as f:
+    lines = f.read().split('\n')
+  for number, line in enumerate(lines, start=1):
+    match = SECTION_RE.match(line)
+    if not match:
+      continue
+    title = match.group('title')
+    for module in MODULE_IN_TITLE_RE.findall(title):
+      if module in seen:
+        first_line, first_title = seen[module]
+        errors.append(f'{path}:{number}: section "{title}" re-documents '
+                      f'{module}, already covered by "{first_title}" at '
+                      f'line {first_line} — merge them')
+      else:
+        seen[module] = (number, title)
+  return errors
+
+
+def render_table(entries):
+  """Renders the fielded map as the cookbook's markdown table."""
+  out = [
+      '| Resource | Module | Address pattern | Import ID | Verified |',
+      '|---|---|---|---|---|',
+  ]
+  for slug in sorted(entries, key=lambda s: (entries[s]['module'], s)):
+    entry = entries[slug]
+    verified = entry.get('verified', False)
+    verified = verified if isinstance(verified, str) else '—'
+    module = entry['module']
+    module = module if module == 'raw' else f'`{module}`'
+    out.append(f'| {entry["resource"]} | {module} | `{entry["address"]}` | '
+               f'`{entry["import_id"]}` | {verified} |')
+  return '\n'.join(out)
+
+
+def render_cookbook(entries, path=DEFAULT_COOKBOOK, check=False):
+  """Replaces the generated block in the cookbook. Returns True if changed."""
+  with open(path, encoding='utf-8') as f:
+    content = f.read()
+  if BEGIN_MARKER not in content or END_MARKER not in content:
+    raise SystemExit(f'{path}: missing {BEGIN_MARKER} / {END_MARKER} markers')
+  head, rest = content.split(BEGIN_MARKER, 1)
+  _, tail = rest.split(END_MARKER, 1)
+  block = f'{BEGIN_MARKER}\n\n{render_table(entries)}\n\n{END_MARKER}'
+  updated = f'{head}{block}{tail}'
+  if updated == content:
+    return False
+  if not check:
+    with open(path, 'w', encoding='utf-8') as f:
+      f.write(updated)
+  return True
+
+
+def _address_regex(pattern):
+  """Turns an address pattern into a regex, with <placeholder> as a wildcard.
+
+  Module instance names and for_each keys are chosen per engagement, so
+  only the resource-type skeleton is comparable.
+  """
+  parts = re.split(r'<[a-z_]+>', pattern)
+  return re.compile('^' + '[^.\\[\\]"]*'.join(re.escape(p) for p in parts) +
+                    '$')
+
+
+def check_workspace(entries, workspace):
+  """ADVISORY: reports emitted import targets matching no known pattern.
+
+  Never fails. A miss means the cookbook has not seen the type yet,
+  which SKILL.md calls the normal case, not an error.
+  """
+  patterns = [_address_regex(e['address']) for e in entries.values()]
+  targets = []
+  target_re = re.compile(r'^\s*to\s*=\s*(?P<addr>\S.*?)\s*$')
+  for root, _, files in os.walk(workspace):
+    for name in sorted(files):
+      if not name.endswith('.tf'):
+        continue
+      full = os.path.join(root, name)
+      with open(full, encoding='utf-8') as f:
+        for number, line in enumerate(f, start=1):
+          match = target_re.match(line)
+          if match:
+            targets.append((full, number, match.group('addr')))
+  unknown = [t for t in targets if not any(p.match(t[2]) for p in patterns)]
+  return targets, unknown
+
+
+def main(argv=None):
+  parser = argparse.ArgumentParser(description=__doc__.split('\n')[0])
+  parser.add_argument('--map', default=DEFAULT_MAP)
+  parser.add_argument('--cookbook', default=DEFAULT_COOKBOOK)
+  parser.add_argument('--validate', action='store_true')
+  parser.add_argument('--lint-cookbook', action='store_true')
+  parser.add_argument('--render-cookbook', action='store_true')
+  parser.add_argument('--check', action='store_true',
+                      help='with --render-cookbook, fail instead of writing')
+  parser.add_argument('--check-workspace', metavar='DIR')
+  args = parser.parse_args(argv)
+
+  if not any((args.validate, args.lint_cookbook, args.render_cookbook,
+              args.check_workspace)):
+    args.validate = args.lint_cookbook = True
+
+  entries = load(args.map)
+  failed = False
+
+  if args.validate:
+    errors = validate(entries)
+    for error in errors:
+      print(f'ERROR {error}', file=sys.stderr)
+    print(f'address map: {len(entries)} entries, {len(errors)} error(s)')
+    failed |= bool(errors)
+
+  if args.lint_cookbook:
+    errors = lint_cookbook(args.cookbook)
+    for error in errors:
+      print(f'ERROR {error}', file=sys.stderr)
+    print(f'cookbook lint: {len(errors)} error(s)')
+    failed |= bool(errors)
+
+  if args.render_cookbook:
+    changed = render_cookbook(entries, args.cookbook, check=args.check)
+    if args.check and changed:
+      print('ERROR generated table is stale — run --render-cookbook',
+            file=sys.stderr)
+      failed = True
+    else:
+      print(f'cookbook table: {"rewritten" if changed else "up to date"}')
+
+  if args.check_workspace:
+    targets, unknown = check_workspace(entries, args.check_workspace)
+    for path, number, address in unknown:
+      print(f'ADVISORY {path}:{number}: {address} matches no known pattern')
+    print(f'workspace: {len(targets)} import target(s), '
+          f'{len(unknown)} unrecognised (advisory only)')
+
+  return 1 if failed else 0
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/skills/fabric-importer/scripts/integrity.py
+++ b/skills/fabric-importer/scripts/integrity.py
@@ -67,6 +67,7 @@ import sys
 # at hash time, so this list may be extended without invalidating the
 # meaning of a digest for an unchanged set.
 FROZEN_FILES = (
+    'address_map.py',
     'benign-drift.yaml',
     'coverage.py',
     'integrity.py',

--- a/skills/fabric-importer/tests/test_scripts.py
+++ b/skills/fabric-importer/tests/test_scripts.py
@@ -38,6 +38,7 @@ sys.path.insert(0, os.path.join(_BASE, 'scripts'))
 
 import yaml  # noqa: E402
 
+import address_map  # noqa: E402
 import coverage  # noqa: E402
 import integrity  # noqa: E402
 import inventory  # noqa: E402
@@ -4194,6 +4195,191 @@ class TestCaiSplitTypes(unittest.TestCase):
         self.assertNotEqual(s, unified)
         self.assertNotIn(s, inventory.CAI_SPLIT_TYPES,
                          f'{s} is both a unified type and a sibling')
+
+
+class TestAddressMap(unittest.TestCase):
+  """The fielded subset of the cookbook, and the checks that keep it honest.
+
+  These tests exist because the duplication they catch actually shipped:
+  three families were documented twice in `mapping-cookbook.md` because
+  nothing could see it, and the two copies disagreed.
+  """
+
+  def _entry(self, **kw):
+    base = {
+        'resource': 'Thing',
+        'module': 'modules/thing',
+        'address': 'module.<instance>.google_thing.default[0]',
+        'import_id': 'projects/<project_id>/things/<name>',
+    }
+    base.update(kw)
+    return base
+
+  def test_shipped_map_validates(self):
+    self.assertEqual(address_map.validate(address_map.load()), [])
+
+  def test_the_data_is_not_frozen_but_the_linter_is(self):
+    """Human-owned map data must not need gate ceremony to edit; the
+    executable that reads it is still tamper-evident like everything
+    else shipped in scripts/."""
+    self.assertNotIn('address-map.yaml', integrity.FROZEN_FILES)
+    self.assertIn('address_map.py', integrity.FROZEN_FILES)
+    self.assertFalse(
+        os.path.exists(
+            os.path.join(os.path.dirname(os.path.dirname(__file__)), 'scripts',
+                         'address-map.yaml')),
+        'the map belongs in references/, outside the frozen scripts dir')
+
+  def test_the_gates_do_not_consume_the_address_map(self):
+    """An advisory linter must never become a hidden precondition for a
+    gate verdict."""
+    scripts = os.path.join(os.path.dirname(os.path.dirname(__file__)),
+                           'scripts')
+    for name in ('coverage.py', 'verify_plan.py'):
+      with open(os.path.join(scripts, name), encoding='utf-8') as f:
+        body = f.read()
+      self.assertNotIn('address_map', body, name)
+      self.assertNotIn('address-map', body, name)
+
+  def test_shipped_cookbook_has_no_duplicate_module_sections(self):
+    self.assertEqual(address_map.lint_cookbook(), [])
+
+  def test_shipped_cookbook_table_is_in_sync(self):
+    self.assertFalse(
+        address_map.render_cookbook(address_map.load(), check=True),
+        'generated table is stale — run --render-cookbook')
+
+  def test_duplicate_address_is_rejected(self):
+    """Two entries claiming one address is the duplication that shipped."""
+    entries = {'a': self._entry(), 'b': self._entry(module='modules/other')}
+    errors = address_map.validate(entries)
+    self.assertTrue(any('duplicate address' in e for e in errors), errors)
+
+  def test_shared_asset_type_across_modules_requires_disambiguation(self):
+    """The live case: net-cloudnat and net-vpn-ha both make a Router."""
+    entries = {
+        'nat':
+            self._entry(address='module.<a>.google_compute_router.router[0]',
+                        module='modules/net-cloudnat',
+                        asset_type='compute.googleapis.com/Router'),
+        'vpn':
+            self._entry(address='module.<b>.google_compute_router.router[0]',
+                        module='modules/net-vpn-ha',
+                        asset_type='compute.googleapis.com/Router'),
+    }
+    errors = address_map.validate(entries)
+    self.assertEqual(len(errors), 2, errors)
+    self.assertTrue(all('disambiguation' in e for e in errors), errors)
+
+    for entry in entries.values():
+      entry['disambiguation'] = 'decided from the live router attachments'
+    self.assertEqual(address_map.validate(entries), [])
+
+  def test_same_asset_type_one_module_needs_no_disambiguation(self):
+    entries = {
+        'a':
+            self._entry(address='module.<a>.google_compute_route.ip["<k>"]',
+                        asset_type='compute.googleapis.com/Route'),
+        'b':
+            self._entry(address='module.<a>.google_compute_route.ilb["<k>"]',
+                        asset_type='compute.googleapis.com/Route'),
+    }
+    self.assertEqual(address_map.validate(entries), [])
+
+  def test_verified_must_be_false_or_a_round(self):
+    self.assertEqual(address_map.validate({'a': self._entry(verified='r19')}),
+                     [])
+    self.assertEqual(address_map.validate({'a': self._entry(verified=False)}),
+                     [])
+    for bad in ('yes', 'round 19', 'r', True):
+      errors = address_map.validate({'a': self._entry(verified=bad)})
+      self.assertTrue(any('verified' in e for e in errors), (bad, errors))
+
+  def test_multi_line_note_is_rejected(self):
+    """Reasoning belongs in the cookbook prose, not smuggled into YAML."""
+    entries = {'a': self._entry(note='first line\nsecond line')}
+    errors = address_map.validate(entries)
+    self.assertTrue(any('single line' in e for e in errors), errors)
+
+  def test_missing_required_field_is_rejected(self):
+    entry = self._entry()
+    del entry['import_id']
+    errors = address_map.validate({'a': entry})
+    self.assertTrue(any('import_id' in e for e in errors), errors)
+
+  def test_unknown_key_is_rejected(self):
+    errors = address_map.validate({'a': self._entry(verifed='r1')})
+    self.assertTrue(any('unknown keys' in e for e in errors), errors)
+
+  def test_cookbook_lint_flags_a_repeated_module_section(self):
+    body = ('### DNS zones (`modules/dns`)\n\n- a\n\n'
+            '### Cloud DNS (`modules/dns`)\n\n- b\n')
+    with tempfile.TemporaryDirectory() as t:
+      path = os.path.join(t, 'cookbook.md')
+      with open(path, 'w', encoding='utf-8') as f:
+        f.write(body)
+      errors = address_map.lint_cookbook(path)
+    self.assertEqual(len(errors), 1, errors)
+    self.assertIn('modules/dns', errors[0])
+
+  def test_cookbook_lint_accepts_distinct_modules(self):
+    body = ('### A (`modules/dns`)\n\n- a\n\n'
+            '### B (`modules/net-vpc`)\n\n- b\n')
+    with tempfile.TemporaryDirectory() as t:
+      path = os.path.join(t, 'cookbook.md')
+      with open(path, 'w', encoding='utf-8') as f:
+        f.write(body)
+      self.assertEqual(address_map.lint_cookbook(path), [])
+
+  def test_workspace_check_matches_across_placeholders(self):
+    """Instance names are per-engagement, so only the skeleton compares."""
+    entries = {
+        'a': self._entry(address='module.<instance>.google_thing.default[0]'),
+    }
+    tf = ('import {\n'
+          '  to = module.thing_a.google_thing.default[0]\n'
+          '  id = "projects/p/things/t"\n'
+          '}\n')
+    with tempfile.TemporaryDirectory() as t:
+      with open(os.path.join(t, 'main.tf'), 'w', encoding='utf-8') as f:
+        f.write(tf)
+      targets, unknown = address_map.check_workspace(entries, t)
+    self.assertEqual(len(targets), 1)
+    self.assertEqual(unknown, [])
+
+  def test_workspace_check_reports_unknown_without_failing(self):
+    """An unmapped type is the normal case per SKILL.md, never an error."""
+    entries = {'a': self._entry()}
+    tf = ('import {\n'
+          '  to = google_unmapped_thing.raw\n'
+          '  id = "whatever"\n'
+          '}\n')
+    with tempfile.TemporaryDirectory() as t:
+      with open(os.path.join(t, 'main.tf'), 'w', encoding='utf-8') as f:
+        f.write(tf)
+      targets, unknown = address_map.check_workspace(entries, t)
+      self.assertEqual(len(unknown), 1)
+      # Advisory: the CLI surface must still exit 0.
+      buf = io.StringIO()
+      with contextlib.redirect_stdout(buf):
+        rc = address_map.main(['--check-workspace', t])
+    self.assertEqual(rc, 0)
+    self.assertIn('advisory only', buf.getvalue())
+
+  def test_placeholder_wildcard_does_not_cross_address_segments(self):
+    """`<instance>` must not swallow a dot and match a different resource."""
+    entries = {
+        'a': self._entry(address='module.<instance>.google_thing.default[0]'),
+    }
+    tf = ('import {\n'
+          '  to = module.a.google_other.default[0]\n'
+          '  id = "x"\n'
+          '}\n')
+    with tempfile.TemporaryDirectory() as t:
+      with open(os.path.join(t, 'main.tf'), 'w', encoding='utf-8') as f:
+        f.write(tf)
+      _, unknown = address_map.check_workspace(entries, t)
+    self.assertEqual(len(unknown), 1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Supersedes #4120, which can be closed.

## Why

#4120 grew `mapping-cookbook.md` by ~68% and, in doing so, re-added three sections that already existed (`modules/dns`, `modules/net-cloudnat`, NCC), with the copies disagreeing. That prompted the question of whether the cookbook should become tooling data.

The answer turned out to be "half of it". The cookbook carries two kinds of knowledge that fail differently:

- **Fielded tuples** — asset type, module, address pattern, import ID, verification round. Uniform, mechanically checkable, and duplicated by construction: every address lived once in per-type prose and again in a hand-maintained markdown table. About a quarter of the per-type bullets.
- **Reasoning** — ForceNew traps, provider quirks, waiver postures, capability gaps. Causal prose that only degrades when squeezed into a schema. The other three quarters.

Migrating the whole file to YAML would have turned the second kind into `notes:` blobs, and — worse — a lookup table signals a closed world, which is the opposite of what `SKILL.md` says the cookbook is ("deliberately incomplete… the precipitate of a method, not a precondition for it").

## What

**Fielded data moves to `references/address-map.yaml`** (80 entries). Two invariants are now machine-enforced by `scripts/address_map.py`:

- an address pattern is claimed by exactly one entry;
- a CAI asset type serviced by more than one module must say how to tell the carriers apart.

The second one fired on the first run and found a live defect (below). The import-ID table is now generated from the YAML and marked do-not-edit.

**Reasoning stays in prose**, in `mapping-cookbook.md`.

**A cookbook linter** flags any `###` section that re-documents a module already covered — the cheap check that would have caught #4120's duplicates in CI instead of in review.

### Not a gate

`coverage.py` and `verify_plan.py` never read the address map, and a test enforces that. A wrong entry here is caught by `terraform plan` erroring loudly, unlike a wrong `benign-drift.yaml` entry which would silently pass a gate — different blast radius, different rigour budget. `--check-workspace` is advisory and always exits 0, because an unrecognised address means "nobody has mapped this type yet", which `SKILL.md` calls the normal case.

`address_map.py` **is** in `FROZEN_FILES`, so the existing "everything executable in `scripts/` is tamper-evident" invariant stays unqualified. The human-owned YAML deliberately is not, so recording a newly mapped type needs no gate ceremony.

## Correctness fixes

Each verified against module source in this repository, not memory.

| Issue | Detail |
|---|---|
| **`net-vpn-ha` `shared_secret` posture was unreachable** | The module sets `shared_secret = coalesce(each.value.shared_secret, local.secret)` over `random_id.secret` (`main.tf:53,190`), so the value can never be left unset. Omitting it plans a **replacement** on a ForceNew attribute. `verify_plan.py:32` classifies `replace` as RESIDUAL, so no waiver can carry it — the documented "record a signed waiver for the preview diff" posture would have destroyed live tunnels on apply. Corrected to obtaining the secret out of band, with raw resource + `ignore_changes` demoted to an explicit capability gap. |
| **`google_compute_firewall.rules` does not exist** | #4120 hedged `custom_rules["<rule>"]` *"(or `rules["<rule>"]`)"*. Documented the real five addresses, including the four `count`-based `default_rules_config` rules (`allow_admins[0]` etc.) that any FAST-built estate already has. |
| **`compute.googleapis.com/Router` double-claim** | Claimed by both `net-cloudnat` and `net-vpn-ha` with no rule for choosing. Caught by the new validator. Both sections now state the disambiguation and the schema requires it. |
| **NCC normative weakening** | The duplicate section had dropped the **MUST** for the capability-gaps report and the `moved {}` lift instruction; restored. Also documented that `ncc-spoke-ra` *does* carry the hub (`google_network_connectivity_hub.hub[0]`), so a hub is not a gap. |
| **`modules/dns` has no factory** | The canonical module map claimed `factories_config.recordsets_file`, which does not exist — the module has no `factories_config` variable at all. Recordsets are the `recordsets` input, keyed `"<type> <name>"`. |
| **DNS CAI types** | `ResourceRecordSet`, `ResponsePolicy` and `ResponsePolicyRule` are real CAI types but absent from the analysis APIs, so `--verify-search-parity` reporting them as `only_in_list` is expected, not a collection bug. `ResponsePolicyRule` was missing entirely. |
| **ACM asset types** | Corrected to the `identity.accesscontextmanager.googleapis.com/` prefix. |
| **Interconnect attachment carrier** | Corrected to `modules/net-vlan-attachment`. |

Also merges the duplicated DNS, Cloud NAT and NCC sections, keeping the stronger text from each, and fixes stray blank lines.

## Verification

```
$ uv run scripts/address_map.py
address map: 80 entries, 0 error(s)
cookbook lint: 0 error(s)

$ uv run scripts/address_map.py --render-cookbook --check
cookbook table: up to date

$ python3 -m pytest tests/test_scripts.py -q
211 passed
```

16 new tests cover the duplicate-address invariant, the shared-asset-type disambiguation requirement, the frozen/not-frozen split, the "gates must not consume the map" boundary, and the advisory workspace reader. `yapf` (repo `.style.yapf`), `yamllint` and `check_boilerplate.py` all clean.
