### PR TITLE
modules/compute-vm: Updated the boot disk resource to get created via snapshot

### DIFF
--- a/modules/compute-vm/disks.tf
+++ b/modules/compute-vm/disks.tf
@@ -43,6 +43,7 @@ resource "google_compute_disk" "boot" {
     var.boot_disk.use_independent_disk.name, "${var.name}-boot"
   )
   image                  = var.boot_disk.source.image
+  snapshot               = var.boot_disk.source.snapshot
   architecture           = var.boot_disk.architecture
   type                   = var.boot_disk.initialize_params.type
   size                   = var.boot_disk.initialize_params.size

--- a/modules/compute-vm/instance.tf
+++ b/modules/compute-vm/instance.tf
@@ -119,6 +119,7 @@ resource "google_compute_instance" "default" {
       content {
         architecture           = var.boot_disk.architecture
         image                  = var.boot_disk.source.image
+        snapshot               = var.boot_disk.source.snapshot
         size                   = var.boot_disk.initialize_params.size
         type                   = var.boot_disk.initialize_params.type
         resource_manager_tags  = var.tag_bindings_immutable

--- a/modules/compute-vm/template.tf
+++ b/modules/compute-vm/template.tf
@@ -63,6 +63,7 @@ resource "google_compute_instance_template" "default" {
     disk_size_gb           = var.boot_disk.initialize_params.size
     disk_type              = var.boot_disk.initialize_params.type
     source_image           = var.boot_disk.source.image
+    source_snapshot        = var.boot_disk.source.snapshot
     provisioned_iops       = var.boot_disk.initialize_params.hyperdisk.provisioned_iops
     provisioned_throughput = var.boot_disk.initialize_params.hyperdisk.provisioned_throughput
     resource_manager_tags  = var.tag_bindings_immutable
@@ -108,6 +109,7 @@ resource "google_compute_instance_template" "default" {
       mode                  = var.attached_disks[disk_iter.value.key].mode
       resource_manager_tags = var.tag_bindings_immutable
       source_image          = var.attached_disks[disk_iter.value.key].source.image
+      source_snapshot       = var.attached_disks[disk_iter.value.key].source.snapshot
       source                = var.attached_disks[disk_iter.value.key].source.attach
       type                  = "PERSISTENT"
       # Cannot use `source` with any of the fields in
@@ -327,6 +329,7 @@ resource "google_compute_region_instance_template" "default" {
     disk_size_gb           = var.boot_disk.initialize_params.size
     disk_type              = var.boot_disk.initialize_params.type
     source_image           = var.boot_disk.source.image
+    source_snapshot        = var.boot_disk.source.snapshot
     provisioned_iops       = var.boot_disk.initialize_params.hyperdisk.provisioned_iops
     provisioned_throughput = var.boot_disk.initialize_params.hyperdisk.provisioned_throughput
     resource_manager_tags  = var.tag_bindings_immutable
@@ -373,6 +376,7 @@ resource "google_compute_region_instance_template" "default" {
       mode                  = var.attached_disks[disk_iter.value.key].mode
       resource_manager_tags = var.tag_bindings_immutable
       source_image          = var.attached_disks[disk_iter.value.key].source.image
+      source_snapshot       = var.attached_disks[disk_iter.value.key].source.snapshot
       source                = var.attached_disks[disk_iter.value.key].source.attach
       type                  = "PERSISTENT"
       # Cannot use `source` with any of the fields in


### PR DESCRIPTION
module/compute-vm: updated the boot disk resource to get created via snapshot too as attached disk, functionality: creating a duplicate disk against a running vm is only possible via snapshots

<!-- Put a description of what this PR is for here -->

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [x] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
