### PR TITLE
Scopes-only Import Manifest Grammar With Per-scope Types

### DIFF
--- a/skills/fabric-importer/README.md
+++ b/skills/fabric-importer/README.md
@@ -98,7 +98,7 @@ run with a message rather than warning — before any API call, exit 1:
 | Every scope declares `types:`; `types: []` is rejected | A scope that collects nothing passes every check by not collecting |
 | A type whose `levels` cannot intersect its scope's `levels` is rejected | A dead declaration reads like coverage and produces none (an entry listing `unknown` is exempt) |
 | A type declared twice in one list is rejected | Last-wins would quietly narrow levels |
-| The retired grammar (top-level `scope:` / `types:`) is rejected with migration instructions | Half-accepting it would change what the denominator means |
+| The retired grammar (top-level `scope:` / `types:`) is rejected with migration instructions | Half-accepting it would change what the denominator means — see [references/manifest-migration.md](./references/manifest-migration.md) |
 
 `examples/import-manifest.multi-domain.yaml` is a worked four-scope manifest;
 `examples/import-manifest.org-foundation.yaml` is the single-scope reference.
@@ -569,6 +569,7 @@ skills/fabric-importer/
 │   ├── mapping-cookbook.md      #   Traps, reasoning, capability gaps (prose)
 │   ├── address-map.yaml         #   Addresses, import IDs, asset types (data)
 │   ├── inferring-manifests-from-state.md # State-driven manifest inference workflow
+│   ├── manifest-migration.md    #   Migrating manifests from the retired grammar
 │   ├── cai-blind-spots.md       #   Known CAI gaps and service API mitigations
 │   └── operating-contract.md    #   Safety invariants and trust boundaries
 └── tests/                       # Unit test suite

--- a/skills/fabric-importer/README.md
+++ b/skills/fabric-importer/README.md
@@ -24,13 +24,13 @@ The important part is what that file contains. **It names resource types, not
 resources.** You never write a list of your 47 org policies. You write:
 
 ```yaml
-scope:
-  root: organizations/123456789012
-types:
-  - type: org-policy
-    levels: [organization]
-  - type: cloudresourcemanager.googleapis.com/Folder
-    levels: [organization, folder]
+scopes:
+  - root: organizations/123456789012
+    types:
+      - type: org-policy
+        levels: [organization]
+      - type: cloudresourcemanager.googleapis.com/Folder
+        levels: [organization, folder]
 ```
 
 That means "in this organization, take over org policies attached at org level,
@@ -57,6 +57,59 @@ estate need a manifest first. Neither is a gate, neither produces anything
 binding, and you can skip both if you already know your scope. Run them anyway
 the first time: the gap between "what Terraform manages" and "what exists" is
 usually the most useful thing discovered all week.
+
+### Different depth per subtree: per-scope `types:`
+
+One estate rarely wants the same depth everywhere — governance at org and
+folder level, the full connectivity stack in the networking folder, two named
+workload projects and nothing else. `scopes:` is a list, and **every scope
+carries its own `types:` list**; there is no other place to declare types, so
+what a scope collects is exactly what is written on it:
+
+```yaml
+scopes:
+  - name: org-foundation
+    root: organizations/123456789012
+    levels: [organization, folder]
+    types:
+      - type: org-policy
+        levels: [organization, folder]
+      - type: cloudresourcemanager.googleapis.com/Folder
+        levels: [organization, folder]
+
+  - name: workloads
+    root: organizations/123456789012
+    levels: [project]
+    include:
+      - projects/111111111111
+    types:
+      - type: iam
+        levels: [project]
+      - type: storage.googleapis.com/Bucket
+        levels: [project]
+```
+
+The same type may appear in several scopes with different `levels`, `iam` or
+`enumerate`. Because a type list decides the denominator, the rules fail the
+run with a message rather than warning — before any API call, exit 1:
+
+| Rule | Why |
+|---|---|
+| Every scope declares `types:`; `types: []` is rejected | A scope that collects nothing passes every check by not collecting |
+| A type whose `levels` cannot intersect its scope's `levels` is rejected | A dead declaration reads like coverage and produces none (an entry listing `unknown` is exempt) |
+| A type declared twice in one list is rejected | Last-wins would quietly narrow levels |
+| The retired grammar (top-level `scope:` / `types:`) is rejected with migration instructions | Half-accepting it would change what the denominator means |
+
+`examples/import-manifest.multi-domain.yaml` is a worked four-scope manifest;
+`examples/import-manifest.org-foundation.yaml` is the single-scope reference.
+
+Afterwards, read the **per-scope** tables in `inventory.json`:
+`_meta.scopes[].declared_types` and `_meta.scopes[].zero_yield_types`.
+`_meta.declared_types` is the aggregate across scopes, and the aggregate can
+hide a scope whose own declaration yielded nothing — a type non-zero org-wide
+and zero in the one scope you cared about. Every inventory entry (and
+therefore every worklist entry) also names the scope(s) that collected it in
+its `scopes` field.
 
 ### `survey` and `collect` are not the same thing
 
@@ -115,7 +168,7 @@ Gate on steps that are hard to reverse, costly, or where human judgment is requi
 
 | Gate | When | What the human decides |
 | :--- | :--- | :--- |
-| **Scope Approval** | Manifest drafting, before any enumeration | Reviews and commits `import-manifest.yaml`: which resource types, hierarchy levels (org/folder/project), and included/excluded subtrees are in scope. |
+| **Scope Approval** | Manifest drafting, before any enumeration | Reviews and commits `import-manifest.yaml`: which resource types each scope declares, at which hierarchy levels (org/folder/project), under which included/excluded subtrees. |
 | **Waiver Signing** | Completeness Gate (`coverage.py`) | Reviews deliberate exclusions in `waivers.yaml` and signs them with attribution (`signed_by`) for unmanaged or auto-generated resources (e.g. default log sinks, default compute service accounts). |
 | **Benign Drift Review** | Plan Convergence Gate (`verify_plan.py`) | Evaluates proposed cosmetic provider quirks (e.g. computed labels, default timeouts) and commits reviewed entries to `scripts/benign-drift.yaml`. |
 | **Final Review & Apply** | Handover, before `terraform apply` | Inspects the final zero-drift plan, run report, and input provenance digests before running `terraform apply` on their own schedule. |
@@ -160,7 +213,7 @@ and binding.
 
 ```mermaid
 flowchart TD
-    T["One type declared<br/>in the manifest"] --> Q1{"pseudo-type?"}
+    T["One type declared in a<br/>scope's types: list"] --> Q1{"pseudo-type?"}
     Q1 -- "iam" --> S1["asset list<br/>--content-type=iam-policy"]
     Q1 -- "org-policy" --> S2["three streams merged:<br/>org-policy content type<br/>+ orgpolicy Policy assets<br/>+ gcloud org-policies list<br/>per container"]
     Q1 -- "no, a real asset type" --> Q2{"enumerator registered?<br/>built-in table, or a<br/>manifest enumerate: block"}
@@ -179,7 +232,9 @@ flowchart TD
 
 No path exits with "skip it". Every branch ends in the denominator or in a stop,
 because an unenumerated asset is invisible to both gates at once — it would pass
-every check by not existing.
+every check by not existing. The funnel runs once per scope: the same type can
+enter it from two scopes' lists with different levels, and a type declared in
+only one scope is swept only there.
 
 ### Funnel 2: how a worklist item becomes code
 
@@ -242,7 +297,7 @@ middle two is to force the module to fit, or to call the leftover diff benign.
 ## Step-by-Step Operator Guide
 
 ### 1. Declare the Scope (`import-manifest.yaml`)
-You and the agent agree on an `import-manifest.yaml` declaring which resource types to import (e.g., folders, service accounts, VPC networks, org policies), at which container levels (organization, folder, or project), and which subtrees to include or exclude.
+You and the agent agree on an `import-manifest.yaml` declaring, per scope, which resource types to import (e.g., folders, service accounts, VPC networks, org policies), at which container levels (organization, folder, or project), and which subtrees to include or exclude — see [Different depth per subtree](#different-depth-per-subtree-per-scope-types).
 
 This is the only file you author, and it names types, not resources. The two
 options below are drafting aids that answer different questions — A tells you
@@ -261,7 +316,10 @@ See [references/inferring-manifests-from-state.md](./references/inferring-manife
 uv run scripts/inventory.py survey --scope organizations/ORG_ID --out survey.json
 uv run scripts/manifest_init.py --survey survey.json --scope organizations/ORG_ID --out import-manifest.yaml
 ```
-Ready-made examples aligned with FAST stages are provided in [`examples/`](./examples/).
+Ready-made examples aligned with FAST stages are provided in
+[`examples/`](./examples/); `import-manifest.org-foundation.yaml` is the
+single-scope reference and `import-manifest.multi-domain.yaml` the per-scope
+multi-domain one.
 
 ### 2. Enumerate the Denominator (`inventory.json`)
 The enumeration script queries Cloud Asset Inventory (CAI) and service APIs to construct the exact denominator of all matching live assets:
@@ -280,15 +338,17 @@ type string is wrong (checked against the
 [supported types list](https://cloud.google.com/asset-inventory/docs/supported-asset-types)),
 or the type needs a native enumerator declared in the manifest — a
 read-only `gcloud` command run per in-scope container, normalized into
-the same inventory (this also overrides a built-in):
+the same inventory (this also overrides a built-in). The block lives in
+the `types:` list of each scope that needs it; per-scope lists never
+inherit:
 
 ```yaml
-  - type: iam.googleapis.com/DenyPolicy       # not in the CAI catalogue
-    levels: [organization, folder]
-    enumerate:
-      command: [iam, policies, list, --kind=denypolicies]
-      container_arg: '--attachment-point=cloudresourcemanager.googleapis.com/{container}'
-      key: '//iam.googleapis.com/{container}/denypolicies/{item.name}'
+      - type: iam.googleapis.com/DenyPolicy   # not in the CAI catalogue
+        levels: [organization, folder]
+        enumerate:
+          command: [iam, policies, list, --kind=denypolicies]
+          container_arg: '--attachment-point=cloudresourcemanager.googleapis.com/{container}'
+          key: '//iam.googleapis.com/{container}/denypolicies/{item.name}'
 ```
 
 CAI is also not one taxonomy but two, and they disagree. For a few
@@ -337,6 +397,14 @@ scope stays auditable without making the run unreadable: on a large
 estate the per-container sweeps produce a pair of lines per container,
 and those would bury the warnings that decide whether the denominator
 can be trusted.
+
+Provenance is per scope: each `_meta.scopes[]` entry records its own
+`declared_types` yield counts and `zero_yield_types`, and every
+inventory entry names the scope(s) that collected it.
+`_meta.declared_types` is the aggregate — read the per-scope counts
+too, because a type that yields zero in one scope and non-zero in
+another does not show up in the aggregate zero-yield warning (the
+per-scope warning on stderr does).
 
 CAI listings request the largest page each API allows (1000 for
 `asset list`, 500 for `search-all-resources`), which is what decides how
@@ -416,8 +484,12 @@ Exit codes — `coverage.py`: `0` reconciled, `1` malformed input, `2` gaps
 or problems. `verify_plan.py`: `0` converged, `1` malformed input, `2`
 residual changes, `3` converged but ADVISORY (a substituted `--rules`
 file). A substituted ruleset can never exit `0`; a residual plan still
-exits `2`. Note that argparse usage errors also exit `2`, so read the
-message, not only the code.
+exits `2`. `inventory.py`: `0` ok, `1` a manifest the validator refuses
+(retired grammar, missing/empty per-scope `types:`, duplicate type,
+invalid level, dead per-scope declaration — printed with the reason
+before any API call), `3` a partial denominator (unsupported type,
+tolerated sweep failure, split-parity gap). Note that argparse usage
+errors also exit `2`, so read the message, not only the code.
 
 There is no checked-in expected digest. To check a recorded gate run,
 compute `uv run scripts/integrity.py` from a pristine checkout of the
@@ -462,7 +534,7 @@ Three human-owned files govern the process. The agent may propose edits, but onl
 
 | File | Purpose |
 |---|---|
-| `import-manifest.yaml` | Declares in-scope resource types, container levels, and subtree filters. |
+| `import-manifest.yaml` | Declares the scopes, each with its own resource-type list, container levels, and subtree filters. |
 | `waivers.yaml` | Written waivers for resources deliberately excluded from management (e.g. `_Default` log sinks, default compute service accounts). Requires a `signed_by` attribute. |
 | `scripts/benign-drift.yaml` | Scoped provider quirks accepted as cosmetic diffs (e.g., computed provider labels or default timeouts). |
 | `references/address-map.yaml` | The fielded subset of the mapping cookbook: asset type, module, address pattern, import ID, verification round. Advisory, not a gate input — see below. |
@@ -487,6 +559,7 @@ skills/fabric-importer/
 │   └── benign-drift.yaml        #   Human-reviewed provider quirk ruleset
 ├── examples/                    # Manifest and waiver templates
 │   ├── import-manifest.org-foundation.yaml
+│   ├── import-manifest.multi-domain.yaml
 │   ├── import-manifest.fast-org-setup.yaml
 │   ├── import-manifest.fast-security.yaml
 │   ├── import-manifest.fast-vpcsc.yaml

--- a/skills/fabric-importer/SKILL.md
+++ b/skills/fabric-importer/SKILL.md
@@ -203,7 +203,10 @@ validator refuses: a scope without a `types:` list or with `types: []`
 `levels` cannot intersect its scope's `levels` (dead declaration —
 entries listing `unknown` are exempt); a duplicate `type:` within one
 list; and the retired top-level `scope:`/`types:` grammar, which is
-rejected with migration instructions. Unlike `types:`, a scope's
+rejected with migration instructions — a manifest from an earlier
+engagement is migrated per
+[references/manifest-migration.md](./references/manifest-migration.md).
+Unlike `types:`, a scope's
 `emission:` map inherits built-in defaults for omitted families — it
 is denominator-neutral; do not reason from one knob to the other.
 
@@ -628,6 +631,10 @@ missing permission when one is needed.
   `scripts/address_map.py`, never read by the gates
 - [references/inferring-manifests-from-state.md](./references/inferring-manifests-from-state.md)
   — inferring import manifests from existing Terraform states
+- [references/manifest-migration.md](./references/manifest-migration.md)
+  — the manifest grammar changed to scopes-only with per-scope
+  `types:` lists; how to migrate a manifest written for the retired
+  grammar, and what stayed identical
 - [references/cai-blind-spots.md](./references/cai-blind-spots.md) —
   where the CAI denominator is incomplete and what to do about it
 - [references/operating-contract.md](./references/operating-contract.md)

--- a/skills/fabric-importer/SKILL.md
+++ b/skills/fabric-importer/SKILL.md
@@ -59,7 +59,7 @@ Gate on steps that are hard to reverse, costly, or where human judgment is requi
 
 | Gate | When | What the human decides |
 | :--- | :--- | :--- |
-| **Scope Approval** | Manifest drafting, before any enumeration | Reviews and commits `import-manifest.yaml`: which resource types, hierarchy levels (org/folder/project), and included/excluded subtrees are in scope. |
+| **Scope Approval** | Manifest drafting, before any enumeration | Reviews and commits `import-manifest.yaml`: which resource types each scope declares, at which hierarchy levels (org/folder/project), under which included/excluded subtrees. |
 | **Waiver Signing** | Completeness Gate (`coverage.py`) | Reviews deliberate exclusions in `waivers.yaml` and signs them with attribution (`signed_by`) for unmanaged or auto-generated resources (e.g. default log sinks, default compute service accounts). |
 | **Benign Drift Review** | Plan Convergence Gate (`verify_plan.py`) | Evaluates proposed cosmetic provider quirks (e.g. computed labels, default timeouts) and commits reviewed entries to `scripts/benign-drift.yaml`. |
 | **Final Review & Apply** | Handover, before `terraform apply` | Inspects the final zero-drift plan, run report, and input provenance digests before running `terraform apply` on their own schedule. |
@@ -73,7 +73,7 @@ flowchart TD
     subgraph S0["Discovery &amp; scope declaration"]
         MA["<b>Mode A: State-Driven Inference</b><br/><code>manifest_from_state.py</code><br/><i>(Existing .tfstate files)</i>"]
         MB["<b>Mode B: Live Cloud Survey</b><br/><code>inventory.py survey</code> &amp;<br/><code>manifest_init.py</code><br/><i>(Untracked brownfield)</i>"]
-        Draft["Draft <code>import-manifest.yaml</code><br/><i>(Resource types, levels &amp; subtree filters)</i>"]
+        Draft["Draft <code>import-manifest.yaml</code><br/><i>(Scopes, each with its own<br/>types, levels &amp; subtree filters)</i>"]
         G_Scope{"<b>Gate: Scope Approval</b><br/>Human reviews &amp; commits manifest"}
         Stop_Scope["Stop / Re-scope"]
     end
@@ -155,8 +155,10 @@ flowchart TD
 ### Step 0 — establish the manifest (with the user)
 
 The manifest is the user's contract: which resource types, at which
-levels, under which subtrees. Never invent it silently. If one exists,
-confirm it; otherwise run one of the drafting workflows:
+levels, under which subtrees — declared per scope, since `scopes:` is
+a list and **every scope carries its own `types:` list**. Never invent
+it silently. If one exists, confirm it; otherwise run one of the
+drafting workflows:
 
 **Option A — Inferred from existing Terraform state(s)** (preferred when migrating existing TF):
 
@@ -182,12 +184,28 @@ with per-level counts, commented out; foundation types are pre-enabled):
   org foundation first, workloads later. Show them
   `examples/import-manifest.org-foundation.yaml` as the reference.)
 - At which levels? (e.g. org IAM yes, project IAM no.)
+- Same depth everywhere, or different depths per subtree? (Different ⇒
+  several scopes, each with its own `types:` list —
+  `examples/import-manifest.multi-domain.yaml` is the reference.)
 - Any subtrees to exclude (sandboxes, decommissioning trees)?
 
-When writing `scope.include`/`scope.exclude`, note that CAI `ancestors`
+When writing a scope's `include`/`exclude`, note that CAI `ancestors`
 store NUMERIC project numbers; `inventory.py` automatically resolves
 alphanumeric project IDs to numbers during enumeration, but project numbers
 remain supported and canonical.
+
+**Per-scope `types:` rules (fail-closed, exit 1 before any API call).**
+A scope's list is the only place types are declared, so what a scope
+collects is exactly what is written on it. The same type may appear in
+several scopes with different `levels`, `iam` or `enumerate`. The
+validator refuses: a scope without a `types:` list or with `types: []`
+(a scope that collects nothing may not say so quietly); a type whose
+`levels` cannot intersect its scope's `levels` (dead declaration —
+entries listing `unknown` are exempt); a duplicate `type:` within one
+list; and the retired top-level `scope:`/`types:` grammar, which is
+rejected with migration instructions. Unlike `types:`, a scope's
+`emission:` map inherits built-in defaults for omitted families — it
+is denominator-neutral; do not reason from one knob to the other.
 
 The user commits the manifest. Scope changes later = manifest edit +
 incremental re-run, never a rewrite.
@@ -223,8 +241,9 @@ exact failure the gates exist to prevent.
 
 `inventory.py` does this for you where it can: it ships built-in gcloud
 enumerators for types known to be absent from the CAI catalogue
-(`NATIVE_ENUMERATORS`), so declaring the type in the manifest is enough
-— the tool skips CAI, sweeps with gcloud, and says so. Where no
+(`NATIVE_ENUMERATORS`), so declaring the type in a scope's `types:`
+list is enough — the tool skips CAI, sweeps with gcloud in that scope,
+and says so. Where no
 enumerator exists it refuses to proceed rather than guess, and it
 separates that case from a permission failure. Three remedies, in order:
 
@@ -258,17 +277,19 @@ separates that case from a permission failure. Three remedies, in order:
   which in the report. See
   [references/cai-blind-spots.md](./references/cai-blind-spots.md).
 - **CAI genuinely does not model the type, and no built-in covers it.**
-  Give it a native enumerator in the manifest — a read-only gcloud
-  command run per in-scope container, normalized into inventory
-  entries. It also overrides a built-in when you know better:
+  Give it a native enumerator — a read-only gcloud command run per
+  in-scope container, normalized into inventory entries. The
+  `enumerate:` block lives in the `types:` list of each scope that
+  needs it (per-scope lists never inherit), and also overrides a
+  built-in when you know better:
 
   ```yaml
-  - type: iam.googleapis.com/DenyPolicy       # not in the CAI catalogue
-    levels: [organization, folder]
-    enumerate:
-      command: [iam, policies, list, --kind=denypolicies]
-      container_arg: '--attachment-point=cloudresourcemanager.googleapis.com/{container}'
-      key: '//iam.googleapis.com/{container}/denypolicies/{item.name}'
+      - type: iam.googleapis.com/DenyPolicy   # not in the CAI catalogue
+        levels: [organization, folder]
+        enumerate:
+          command: [iam, policies, list, --kind=denypolicies]
+          container_arg: '--attachment-point=cloudresourcemanager.googleapis.com/{container}'
+          key: '//iam.googleapis.com/{container}/denypolicies/{item.name}'
   ```
 
   The manifest is human-owned: draft the block, a human commits it.
@@ -536,7 +557,13 @@ believe deserves attention. State whether `--verify-search-parity` was
 run and what it found. An empty `_meta.split_parity` means the probe did
 not run; a clean probe is a record whose `only_in_search` is empty.
 Reporting an unchecked table as clean is exactly the kind of claim this
-section exists to prevent. Plain facts; no "100%" claims beyond what the
+section exists to prevent. Quote the **per-scope** yield tables
+(`_meta.scopes[].declared_types` / `zero_yield_types`), not only the
+aggregate `_meta.declared_types`: a type can be non-zero org-wide while
+the one scope that declared it yielded nothing, and only the per-scope
+record shows that. Convergence claims are bounded per scope — state
+each scope's declared surface, not one sentence about "the manifest".
+Plain facts; no "100%" claims beyond what the
 gates literally verified.
 
 The report MUST include the verbatim stdout of both final gate runs —

--- a/skills/fabric-importer/examples/import-manifest.fast-networking.yaml
+++ b/skills/fabric-importer/examples/import-manifest.fast-networking.yaml
@@ -22,48 +22,47 @@
 # networking folder. See COVERAGE.md.
 # ---------------------------------------------------------------------------
 
-scope:
-  root: organizations/000000000000
-  # include:
-  #   - folders/333333333333         # networking folder number
-
-types:
-  - type: iam                                              # [V]
-    levels: [project]
-  - type: org-policy                                       # [V]
-    levels: [folder, project]
-  - type: cloudresourcemanager.googleapis.com/Project      # [V]
-    levels: [folder]
-  - type: serviceusage.googleapis.com/Service              # [V]
-    levels: [project]
-  - type: iam.googleapis.com/ServiceAccount                # [V]
-    levels: [project]
-    iam: true
-  - type: compute.googleapis.com/Network                   # [V]
-    levels: [project]
-  - type: compute.googleapis.com/Subnetwork                # [V]
-    levels: [project]
-  - type: compute.googleapis.com/Route                     # [V] (dynamic routes waived)
-    levels: [project]
-  - type: dns.googleapis.com/ManagedZone                   # [V] modules/dns
-    levels: [project]
-  - type: dns.googleapis.com/Policy                        # [N] DNS server policies
-    levels: [project]
-  - type: dns.googleapis.com/ResponsePolicy                # [N]
-    levels: [project]
-  - type: networkconnectivity.googleapis.com/Hub           # [N] NCC hub
-    levels: [project]
-  - type: networkconnectivity.googleapis.com/Spoke         # [V] NCC linked-VPC spoke (raw fallback)
-    levels: [project]
-  - type: compute.googleapis.com/Router                    # [V] modules/net-cloudnat (router + NAT)
-    levels: [project]
-  - type: compute.googleapis.com/Address                   # [N] reserved addresses
-    levels: [project]
-  # - type: compute.googleapis.com/FirewallPolicy          # [C] net-firewall-policy
-  #   levels: [folder]
-  # - type: compute.googleapis.com/VpnGateway              # [C] net-vpn-*
-  #   levels: [project]
-  # - type: compute.googleapis.com/VpnTunnel               # [C]
-  #   levels: [project]
-  # - type: compute.googleapis.com/InterconnectAttachment  # [C] vlan attachments
-  #   levels: [project]
+scopes:
+  - root: organizations/000000000000
+    # include:
+    #   - folders/333333333333         # networking folder number
+    types:
+      - type: iam                                              # [V]
+        levels: [project]
+      - type: org-policy                                       # [V]
+        levels: [folder, project]
+      - type: cloudresourcemanager.googleapis.com/Project      # [V]
+        levels: [folder]
+      - type: serviceusage.googleapis.com/Service              # [V]
+        levels: [project]
+      - type: iam.googleapis.com/ServiceAccount                # [V]
+        levels: [project]
+        iam: true
+      - type: compute.googleapis.com/Network                   # [V]
+        levels: [project]
+      - type: compute.googleapis.com/Subnetwork                # [V]
+        levels: [project]
+      - type: compute.googleapis.com/Route                     # [V] (dynamic routes waived)
+        levels: [project]
+      - type: dns.googleapis.com/ManagedZone                   # [V] modules/dns
+        levels: [project]
+      - type: dns.googleapis.com/Policy                        # [N] DNS server policies
+        levels: [project]
+      - type: dns.googleapis.com/ResponsePolicy                # [N]
+        levels: [project]
+      - type: networkconnectivity.googleapis.com/Hub           # [N] NCC hub
+        levels: [project]
+      - type: networkconnectivity.googleapis.com/Spoke         # [V] NCC linked-VPC spoke (raw fallback)
+        levels: [project]
+      - type: compute.googleapis.com/Router                    # [V] modules/net-cloudnat (router + NAT)
+        levels: [project]
+      - type: compute.googleapis.com/Address                   # [N] reserved addresses
+        levels: [project]
+      # - type: compute.googleapis.com/FirewallPolicy          # [C] net-firewall-policy
+      #   levels: [folder]
+      # - type: compute.googleapis.com/VpnGateway              # [C] net-vpn-*
+      #   levels: [project]
+      # - type: compute.googleapis.com/VpnTunnel               # [C]
+      #   levels: [project]
+      # - type: compute.googleapis.com/InterconnectAttachment  # [C] vlan attachments
+      #   levels: [project]

--- a/skills/fabric-importer/examples/import-manifest.fast-org-setup.yaml
+++ b/skills/fabric-importer/examples/import-manifest.fast-org-setup.yaml
@@ -21,48 +21,48 @@
 # Maturity legend (see COVERAGE.md): [V] live-verified  [C] cookbook
 # rules exist, not yet plan-tested  [N] new territory (fallback +
 # capability-gap report). Validate counts with `inventory.py collect`
-# before mapping; adjust scope.include to your IaC folder/projects.
+# before mapping; adjust the scope's include to your IaC folder/projects.
 # ---------------------------------------------------------------------------
 
-scope:
-  root: organizations/000000000000   # <- your org id
-  # include/exclude match CAI `ancestors` (NUMERIC project ids).
-  # Restrict project-level types to the org-setup projects:
-  # include:
-  #   - projects/111111111111        # iac-core project NUMBER; see the
-  #     "RECIPES" section in import-manifest.org-foundation.yaml for
-  #     selecting specific projects (incl. the include-vs-exclude trap)
-
-types:
-  - type: iam                                              # [V]
-    levels: [organization, project]
-  - type: org-policy                                       # [V]
-    levels: [organization]
-  - type: iam.googleapis.com/Role                          # [V] (org custom roles)
-    levels: [organization]
-  - type: logging.googleapis.com/LogSink                   # [V]
-    levels: [organization]
-  - type: cloudresourcemanager.googleapis.com/Folder       # [V]
-    levels: [organization, folder]
-  - type: cloudresourcemanager.googleapis.com/Project      # [V]
-    levels: [organization, folder]
-  - type: serviceusage.googleapis.com/Service              # [V]
-    levels: [project]
-  - type: iam.googleapis.com/ServiceAccount                # [V]
-    levels: [project]
-    iam: true          # impersonation grants enter the denominator
-  - type: logging.googleapis.com/LogBucket                 # [V]
-    levels: [project]
-  - type: storage.googleapis.com/Bucket                    # [V] state buckets
-    levels: [project]
-  - type: iam.googleapis.com/WorkloadIdentityPool          # [V] WIF federation
-    levels: [project]
-  - type: cloudresourcemanager.googleapis.com/TagKey       # [V] Resource Manager tags
-    levels: [organization]
-  - type: cloudresourcemanager.googleapis.com/TagValue     # [V]
-    levels: [organization]
-  - type: cloudresourcemanager.googleapis.com/TagBinding   # [V]
-    levels: [organization, folder, project]
-  # --- Optional additional types ---
-  # - type: cloudbilling.googleapis.com/BillingAccount     # [N] billing IAM
-  #   levels: [organization]
+scopes:
+  - root: organizations/000000000000   # <- your org id
+    # include/exclude match CAI `ancestors` (NUMERIC project ids).
+    # Restrict project-level types to the org-setup projects:
+    # include:
+    #   - projects/111111111111        # iac-core project NUMBER; see
+    #     import-manifest.multi-domain.yaml for selecting specific
+    #     projects per scope, and import-manifest.org-foundation.yaml
+    #     for the include-vs-exclude numeric-id trap
+    types:
+      - type: iam                                              # [V]
+        levels: [organization, project]
+      - type: org-policy                                       # [V]
+        levels: [organization]
+      - type: iam.googleapis.com/Role                          # [V] (org custom roles)
+        levels: [organization]
+      - type: logging.googleapis.com/LogSink                   # [V]
+        levels: [organization]
+      - type: cloudresourcemanager.googleapis.com/Folder       # [V]
+        levels: [organization, folder]
+      - type: cloudresourcemanager.googleapis.com/Project      # [V]
+        levels: [organization, folder]
+      - type: serviceusage.googleapis.com/Service              # [V]
+        levels: [project]
+      - type: iam.googleapis.com/ServiceAccount                # [V]
+        levels: [project]
+        iam: true          # impersonation grants enter the denominator
+      - type: logging.googleapis.com/LogBucket                 # [V]
+        levels: [project]
+      - type: storage.googleapis.com/Bucket                    # [V] state buckets
+        levels: [project]
+      - type: iam.googleapis.com/WorkloadIdentityPool          # [V] WIF federation
+        levels: [project]
+      - type: cloudresourcemanager.googleapis.com/TagKey       # [V] Resource Manager tags
+        levels: [organization]
+      - type: cloudresourcemanager.googleapis.com/TagValue     # [V]
+        levels: [organization]
+      - type: cloudresourcemanager.googleapis.com/TagBinding   # [V]
+        levels: [organization, folder, project]
+      # --- Optional additional types ---
+      # - type: cloudbilling.googleapis.com/BillingAccount     # [N] billing IAM
+      #   levels: [organization]

--- a/skills/fabric-importer/examples/import-manifest.fast-security.yaml
+++ b/skills/fabric-importer/examples/import-manifest.fast-security.yaml
@@ -21,29 +21,28 @@
 # Note: KMS keyrings cannot be deleted in GCP; CAS pools bill monthly.
 # ---------------------------------------------------------------------------
 
-scope:
-  root: organizations/000000000000
-  # include:
-  #   - folders/222222222222         # security folder number
-
-types:
-  - type: iam                                              # [V]
-    levels: [project]
-  - type: org-policy                                       # [V]
-    levels: [folder, project]
-  - type: cloudresourcemanager.googleapis.com/Project      # [V]
-    levels: [folder]
-  - type: serviceusage.googleapis.com/Service              # [V]
-    levels: [project]
-  - type: iam.googleapis.com/ServiceAccount                # [V]
-    levels: [project]
-    iam: true
-  - type: cloudkms.googleapis.com/KeyRing                  # [V] modules/kms
-    levels: [project]
-  - type: cloudkms.googleapis.com/CryptoKey                # [V] modules/kms
-    levels: [project]
-    iam: true          # per-key IAM is leaf IAM - opt in explicitly
-  - type: privateca.googleapis.com/CaPool                  # [V] modules/certificate-authority-service
-    levels: [project]
-  # - type: privateca.googleapis.com/CertificateAuthority  # [C]
-  #   levels: [project]
+scopes:
+  - root: organizations/000000000000
+    # include:
+    #   - folders/222222222222         # security folder number
+    types:
+      - type: iam                                              # [V]
+        levels: [project]
+      - type: org-policy                                       # [V]
+        levels: [folder, project]
+      - type: cloudresourcemanager.googleapis.com/Project      # [V]
+        levels: [folder]
+      - type: serviceusage.googleapis.com/Service              # [V]
+        levels: [project]
+      - type: iam.googleapis.com/ServiceAccount                # [V]
+        levels: [project]
+        iam: true
+      - type: cloudkms.googleapis.com/KeyRing                  # [V] modules/kms
+        levels: [project]
+      - type: cloudkms.googleapis.com/CryptoKey                # [V] modules/kms
+        levels: [project]
+        iam: true          # per-key IAM is leaf IAM - opt in explicitly
+      - type: privateca.googleapis.com/CaPool                  # [V] modules/certificate-authority-service
+        levels: [project]
+      # - type: privateca.googleapis.com/CertificateAuthority  # [C]
+      #   levels: [project]

--- a/skills/fabric-importer/examples/import-manifest.fast-vpcsc.yaml
+++ b/skills/fabric-importer/examples/import-manifest.fast-vpcsc.yaml
@@ -22,13 +22,12 @@
 # singletons. See COVERAGE.md.
 # ---------------------------------------------------------------------------
 
-scope:
-  root: organizations/000000000000
-
-types:
-  - type: identity.accesscontextmanager.googleapis.com/AccessPolicy      # [V]
-    levels: [organization]
-  - type: identity.accesscontextmanager.googleapis.com/AccessLevel       # [V]
-    levels: [organization, unknown]
-  - type: identity.accesscontextmanager.googleapis.com/ServicePerimeter  # [V]
-    levels: [organization, unknown]
+scopes:
+  - root: organizations/000000000000
+    types:
+      - type: identity.accesscontextmanager.googleapis.com/AccessPolicy      # [V]
+        levels: [organization]
+      - type: identity.accesscontextmanager.googleapis.com/AccessLevel       # [V]
+        levels: [organization, unknown]
+      - type: identity.accesscontextmanager.googleapis.com/ServicePerimeter  # [V]
+        levels: [organization, unknown]

--- a/skills/fabric-importer/examples/import-manifest.multi-domain.yaml
+++ b/skills/fabric-importer/examples/import-manifest.multi-domain.yaml
@@ -1,0 +1,140 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ---------------------------------------------------------------------------
+# EXAMPLE import manifest: "multi-domain" — PER-SCOPE TYPES
+#
+# One estate, four different depths. Each scope carries its own `types:`
+# list — there is no other place to declare types, so what a scope
+# collects is exactly what is written on it. The same type may appear in
+# several scopes with different `levels`, `iam` or `enumerate`; that is
+# the point, not an accident.
+#
+# Fail-closed rules (all exit 1 with the reason, before any API call):
+#   - a scope without a `types:` list is refused;
+#   - `types: []` is refused: an empty list is a scope that collects
+#     nothing, and that is the one thing no scope may say quietly;
+#   - a type whose `levels` cannot intersect its scope's `levels` is
+#     refused as a dead declaration (an entry listing `unknown` is
+#     exempt — see import-manifest.fast-vpcsc.yaml);
+#   - a duplicate `type:` inside one scope's list is refused.
+#
+# Note the asymmetry with `emission:` (also per scope): emission INHERITS
+# built-in defaults for families you omit, because it only decides how
+# collected assets are written. `types:` never inherits anything, because
+# it decides what is collected at all.
+#
+# After collection, read the PER-SCOPE yield tables in inventory.json
+# (`_meta.scopes[].declared_types` / `zero_yield_types`): the aggregate
+# table can be non-zero for a type while one scope's own declaration
+# yielded nothing — e.g. `iam` non-empty org-wide but empty under
+# `workloads`. Every inventory entry also names the scope(s) that
+# collected it (`scopes: [...]`).
+# ---------------------------------------------------------------------------
+
+scopes:
+
+  # Org foundation: governance only, no project-contained resources.
+  - name: org-foundation
+    root: organizations/000000000000        # <- your org id
+    levels: [organization, folder]
+    emission:
+      folder: factory                       # day-2 operating model
+    types:
+      - type: iam
+        levels: [organization, folder]
+      - type: org-policy
+        levels: [organization, folder]
+      - type: iam.googleapis.com/Role
+        levels: [organization]
+      - type: logging.googleapis.com/LogSink
+        levels: [organization]
+      - type: cloudresourcemanager.googleapis.com/Folder
+        levels: [organization, folder]
+
+  # Networking folder: the connectivity stack, plus folder-level
+  # governance for that subtree only. Same `iam` and `org-policy` types
+  # as above, different levels — per-scope lists make that expressible.
+  - name: networking
+    root: folders/111111111111              # <- networking folder
+    levels: [folder, project]
+    types:
+      - type: iam
+        levels: [folder, project]
+      - type: org-policy
+        levels: [folder, project]
+      - type: cloudresourcemanager.googleapis.com/Project
+        levels: [folder]
+      - type: serviceusage.googleapis.com/Service
+        levels: [project]
+      - type: compute.googleapis.com/Network
+        levels: [project]
+      - type: compute.googleapis.com/Subnetwork
+        levels: [project]
+      - type: compute.googleapis.com/Router
+        levels: [project]
+      - type: dns.googleapis.com/ManagedZone
+        levels: [project]
+
+  # Security folder: KMS and service accounts, with leaf IAM opted in
+  # per type. `iam: true` is a property of the type ENTRY, so it is
+  # per-scope too: another scope may collect the same CryptoKey type
+  # without leaf IAM.
+  - name: security
+    root: folders/222222222222              # <- security folder
+    levels: [folder, project]
+    types:
+      - type: iam
+        levels: [folder, project]
+      - type: org-policy
+        levels: [folder, project]
+      - type: cloudresourcemanager.googleapis.com/Project
+        levels: [folder]
+      - type: serviceusage.googleapis.com/Service
+        levels: [project]
+      - type: iam.googleapis.com/ServiceAccount
+        levels: [project]
+        iam: true
+      - type: cloudkms.googleapis.com/KeyRing
+        levels: [project]
+      - type: cloudkms.googleapis.com/CryptoKey
+        levels: [project]
+        iam: true
+
+  # Two workload projects, named explicitly. Project IAM is in scope
+  # here and nowhere else; no org-policy at all — a deliberate, declared
+  # gap, not a silent one.
+  - name: workloads
+    root: organizations/000000000000
+    levels: [project]
+    include:
+      - projects/333333333333               # app-prod  (project NUMBER)
+      - projects/444444444444               # app-dev
+    types:
+      - type: iam
+        levels: [project]
+      - type: serviceusage.googleapis.com/Service
+        levels: [project]
+      - type: iam.googleapis.com/ServiceAccount
+        levels: [project]
+        iam: true
+      - type: storage.googleapis.com/Bucket
+        levels: [project]
+
+# ---------------------------------------------------------------------------
+# `enumerate:` blocks live in the list that declares them: a natively
+# enumerated type is swept only in the scopes whose `types:` names it.
+# Repeat the block in every scope that needs it — see
+# references/cai-blind-spots.md.
+# ---------------------------------------------------------------------------

--- a/skills/fabric-importer/examples/import-manifest.org-foundation.yaml
+++ b/skills/fabric-importer/examples/import-manifest.org-foundation.yaml
@@ -20,177 +20,126 @@
 # policies, org log sinks, the folder hierarchy, and folder IAM.
 #
 # A manifest is the user-owned contract for a fabric-importer run:
-#   - inventory.py collects ONLY what is declared here (the completeness
+#   - inventory.py collects ONLY what the scopes declare (the completeness
 #     denominator becomes "what you asked for", not "everything");
 #   - coverage.py fails the run until every collected asset is mapped to a
 #     Terraform address or waived by a human;
-#   - re-runs are incremental: widen this manifest (or let the org grow)
-#     and only the delta is added to the workspace. Existing addresses are
-#     never rewritten.
+#   - re-runs are incremental: widen a scope's `types:` list (or let the
+#     org grow) and only the delta is added to the workspace. Existing
+#     addresses are never rewritten.
+#
+# The grammar is scopes-only: `scopes:` is a list, and EVERY scope carries
+# its own `types:` list. One estate, different depths per subtree = several
+# scopes, each with its own list — see import-manifest.multi-domain.yaml
+# for the worked multi-scope example and the fail-closed rules.
 # ---------------------------------------------------------------------------
 
-scope:
+scopes:
+
   # Root of the import. organizations/N, folders/N and projects/N are all
   # valid roots; everything below is evaluated inside this subtree.
-  root: organizations/000000000000   # <- replace with your org id
+  - root: organizations/000000000000   # <- replace with your org id
 
-  # Optional: restrict to specific subtrees inside the root. An asset is
-  # in scope only if one of these appears among its ancestors. Omit to
-  # cover the whole root.
-  # include:
-  #   - folders/111111111111
+    # Optional: restrict to specific subtrees inside the root. An asset is
+    # in scope only if one of these appears among its ancestors. Omit to
+    # cover the whole root.
+    # include:
+    #   - folders/111111111111
 
-  # Optional: carve out subtrees. Exclusion wins over inclusion.
-  #
-  # NOTE (live-verified): include/exclude match against the CAI
-  # `ancestors` array, which stores NUMERIC ids. Both spellings work:
-  # `projects/123456789` (the project NUMBER) matches directly, and a
-  # project ID is resolved to its number by inventory.py via
-  # `gcloud projects describe`. Prefer the number where you know it —
-  # resolution needs the describe permission, and a project that cannot
-  # be resolved is reported as an enumeration failure rather than
-  # silently matching nothing.
-  # exclude:
-  #   - projects/123456789012
-  #
-  # -------------------------------------------------------------------
-  # RECIPES: importing only SPECIFIC projects or combining scopes
-  # -------------------------------------------------------------------
-  #
-  # (a) Multi-scope manifest (Org/Folder governance + Selected Projects):
-  #     Use `scopes:` to declare separate roots and level boundaries.
-  #     Alphanumeric project IDs (e.g. 'my-app-prod') are resolved to
-  #     project numbers automatically; see the NOTE above.
-  #
-  #   scopes:
-  #     - name: org-foundation
-  #       root: organizations/000000000000
-  #       levels: [organization, folder]
-  #
-  #     - name: logging-and-apps
-  #       root: organizations/000000000000
-  #       levels: [project]
-  #       include:
-  #         - my-app-prod              # project ID, or projects/<number>
-  #         - my-app-dev
-  #
-  # (b) Projects-only manifest (no organization/folder-level types):
-  #     A plain include or direct project root:
-  #
-  #   scopes:
-  #     - root: projects/my-app-prod
-  #       levels: [project]
-  #
-  # Widening later (adding a project or scope) is safe and incremental:
-  # only the new assets appear in the worklist. Types' `levels` still
-  # apply on top of scope.
+    # Optional: carve out subtrees. Exclusion wins over inclusion.
+    #
+    # NOTE (live-verified): include/exclude match against the CAI
+    # `ancestors` array, which stores NUMERIC ids. Both spellings work:
+    # `projects/123456789` (the project NUMBER) matches directly, and a
+    # project ID is resolved to its number by inventory.py via
+    # `gcloud projects describe`. Prefer the number where you know it —
+    # resolution needs the describe permission, and a project that cannot
+    # be resolved is reported as an enumeration failure rather than
+    # silently matching nothing.
+    # exclude:
+    #   - projects/123456789012
 
-# ---------------------------------------------------------------------
-# Optional: emission style, per resource family. This is YOUR call —
-# the scripts do not consume it; it directs step-3 mapping (see the
-# cookbook's "Factory emission (opt-in)" section, normative).
-#
-#   per-instance (default) : one module instance per container, HCL
-#                            inputs, shallow chosen addresses.
-#   factory                : data-driven YAML via the family's Fabric
-#                            factory carrier (canonical map names it;
-#                            FACTORIES.md is the full catalog).
-#
-# An org foundation is the canonical factory case: folder tree, folder
-# IAM and org policies maintained as hierarchical data/ YAML via
-# project-factory — the imported workspace doubles as the day-2
-# operating model. Mind the tradeoffs (4-level nesting cap, data-path =
-# key so directory moves re-key the subtree, deeper import addresses).
-#
-# emission is valid in TWO positions:
-#   - here (top level): manifest-wide default — the only position in a
-#     singular-`scope:` manifest like this one;
-#   - per scope (scopes[].emission): same map, overrides the top level
-#     for that scope's assets.
-# Resolution per family: scopes[].emission -> top-level emission ->
-# per-instance. Omission defers to the next level; it never means
-# per-instance directly.
-#
-# emission:
-#   folder: factory
-#   project: per-instance
-#   iam: additive       # default — google_*_iam_member per tuple; an
-#                       # apply can never strip unmanaged members. Use
-#                       # `authoritative` to make IAM fully declarative
-#
-# To factory-manage only SOME folders, split the tree into scopes
-# along subtree boundaries (include/exclude) and set emission per
-# scope — see "Subtree-granular emission (scope splitting)" in the
-# cookbook's factory-emission section:
-#
-#   scopes:
-#     - name: teams
-#       root: organizations/000000000000
-#       include: [folders/111111111111]
-#       levels: [folder]
-#       emission: {folder: factory}
-#     - name: rest
-#       root: organizations/000000000000
-#       exclude: [folders/111111111111]
-#       levels: [folder]           # inherits/defaults to per-instance
+    # Optional: emission style, per resource family. YOUR call — the
+    # scripts do not consume it; it directs step-3 mapping (the
+    # cookbook's "Factory emission (opt-in)" section is normative).
+    #   per-instance (default) : one module instance per container.
+    #   factory                : data-driven YAML via the family's
+    #                            Fabric factory carrier.
+    # An org foundation is the canonical factory case: folder tree,
+    # folder IAM and org policies maintained as hierarchical data/ YAML
+    # via project-factory.
+    #
+    # `emission` is per scope and INHERITS: a family key you omit gets
+    # the built-in default (per-instance; additive for iam). `types:`
+    # does NOT: every scope declares its full list, and an omission is
+    # an error, not inheritance. Types decide the denominator; emission
+    # only decides how collected assets are written. Do not reason from
+    # one knob to the other.
+    #
+    # emission:
+    #   folder: factory
+    #   iam: additive     # default — google_*_iam_member per tuple; an
+    #                     # apply can never strip unmanaged members. Use
+    #                     # `authoritative` to make IAM fully declarative
 
-types:
-  # -------------------------------------------------------------------
-  # IAM policies (pseudo-type). CAI models IAM as a content type attached
-  # to resources, not as an asset type, hence the reserved name `iam`.
-  # `levels` controls WHERE bindings are replicated:
-  #   organization -> org IAM bindings + audit configs
-  #                   (including logging_data_access)
-  #   folder       -> folder IAM bindings
-  # Project-level IAM stays unmanaged in this example (add `project` to
-  # take it over). Only container-attached IAM (org/folder/project) is
-  # covered by this pseudo-type; IAM on leaf assets (tag values, buckets,
-  # service accounts, ...) needs explicit per-type manifest entries.
-  # -------------------------------------------------------------------
-  - type: iam
-    levels: [organization, folder]
+    types:
+      # ---------------------------------------------------------------
+      # IAM policies (pseudo-type). CAI models IAM as a content type
+      # attached to resources, not as an asset type, hence the reserved
+      # name `iam`. `levels` controls WHERE bindings are replicated:
+      #   organization -> org IAM bindings + audit configs
+      #                   (including logging_data_access)
+      #   folder       -> folder IAM bindings
+      # Project-level IAM stays unmanaged in this example (add `project`
+      # to take it over). Only container-attached IAM is covered by this
+      # pseudo-type; IAM on leaf assets (tag values, buckets, service
+      # accounts, ...) needs an `iam: true` opt-in on the leaf type's
+      # own entry.
+      # ---------------------------------------------------------------
+      - type: iam
+        levels: [organization, folder]
 
-  # -------------------------------------------------------------------
-  # Org policies (pseudo-type; CAI content type org-policy). One
-  # inventory entry per (resource, constraint) pair, so coverage is
-  # per-constraint. This example covers org-level only; folder-level
-  # policies were discovered-but-unmodelled — declaring only
-  # [organization] here makes that same restriction explicit and honest:
-  # folder policies are then out of scope BY DECLARATION rather than
-  # silently dropped.
-  # -------------------------------------------------------------------
-  - type: org-policy
-    levels: [organization]
+      # ---------------------------------------------------------------
+      # Org policies (pseudo-type; CAI content type org-policy). One
+      # inventory entry per (resource, constraint) pair, so coverage is
+      # per-constraint. This example covers org-level only; declaring
+      # [organization] makes the folder-level restriction explicit and
+      # honest: folder policies are out of scope BY DECLARATION rather
+      # than silently dropped.
+      # ---------------------------------------------------------------
+      - type: org-policy
+        levels: [organization]
 
-  # -------------------------------------------------------------------
-  # Custom IAM roles. Fabric target: modules/organization factory,
-  # data/custom-roles/<role_id>.yaml. Org-level only;
-  # project-level custom roles would need `project` here.
-  # -------------------------------------------------------------------
-  - type: iam.googleapis.com/Role
-    levels: [organization]
+      # ---------------------------------------------------------------
+      # Custom IAM roles. Fabric target: modules/organization factory,
+      # data/custom-roles/<role_id>.yaml. Org-level only; project-level
+      # custom roles would need `project` here.
+      # ---------------------------------------------------------------
+      - type: iam.googleapis.com/Role
+        levels: [organization]
 
-  # -------------------------------------------------------------------
-  # Log sinks. Fabric target: modules/organization logging_sinks locals
-  # (with iam=false; _Default/_Required are quarantined). Folder and
-  # project sinks stay unmanaged here.
-  # -------------------------------------------------------------------
-  - type: logging.googleapis.com/LogSink
-    levels: [organization]
+      # ---------------------------------------------------------------
+      # Log sinks. Fabric target: modules/organization logging_sinks
+      # locals (with iam=false; _Default/_Required are quarantined).
+      # Folder and project sinks stay unmanaged here.
+      # ---------------------------------------------------------------
+      - type: logging.googleapis.com/LogSink
+        levels: [organization]
 
-  # -------------------------------------------------------------------
-  # Folder hierarchy. Fabric target: one modules/folder instance per
-  # folder (stable instance keys; parent chaining by module reference).
-  # `levels` refers to the CONTAINER of the asset: a folder whose parent
-  # is the org sits at level `organization`, a nested folder at `folder`.
-  # -------------------------------------------------------------------
-  - type: cloudresourcemanager.googleapis.com/Folder
-    levels: [organization, folder]
+      # ---------------------------------------------------------------
+      # Folder hierarchy. Fabric target: one modules/folder instance per
+      # folder (stable instance keys; parent chaining by module
+      # reference). `levels` refers to the CONTAINER of the asset: a
+      # folder whose parent is the org sits at level `organization`, a
+      # nested folder at `folder`.
+      # ---------------------------------------------------------------
+      - type: cloudresourcemanager.googleapis.com/Folder
+        levels: [organization, folder]
 
 # ---------------------------------------------------------------------------
 # What this manifest deliberately does NOT cover (would have been silent
-# gaps in v1; here they are visible declarations — add entries to take
-# them over):
+# gaps in v1; here they are visible declarations — add entries to the
+# scope's `types:` list to take them over):
 #
 #   - type: cloudresourcemanager.googleapis.com/Project
 #     levels: [organization, folder]
@@ -213,30 +162,20 @@ types:
 # ---------------------------------------------------------------------------
 # TYPES CLOUD ASSET INVENTORY DOES NOT MODEL
 #
-# CAI is the default source of the denominator, not its boundary. A type
-# CAI cannot see would be invisible to BOTH gates at once, so it is
-# enumerated by other means and merged into the same inventory --
-# `gcloud` first. Declare it with an `enumerate:` block: the command runs
-# once per in-scope container at the declared levels, with the container
-# flag (--organization/--folder/--project) and --format=json appended.
+# A type CAI cannot see would be invisible to BOTH gates at once, so it
+# is enumerated by other means and merged into the same inventory —
+# `gcloud` first. Declare it with an `enumerate:` block in the `types:`
+# list of every scope that needs it (per-scope lists never inherit):
 #
 #   - type: iam.googleapis.com/DenyPolicy      # not in the CAI catalogue
 #     levels: [organization, folder]
 #     enumerate:
 #       command: [iam, policies, list, --kind=denypolicies]
-#       # Optional: only when the command does not take
-#       # --organization/--folder/--project=<id>.
 #       container_arg: '--attachment-point=cloudresourcemanager.googleapis.com/{container}'
 #       key: '//iam.googleapis.com/{container}/denypolicies/{item.name}'
 #
-# Refused by design: anything that is not a read-only verb, and
-# --format/--filter/--limit/--page-size/--flatten/--sort-by/--uri --
-# narrowing belongs in `scope` above, where it is reviewed, not in a flag
-# that shrinks the denominator invisibly. A key template that renders the
-# same key twice is fatal for the same reason.
-#
-# See references/cai-blind-spots.md for the full ladder (CAI -> gcloud ->
-# REST API -> signed waiver): not every gap has a gcloud command. Log
-# exclusions, for instance, are neither a CAI type nor a gcloud group,
-# and have to be enumerated against the REST API and reported by hand.
+# Guard rails (read-only verbs only, no --filter/--limit, unique key
+# templates), the built-in enumerator table, and the full ladder (CAI ->
+# gcloud -> REST API -> signed waiver) are in
+# references/cai-blind-spots.md.
 # ---------------------------------------------------------------------------

--- a/skills/fabric-importer/references/cai-blind-spots.md
+++ b/skills/fabric-importer/references/cai-blind-spots.md
@@ -92,7 +92,9 @@ The silent-gap condition needs a family whose declared type yields
 and at least one GLOBAL address, in the same in-scope project. With only
 global addresses present the declared type yields zero, the pre-existing
 zero-yield warning fires, and the tool is loud — a real bug, but not
-THIS bug. A test estate built only from a freshly created global address
+THIS bug. (With several scopes, remember the aggregate warning can stay
+quiet while one scope's own declaration yielded nothing — the per-scope
+`_meta.scopes[].zero_yield_types` record is the loud one there.) A test estate built only from a freshly created global address
 therefore validates that siblings are swept, and validates nothing about
 the silence.
 
@@ -227,28 +229,40 @@ container at the type's `levels`, and its JSON becomes inventory
 entries:
 
 ```yaml
-types:
-  # IAM deny policies: managed by modules/organization, modules/folder
-  # and modules/project, and absent from the CAI catalogue entirely.
-  - type: iam.googleapis.com/DenyPolicy
-    levels: [organization, folder]
-    enumerate:
-      # `gcloud` is implicit and is the only executable a manifest can
-      # name. The tool appends --format=json and one container argument.
-      command: [iam, policies, list, --kind=denypolicies]
-      # Optional: the shape of that container argument, when the command
-      # does not take --organization/--folder/--project=<id>. Fields:
-      # {container} (e.g. organizations/1) and {container_id} (1).
-      container_arg: '--attachment-point=cloudresourcemanager.googleapis.com/{container}'
-      # Key template. Fields: {container}, {container_id} and
-      # {item.<dotted.path>} into each returned JSON object. Where the
-      # type has a CAI name format, mirror it, so entries from the two
-      # sources dedupe instead of double-counting.
-      key: '//iam.googleapis.com/{container}/denypolicies/{item.name}'
+    types:   # a scope's own list — the only position types are declared in
+      # IAM deny policies: managed by modules/organization,
+      # modules/folder and modules/project, and absent from the CAI
+      # catalogue entirely.
+      - type: iam.googleapis.com/DenyPolicy
+        levels: [organization, folder]
+        enumerate:
+          # `gcloud` is implicit and is the only executable a manifest
+          # can name. The tool appends --format=json and one container
+          # argument.
+          command: [iam, policies, list, --kind=denypolicies]
+          # Optional: the shape of that container argument, when the
+          # command does not take --organization/--folder/--project=<id>.
+          # Fields: {container} (e.g. organizations/1) and
+          # {container_id} (1).
+          container_arg: '--attachment-point=cloudresourcemanager.googleapis.com/{container}'
+          # Key template. Fields: {container}, {container_id} and
+          # {item.<dotted.path>} into each returned JSON object. Where
+          # the type has a CAI name format, mirror it, so entries from
+          # the two sources dedupe instead of double-counting.
+          key: '//iam.googleapis.com/{container}/denypolicies/{item.name}'
 ```
 
+Declared in one scope's list, the command runs only for that scope's
+containers; another scope may declare the same type with a different
+`enumerate:` block. What it may not do is inherit: per-scope lists
+never inherit anything, so the block is repeated in every scope that
+needs it.
+
 **The mechanism is per hierarchy container**, because that is the shape
-of the manifest's `levels`. A command that enumerates inside another
+of `levels` — the type entry's `levels` intersected with its scope's.
+An empty intersection is refused when the manifest is parsed (a
+per-scope declaration that can never fire is a mistake, not a
+leftover), unless the entry lists `unknown`. A command that enumerates inside another
 resource — `gcloud storage managed-folders list gs://BUCKET` — cannot be
 expressed as an `enumerate:` block: there is no container flag to fill
 in. Those types are enumerated out of band and named in the run report
@@ -312,8 +326,8 @@ agent may draft one; a human signs it, exactly as with waivers.
 
 ## Rules
 
-1. When the manifest declares a type, confirm it appears in the CAI
-   supported-types list. If it does not, it gets a native enumerator, an
+1. When a scope's `types:` list declares a type, confirm it appears in
+   the CAI supported-types list. If it does not, it gets a native enumerator, an
    out-of-band enumeration recorded in the report, or a signed waiver —
    one of the three, always. Never a quiet removal from the manifest.
 2. Any count mismatch between CAI and a service API is a **failure to
@@ -330,6 +344,11 @@ agent may draft one; a human signs it, exactly as with waivers.
    `inventory.json` carries this for declared enumerators;
    `_meta.split_type_sweeps` carries entries that came from CAI under a
    different type than the one declared; out-of-band enumeration is on
-   you to quote.
-5. New blind spots discovered during an engagement get added here (this
+   you to quote. Per-scope yields live in
+   `_meta.scopes[].declared_types` / `zero_yield_types` — the aggregate
+   table can hide a scope whose own declaration yielded nothing.
+5. A scope's `types:` list narrows the denominator, so it belongs to
+   the Scope Approval gate like any other narrowing. A convergence
+   claim is bounded per scope, not per manifest — report it that way.
+6. New blind spots discovered during an engagement get added here (this
    file is reference documentation, not a frozen tool).

--- a/skills/fabric-importer/references/inferring-manifests-from-state.md
+++ b/skills/fabric-importer/references/inferring-manifests-from-state.md
@@ -154,6 +154,11 @@ scopes:
   - name: org-foundation
     root: organizations/123456789012
     levels: [organization, folder]
+    types:
+      - type: iam
+        levels: [organization, folder, project]
+      - type: cloudresourcemanager.googleapis.com/Folder
+        levels: [organization, folder]
 
   - name: stage-projects
     root: organizations/123456789012
@@ -161,6 +166,14 @@ scopes:
     include:
       - projects/111111111111   # prj-prod-audit-logs-0
       - projects/222222222222   # prj-prod-iac-core-0
+    types:
+      - type: iam
+        levels: [organization, folder, project]
+      - type: iam.googleapis.com/ServiceAccount
+        levels: [project]
+        iam: true
 ```
 
 This prevents project-level queries from accidentally scanning every unrelated project in the organization while still managing org-level policies and folders.
+
+Every scope carries its own `types:` list; the generator filters the inferred types per scope (a type whose `levels` cannot fire at a scope's levels is left out, because `inventory.py` refuses dead per-scope declarations) but keeps each entry's full inferred `levels` — the intersection with the scope's `levels` happens at collect time, so the entry reads the same in every scope that carries it. Narrowing a generated list further — dropping a type or a level from one scope but not another — is a normal human refinement of the draft. Regenerating the manifest discards such refinements, so refine after generation, not before.

--- a/skills/fabric-importer/references/manifest-migration.md
+++ b/skills/fabric-importer/references/manifest-migration.md
@@ -1,0 +1,178 @@
+# Manifest migration — from the retired grammar to scopes-only
+
+The import-manifest grammar changed once, and this file is the record of
+it. If `inventory.py` refused your manifest with *"manifest declares
+retired top-level key(s)"*, you are holding a manifest written for the
+old grammar; this page is the complete migration path.
+
+## What changed, and why
+
+**Old grammar (retired).** A manifest declared WHERE to look and WHAT to
+collect in two separate places: a singular `scope:` (or a `scopes:`
+list) for the subtrees, and one manifest-global `types:` list shared by
+every scope. The only per-scope discrimination was the `levels` axis
+(organization / folder / project / unknown): a type declared anywhere
+was swept in every scope whose levels intersected its own.
+
+**New grammar (current).** `scopes:` is the only form, and **every scope
+carries its own `types:` list**. There is no top-level `types:` and no
+singular `scope:`. What a scope collects is exactly what is written on
+it.
+
+The motivation is per-scope type declarations — different resource
+types under different subtrees (org governance at org/folder level, the
+connectivity stack under the networking folder, project IAM only in
+named workload projects), which the global list could not express
+without waiving every out-of-domain asset by hand. Making the new form
+the ONLY form, rather than an option next to the old one, makes three
+whole classes of silent-denominator failure unrepresentable instead of
+merely validated: there is no inheritance to half-apply, no global list
+to go stale behind the scopes, and no mixed manifest whose meaning
+depends on which scope the reviewer happened to read.
+
+The tool refuses the old grammar rather than silently accepting half of
+it, because a half-read manifest would change what the denominator
+means — the exact failure the gates exist to prevent.
+
+## Migration: singular `scope:`
+
+Wrap the scope as a one-element `scopes:` list and move the `types:`
+list inside it (indent by four spaces). Nothing else changes — same
+types, same levels, same include/exclude, same collected denominator.
+
+```yaml
+# OLD (refused)                     # NEW
+scope:                              scopes:
+  root: organizations/123            - root: organizations/123
+  include:                             include:
+    - folders/456                        - folders/456
+types:                                 types:
+  - type: org-policy                     - type: org-policy
+    levels: [organization]                 levels: [organization]
+  - type: iam                            - type: iam
+    levels: [organization, folder]         levels: [organization, folder]
+```
+
+## Migration: `scopes:` list with a shared top-level `types:`
+
+Copy the top-level list into EVERY scope, then (optionally, later)
+narrow each copy. The unnarrowed copy is semantically identical to the
+old manifest: the collect-time intersection of a type's `levels` with
+each scope's `levels` is unchanged, so the same assets enter the
+denominator.
+
+```yaml
+# OLD (refused)
+scopes:
+  - name: org-foundation
+    root: organizations/123
+    levels: [organization, folder]
+  - name: stage-projects
+    root: organizations/123
+    levels: [project]
+    include: [projects/111111111111]
+types:
+  - type: iam
+    levels: [organization, folder, project]
+  - type: cloudresourcemanager.googleapis.com/Folder
+    levels: [organization, folder]
+
+# NEW — verbatim copy first, narrow later
+scopes:
+  - name: org-foundation
+    root: organizations/123
+    levels: [organization, folder]
+    types:
+      - type: iam
+        levels: [organization, folder, project]
+      - type: cloudresourcemanager.googleapis.com/Folder
+        levels: [organization, folder]
+  - name: stage-projects
+    root: organizations/123
+    levels: [project]
+    include: [projects/111111111111]
+    types:
+      - type: iam
+        levels: [organization, folder, project]
+```
+
+Note the second scope: `cloudresourcemanager.googleapis.com/Folder`
+was NOT copied into it. A per-scope entry whose `levels` cannot
+intersect its scope's `levels` is refused as a dead declaration
+(`[organization, folder] ∩ [project] = ∅`), so a verbatim copy is only
+valid where the type could actually fire. Under the old grammar that
+entry was silently inactive for the scope; now it is an error — drop
+it from the scopes it cannot fire in. Entries whose `levels` include
+`unknown` are exempt and may be copied everywhere.
+
+If YAML repetition bothers you, anchors keep shared lists in one
+place:
+
+```yaml
+scopes:
+  - name: teams
+    root: organizations/123
+    include: [folders/111]
+    types: &folder-types
+      - type: cloudresourcemanager.googleapis.com/Folder
+        levels: [organization, folder]
+  - name: rest
+    root: organizations/123
+    exclude: [folders/111]
+    types: *folder-types
+```
+
+## Key mappings, old → new
+
+| Old | New |
+|---|---|
+| `scope:` (singular) | `scopes:` with one entry |
+| top-level `types:` | each scope's own `types:` (copy, then narrow) |
+| top-level `emission:` (manifest-wide default) | `scopes[].emission` on each scope that wants a non-default style; an omitted family falls back to the built-in default (`per-instance`; `additive` for `iam`), not to another scope |
+| `enumerate:` block, declared once | declared in the `types:` list of every scope that needs the sweep — per-scope lists never inherit, so the block is repeated per scope (a different scope may even carry a different block for the same type) |
+| `iam: true` leaf opt-in, declared once | per scope, like everything else on a type entry: a scope that omits it collects the resource without its leaf IAM |
+| type silently inactive in a scope (empty levels intersection) | refused as a dead declaration (drop the entry from that scope; `unknown` entries exempt) |
+
+## What did NOT change
+
+- The type entry schema: `type`, `levels`, `iam`, `enumerate` are
+  unchanged, including all `enumerate:` guard rails.
+- Scope fields: `name`, `root`, `include`, `exclude`, `levels` are
+  unchanged, including numeric-id resolution for include/exclude.
+- Collect-time semantics for a faithful copy: same sweeps, same
+  intersection rule, same deduplicated denominator. A migrated
+  manifest that copies the old list into every (compatible) scope
+  yields the same `assets` — diffing old and new `inventory.json`
+  asset keys is the cheap proof.
+- Gates and waivers: `coverage.py` and `verify_plan.py` are untouched;
+  existing workspaces, coverage maps and waiver ledgers keep working.
+
+## New output you should start reading
+
+- `_meta.scopes[].declared_types` / `zero_yield_types` — per-scope
+  yield tables. The aggregate `_meta.declared_types` cannot show a type
+  that yields zero in one scope while non-zero in another; the
+  per-scope record (and its stderr warning) can. Quote the per-scope
+  tables in the step-5 report.
+- Every inventory entry carries `scopes: [...]` — the scope(s) that
+  collected it, merged and sorted when scopes overlap.
+
+## Migration checklist
+
+1. Rewrite the manifest as above (or regenerate:
+   `manifest_from_state.py` and `manifest_init.py` emit the new
+   grammar directly).
+2. Run `inventory.py collect` — validation is fail-closed and runs
+   before any API call, so a wrong migration is a refused manifest
+   with the reason, never a shrunken denominator.
+3. Diff the new `inventory.json` asset keys against the last
+   pre-migration one. Identical keys = faithful migration. Missing
+   keys = you narrowed while migrating; deliberate narrowing belongs
+   in its own reviewed manifest change, not folded into the migration.
+4. The manifest is human-owned: the migrated file goes through the
+   same Scope Approval gate as any other manifest edit.
+
+Worked references: `examples/import-manifest.org-foundation.yaml`
+(single scope) and `examples/import-manifest.multi-domain.yaml` (four
+scopes, per-scope types). The fail-closed rules live in SKILL.md
+step 0 and the cookbook's "Per-scope type declaration" subsection.

--- a/skills/fabric-importer/references/mapping-cookbook.md
+++ b/skills/fabric-importer/references/mapping-cookbook.md
@@ -93,42 +93,39 @@ map of family → style, where family names are the canonical-map rows
 and styles are family-specific: `per-instance` (default) or `factory`
 for module-instance families (those without a factory carrier reject
 `factory`), and `additive` (default) or `authoritative` for the `iam`
-pseudo-family (see "Organization and containers: IAM"). It is valid in **two positions**:
+pseudo-family (see "Organization and containers: IAM"). It lives on
+the scope entry, like everything else in the manifest: the grammar is
+scopes-only, and there is no top-level position.
 
-1. **Top level** — the manifest-wide default. This is the only
-   position available in singular-`scope:` manifests (no scope
-   entries, nothing to override).
-2. **Per scope** (`scopes[].emission`) — same map, same enum,
-   overriding the top level for assets collected by that scope.
-
-Resolution, per family, most specific wins:
+Resolution, per family:
 
 ```text
-scopes[].emission.<family>  →  emission.<family>  →  per-instance
+scopes[].emission.<family>  →  built-in default (per-instance / additive)
 ```
 
-Omission at either level means "defer", never "per-instance": a scope
-without an `emission:` block (or without a given family key) inherits
-the top level, and only when both are silent does the built-in
-per-instance default apply.
+Omission means the built-in default — for `emission` only. **Do not
+generalise this to `types:`.** Both keys sit on a scope entry, and
+there the resemblance stops: `emission` is denominator-neutral (it
+decides how collected assets are written, and a missing family key
+falls back safely), while `types:` decides what is collected at all —
+every scope must declare its full list, and an omission is a refused
+manifest, not a default. A wrong emission choice still faces both
+gates; a wrong type list shrinks the denominator the gates are
+measured against.
 
 ```yaml
-emission:                    # top level: manifest-wide defaults
-  folder: factory            # -> project-factory hierarchy data/
-  project: per-instance
-  iam: additive              # default; authoritative is the opt-in
-
 scopes:
   - name: org-foundation
     levels: [organization, folder]
-    # no emission: -> inherits folder: factory from the top level
+    # types: … (each scope carries its own list — elided here)
+    emission:
+      folder: factory        # -> project-factory hierarchy data/
 
   - name: sandbox
     levels: [folder, project]
     include: [folders/333333333333]
-    emission:
-      folder: per-instance   # override for this scope only;
-                             # project still inherits the top level
+    # types: …
+    # no emission: -> built-in defaults (per-instance; iam additive)
 ```
 
 ### Subtree-granular emission (scope splitting)
@@ -137,7 +134,10 @@ Emission granularity follows scope granularity: to manage *some*
 folders via factory and others per-instance, split the tree into
 scopes along subtree boundaries and give each its own `emission:` —
 scope `include`/`exclude` already speak subtrees (CAI `ancestors`
-matching), so no new selector machinery is needed:
+matching), so no new selector machinery is needed. Remember the
+coupling: every scope carries its own `types:` list, so a scope added
+for emission reasons declares its list like any other (usually a copy
+of the list it split from):
 
 ```yaml
 scopes:
@@ -145,6 +145,9 @@ scopes:
     root: organizations/000000000000
     include: [folders/111111111111]
     levels: [folder]
+    types: &folder-types
+      - type: cloudresourcemanager.googleapis.com/Folder
+        levels: [organization, folder]
     emission:
       folder: factory
 
@@ -152,6 +155,7 @@ scopes:
     root: organizations/000000000000
     exclude: [folders/111111111111]
     levels: [folder]
+    types: *folder-types      # same list; YAML anchors avoid drift
 ```
 
 Rules that make the split sound (from `project-factory` source,
@@ -298,11 +302,46 @@ join artifacts, and determinism and auditability win.
   destinations, IAM bindings without their SA principals — as long as
   convergence does not depend on the referenced side and the report
   names it. The manifest decides scope.
-- Manifest `scope.include` / `scope.exclude` match the CAI `ancestors`
-  array, which stores numeric ids (`projects/123456789` — the project
-  NUMBER, never the project id string). See the recipes in
-  `examples/import-manifest.org-foundation.yaml` for selecting specific
-  projects, including the include-vs-exclude trap.
+- Scopes narrow on two axes: subtrees (`include`/`exclude`) and what
+  is collected inside them (`levels`, and each scope's own `types:`
+  list). Both are Scope-Approval-gate surface: they move the
+  denominator.
+- Manifest `include` / `exclude` match the CAI `ancestors` array,
+  which stores numeric ids. Both spellings work: `projects/123456789`
+  (the project NUMBER) matches directly, and a project ID is resolved
+  to its number by `inventory.py` via `gcloud projects describe` —
+  prefer the number where known, since resolution needs the describe
+  permission. See `examples/import-manifest.org-foundation.yaml` for
+  the include-vs-exclude trap and
+  `examples/import-manifest.multi-domain.yaml` for selecting specific
+  projects per scope.
+
+#### Per-scope type declaration (`scopes[].types`)
+
+Every scope carries its own `types:` list — there is no other place
+to declare types, so what a scope collects is exactly what is written
+on it. The same type may appear in several scopes with different
+`levels`, `iam` or `enumerate`; an `enumerate:` block is swept only
+in the scopes whose list names it.
+
+Fail-closed rules (all refuse the manifest before any API call):
+
+- a scope without a `types:` list, or with `types: []`, is refused —
+  an empty list is a scope that collects nothing, and that is the one
+  thing no scope may say quietly;
+- a type whose `levels` cannot intersect its scope's `levels` is
+  refused as a dead declaration (an entry listing `unknown` is
+  exempt): it reads as coverage and produces none;
+- a duplicate `type:` inside one scope's list is refused.
+
+Provenance in `inventory.json`: each `_meta.scopes[]` entry records
+its own `declared_types` yield counts and `zero_yield_types`;
+`_meta.declared_types` is the aggregate; every inventory entry names
+the scope(s) that collected it (`scopes: [...]`, merged and sorted
+when scopes overlap). **Read the per-scope counts, not only the
+aggregate** — a type that yields zero in one scope and non-zero in
+another never appears in the aggregate zero-yield warning. Same
+discipline as `_meta.split_parity`: read the record, not the key.
 
 ### Serialization traps
 

--- a/skills/fabric-importer/references/operating-contract.md
+++ b/skills/fabric-importer/references/operating-contract.md
@@ -45,15 +45,22 @@ verdict is never evidence of convergence.
 
 **Which decisions need a human.** The pattern behind this table is that
 every human-owned artifact either narrows what the gates check or is
-irreversible. Scope narrows the denominator; a waiver removes an entry
-from it; a benign rule removes an entry from the residual set; an apply
+irreversible. Scope narrows the denominator — on two axes, since each
+scope carries its own `types:` list, and the tool refuses the shapes
+where that narrowing would be invisible (a scope without a list, an
+empty list, a declaration whose levels cannot match its scope), because
+each of those would shrink the denominator while still exiting 0. A
+waiver removes an entry from the denominator; a benign rule removes an
+entry from the residual set; an apply
 cannot be undone. Everything else — module choice, file layout, instance
 keys, raw-vs-module calls — is falsifiable by the plan and can be
 model-owned. Use that test when something new appears: *does this shrink
 what is checked, or is it irreversible?* If yes, a human decides.
 
 The manifest is human-owned for that reason, and it is why a manifest is
-the only place an operator may declare a native (non-CAI) enumerator.
+the only place an operator may declare a native (non-CAI) enumerator —
+in the `types:` list of each scope that needs it, swept only in that
+scope, since per-scope lists never inherit.
 Cloud Asset Inventory does not model every GCP resource, and a type it
 cannot see is invisible to both gates at once, so such types are
 enumerated with a read-only `gcloud` command and merged into the same
@@ -103,16 +110,17 @@ it was meant to support.
 
 ## 3. Convergence definition
 
-A run is converged when, for the manifest-declared scope:
+A run is converged when, for every manifest-declared scope:
 
 1. `coverage.py` exits 0 — every in-scope inventory key is mapped to
    emitted import blocks or human-waived; and
 2. `verify_plan.py` exits 0 — every planned change is a clean import,
    no-op, or matches a reviewed benign-drift rule.
 
-Both are required. The manifest bounds the claim: convergence says
-nothing about undeclared types/levels, and the run report must say so
-plainly.
+Both are required. The manifest bounds the claim, scope by scope:
+convergence says nothing about types or levels a scope did not declare,
+and each scope declares its own list — so the run report must state the
+bound per scope, not as a single sentence about "the manifest".
 
 ## 4. Incremental discipline
 

--- a/skills/fabric-importer/scripts/inventory.py
+++ b/skills/fabric-importer/scripts/inventory.py
@@ -1259,9 +1259,10 @@ def _verify_split_parity(assets, declared_types, sibling_map, scope,
   })
 
 
-def validate_manifest_types(types):
+def validate_manifest_types(types, where='manifest'):
   """Fails closed on manifest mistakes that silently shrink the
-  denominator.
+  denominator. Called once per scope: each scope carries its own
+  `types:` list, and `where` names the scope in every message.
 
   - An unrecognised `levels` value (e.g. `org` for `organization`) used
     to drop every entry of that type with no output at all — the exact
@@ -1274,16 +1275,16 @@ def validate_manifest_types(types):
   for t in types:
     tt = t.get('type')
     if not tt:
-      raise SystemExit('manifest type entry without a `type:` field')
+      raise SystemExit(f'{where} type entry without a `type:` field')
     if tt in seen:
       raise SystemExit(
-          f'manifest declares type {tt!r} more than once; duplicate '
+          f'{where} declares type {tt!r} more than once; duplicate '
           'entries silently narrow the denominator (last one wins) — '
           'merge them into a single entry')
     seen.add(tt)
     if tt == PAM_GRANT_TYPE:
       raise SystemExit(
-          f'manifest type {tt!r} is machine-managed runtime state: active '
+          f'{where} type {tt!r} is machine-managed runtime state: active '
           'PAM grants are enumerated automatically whenever IAM is '
           'collected, and their temporary bindings are stripped from the '
           'denominator (never mapped, never waived — see '
@@ -1291,28 +1292,44 @@ def validate_manifest_types(types):
     if t.get('enumerate') is not None:
       if tt in PSEUDO_TYPES:
         raise SystemExit(
-            f'manifest type {tt!r} is a pseudo-type enumerated by this tool; '
+            f'{where} type {tt!r} is a pseudo-type enumerated by this tool; '
             '`enumerate` is for types CAI does not model')
       validate_native_spec(tt, t['enumerate'])
     bad = set(t.get('levels') or []) - VALID_LEVELS
     if bad:
       raise SystemExit(
-          f'manifest type {tt!r} declares invalid level(s) '
+          f'{where} type {tt!r} declares invalid level(s) '
           f'{sorted(bad)}; valid levels: {sorted(VALID_LEVELS)}. An '
           'unrecognised level would silently drop every entry of this '
           'type from the denominator')
 
 
 def parse_and_validate_scopes(manifest, registry=None):
-  """Parses single or multiple scopes from manifest and validates them."""
-  if 'scopes' in manifest:
-    scopes = manifest['scopes']
-    if not isinstance(scopes, list) or not scopes:
-      raise SystemExit("manifest 'scopes' must be a non-empty list")
-  elif 'scope' in manifest:
-    scopes = [manifest['scope']]
-  else:
-    raise SystemExit("manifest must declare either 'scope' or 'scopes'")
+  """Parses and validates the manifest's `scopes` list.
+
+  The grammar is scopes-only: `scopes:` is required and every scope
+  carries its own `types:` list. The retired top-level `scope:` /
+  `types:` grammar is refused with migration instructions rather than
+  a bare unknown-key error — silently accepting half of it would
+  change what the denominator means.
+  """
+  legacy = [k for k in ('scope', 'types') if k in manifest]
+  if legacy:
+    raise SystemExit(
+        f'manifest declares retired top-level key(s) {legacy}. The '
+        'grammar is scopes-only and every scope carries its own '
+        "'types:' list:\n"
+        '  scopes:\n'
+        '    - root: organizations/<id>\n'
+        '      levels: [organization, folder]\n'
+        '      types:\n'
+        '        - type: iam\n'
+        '          levels: [organization, folder]\n'
+        "Move the old top-level 'types:' entries into every scope that "
+        'should collect them.')
+  scopes = manifest.get('scopes')
+  if not isinstance(scopes, list) or not scopes:
+    raise SystemExit("manifest must declare a non-empty 'scopes' list")
 
   validated_scopes = []
   for i, s in enumerate(scopes):
@@ -1371,12 +1388,39 @@ def parse_and_validate_scopes(manifest, registry=None):
           f"scope #{i + 1} declares invalid level(s) {sorted(bad_levels)}; "
           f"valid levels: {sorted(VALID_LEVELS)}")
 
+    name = s.get('name', f'scope-{i + 1}')
+    label = f'#{i + 1} ({name!r})'
+    if 'types' not in s:
+      raise SystemExit(
+          f"scope {label} declares no 'types' list. Every scope carries "
+          'its own list — a scope without one would collect nothing '
+          'while reading as in scope')
+    scope_types = s['types']
+    if not isinstance(scope_types, list) or not scope_types:
+      raise SystemExit(
+          f"scope {label} has an empty or non-list 'types'. An empty "
+          'list is a scope that collects nothing, and that is the one '
+          'thing no scope may say quietly — delete the scope or declare '
+          'what it collects')
+    validate_manifest_types(scope_types, where=f'scope {label}')
+    for t in scope_types:
+      t_levels = set(t.get('levels') or ('organization', 'folder', 'project'))
+      if 'unknown' in t_levels or t_levels & scope_levels:
+        continue
+      raise SystemExit(
+          f'scope {label} declares type {t["type"]!r} at levels '
+          f'{sorted(t_levels)} but its own levels are '
+          f'{sorted(scope_levels)}: the declaration can never match an '
+          'asset. A per-scope entry that cannot fire reads as coverage '
+          'and produces none — fix the levels or remove the entry')
+
     validated_scopes.append({
-        'name': s.get('name', f'scope-{i + 1}'),
+        'name': name,
         'root': root,
         'include': s.get('include') or [],
         'exclude': s.get('exclude') or [],
         'levels': scope_levels,
+        'types': scope_types,
     })
   return validated_scopes
 
@@ -1422,41 +1466,23 @@ def collect(manifest, include_deleted=False, include_auto_generated=None,
       include_pam_grants=include_pam_grants)
   registry = ProjectRegistry()
   scopes = parse_and_validate_scopes(manifest, registry)
-  types = manifest.get('types') or []
-  validate_manifest_types(types)
 
-  manifest_levels_by_type = {
-      t['type']: set(t.get('levels') or ['organization', 'folder', 'project'])
-      for t in types
-  }
-  iam_types = {
+  # Every scope carries its own `types:` list, so every type-derived
+  # structure (levels, leaf-IAM opt-ins, native enumerators) is resolved
+  # per scope inside the loop below. Built-in native-enumerator notices
+  # are printed once here, for the union across scopes.
+  builtin_native = sorted({
       t['type']
-      for t in types
-      if t.get('iam') and t.get('type') not in PSEUDO_TYPES
-  }
-  # Types the manifest enumerates natively are never sent to CAI: that is
-  # the whole point of declaring one.
-  # Built-in enumerators apply automatically; a manifest block overrides
-  # one for the same type.
-  declared = {t['type'] for t in types}
-  native_specs = {
-      t: dict(spec)
-      for t, spec in NATIVE_ENUMERATORS.items()
-      if t in declared and t not in PSEUDO_TYPES
-  }
-  native_sources = {t: 'builtin' for t in native_specs}
-  for t in types:
-    if t.get('enumerate'):
-      native_specs[t['type']] = t['enumerate']
-      native_sources[t['type']] = 'manifest'
-  if native_specs:
-    for t in sorted(native_specs):
-      if native_sources[t] == 'builtin':
-        print(
-            f'NOTICE: {t} is not modelled by Cloud Asset Inventory; using '
-            'the built-in gcloud\nenumerator. It stays in the denominator '
-            'and must be mapped or waived like any other asset.',
-            file=sys.stderr)
+      for s in scopes
+      for t in s['types']
+      if t['type'] in NATIVE_ENUMERATORS and t['type'] not in PSEUDO_TYPES and
+      not t.get('enumerate')
+  })
+  for t in builtin_native:
+    print(
+        f'NOTICE: {t} is not modelled by Cloud Asset Inventory; using '
+        'the built-in gcloud\nenumerator. It stays in the denominator '
+        'and must be mapped or waived like any other asset.', file=sys.stderr)
 
   all_entries = []
   scope_summaries = []
@@ -1468,6 +1494,35 @@ def collect(manifest, include_deleted=False, include_auto_generated=None,
     scope_levels = s['levels']
     include = s['include']
     exclude = s['exclude']
+    types = s['types']
+
+    # This scope's type-derived structures. A scope's list REPLACES any
+    # other scope's — there is no manifest-global list to fall back to.
+    manifest_levels_by_type = {
+        t['type']: set(
+            t.get('levels') or
+            ['organization', 'folder', 'project']) for t in types
+    }
+    iam_types = {
+        t['type']
+        for t in types
+        if t.get('iam') and t.get('type') not in PSEUDO_TYPES
+    }
+    # Types this scope enumerates natively are never sent to CAI: that
+    # is the whole point of declaring one. Built-in enumerators apply
+    # automatically; a manifest block overrides one for the same type,
+    # in the scope that declares it.
+    declared = {t['type'] for t in types}
+    native_specs = {
+        t: dict(spec)
+        for t, spec in NATIVE_ENUMERATORS.items()
+        if t in declared and t not in PSEUDO_TYPES
+    }
+    native_sources = {t: 'builtin' for t in native_specs}
+    for t in types:
+      if t.get('enumerate'):
+        native_specs[t['type']] = t['enumerate']
+        native_sources[t['type']] = 'manifest'
 
     scope_flag = {
         'organizations': '--organization',
@@ -1709,16 +1764,44 @@ def collect(manifest, include_deleted=False, include_auto_generated=None,
     # Filter this scope's entries by its effective levels
     scope_entries = apply_level_filter(scope_entries, effective_levels_by_type,
                                        report=False)
+    # Stamp provenance: which scope collected the entry. Overlapping
+    # scopes are merged at dedupe time into a sorted list, so the field
+    # is honest about multiple collectors instead of last-wins.
+    for e in scope_entries:
+      e['scopes'] = [s['name']]
+    # Per-scope yield table. The aggregate table alone cannot show a
+    # type that yields zero in one scope and non-zero in another — the
+    # exact shape of a type declared in the wrong scope.
+    uniq = {e['key']: e['asset_type'] for e in scope_entries}
+    declared_list = [t['type'] for t in types]
+    per_type = {d: 0 for d in declared_list}
+    for at in uniq.values():
+      if at in per_type:
+        per_type[at] += 1
     scope_summaries.append({
         'name': s['name'],
         'root': root,
         'levels': sorted(scope_levels),
-        'yield_count': len({e['key'] for e in scope_entries}),
+        'yield_count': len(uniq),
+        'declared_types': per_type,
+        'zero_yield_types': [d for d in declared_list if per_type[d] == 0],
     })
     all_entries += scope_entries
 
-  # Dedupe merged streams across all scopes
-  entries = list({e['key']: e for e in all_entries}.values())
+  # Dedupe merged streams across all scopes, merging scope attribution:
+  # an asset that two scopes both collect names both, deterministically.
+  merged = {}
+  for e in all_entries:
+    prev = merged.get(e['key'])
+    if prev is None:
+      merged[e['key']] = e
+    else:
+      for n in e.get('scopes', []):
+        if n not in prev.setdefault('scopes', []):
+          prev['scopes'].append(n)
+  entries = list(merged.values())
+  for e in entries:
+    e['scopes'] = sorted(e.get('scopes', []))
   entries.sort(key=lambda e: e['key'])
 
   print(f'\n{api_call_summary()}', file=sys.stderr)
@@ -2008,23 +2091,38 @@ def main():
       kwargs['verify_search_parity'] = True
     entries, registry, scope_summaries = collect(manifest, **kwargs)
 
-    # Per-declared-type yield table.
-    declared = [t['type'] for t in manifest.get('types') or []]
+    # Per-declared-type yield table: aggregate across scopes, then per
+    # scope. With per-scope type lists the aggregate alone can hide a
+    # scope whose own declaration yielded nothing.
+    declared = sorted(
+        {d for ss in scope_summaries for d in ss.get('declared_types', {})})
     type_counts = {
         d: sum(1 for e in entries if e['asset_type'] == d) for d in declared
     }
-    print('\nper-declared-type yield:', file=sys.stderr)
+    print('\nper-declared-type yield (all scopes):', file=sys.stderr)
     for d in declared:
       print(f'  {d}: {type_counts[d]}', file=sys.stderr)
     zero_yield = [d for d in declared if type_counts[d] == 0]
     if zero_yield:
       print(
-          '\nWARNING: declared type(s) yielded ZERO entries. Confirm '
-          'each type string\nagainst live `gcloud asset list` output '
-          '(a mistyped asset type matches\nnothing and exits 0):',
-          file=sys.stderr)
+          '\nWARNING: declared type(s) yielded ZERO entries in every '
+          'scope that declares\nthem. Confirm each type string against '
+          'live `gcloud asset list` output\n(a mistyped asset type '
+          'matches nothing and exits 0):', file=sys.stderr)
       for d in zero_yield:
         print(f'  - {d}', file=sys.stderr)
+    for ss in scope_summaries:
+      hidden = [
+          d for d in ss.get('zero_yield_types', []) if d not in zero_yield
+      ]
+      if hidden:
+        print(
+            f'\nWARNING: scope {ss["name"]!r} declared type(s) that '
+            'yielded ZERO entries in\nthat scope. The aggregate table '
+            'above cannot show this (the type is\nnon-zero elsewhere); '
+            'confirm the declaration belongs in this scope:', file=sys.stderr)
+        for d in hidden:
+          print(f'  - {d}', file=sys.stderr)
 
     # Provenance metadata
     payload = json.dumps(

--- a/skills/fabric-importer/scripts/manifest_from_state.py
+++ b/skills/fabric-importer/scripts/manifest_from_state.py
@@ -478,31 +478,54 @@ def _project_rooted_manifest(projects, project_numbers, types_found,
   ]
   has_unknown = any('unknown' in v['levels'] for v in types_found.values())
   levels = ['project'] + (['unknown'] if has_unknown else [])
+  type_lines = _type_lines(types_found, set(levels))
+  if not type_lines:
+    raise SystemExit(
+        'ERROR: no inferred type can fire at project level, so a '
+        'project-rooted manifest would declare scopes that collect '
+        'nothing — inventory.py refuses those. Write the manifest by '
+        'hand.')
   for i, entry in enumerate(_project_include_lines(projects, project_numbers)):
     root = entry.strip().lstrip('- ').split()[0]
     lines += [
         f'  - name: project-{i + 1}',
         f'    root: {root}',
         f'    levels: [{", ".join(levels)}]',
-        '',
-    ]
-  return '\n'.join(lines + _type_lines(types_found)) + '\n'
+    ] + type_lines + ['']
+  while lines and lines[-1] == '':
+    lines.pop()
+  return '\n'.join(lines) + '\n'
 
 
-def _type_lines(types_found):
-  """The `types:` block, shared by every manifest shape."""
-  lines = ['types:']
+def _type_lines(types_found, scope_levels, indent='    '):
+  """One scope's `types:` block, filtered to the entries that can fire
+  there.
+
+  Every scope carries its own list, and inventory.py rejects an entry
+  whose levels cannot intersect its scope's levels (unless the entry
+  declares `unknown`). Emitting the full inferred list into every scope
+  would therefore produce an invalid manifest; this filter mirrors the
+  validator exactly. Returns [] when nothing can fire — the caller must
+  then skip the scope, because an empty `types:` list is refused too.
+  """
+  lines = [f'{indent}types:']
   pseudo_order = ['iam', 'org-policy']
   ordered_types = [pt for pt in pseudo_order if pt in types_found]
   ordered_types += [t for t in sorted(types_found) if t not in pseudo_order]
+  emitted = 0
   for t in ordered_types:
+    t_levels = set(
+        types_found[t]['levels']) or {'organization', 'folder', 'project'}
+    if 'unknown' not in t_levels and not t_levels & scope_levels:
+      continue
     levels = sorted(types_found[t]['levels'],
                     key=lambda lvl: LEVEL_ORDER.get(lvl, 99))
-    lines.append(f'  - type: {t}')
-    lines.append(f'    levels: [{", ".join(levels)}]')
+    lines.append(f'{indent}  - type: {t}')
+    lines.append(f'{indent}    levels: [{", ".join(levels)}]')
     for fk, fv in sorted(types_found[t]['flags'].items()):
-      lines.append(f'    {fk}: {str(fv).lower()}')
-  return lines
+      lines.append(f'{indent}    {fk}: {str(fv).lower()}')
+    emitted += 1
+  return lines if emitted else []
 
 
 def generate_manifest(org_ids, projects, project_numbers, folders, types_found,
@@ -568,18 +591,26 @@ def generate_manifest(org_ids, projects, project_numbers, folders, types_found,
   # discarded (pseudo-types are skipped outright). Retaining an
   # unclassifiable asset is the whole point of the level.
   has_unknown = any('unknown' in v['levels'] for v in types_found.values())
+  emitted_scopes = 0
   if has_org_level or has_unknown:
     # A folder root cannot carry organization-level assets; declaring it
     # anyway asks inventory.py for a sweep that cannot match.
     levels = ['organization', 'folder'] if root_is_org else ['folder']
     if has_unknown:
       levels.append('unknown')
-    lines += [
-        '  - name: org-foundation',
-        f'    root: {scope_root}',
-        f'    levels: [{", ".join(levels)}]',
-        '',
-    ]
+    type_lines = _type_lines(types_found, set(levels))
+    if type_lines:
+      lines += [
+          '  - name: org-foundation',
+          f'    root: {scope_root}',
+          f'    levels: [{", ".join(levels)}]',
+      ] + type_lines + ['']
+      emitted_scopes += 1
+    else:
+      print(
+          'WARNING: no inferred type can fire at the org-foundation '
+          "scope's levels, so the scope was not emitted (a scope's "
+          '`types:` list may not be empty).', file=sys.stderr)
     if not root_is_org:
       org_only = sorted(
           t for t, v in types_found.items() if v['levels'] == {'organization'})
@@ -596,14 +627,29 @@ def generate_manifest(org_ids, projects, project_numbers, folders, types_found,
     levels = ['project']
     if has_unknown:
       levels.append('unknown')
-    lines += [
-        '  - name: stage-projects',
-        f'    root: {scope_root}',
-        f'    levels: [{", ".join(levels)}]',
-        '    include:',
-    ] + include + ['']
+    type_lines = _type_lines(types_found, set(levels))
+    if type_lines:
+      lines += [
+          '  - name: stage-projects',
+          f'    root: {scope_root}',
+          f'    levels: [{", ".join(levels)}]',
+          '    include:',
+      ] + include + type_lines + ['']
+      emitted_scopes += 1
+    else:
+      print(
+          'WARNING: project include(s) were discovered but no inferred '
+          'type can fire at project level, so no stage-projects scope '
+          'was emitted.', file=sys.stderr)
 
-  return '\n'.join(lines + _type_lines(types_found)) + '\n'
+  if not emitted_scopes:
+    raise SystemExit(
+        'ERROR: no scope could be emitted — every candidate scope would '
+        'carry an empty `types:` list, which inventory.py refuses. '
+        'Write the manifest by hand.')
+  while lines and lines[-1] == '':
+    lines.pop()
+  return '\n'.join(lines) + '\n'
 
 
 def main():

--- a/skills/fabric-importer/scripts/manifest_init.py
+++ b/skills/fabric-importer/scripts/manifest_init.py
@@ -60,31 +60,32 @@ def draft_manifest(survey_entries, scope_root):
   lines = [
       '# Import manifest drafted by manifest_init.py — review with care.',
       '# Uncomment the types you want under management; restrict levels',
-      '# and scope to keep plans small. See examples/ for a documented',
+      '# and scope to keep plans small. Every scope carries its own',
+      '# types: list; split into several scopes to import different',
+      '# types under different subtrees. See examples/ for a documented',
       '# reference manifest.',
       '',
-      'scope:',
-      f'  root: {scope_root}',
-      '  # include: [folders/1234]   # optional subtree restriction',
-      '  # exclude: [projects/foo]   # optional subtree exclusion',
-      '',
-      'types:',
+      'scopes:',
+      f'  - root: {scope_root}',
+      '    # include: [folders/1234]   # optional subtree restriction',
+      '    # exclude: [projects/foo]   # optional subtree exclusion',
+      '    types:',
   ]
 
   def type_block(asset_type, levels, count_note, enabled):
-    prefix = '  ' if enabled else '  # '
+    prefix = '      ' if enabled else '      # '
     out = [f'{prefix}- type: {asset_type}{count_note}']
     out.append(f'{prefix}  levels: [{", ".join(levels)}]')
     return out
 
   # Pseudo-types first (IAM policies and org policies are content types in
   # CAI, not asset types, so a survey cannot count them).
-  lines.append('  # -- IAM policies and org policies (pseudo-types; not')
-  lines.append('  #    counted by a resource survey) --')
+  lines.append('      # -- IAM policies and org policies (pseudo-types; not')
+  lines.append('      #    counted by a resource survey) --')
   for pseudo, levels in FOUNDATION_PSEUDO.items():
     lines += type_block(pseudo, levels, '', enabled=True)
   lines.append('')
-  lines.append('  # -- discovered resource types (count by level) --')
+  lines.append('      # -- discovered resource types (count by level) --')
 
   for asset_type in sorted(counts):
     per_level = counts[asset_type]

--- a/skills/fabric-importer/tests/test_scripts.py
+++ b/skills/fabric-importer/tests/test_scripts.py
@@ -46,6 +46,15 @@ import manifest_from_state  # noqa: E402
 import manifest_init  # noqa: E402
 import verify_plan  # noqa: E402
 
+# A harmless declared type for tests that need a grammar-valid manifest
+# but stub every gcloud call: the scopes-only grammar refuses an empty
+# `types:` list, so "a manifest that collects nothing" is expressed as
+# one type whose (stubbed) sweep returns no assets.
+_NOOP_TYPES = [{
+    'type': 'storage.googleapis.com/Bucket',
+    'levels': ['project'],
+}]
+
 _BENIGN_RULES = [
     {
         'resource': 'google_folder',
@@ -943,12 +952,13 @@ class TestInventoryHelpers(unittest.TestCase):
     # end - a silently shrunken denominator is never acceptable.
     with self.assertRaises(SystemExit) as ctx:
       self._collect_with_failing_sweep({
-          'scope': {
-              'root': 'organizations/1'
-          },
-          'types': [{
-              'type': 'storage.googleapis.com/Bucket',
-              'levels': ['project']
+          'scopes': [{
+              'root':
+                  'organizations/1',
+              'types': [{
+                  'type': 'storage.googleapis.com/Bucket',
+                  'levels': ['project']
+              }]
           }]
       })
     self.assertEqual(ctx.exception.code, 3)
@@ -959,12 +969,16 @@ class TestInventoryHelpers(unittest.TestCase):
     exited 3 with stale messages — and a caller retrying after a
     transient error could never get a clean result."""
     inventory.SWEEP_FAILURES.append('stale failure from an earlier run')
-    entries, _, _ = inventory.collect({
-        'scope': {
-            'root': 'organizations/1'
-        },
-        'types': []
-    })
+    real = inventory.run_json
+    inventory.run_json = lambda cmd, **kw: []
+    try:
+      entries, _, _ = inventory.collect(
+          {'scopes': [{
+              'root': 'organizations/1',
+              'types': _NOOP_TYPES
+          }]})
+    finally:
+      inventory.run_json = real
     self.assertEqual(entries, [])
     self.assertEqual(inventory.SWEEP_FAILURES, [])
 
@@ -975,27 +989,29 @@ class TestInventoryHelpers(unittest.TestCase):
     for field in ('include', 'exclude'):
       with self.assertRaises(SystemExit) as ctx:
         inventory.parse_and_validate_scopes(
-            {'scope': {
+            {'scopes': [{
                 'root': 'organizations/1',
                 field: ['12345']
-            }})
+            }]})
       self.assertIn('ambiguous', str(ctx.exception))
 
   def test_misspelled_include_prefix_is_refused(self):
     with self.assertRaises(SystemExit) as ctx:
       inventory.parse_and_validate_scopes(
-          {'scope': {
+          {'scopes': [{
               'root': 'organizations/1',
               'include': ['folder/22']
-          }})
+          }]})
     self.assertIn('unsupported prefix', str(ctx.exception))
 
   def test_bare_project_id_include_is_still_accepted(self):
-    scopes = inventory.parse_and_validate_scopes(
-        {'scope': {
+    scopes = inventory.parse_and_validate_scopes({
+        'scopes': [{
             'root': 'organizations/1',
-            'include': ['my-app-prod']
-        }})
+            'include': ['my-app-prod'],
+            'types': _NOOP_TYPES,
+        }]
+    })
     self.assertEqual(scopes[0]['include'], ['my-app-prod'])
 
   def test_unresolvable_project_id_is_recorded_not_swallowed(self):
@@ -1593,12 +1609,12 @@ class TestInventoryManifestValidation(unittest.TestCase):
   def test_collect_validates_before_any_enumeration(self):
     with self.assertRaises(SystemExit) as ctx:
       inventory.collect({
-          'scope': {
-              'root': 'organizations/1'
-          },
-          'types': [{
-              'type': 'iam',
-              'levels': ['orgs']
+          'scopes': [{
+              'root': 'organizations/1',
+              'types': [{
+                  'type': 'iam',
+                  'levels': ['orgs']
+              }]
           }]
       })
     self.assertIn('invalid level', str(ctx.exception))
@@ -1652,12 +1668,13 @@ class TestApiCallLoggingAndPaging(unittest.TestCase):
     try:
       with contextlib.redirect_stderr(io.StringIO()):
         inventory.collect({
-            'scope': {
-                'root': 'organizations/1'
-            },
-            'types': [{
-                'type': 'storage.googleapis.com/Bucket',
-                'levels': ['project']
+            'scopes': [{
+                'root':
+                    'organizations/1',
+                'types': [{
+                    'type': 'storage.googleapis.com/Bucket',
+                    'levels': ['project']
+                }]
             }]
         })
     finally:
@@ -1694,7 +1711,11 @@ class TestApiCallLoggingAndPaging(unittest.TestCase):
       return [], inventory.ProjectRegistry(), []
 
     with tempfile.NamedTemporaryFile('w', suffix='.yaml', delete=False) as f:
-      yaml.safe_dump({'scope': {'root': 'organizations/1'}, 'types': []}, f)
+      yaml.safe_dump(
+          {'scopes': [{
+              'root': 'organizations/1',
+              'types': _NOOP_TYPES
+          }]}, f)
       mpath = f.name
     try:
       inventory.collect = fake_collect
@@ -1763,7 +1784,11 @@ class TestApiCallLoggingAndPaging(unittest.TestCase):
     inventory.run_json = lambda cmd, **kw: []
     try:
       with contextlib.redirect_stderr(io.StringIO()):
-        inventory.collect({'scope': {'root': 'organizations/1'}, 'types': []})
+        inventory.collect(
+            {'scopes': [{
+                'root': 'organizations/1',
+                'types': _NOOP_TYPES
+            }]})
     finally:
       inventory.run_json = real
     self.assertEqual(inventory.API_CALLS, [])
@@ -1809,12 +1834,13 @@ class TestNonCaiEnumeration(unittest.TestCase):
       with self.assertRaises(SystemExit) as ctx:
         self._collect(
             {
-                'scope': {
-                    'root': 'organizations/1'
-                },
-                'types': [{
-                    'type': 'logging.googleapis.com/OrganizationSettings',
-                    'levels': ['organization']
+                'scopes': [{
+                    'root':
+                        'organizations/1',
+                    'types': [{
+                        'type': 'logging.googleapis.com/OrganizationSettings',
+                        'levels': ['organization']
+                    }]
                 }]
             }, handler)
     self.assertEqual(ctx.exception.code, 3)
@@ -1842,12 +1868,13 @@ class TestNonCaiEnumeration(unittest.TestCase):
       with self.assertRaises(SystemExit):
         self._collect(
             {
-                'scope': {
-                    'root': 'organizations/1'
-                },
-                'types': [{
-                    'type': 'logging.googleapis.com/OrganizationSettings',
-                    'levels': ['organization']
+                'scopes': [{
+                    'root':
+                        'organizations/1',
+                    'types': [{
+                        'type': 'logging.googleapis.com/OrganizationSettings',
+                        'levels': ['organization']
+                    }]
                 }]
             }, handler)
     self.assertFalse([c for c in calls if 'search-all-resources' in c])
@@ -1869,12 +1896,13 @@ class TestNonCaiEnumeration(unittest.TestCase):
       with self.assertRaises(SystemExit) as ctx:
         self._collect(
             {
-                'scope': {
-                    'root': 'organizations/1'
-                },
-                'types': [{
-                    'type': 'storage.googleapis.com/Bucket',
-                    'levels': ['project']
+                'scopes': [{
+                    'root':
+                        'organizations/1',
+                    'types': [{
+                        'type': 'storage.googleapis.com/Bucket',
+                        'levels': ['project']
+                    }]
                 }]
             }, handler)
     self.assertEqual(ctx.exception.code, 3)
@@ -1883,17 +1911,18 @@ class TestNonCaiEnumeration(unittest.TestCase):
     self.assertTrue([c for c in calls if 'search-all-resources' in c])
 
   _EXCLUSION_MANIFEST = {
-      'scope': {
-          'root': 'organizations/1'
-      },
-      'types': [{
-          'type': 'logging.googleapis.com/LogExclusion',
-          'levels': ['organization'],
-          'enumerate': {
-              'command': ['logging', 'exclusions', 'list'],
-              'key': '//logging.googleapis.com/{container}/exclusions/'
-                     '{item.name}',
-          },
+      'scopes': [{
+          'root':
+              'organizations/1',
+          'types': [{
+              'type': 'logging.googleapis.com/LogExclusion',
+              'levels': ['organization'],
+              'enumerate': {
+                  'command': ['logging', 'exclusions', 'list'],
+                  'key': '//logging.googleapis.com/{container}/exclusions/'
+                         '{item.name}',
+              },
+          }]
       }]
   }
 
@@ -1955,12 +1984,13 @@ class TestNonCaiEnumeration(unittest.TestCase):
     with contextlib.redirect_stderr(buf):
       entries, _, _ = self._collect(
           {
-              'scope': {
-                  'root': 'organizations/1'
-              },
-              'types': [{
-                  'type': 'iam.googleapis.com/DenyPolicy',
-                  'levels': ['organization']
+              'scopes': [{
+                  'root':
+                      'organizations/1',
+                  'types': [{
+                      'type': 'iam.googleapis.com/DenyPolicy',
+                      'levels': ['organization']
+                  }]
               }]
           }, handler)
     self.assertEqual(len(entries), 1)
@@ -1982,17 +2012,19 @@ class TestNonCaiEnumeration(unittest.TestCase):
     with contextlib.redirect_stderr(io.StringIO()):
       self._collect(
           {
-              'scope': {
-                  'root': 'organizations/1'
-              },
-              'types': [{
-                  'type': 'iam.googleapis.com/DenyPolicy',
-                  'levels': ['organization'],
-                  'enumerate': {
-                      'command':
-                          ['iam', 'policies', 'list', '--kind=denypolicies'],
-                      'key': '//custom/{container}/{item.name}',
-                  },
+              'scopes': [{
+                  'root':
+                      'organizations/1',
+                  'types': [{
+                      'type': 'iam.googleapis.com/DenyPolicy',
+                      'levels': ['organization'],
+                      'enumerate': {
+                          'command': [
+                              'iam', 'policies', 'list', '--kind=denypolicies'
+                          ],
+                          'key': '//custom/{container}/{item.name}',
+                      },
+                  }]
               }]
           }, handler)
     self.assertEqual(inventory.NATIVE_SWEEPS[0]['source'], 'manifest')
@@ -2016,12 +2048,13 @@ class TestNonCaiEnumeration(unittest.TestCase):
       with self.assertRaises(SystemExit) as ctx:
         self._collect(
             {
-                'scope': {
-                    'root': 'organizations/1'
-                },
-                'types': [{
-                    'type': 'storage.googleapis.com/ManagedFolder',
-                    'levels': ['project']
+                'scopes': [{
+                    'root':
+                        'organizations/1',
+                    'types': [{
+                        'type': 'storage.googleapis.com/ManagedFolder',
+                        'levels': ['project']
+                    }]
                 }]
             }, handler)
     self.assertEqual(ctx.exception.code, 3)
@@ -2046,8 +2079,17 @@ class TestNonCaiEnumeration(unittest.TestCase):
   def test_native_sweeps_do_not_leak_into_the_next_collect(self):
     inventory.NATIVE_SWEEPS.append({'asset_type': 'stale'})
     inventory.UNSUPPORTED_CAI_TYPES.append('stale')
-    with contextlib.redirect_stderr(io.StringIO()):
-      inventory.collect({'scope': {'root': 'organizations/1'}, 'types': []})
+    real = inventory.run_json
+    inventory.run_json = lambda cmd, **kw: []
+    try:
+      with contextlib.redirect_stderr(io.StringIO()):
+        inventory.collect(
+            {'scopes': [{
+                'root': 'organizations/1',
+                'types': _NOOP_TYPES
+            }]})
+    finally:
+      inventory.run_json = real
     self.assertEqual(inventory.NATIVE_SWEEPS, [])
     self.assertEqual(inventory.UNSUPPORTED_CAI_TYPES, [])
 
@@ -2056,7 +2098,7 @@ class TestNonCaiEnumeration(unittest.TestCase):
     a green gate - the exact failure mode this tool exists to prevent -
     so it fails rather than deduplicating."""
     manifest = json.loads(json.dumps(self._EXCLUSION_MANIFEST))
-    manifest['types'][0]['enumerate']['key'] = (
+    manifest['scopes'][0]['types'][0]['enumerate']['key'] = (
         '//logging.googleapis.com/{container}/exclusions/fixed')
 
     def handler(cmd, **kwargs):
@@ -2136,21 +2178,23 @@ class TestNonCaiEnumeration(unittest.TestCase):
     with contextlib.redirect_stderr(io.StringIO()):
       entries, _, _ = self._collect(
           {
-              'scope': {
-                  'root': 'organizations/1'
-              },
-              'types': [{
-                  'type': 'iam.googleapis.com/DenyPolicy',
-                  'levels': ['organization'],
-                  'enumerate': {
-                      'command':
-                          ['iam', 'policies', 'list', '--kind=denypolicies'],
-                      'container_arg':
-                          '--attachment-point=cloudresourcemanager.'
-                          'googleapis.com/{container}',
-                      'key': '//iam.googleapis.com/{container}/'
-                             'denypolicies/{item.name}',
-                  },
+              'scopes': [{
+                  'root':
+                      'organizations/1',
+                  'types': [{
+                      'type': 'iam.googleapis.com/DenyPolicy',
+                      'levels': ['organization'],
+                      'enumerate': {
+                          'command': [
+                              'iam', 'policies', 'list', '--kind=denypolicies'
+                          ],
+                          'container_arg':
+                              '--attachment-point=cloudresourcemanager.'
+                              'googleapis.com/{container}',
+                          'key': '//iam.googleapis.com/{container}/'
+                                 'denypolicies/{item.name}',
+                      },
+                  }]
               }]
           }, handler)
     self.assertIn(
@@ -2232,15 +2276,16 @@ class TestNonCaiEnumeration(unittest.TestCase):
     with self.assertRaises(SystemExit):
       self._collect(
           {
-              'scope': {
-                  'root': 'organizations/1'
-              },
-              'types': [{
-                  'type': 'logging.googleapis.com/LogExclusion',
-                  'enumerate': {
-                      'command': ['logging', 'settings', 'update'],
-                      'key': '{item.name}'
-                  }
+              'scopes': [{
+                  'root':
+                      'organizations/1',
+                  'types': [{
+                      'type': 'logging.googleapis.com/LogExclusion',
+                      'enumerate': {
+                          'command': ['logging', 'settings', 'update'],
+                          'key': '{item.name}'
+                      }
+                  }]
               }]
           }, handler)
     self.assertEqual(calls, [])
@@ -2371,8 +2416,8 @@ class TestManifestInit(unittest.TestCase):
     ]
     draft = manifest_init.draft_manifest(survey, 'organizations/1')
     parsed = yaml.safe_load(draft)
-    self.assertEqual(parsed['scope']['root'], 'organizations/1')
-    types = {t['type'] for t in parsed['types']}
+    self.assertEqual(parsed['scopes'][0]['root'], 'organizations/1')
+    types = {t['type'] for t in parsed['scopes'][0]['types']}
     # Foundation pseudo-types and discovered foundation types enabled.
     self.assertIn('iam', types)
     self.assertIn('org-policy', types)
@@ -2406,7 +2451,7 @@ class TestManifestInit(unittest.TestCase):
         self.assertTrue(os.path.exists(out_path))
         with open(out_path, "r") as f:
           parsed = yaml.safe_load(f)
-        self.assertEqual(parsed["scope"]["root"], "organizations/1")
+        self.assertEqual(parsed["scopes"][0]["root"], "organizations/1")
       finally:
         sys.argv = sys_argv
 
@@ -2414,7 +2459,7 @@ class TestManifestInit(unittest.TestCase):
 class TestMultiScopeAndProjectRegistry(unittest.TestCase):
 
   def test_parse_single_scope(self):
-    manifest = {'scope': {'root': 'organizations/123'}}
+    manifest = {'scopes': [{'root': 'organizations/123', 'types': _NOOP_TYPES}]}
     scopes = inventory.parse_and_validate_scopes(manifest)
     self.assertEqual(len(scopes), 1)
     self.assertEqual(scopes[0]['root'], 'organizations/123')
@@ -2424,15 +2469,22 @@ class TestMultiScopeAndProjectRegistry(unittest.TestCase):
     manifest = {
         'scopes': [
             {
-                'name': 'org',
-                'root': 'organizations/123',
-                'levels': ['organization', 'folder']
+                'name':
+                    'org',
+                'root':
+                    'organizations/123',
+                'levels': ['organization', 'folder'],
+                'types': [{
+                    'type': 'iam',
+                    'levels': ['organization', 'folder']
+                }],
             },
             {
                 'name': 'workload',
                 'root': 'projects/456',
                 'levels': ['project'],
-                'include': ['projects/456']
+                'include': ['projects/456'],
+                'types': _NOOP_TYPES,
             },
         ]
     }
@@ -2445,7 +2497,7 @@ class TestMultiScopeAndProjectRegistry(unittest.TestCase):
 
   def test_invalid_scope_root_rejected(self):
     with self.assertRaises(SystemExit):
-      inventory.parse_and_validate_scopes({'scope': {'root': ''}})
+      inventory.parse_and_validate_scopes({'scopes': [{'root': ''}]})
 
   def test_invalid_scope_levels_rejected(self):
     with self.assertRaises(SystemExit):
@@ -2485,6 +2537,411 @@ class TestMultiScopeAndProjectRegistry(unittest.TestCase):
 
     # Exclusion with alphanumeric ID
     self.assertFalse(inventory.in_subtree(asset, [], ['my-app'], reg))
+
+
+class TestPerScopeTypes(unittest.TestCase):
+  """The scopes-only grammar: every scope carries its own `types:` list.
+
+  The list decides the denominator, so every shape in which it could
+  quietly mean "collect less" is refused, not warned: the retired
+  top-level grammar, a scope without a list, an empty list, and a
+  declaration whose levels can never intersect its scope's.
+  """
+
+  def setUp(self):
+    self._real_run_json = inventory.run_json
+
+  def tearDown(self):
+    inventory.run_json = self._real_run_json
+
+  def _collect(self, manifest, handler):
+    inventory.run_json = handler
+    with contextlib.redirect_stderr(io.StringIO()):
+      return inventory.collect(manifest)
+
+  def test_legacy_top_level_scope_is_refused_with_migration_help(self):
+    with self.assertRaises(SystemExit) as ctx:
+      inventory.parse_and_validate_scopes(
+          {'scope': {
+              'root': 'organizations/1'
+          }})
+    msg = str(ctx.exception)
+    self.assertIn('retired top-level key', msg)
+    self.assertIn("'scope'", msg)
+    # The message must show the new shape, not just reject the old one.
+    self.assertIn('scopes:', msg)
+    self.assertIn('types:', msg)
+
+  def test_legacy_top_level_types_is_refused_with_migration_help(self):
+    with self.assertRaises(SystemExit) as ctx:
+      inventory.parse_and_validate_scopes({
+          'scopes': [{
+              'root': 'organizations/1',
+              'types': _NOOP_TYPES
+          }],
+          'types': _NOOP_TYPES,
+      })
+    self.assertIn('retired top-level key', str(ctx.exception))
+    self.assertIn("'types'", str(ctx.exception))
+
+  def test_scope_without_types_is_refused(self):
+    with self.assertRaises(SystemExit) as ctx:
+      inventory.parse_and_validate_scopes(
+          {'scopes': [{
+              'root': 'organizations/1'
+          }]})
+    self.assertIn("declares no 'types'", str(ctx.exception))
+
+  def test_empty_types_list_is_refused(self):
+    with self.assertRaises(SystemExit) as ctx:
+      inventory.parse_and_validate_scopes(
+          {'scopes': [{
+              'root': 'organizations/1',
+              'types': []
+          }]})
+    self.assertIn('empty or non-list', str(ctx.exception))
+
+  def test_dead_per_scope_declaration_is_refused(self):
+    """A type whose levels cannot intersect its scope's levels reads as
+    coverage and produces none."""
+    with self.assertRaises(SystemExit) as ctx:
+      inventory.parse_and_validate_scopes({
+          'scopes': [{
+              'root':
+                  'organizations/1',
+              'levels': ['project'],
+              'types': [{
+                  'type': 'iam.googleapis.com/Role',
+                  'levels': ['organization']
+              }],
+          }]
+      })
+    self.assertIn('can never match', str(ctx.exception))
+
+  def test_unknown_level_exempts_the_dead_declaration_check(self):
+    scopes = inventory.parse_and_validate_scopes({
+        'scopes': [{
+            'root':
+                'organizations/1',
+            'levels': ['project'],
+            'types': [{
+                'type': 'iam.googleapis.com/Role',
+                'levels': ['organization', 'unknown']
+            }],
+        }]
+    })
+    self.assertEqual(len(scopes), 1)
+
+  def test_duplicate_type_message_names_the_scope(self):
+    with self.assertRaises(SystemExit) as ctx:
+      inventory.parse_and_validate_scopes({
+          'scopes': [{
+              'name': 'net',
+              'root': 'organizations/1',
+              'types': _NOOP_TYPES + _NOOP_TYPES,
+          }]
+      })
+    msg = str(ctx.exception)
+    self.assertIn('more than once', msg)
+    self.assertIn('net', msg)
+
+  def test_same_type_in_two_scopes_with_different_settings_is_valid(self):
+    """Repeating a type across scopes with different levels/iam is the
+    point of per-scope lists, not a duplicate."""
+    scopes = inventory.parse_and_validate_scopes({
+        'scopes': [
+            {
+                'name':
+                    'a',
+                'root':
+                    'organizations/1',
+                'levels': ['organization', 'folder'],
+                'types': [{
+                    'type': 'iam',
+                    'levels': ['organization', 'folder']
+                }],
+            },
+            {
+                'name': 'b',
+                'root': 'folders/2',
+                'levels': ['project'],
+                'types': [{
+                    'type': 'iam',
+                    'levels': ['project']
+                }],
+            },
+        ]
+    })
+    self.assertEqual([s['name'] for s in scopes], ['a', 'b'])
+
+  def test_sweeps_are_isolated_per_scope(self):
+    """A type declared in one scope is swept only there: the other
+    scope's CAI call must not ask for it."""
+    calls = []
+
+    def handler(cmd, **kwargs):
+      del kwargs
+      calls.append(' '.join(cmd))
+      return []
+
+    self._collect(
+        {
+            'scopes': [
+                {
+                    'name':
+                        'org',
+                    'root':
+                        'organizations/1',
+                    'types': [{
+                        'type': 'storage.googleapis.com/Bucket',
+                        'levels': ['project']
+                    }],
+                },
+                {
+                    'name':
+                        'net',
+                    'root':
+                        'folders/2',
+                    'types': [{
+                        'type': 'compute.googleapis.com/Network',
+                        'levels': ['project']
+                    }],
+                },
+            ]
+        }, handler)
+    org_sweeps = [
+        c for c in calls if '--organization=1' in c and '--asset-types=' in c
+    ]
+    folder_sweeps = [
+        c for c in calls if '--folder=2' in c and '--asset-types=' in c
+    ]
+    self.assertTrue(org_sweeps)
+    self.assertTrue(folder_sweeps)
+    self.assertTrue(all('Bucket' in c for c in org_sweeps))
+    self.assertTrue(all('Network' not in c for c in org_sweeps))
+    self.assertTrue(all('Network' in c for c in folder_sweeps))
+    self.assertTrue(all('Bucket' not in c for c in folder_sweeps))
+
+  def test_native_enumerator_runs_only_in_its_scope(self):
+    calls = []
+
+    def handler(cmd, **kwargs):
+      del kwargs
+      calls.append(' '.join(cmd))
+      return []
+
+    self._collect(
+        {
+            'scopes': [
+                {
+                    'name':
+                        'org',
+                    'root':
+                        'organizations/1',
+                    'levels': ['organization'],
+                    'types': [{
+                        'type': 'logging.googleapis.com/LogExclusion',
+                        'levels': ['organization'],
+                        'enumerate': {
+                            'command': ['logging', 'exclusions', 'list'],
+                            'key': ('//logging.googleapis.com/{container}/'
+                                    'exclusions/{item.name}'),
+                        },
+                    }],
+                },
+                {
+                    'name':
+                        'net',
+                    'root':
+                        'folders/2',
+                    'levels': ['folder'],
+                    'types': [{
+                        'type': 'storage.googleapis.com/Bucket',
+                        'levels': ['folder']
+                    }],
+                },
+            ]
+        }, handler)
+    exclusion_calls = [c for c in calls if 'exclusions list' in c]
+    self.assertTrue(exclusion_calls)
+    self.assertTrue(all('--organization=1' in c for c in exclusion_calls))
+    self.assertFalse([c for c in exclusion_calls if '--folder=2' in c])
+
+  def test_leaf_iam_opt_in_is_per_scope(self):
+    """`iam: true` is a property of one scope's type entry: the scope
+    that declared it mints the #iam entry, the scope that did not
+    contributes only the resource entry."""
+    sa_name = ('//iam.googleapis.com/projects/p1/serviceAccounts/'
+               'sa@p1.iam.gserviceaccount.com')
+
+    def handler(cmd, **kwargs):
+      del kwargs
+      joined = ' '.join(cmd)
+      if 'privilegedaccessmanager' in joined:
+        return []
+      if '--content-type=iam-policy' in joined:
+        return [{
+            'name': sa_name,
+            'assetType': 'iam.googleapis.com/ServiceAccount',
+            'ancestors': ['projects/9', 'organizations/1'],
+            'iamPolicy': {
+                'bindings': [{
+                    'role': 'roles/iam.serviceAccountUser',
+                    'members': ['user:a@example.com'],
+                }]
+            },
+        }]
+      if '--content-type=resource' in joined and 'ServiceAccount' in joined:
+        return [{
+            'name': sa_name,
+            'assetType': 'iam.googleapis.com/ServiceAccount',
+            'ancestors': ['projects/9', 'organizations/1'],
+        }]
+      return []
+
+    entries, _, summaries = self._collect(
+        {
+            'scopes': [
+                {
+                    'name':
+                        'with-iam',
+                    'root':
+                        'organizations/1',
+                    'types': [{
+                        'type': 'iam.googleapis.com/ServiceAccount',
+                        'levels': ['project'],
+                        'iam': True,
+                    }],
+                },
+                {
+                    'name':
+                        'without-iam',
+                    'root':
+                        'organizations/1',
+                    'types': [{
+                        'type': 'iam.googleapis.com/ServiceAccount',
+                        'levels': ['project'],
+                    }],
+                },
+            ]
+        }, handler)
+    by_key = {e['key']: e for e in entries}
+    self.assertIn(sa_name, by_key)
+    self.assertIn(f'{sa_name}#iam', by_key)
+    self.assertEqual(by_key[sa_name]['scopes'], ['with-iam', 'without-iam'])
+    self.assertEqual(by_key[f'{sa_name}#iam']['scopes'], ['with-iam'])
+    del summaries
+
+  def test_scope_attribution_is_merged_and_sorted(self):
+    """An asset collected by two overlapping scopes names both, sorted
+    — never last-wins."""
+    bucket = {
+        'name': '//storage.googleapis.com/projects/_/buckets/b1',
+        'assetType': 'storage.googleapis.com/Bucket',
+        'ancestors': ['projects/9', 'organizations/1'],
+    }
+
+    def handler(cmd, **kwargs):
+      del kwargs
+      joined = ' '.join(cmd)
+      if '--content-type=resource' in joined and 'Bucket' in joined:
+        return [dict(bucket)]
+      return []
+
+    entries, _, summaries = self._collect(
+        {
+            'scopes': [
+                {
+                    'name':
+                        'zeta',
+                    'root':
+                        'organizations/1',
+                    'types': [{
+                        'type': 'storage.googleapis.com/Bucket',
+                        'levels': ['project']
+                    }],
+                },
+                {
+                    'name':
+                        'alpha',
+                    'root':
+                        'organizations/1',
+                    'types': [{
+                        'type': 'storage.googleapis.com/Bucket',
+                        'levels': ['project']
+                    }],
+                },
+            ]
+        }, handler)
+    self.assertEqual(len(entries), 1)
+    self.assertEqual(entries[0]['scopes'], ['alpha', 'zeta'])
+    self.assertEqual([s['yield_count'] for s in summaries], [1, 1])
+
+  def test_scope_summaries_carry_per_scope_yield_tables(self):
+    """The aggregate table cannot show a type that yields zero in one
+    scope and non-zero in another; the per-scope table is the only
+    place that shape is visible."""
+    bucket = {
+        'name': '//storage.googleapis.com/projects/_/buckets/b1',
+        'assetType': 'storage.googleapis.com/Bucket',
+        'ancestors': ['projects/9', 'organizations/1'],
+    }
+
+    def handler(cmd, **kwargs):
+      del kwargs
+      joined = ' '.join(cmd)
+      if ('--organization=1' in joined and
+          '--content-type=resource' in joined and 'Bucket' in joined):
+        return [dict(bucket)]
+      return []
+
+    _, _, summaries = self._collect(
+        {
+            'scopes': [
+                {
+                    'name':
+                        'org',
+                    'root':
+                        'organizations/1',
+                    'types': [{
+                        'type': 'storage.googleapis.com/Bucket',
+                        'levels': ['project']
+                    }],
+                },
+                {
+                    'name':
+                        'net',
+                    'root':
+                        'folders/2',
+                    'types': [{
+                        'type': 'storage.googleapis.com/Bucket',
+                        'levels': ['project']
+                    }],
+                },
+            ]
+        }, handler)
+    by_name = {s['name']: s for s in summaries}
+    self.assertEqual(by_name['org']['declared_types'],
+                     {'storage.googleapis.com/Bucket': 1})
+    self.assertEqual(by_name['org']['zero_yield_types'], [])
+    self.assertEqual(by_name['net']['declared_types'],
+                     {'storage.googleapis.com/Bucket': 0})
+    self.assertEqual(by_name['net']['zero_yield_types'],
+                     ['storage.googleapis.com/Bucket'])
+
+  def test_shipped_example_manifests_are_grammar_valid(self):
+    """The examples are the templates users copy; an example that
+    violates the tool's own grammar ships the violation."""
+    examples_dir = os.path.join(os.path.dirname(__file__), '..', 'examples')
+    manifests = sorted(
+        f for f in os.listdir(examples_dir)
+        if f.startswith('import-manifest.') and f.endswith('.yaml'))
+    self.assertTrue(manifests)
+    for fname in manifests:
+      with open(os.path.join(examples_dir, fname), encoding='utf-8') as f:
+        parsed = yaml.safe_load(f)
+      scopes = inventory.parse_and_validate_scopes(parsed)
+      self.assertTrue(scopes, msg=fname)
 
 
 class TestDeletedContainersFilter(unittest.TestCase):
@@ -2660,17 +3117,18 @@ class TestDeletedContainersFilter(unittest.TestCase):
     inventory.run_json = fake
     try:
       manifest = {
-          'scope': {
-              'root': 'organizations/1'
-          },
-          'types': [
-              {
-                  'type': 'cloudresourcemanager.googleapis.com/Folder'
-              },
-              {
-                  'type': 'cloudresourcemanager.googleapis.com/Project'
-              },
-          ]
+          'scopes': [{
+              'root':
+                  'organizations/1',
+              'types': [
+                  {
+                      'type': 'cloudresourcemanager.googleapis.com/Folder'
+                  },
+                  {
+                      'type': 'cloudresourcemanager.googleapis.com/Project'
+                  },
+              ]
+          }]
       }
       # Default: excludes deleted folder 222 and its child project 333
       entries_default, reg_default, _ = inventory.collect(
@@ -2788,17 +3246,18 @@ class TestDeletedContainersFilter(unittest.TestCase):
     inventory.run_json = fake
     try:
       manifest = {
-          'scope': {
-              'root': 'organizations/1'
-          },
-          'types': [
-              {
-                  'type': 'logging.googleapis.com/LogSink'
-              },
-              {
-                  'type': 'logging.googleapis.com/LogBucket'
-              },
-          ]
+          'scopes': [{
+              'root':
+                  'organizations/1',
+              'types': [
+                  {
+                      'type': 'logging.googleapis.com/LogSink'
+                  },
+                  {
+                      'type': 'logging.googleapis.com/LogBucket'
+                  },
+              ]
+          }]
       }
       # Default: excludes _Default and _Required sinks and buckets
       entries_default, _, _ = inventory.collect(manifest,
@@ -3014,10 +3473,10 @@ class TestDeletedContainersFilter(unittest.TestCase):
       manifest = {
           'scopes': [{
               'name': 'p1',
-              'root': 'projects/12345'
-          }],
-          'types': [{
-              'type': 'compute.googleapis.com/Route'
+              'root': 'projects/12345',
+              'types': [{
+                  'type': 'compute.googleapis.com/Route'
+              }],
           }],
       }
 
@@ -3186,20 +3645,22 @@ class TestDeletedContainersFilter(unittest.TestCase):
     try:
       manifest = {
           'scopes': [{
-              'name': 'p1',
-              'root': 'projects/12345'
+              'name':
+                  'p1',
+              'root':
+                  'projects/12345',
+              'types': [
+                  {
+                      'type': 'logging.googleapis.com/LogSink'
+                  },
+                  {
+                      'type': 'logging.googleapis.com/LogBucket'
+                  },
+                  {
+                      'type': 'compute.googleapis.com/Route'
+                  },
+              ],
           }],
-          'types': [
-              {
-                  'type': 'logging.googleapis.com/LogSink'
-              },
-              {
-                  'type': 'logging.googleapis.com/LogBucket'
-              },
-              {
-                  'type': 'compute.googleapis.com/Route'
-              },
-          ],
       }
 
       # 1. Default: only user route survives (all 3 auto-generated filtered)
@@ -3722,15 +4183,18 @@ class TestManifestFromState(unittest.TestCase):
                                                  folders, types_found,
                                                  ['s.tfstate'])
     parsed = yaml.safe_load(text)
-    # Must be accepted by the tool that consumes it...
+    # Must be accepted by the tool that consumes it (which also
+    # validates every scope's own types list)...
     scopes = inventory.parse_and_validate_scopes(parsed)
-    inventory.validate_manifest_types(parsed['types'])
     # ... the project seen only as a number must be prefixed, not bare...
     self.assertIn('projects/987654321', parsed['scopes'][-1]['include'])
     # ... and a type declared at `unknown` needs `unknown` in some scope,
     # or it intersects to the empty set and is swept then discarded.
     unknown_types = [
-        t['type'] for t in parsed['types'] if 'unknown' in t['levels']
+        t['type']
+        for s in parsed['scopes']
+        for t in s['types']
+        if 'unknown' in t['levels']
     ]
     self.assertTrue(unknown_types)
     self.assertTrue(any('unknown' in s['levels'] for s in scopes))
@@ -3898,12 +4362,13 @@ class TestCaiSplitTypes(unittest.TestCase):
   """
 
   _MANIFEST = {
-      'scope': {
-          'root': 'projects/my-prj'
-      },
-      'types': [{
-          'type': 'compute.googleapis.com/Address',
-          'levels': ['project']
+      'scopes': [{
+          'root':
+              'projects/my-prj',
+          'types': [{
+              'type': 'compute.googleapis.com/Address',
+              'levels': ['project']
+          }]
       }],
   }
 
@@ -4021,12 +4486,13 @@ class TestCaiSplitTypes(unittest.TestCase):
     own type would match no manifest entry and be filtered by the
     permissive default instead of by the operator's `levels`."""
     manifest = {
-        'scope': {
-            'root': 'projects/my-prj'
-        },
-        'types': [{
-            'type': 'compute.googleapis.com/Address',
-            'levels': ['project']
+        'scopes': [{
+            'root':
+                'projects/my-prj',
+            'types': [{
+                'type': 'compute.googleapis.com/Address',
+                'levels': ['project']
+            }]
         }],
     }
     calls = []
@@ -4084,13 +4550,14 @@ class TestCaiSplitTypes(unittest.TestCase):
       return []
 
     manifest = {
-        'scope': {
-            'root': 'organizations/1',
+        'scopes': [{
+            'root':
+                'organizations/1',
             'include': ['projects/111'],
-        },
-        'types': [{
-            'type': 'compute.googleapis.com/Address',
-            'levels': ['project']
+            'types': [{
+                'type': 'compute.googleapis.com/Address',
+                'levels': ['project']
+            }]
         }],
     }
     buf = io.StringIO()


### PR DESCRIPTION
## Summary

Replaces the fabric-importer manifest grammar with a **scopes-only** form: `scopes:` is required and **every scope carries its own `types:` list**. The retired top-level `scope:` / `types:` grammar is refused with migration instructions.

This makes per-scope type declarations first-class — different resource types under different subtrees (org governance at org/folder level, the connectivity stack under the networking folder, KMS under security, project IAM only in named workload projects) — which the previous global type list could not express. Choosing a single grammar (rather than adding per-scope types alongside the global list) makes three whole classes of silent-denominator failures *unrepresentable* instead of merely validated: there is no inheritance to mix, no global list to go stale, and no all-or-nothing rule to enforce.

## Fail-closed validation (exit 1, before any API call)

- a scope without a `types:` list, or with `types: []`, is refused — a scope that collects nothing may not say so quietly;
- a type whose `levels` cannot intersect its scope's `levels` is refused as a dead declaration (entries listing `unknown` are exempt);
- a duplicate `type:` within one scope's list is refused, with the scope named;
- the retired grammar is refused with a worked migration snippet.

## Changes

**`scripts/inventory.py`** (frozen — reviewed change): per-scope resolution of levels, leaf-IAM opt-ins and native enumerators; entries carry a merged sorted `scopes` attribution (never last-wins under overlapping scopes); `_meta.scopes[]` records per-scope `declared_types` / `zero_yield_types`; new stderr warning for a type that yields zero in one scope while non-zero elsewhere — the shape the aggregate table cannot show.

**`scripts/manifest_init.py` / `scripts/manifest_from_state.py`**: emit the new grammar; the state-driven generator filters each scope's list with exactly the validator's rule, so it can never emit a manifest `inventory.py` refuses.

**Examples**: all migrated; new `examples/import-manifest.multi-domain.yaml` is the worked four-scope reference; `org-foundation.yaml` rewritten as the single-scope reference with comment-block trims.

**Tests**: 211 → 225. Fixture migration plus `TestPerScopeTypes`: legacy rejection, missing/empty/dead/duplicate lists, per-scope sweep isolation (CAI calls asserted per root), per-scope `enumerate:` and `iam: true` isolation, scope-attribution merging, per-scope yield tables, and shipped examples now validated through the real parser.

**Docs**: SKILL.md step-0 rules and step-5 per-scope reporting duties; README schema section, new *Different depth per subtree* section, `inventory.py` exit codes (previously undocumented); cookbook emission section rewrite plus an explicit emission-vs-types contrast (emission inherits defaults because it is denominator-neutral; types never inherit because they decide the denominator), new *Per-scope type declaration* subsection; operating-contract convergence bounded **per scope**; inferring-manifests examples match real generator output. Also fixes the pre-existing cookbook contradiction on numeric-vs-alphanumeric project ids in include/exclude.

## Validation

- `pytest tests/test_scripts.py`: **225 passed**
- `yamllint` on all examples: clean
- `check_boilerplate.py` on all touched files: clean
- `address_map.py` + AddressMap sync tests: clean
- `yapf` (repo style) applied to all touched Python
- live smoke: `inventory.py collect` on the multi-domain example validates and proceeds to enumeration (fails only on placeholder-org credentials, as expected)