### PR TITLE
Add remote repository support for Go to modules/artifact-registry

### DIFF
--- a/modules/artifact-registry/README.md
+++ b/modules/artifact-registry/README.md
@@ -370,9 +370,9 @@ module "additive_iam" {
 |---|---|:---:|:---:|:---:|
 | [cleanup_policies](variables.tf#L17) | Object containing details about the cleanup policies for an Artifact Registry repository. | <code>map&#40;object&#40;&#123;&#8230;default &#61; null</code> | ✓ |  |
 | [format](variables.tf#L83) | Repository format. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
-| [location](variables.tf#L236) | Registry location. Use `gcloud beta artifacts locations list' to get valid values. | <code>string</code> | ✓ |  |
-| [name](variables.tf#L241) | Registry name. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L246) | Registry project id. | <code>string</code> | ✓ |  |
+| [location](variables.tf#L244) | Registry location. Use `gcloud beta artifacts locations list' to get valid values. | <code>string</code> | ✓ |  |
+| [name](variables.tf#L249) | Registry name. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L254) | Registry project id. | <code>string</code> | ✓ |  |
 | [cleanup_policy_dry_run](variables.tf#L38) | If true, the cleanup pipeline is prevented from deleting versions in this repository. | <code>bool</code> |  | <code>null</code> |
 | [context](variables.tf#L44) | Context-specific interpolations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [description](variables.tf#L65) | An optional description for the repository. | <code>string</code> |  | <code>&#34;Terraform-managed registry&#34;</code> |
@@ -382,9 +382,9 @@ module "additive_iam" {
 | [iam_bindings](variables-iam.tf#L43) | Authoritative IAM bindings in {KEY => {role = ROLE, members = [], condition = {}}}. Keys are arbitrary. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_bindings_additive](variables-iam.tf#L58) | Individual additive IAM bindings. Keys are arbitrary. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_by_principals](variables-iam.tf#L73) | Authoritative IAM binding in {PRINCIPAL => [ROLES]} format. Principals need to be statically defined to avoid cycle errors. Merged internally with the `iam` variable. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [labels](variables.tf#L230) | Labels to be attached to the registry. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
-| [tag_bindings](variables.tf#L251) | Tag bindings for this repository, in key => tag value id format. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
-| [universe](variables.tf#L258) | GCP universe where to deploy the project. The prefix will be prepended to the project id. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [labels](variables.tf#L238) | Labels to be attached to the registry. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [tag_bindings](variables.tf#L259) | Tag bindings for this repository, in key => tag value id format. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [universe](variables.tf#L266) | GCP universe where to deploy the project. The prefix will be prepended to the project id. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
 
 ## Outputs
 

--- a/modules/artifact-registry/main.tf
+++ b/modules/artifact-registry/main.tf
@@ -134,7 +134,7 @@ resource "google_artifact_registry_repository" "registry" {
       }
       dynamic "common_repository" {
         for_each = (
-          contains(["docker", "maven", "npm", "python"], local.format_string) &&
+          contains(["docker", "go", "maven", "npm", "python"], local.format_string) &&
           try(local.format_obj.remote.common_repository, null) != null
           ? [""] : []
         )
@@ -241,7 +241,7 @@ resource "google_artifact_registry_repository" "registry" {
   lifecycle {
     precondition {
       condition = local.mode_string != "remote" || contains(
-        ["apt", "docker", "maven", "npm", "python", "yum"], local.format_string
+        ["apt", "docker", "go", "maven", "npm", "python", "yum"], local.format_string
       )
       error_message = "Invalid format for remote repository."
     }

--- a/modules/artifact-registry/variables.tf
+++ b/modules/artifact-registry/variables.tf
@@ -123,6 +123,14 @@ variable "format" {
       standard = optional(bool)
     }))
     go = optional(object({
+      remote = optional(object({
+        common_repository           = optional(string)
+        disable_upstream_validation = optional(bool)
+        upstream_credentials = optional(object({
+          username                = string
+          password_secret_version = string
+        }))
+      }))
       standard = optional(bool)
     }))
     googet = optional(object({

--- a/tests/modules/artifact_registry/remote_go_common.tfvars
+++ b/tests/modules/artifact_registry/remote_go_common.tfvars
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+project_id = "my-project"
+location   = "europe-west1"
+name       = "go-remote"
+format = {
+  go = {
+    remote = {
+      common_repository = "https://proxy.golang.org"
+    }
+  }
+}

--- a/tests/modules/artifact_registry/remote_go_common.yaml
+++ b/tests/modules/artifact_registry/remote_go_common.yaml
@@ -1,0 +1,61 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values:
+  google_artifact_registry_repository.registry:
+    cleanup_policies: []
+    cleanup_policy_dry_run: null
+    deletion_policy: DELETE
+    description: Terraform-managed registry
+    docker_config: []
+    effective_labels:
+      goog-terraform-provisioned: 'true'
+    format: GO
+    kms_key_name: null
+    labels: null
+    location: europe-west1
+    maven_config: []
+    mode: REMOTE_REPOSITORY
+    project: my-project
+    remote_repository_config:
+    - apt_repository: []
+      common_repository:
+      - uri: https://proxy.golang.org
+      description: null
+      disable_upstream_validation: null
+      docker_repository: []
+      maven_repository: []
+      no_cache: []
+      npm_repository: []
+      python_repository: []
+      upstream_credentials: []
+      yum_repository: []
+    repository_id: go-remote
+    terraform_labels:
+      goog-terraform-provisioned: 'true'
+    timeouts: null
+    virtual_repository_config: []
+    vulnerability_scanning_config:
+    - enablement_config: null
+
+counts:
+  google_artifact_registry_repository: 1
+  modules: 0
+  resources: 1
+
+outputs:
+  id: __missing__
+  name: __missing__
+  repository: __missing__
+  url: europe-west1-go.pkg.dev/my-project/go-remote

--- a/tests/modules/artifact_registry/remote_go_common.yaml
+++ b/tests/modules/artifact_registry/remote_go_common.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,48 +14,11 @@
 
 values:
   google_artifact_registry_repository.registry:
-    cleanup_policies: []
-    cleanup_policy_dry_run: null
-    deletion_policy: DELETE
-    description: Terraform-managed registry
-    docker_config: []
-    effective_labels:
-      goog-terraform-provisioned: 'true'
     format: GO
-    kms_key_name: null
-    labels: null
-    location: europe-west1
-    maven_config: []
     mode: REMOTE_REPOSITORY
+    location: europe-west1
     project: my-project
-    remote_repository_config:
-    - apt_repository: []
-      common_repository:
-      - uri: https://proxy.golang.org
-      description: null
-      disable_upstream_validation: null
-      docker_repository: []
-      maven_repository: []
-      no_cache: []
-      npm_repository: []
-      python_repository: []
-      upstream_credentials: []
-      yum_repository: []
     repository_id: go-remote
-    terraform_labels:
-      goog-terraform-provisioned: 'true'
-    timeouts: null
-    virtual_repository_config: []
-    vulnerability_scanning_config:
-    - enablement_config: null
-
-counts:
-  google_artifact_registry_repository: 1
-  modules: 0
-  resources: 1
-
-outputs:
-  id: __missing__
-  name: __missing__
-  repository: __missing__
-  url: europe-west1-go.pkg.dev/my-project/go-remote
+    remote_repository_config:
+    - common_repository:
+      - uri: https://proxy.golang.org

--- a/tests/modules/artifact_registry/tftest.yaml
+++ b/tests/modules/artifact_registry/tftest.yaml
@@ -17,4 +17,5 @@ module: modules/artifact-registry
 tests:
   context:
   universe:
+  remote_go_common:
   remote_maven_common:


### PR DESCRIPTION
### Description
This change adds support for creating Go remote repositories (pull-through caches) in the `modules/artifact-registry` module using the `common_repository` configuration block.

Previously, the `go` format object only allowed `standard = optional(bool)`. Because the Terraform Google provider implements Go remote repositories via `format = "GO"` and `remote_repository_config.common_repository`, this update extends the `go` format variable to accept `remote` configurations (`common_repository`, `disable_upstream_validation`, `upstream_credentials`).

### Changes
- Updated `modules/artifact-registry/variables.tf` to add `remote` object under `go` format.
- Updated `modules/artifact-registry/main.tf` to include `"go"` in `dynamic "common_repository"` and `lifecycle.precondition`.
- Regenerated documentation tables in `modules/artifact-registry/README.md` via `tfdoc.py`.
- Added test case `remote_go_common` with `.tfvars` and `.yaml` plan assertion in `tests/modules/artifact_registry/`.

### Verification
- Ran module unit tests: `pytest tests/modules/artifact_registry` (4/4 passed).
- Ran example tests: `pytest -k 'modules and artifact-registry:' tests/examples` (8/8 passed).
- Ran full lint pipeline: `tools/lint.sh` (passed).
