### PR TITLE
modules/gke-cluster: backup_plan_ids exported and removed deprecated variable 

### DIFF
--- a/modules/gke-cluster-autopilot/README.md
+++ b/modules/gke-cluster-autopilot/README.md
@@ -291,40 +291,41 @@ module "cluster-1" {
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [location](variables.tf#L186) | Autopilot clusters are always regional. | <code>string</code> | ✓ |  |
-| [name](variables.tf#L269) | Cluster name. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L302) | Cluster project ID. | <code>string</code> | ✓ |  |
-| [vpc_config](variables.tf#L318) | VPC-level configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
+| [location](variables.tf#L185) | Autopilot clusters are always regional. | <code>string</code> | ✓ |  |
+| [name](variables.tf#L268) | Cluster name. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L301) | Cluster project ID. | <code>string</code> | ✓ |  |
+| [vpc_config](variables.tf#L317) | VPC-level configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
 | [access_config](variables.tf#L17) | Control plane endpoint and nodes access configurations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [backup_configs](variables.tf#L49) | Configuration for Backup for GKE. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [deletion_protection](variables.tf#L71) | Whether or not to allow Terraform to destroy the cluster. Unless this field is set to false in Terraform state, a terraform destroy or terraform apply that would delete the cluster will fail. | <code>bool</code> |  | <code>true</code> |
 | [description](variables.tf#L78) | Cluster description. | <code>string</code> |  | <code>null</code> |
 | [enable_addons](variables.tf#L84) | Addons enabled in the cluster (true means enabled). | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [enable_features](variables.tf#L98) | Enable cluster-level features. Certain features allow configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [fleet_project](variables.tf#L168) | The name of the fleet host project where this cluster will be registered. | <code>string</code> |  | <code>null</code> |
-| [issue_client_certificate](variables.tf#L174) | Enable issuing client certificate. | <code>bool</code> |  | <code>false</code> |
-| [labels](variables.tf#L180) | Cluster resource labels. | <code>map&#40;string&#41;</code> |  | <code>null</code> |
-| [logging_config](variables.tf#L191) | Logging configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [maintenance_config](variables.tf#L202) | Maintenance window configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#8230;&#125;</code> |
-| [min_master_version](variables.tf#L225) | Minimum version of the master, defaults to the version of the most recent official release. | <code>string</code> |  | <code>null</code> |
-| [monitoring_config](variables.tf#L231) | Monitoring configuration. System metrics collection cannot be disabled. Control plane metrics are optional. Kube state metrics are optional. Google Cloud Managed Service for Prometheus is enabled by default. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [node_config](variables.tf#L274) | Configuration for nodes and nodepools. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [node_locations](variables.tf#L295) | Zones in which the cluster's nodes are located. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
-| [release_channel](variables.tf#L307) | Release channel for GKE upgrades. Clusters created in the Autopilot mode must use a release channel. Choose between \"RAPID\", \"REGULAR\", and \"STABLE\". | <code>string</code> |  | <code>&#34;REGULAR&#34;</code> |
+| [fleet_project](variables.tf#L167) | The name of the fleet host project where this cluster will be registered. | <code>string</code> |  | <code>null</code> |
+| [issue_client_certificate](variables.tf#L173) | Enable issuing client certificate. | <code>bool</code> |  | <code>false</code> |
+| [labels](variables.tf#L179) | Cluster resource labels. | <code>map&#40;string&#41;</code> |  | <code>null</code> |
+| [logging_config](variables.tf#L190) | Logging configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [maintenance_config](variables.tf#L201) | Maintenance window configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#8230;&#125;</code> |
+| [min_master_version](variables.tf#L224) | Minimum version of the master, defaults to the version of the most recent official release. | <code>string</code> |  | <code>null</code> |
+| [monitoring_config](variables.tf#L230) | Monitoring configuration. System metrics collection cannot be disabled. Control plane metrics are optional. Kube state metrics are optional. Google Cloud Managed Service for Prometheus is enabled by default. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [node_config](variables.tf#L273) | Configuration for nodes and nodepools. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [node_locations](variables.tf#L294) | Zones in which the cluster's nodes are located. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
+| [release_channel](variables.tf#L306) | Release channel for GKE upgrades. Clusters created in the Autopilot mode must use a release channel. Choose between \"RAPID\", \"REGULAR\", and \"STABLE\". | <code>string</code> |  | <code>&#34;REGULAR&#34;</code> |
 
 ## Outputs
 
 | name | description | sensitive |
 |---|---|:---:|
-| [ca_certificate](outputs.tf#L17) | Public certificate of the cluster (base64-encoded). | ✓ |
-| [cluster](outputs.tf#L23) | Cluster resource. | ✓ |
-| [dns_endpoint](outputs.tf#L29) | Control plane DNS endpoint. |  |
-| [endpoint](outputs.tf#L37) | Cluster endpoint. |  |
-| [id](outputs.tf#L42) | Fully qualified cluster ID. |  |
-| [location](outputs.tf#L47) | Cluster location. |  |
-| [master_version](outputs.tf#L52) | Master version. |  |
-| [name](outputs.tf#L57) | Cluster name. |  |
-| [notifications](outputs.tf#L62) | GKE Pub/Sub notifications topic. |  |
-| [self_link](outputs.tf#L67) | Cluster self link. | ✓ |
-| [workload_identity_pool](outputs.tf#L73) | Workload identity pool. |  |
+| [backup_plan_ids](outputs.tf#L17) | GKE backup plan ids. |  |
+| [ca_certificate](outputs.tf#L24) | Public certificate of the cluster (base64-encoded). | ✓ |
+| [cluster](outputs.tf#L30) | Cluster resource. | ✓ |
+| [dns_endpoint](outputs.tf#L36) | Control plane DNS endpoint. |  |
+| [endpoint](outputs.tf#L44) | Cluster endpoint. |  |
+| [id](outputs.tf#L49) | Fully qualified cluster ID. |  |
+| [location](outputs.tf#L54) | Cluster location. |  |
+| [master_version](outputs.tf#L59) | Master version. |  |
+| [name](outputs.tf#L64) | Cluster name. |  |
+| [notifications](outputs.tf#L69) | GKE Pub/Sub notifications topic. |  |
+| [self_link](outputs.tf#L74) | Cluster self link. | ✓ |
+| [workload_identity_pool](outputs.tf#L80) | Workload identity pool. |  |
 <!-- END TFDOC -->

--- a/modules/gke-cluster-autopilot/main.tf
+++ b/modules/gke-cluster-autopilot/main.tf
@@ -415,12 +415,6 @@ resource "google_container_cluster" "cluster" {
       enabled = var.enable_features.vertical_pod_autoscaling
     }
   }
-  dynamic "enterprise_config" {
-    for_each = var.enable_features.enterprise_cluster != null ? [""] : []
-    content {
-      desired_tier = var.enable_features.enterprise_cluster ? "ENTERPRISE" : "STANDARD"
-    }
-  }
 }
 
 resource "google_gke_backup_backup_plan" "backup_plan" {

--- a/modules/gke-cluster-autopilot/outputs.tf
+++ b/modules/gke-cluster-autopilot/outputs.tf
@@ -14,6 +14,13 @@
  * limitations under the License.
  */
 
+output "backup_plan_ids" {
+  description = "GKE backup plan ids."
+  value = {
+    for k, v in google_gke_backup_backup_plan.backup_plan : k => v.id
+  }
+}
+
 output "ca_certificate" {
   description = "Public certificate of the cluster (base64-encoded)."
   value       = google_container_cluster.cluster.master_auth[0].cluster_ca_certificate

--- a/modules/gke-cluster-autopilot/variables.tf
+++ b/modules/gke-cluster-autopilot/variables.tf
@@ -150,7 +150,6 @@ variable "enable_features" {
       kms_key_name = optional(string)
     }))
     vertical_pod_autoscaling = optional(bool, false)
-    enterprise_cluster       = optional(bool)
   })
   default = {}
   validation {

--- a/modules/gke-cluster-standard/README.md
+++ b/modules/gke-cluster-standard/README.md
@@ -544,7 +544,7 @@ module "cluster-1" {
 
 | name | description | sensitive |
 |---|---|:---:|
-| [backup_plan_id](outputs.tf#L17) | GKE backup plan ids. |  |
+| [backup_plan_ids](outputs.tf#L17) | GKE backup plan ids. |  |
 | [ca_certificate](outputs.tf#L24) | Public certificate of the cluster (base64-encoded). | ✓ |
 | [cluster](outputs.tf#L32) | Cluster resource. | ✓ |
 | [dns_endpoint](outputs.tf#L38) | Control plane DNS endpoint. |  |

--- a/modules/gke-cluster-standard/README.md
+++ b/modules/gke-cluster-standard/README.md
@@ -515,10 +515,10 @@ module "cluster-1" {
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [location](variables.tf#L304) | Cluster zone or region. | <code>string</code> | ✓ |  |
-| [name](variables.tf#L419) | Cluster name. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L471) | Cluster project id. | <code>string</code> | ✓ |  |
-| [vpc_config](variables.tf#L482) | VPC-level configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
+| [location](variables.tf#L303) | Cluster zone or region. | <code>string</code> | ✓ |  |
+| [name](variables.tf#L418) | Cluster name. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L470) | Cluster project id. | <code>string</code> | ✓ |  |
+| [vpc_config](variables.tf#L481) | VPC-level configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
 | [access_config](variables.tf#L17) | Control plane endpoint and nodes access configurations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [backup_configs](variables.tf#L49) | Configuration for Backup for GKE. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [cluster_autoscaling](variables.tf#L72) | Enable and configure limits for Node Auto-Provisioning with Cluster Autoscaler. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
@@ -527,32 +527,33 @@ module "cluster-1" {
 | [description](variables.tf#L177) | Cluster description. | <code>string</code> |  | <code>null</code> |
 | [enable_addons](variables.tf#L183) | Addons enabled in the cluster (true means enabled). | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [enable_features](variables.tf#L205) | Enable cluster-level features. Certain features allow configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [fleet_project](variables.tf#L285) | The name of the fleet host project where this cluster will be registered. | <code>string</code> |  | <code>null</code> |
-| [issue_client_certificate](variables.tf#L291) | Enable issuing client certificate. | <code>bool</code> |  | <code>false</code> |
-| [labels](variables.tf#L297) | Cluster resource labels. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
-| [logging_config](variables.tf#L309) | Logging configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [maintenance_config](variables.tf#L330) | Maintenance window configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#8230;&#125;</code> |
-| [max_pods_per_node](variables.tf#L353) | Maximum number of pods per node in this cluster. | <code>number</code> |  | <code>110</code> |
-| [min_master_version](variables.tf#L359) | Minimum version of the master, defaults to the version of the most recent official release. | <code>string</code> |  | <code>null</code> |
-| [monitoring_config](variables.tf#L365) | Monitoring configuration. Google Cloud Managed Service for Prometheus is enabled by default. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [node_config](variables.tf#L424) | Node-level configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [node_locations](variables.tf#L447) | Zones in which the cluster's nodes are located. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
-| [node_pool_auto_config](variables.tf#L454) | Node pool configs that apply to auto-provisioned node pools in autopilot clusters and node auto-provisioning-enabled clusters. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [release_channel](variables.tf#L476) | Release channel for GKE upgrades. | <code>string</code> |  | <code>null</code> |
+| [fleet_project](variables.tf#L284) | The name of the fleet host project where this cluster will be registered. | <code>string</code> |  | <code>null</code> |
+| [issue_client_certificate](variables.tf#L290) | Enable issuing client certificate. | <code>bool</code> |  | <code>false</code> |
+| [labels](variables.tf#L296) | Cluster resource labels. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [logging_config](variables.tf#L308) | Logging configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [maintenance_config](variables.tf#L329) | Maintenance window configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#8230;&#125;</code> |
+| [max_pods_per_node](variables.tf#L352) | Maximum number of pods per node in this cluster. | <code>number</code> |  | <code>110</code> |
+| [min_master_version](variables.tf#L358) | Minimum version of the master, defaults to the version of the most recent official release. | <code>string</code> |  | <code>null</code> |
+| [monitoring_config](variables.tf#L364) | Monitoring configuration. Google Cloud Managed Service for Prometheus is enabled by default. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [node_config](variables.tf#L423) | Node-level configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [node_locations](variables.tf#L446) | Zones in which the cluster's nodes are located. | <code>list&#40;string&#41;</code> |  | <code>&#91;&#93;</code> |
+| [node_pool_auto_config](variables.tf#L453) | Node pool configs that apply to auto-provisioned node pools in autopilot clusters and node auto-provisioning-enabled clusters. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [release_channel](variables.tf#L475) | Release channel for GKE upgrades. | <code>string</code> |  | <code>null</code> |
 
 ## Outputs
 
 | name | description | sensitive |
 |---|---|:---:|
-| [ca_certificate](outputs.tf#L17) | Public certificate of the cluster (base64-encoded). | ✓ |
-| [cluster](outputs.tf#L25) | Cluster resource. | ✓ |
-| [dns_endpoint](outputs.tf#L31) | Control plane DNS endpoint. |  |
-| [endpoint](outputs.tf#L39) | Cluster endpoint. |  |
-| [id](outputs.tf#L44) | FUlly qualified cluster id. |  |
-| [location](outputs.tf#L49) | Cluster location. |  |
-| [master_version](outputs.tf#L54) | Master version. |  |
-| [name](outputs.tf#L59) | Cluster name. |  |
-| [notifications](outputs.tf#L64) | GKE PubSub notifications topic. |  |
-| [self_link](outputs.tf#L69) | Cluster self link. | ✓ |
-| [workload_identity_pool](outputs.tf#L75) | Workload identity pool. |  |
+| [backup_plan_id](outputs.tf#L17) | GKE backup plan ids. |  |
+| [ca_certificate](outputs.tf#L24) | Public certificate of the cluster (base64-encoded). | ✓ |
+| [cluster](outputs.tf#L32) | Cluster resource. | ✓ |
+| [dns_endpoint](outputs.tf#L38) | Control plane DNS endpoint. |  |
+| [endpoint](outputs.tf#L46) | Cluster endpoint. |  |
+| [id](outputs.tf#L51) | FUlly qualified cluster id. |  |
+| [location](outputs.tf#L56) | Cluster location. |  |
+| [master_version](outputs.tf#L61) | Master version. |  |
+| [name](outputs.tf#L66) | Cluster name. |  |
+| [notifications](outputs.tf#L71) | GKE PubSub notifications topic. |  |
+| [self_link](outputs.tf#L76) | Cluster self link. | ✓ |
+| [workload_identity_pool](outputs.tf#L82) | Workload identity pool. |  |
 <!-- END TFDOC -->

--- a/modules/gke-cluster-standard/main.tf
+++ b/modules/gke-cluster-standard/main.tf
@@ -628,12 +628,6 @@ resource "google_container_cluster" "cluster" {
       workload_pool = "${var.project_id}.svc.id.goog"
     }
   }
-  dynamic "enterprise_config" {
-    for_each = var.enable_features.enterprise_cluster != null ? [""] : []
-    content {
-      desired_tier = var.enable_features.enterprise_cluster ? "ENTERPRISE" : "STANDARD"
-    }
-  }
   lifecycle {
     ignore_changes = [node_config]
   }

--- a/modules/gke-cluster-standard/outputs.tf
+++ b/modules/gke-cluster-standard/outputs.tf
@@ -14,6 +14,13 @@
  * limitations under the License.
  */
 
+output "backup_plan_id" {
+  description = "GKE backup plan ids."
+  value = {
+    for k, v in google_gke_backup_backup_plan.backup_plan : k => v.id
+  }
+}
+
 output "ca_certificate" {
   description = "Public certificate of the cluster (base64-encoded)."
   value = (

--- a/modules/gke-cluster-standard/outputs.tf
+++ b/modules/gke-cluster-standard/outputs.tf
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-output "backup_plan_id" {
+output "backup_plan_ids" {
   description = "GKE backup plan ids."
   value = {
     for k, v in google_gke_backup_backup_plan.backup_plan : k => v.id

--- a/modules/gke-cluster-standard/variables.tf
+++ b/modules/gke-cluster-standard/variables.tf
@@ -261,7 +261,6 @@ variable "enable_features" {
     }))
     vertical_pod_autoscaling = optional(bool, false)
     workload_identity        = optional(bool, true)
-    enterprise_cluster       = optional(bool)
   })
   default = {}
   validation {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here -->

This PR removes the deprecated `desired_tier` attribute from the `enterprise_config` block and updates the backup/restore plan configuration as documented in the [Terraform Google provider documentation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#desired_tier-1:~:text=enterprise_config%20block%20supports%3A-,desired_tier,-%2D%20(Optional)%20(DEPRECATED)%20Sets).

The backup plan ID is exposed through a Terraform output so that it can be referenced by the restore plan.

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [x] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [x] Ran `terraform fmt` on all modified files
- [x] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [x] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

**Breaking Changes**

```upgrade-note
`modules/gke-cluster-standard`: Removed the deprecated `desired_tier` attribute from the `enterprise_config` block.
`modules/gke-cluster-autopilot`: Removed the deprecated `desired_tier` attribute from the `enterprise_config` block.
