### PR TITLE
Fix validation in folder module for assured_workload_config.partner variable

### DIFF
--- a/modules/folder/variables.tf
+++ b/modules/folder/variables.tf
@@ -128,7 +128,7 @@ variable "assured_workload_config" {
     error_message = "Field assured_workload_config.compliance_regime must be one of the values listed in https://cloud.google.com/assured-workloads/docs/reference/rest/Shared.Types/ComplianceRegime"
   }
   validation {
-    condition = try(contains([
+    condition = try(var.assured_workload_config.partner == null || contains([
       "LOCAL_CONTROLS_BY_S3NS",
       "PARTNER_UNSPECIFIED",
       "SOVEREIGN_CONTROLS_BY_CNTXT_NO_EKM",
@@ -137,7 +137,7 @@ variable "assured_workload_config" {
       "SOVEREIGN_CONTROLS_BY_SIA_MINSAIT",
       "SOVEREIGN_CONTROLS_BY_T_SYSTEMS",
     ], var.assured_workload_config.partner), true)
-    error_message = "Field assured_workload_config.partner must be one of the values listed in https://cloud.google.com/assured-workloads/docs/reference/rest/Shared.Types/Partner"
+    error_message = "Field assured_workload_config.partner must be null or one of the values listed in https://cloud.google.com/assured-workloads/docs/reference/rest/Shared.Types/Partner"
   }
 }
 


### PR DESCRIPTION
This should resolve issue with trying to pass null parameter to assured_workload_config.partner in folder module.

Related issue: https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/issues/4124

For testing, I run:
```shell
pytest -k 'modules and folder:' tests/examples
```

Output:
```
= test session starts =
platform win32 -- Python 3.14.7, pytest-9.1.1, pluggy-1.6.0
configfile: pytest.ini
plugins: anyio-4.14.2, xdist-3.8.0
collected 786 items / 765 deselected / 21 selected                                                                                                                                                                                                                                                                 

tests\examples\test_plan.py .....................                                                                                                                                                                                                                                                            [100%]

=21 passed, 765 deselected in 129.93s (0:02:09) =
```

Additional note:
I checkout this on Windows 11 and run python virtual environment in Intelij terminal (powershell). I got such error when running tests:
```
tests\examples\utils.py:52: in get_readme_examples
    doc = marko.parse(readme_path.read_text())
                      ^^^^^^^^^^^^^^^^^^^^^^^
C:\Users\redacted\AppData\Local\Python\pythoncore-3.14-64\Lib\pathlib\__init__.py:788: in read_text
    return f.read()
           ^^^^^^^^
C:\Users\redacted\AppData\Local\Python\pythoncore-3.14-64\Lib\encodings\cp1250.py:23: in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   UnicodeDecodeError: 'charmap' codec can't decode byte 0x98 in position 20388: character maps to <undefined>
```

I followed this post: https://stackoverflow.com/questions/9233027/unicodedecodeerror-charmap-codec-cant-decode-byte-x-in-position-y-character

And modified problematic line locally to:
```py
doc = marko.parse(readme_path.read_text(encoding="utf-8"))
```

Such change resolved this issue. I'm not expert in Python. Should such change also be added in separate PR? Or I should just ignore it? Don't know if this is caused by Windows itself or my git/python configuration.

---
**Checklist**

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass
