### PR TITLE
Make contains() validations null-safe across Terraform versions

### DIFF
--- a/modules/cloud-config-container/simple-nva/variables.tf
+++ b/modules/cloud-config-container/simple-nva/variables.tf
@@ -44,8 +44,8 @@ variable "frr_config" {
   })
   default = null
   validation {
-    condition = try(alltrue([
-      for daemon in var.frr_config.daemons_enabled : contains([
+    condition = alltrue([
+      for daemon in coalesce(try(var.frr_config.daemons_enabled, null), []) : contains([
         "zebra",
         "bgpd",
         "ospfd",
@@ -63,8 +63,8 @@ variable "frr_config" {
         "pbrd",
         "bfdd",
         "fabricd"
-      ], daemon)
-    ]), true)
+      ], coalesce(daemon, "-"))
+    ])
     error_message = <<EOF
     Invalid entry specified in daemons_enabled list, must be one of [zebra, bgpd, ospfd, ospf6d,
     ripd, ripngd, isisd, pimd, ldpd, nhrpd, eigrpd, babeld, sharpd, staticd, pbrd, bfdd, fabricd]

--- a/modules/dns/README.md
+++ b/modules/dns/README.md
@@ -198,7 +198,7 @@ module "public-dns" {
 | [iam](variables.tf#L41) | IAM bindings in {ROLE => [MEMBERS]} format. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>null</code> |
 | [labels](variables.tf#L47) | Labels to be assigned to the zone. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
 | [recordsets](variables.tf#L63) | Map of DNS recordsets in \"type name\" => {ttl, [records]} format. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [zone_config](variables.tf#L120) | DNS zone configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [zone_config](variables.tf#L122) | DNS zone configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
 
 ## Outputs
 

--- a/modules/dns/variables.tf
+++ b/modules/dns/variables.tf
@@ -105,10 +105,12 @@ variable "recordsets" {
   validation {
     condition = alltrue(flatten([
       for k, v in coalesce(var.recordsets, {}) : [
-        for r in try(v.geo_routing.health_checked_targets, []) : [
-          contains(
-            ["regionalL4ilb", "regionalL7ilb", "globalL7ilb", null],
-            try(r.load_balancer_type, null)
+        for g in coalesce(v.geo_routing, []) : [
+          for r in coalesce(g.health_checked_targets, []) : (
+            r.load_balancer_type == null ? true : contains(
+              ["regionalL4ilb", "regionalL7ilb", "globalL7ilb"],
+              r.load_balancer_type
+            )
           )
         ]
       ]

--- a/modules/folder/README.md
+++ b/modules/folder/README.md
@@ -807,13 +807,13 @@ module "folder" {
 | [asset_feeds](variables.tf#L18) | Cloud Asset Inventory feeds. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [asset_search](variables.tf#L51) | Cloud Asset Inventory search configurations. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [assured_workload_config](variables.tf#L61) | Create AssuredWorkloads folder instead of regular folder when value is provided. Incompatible with folder_create=false. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [autokey_config](variables.tf#L144) | Enable autokey support for this folder's children. Project accepts either project id or number. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [contacts](variables.tf#L153) | List of essential contacts for this resource. Must be in the form EMAIL -> [NOTIFICATION_TYPES]. Valid notification types are ALL, SUSPENSION, SECURITY, TECHNICAL, BILLING, LEGAL, PRODUCT_UPDATES. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [context](variables.tf#L172) | Context-specific interpolations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [deletion_protection](variables.tf#L197) | Deletion protection setting for this folder. | <code>bool</code> |  | <code>false</code> |
-| [factories_config](variables.tf#L203) | Paths to data files and folders that enable factory functionality. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [firewall_policy](variables.tf#L215) | Hierarchical firewall policy to associate to this folder. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [folder_create](variables.tf#L226) | Create folder. When set to false, uses id to reference an existing folder. | <code>bool</code> |  | <code>true</code> |
+| [autokey_config](variables.tf#L145) | Enable autokey support for this folder's children. Project accepts either project id or number. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [contacts](variables.tf#L154) | List of essential contacts for this resource. Must be in the form EMAIL -> [NOTIFICATION_TYPES]. Valid notification types are ALL, SUSPENSION, SECURITY, TECHNICAL, BILLING, LEGAL, PRODUCT_UPDATES. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [context](variables.tf#L173) | Context-specific interpolations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [deletion_protection](variables.tf#L198) | Deletion protection setting for this folder. | <code>bool</code> |  | <code>false</code> |
+| [factories_config](variables.tf#L204) | Paths to data files and folders that enable factory functionality. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [firewall_policy](variables.tf#L216) | Hierarchical firewall policy to associate to this folder. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [folder_create](variables.tf#L227) | Create folder. When set to false, uses id to reference an existing folder. | <code>bool</code> |  | <code>true</code> |
 | [iam](variables-iam.tf#L17) | IAM bindings in {ROLE => [MEMBERS]} format. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_bindings](variables-iam.tf#L24) | Authoritative IAM bindings in {KEY => {role = ROLE, members = [], condition = {}}}. Keys are arbitrary. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_bindings_additive](variables-iam.tf#L39) | Individual additive IAM bindings. Keys are arbitrary. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
@@ -821,19 +821,19 @@ module "folder" {
 | [iam_by_principals_additive](variables-iam.tf#L54) | Additive IAM binding in {PRINCIPAL => [ROLES]} format. Principals need to be statically defined to avoid errors. Merged internally with the `iam_bindings_additive` variable. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_by_principals_conditional](variables-iam.tf#L68) | Authoritative IAM binding in {PRINCIPAL => {roles = [roles], condition = {cond}}} format. Principals need to be statically defined to avoid errors. Condition is required. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [iam_deny_policies](variables-iam.tf#L98) | IAM Deny policies to be applied to the folder. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [id](variables.tf#L236) | Folder ID in case you use folder_create=false. | <code>string</code> |  | <code>null</code> |
+| [id](variables.tf#L237) | Folder ID in case you use folder_create=false. | <code>string</code> |  | <code>null</code> |
 | [logging_data_access](variables-logging.tf#L17) | Control activation of data access logs. The special 'allServices' key denotes configuration for all services. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [logging_exclusions](variables-logging.tf#L28) | Logging exclusions for this folder in the form {NAME -> FILTER}. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
 | [logging_settings](variables-logging.tf#L35) | Default settings for logging resources. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
 | [logging_sinks](variables-logging.tf#L45) | Logging sinks to create for the folder. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [name](variables.tf#L242) | Folder name. | <code>string</code> |  | <code>null</code> |
-| [org_policies](variables.tf#L248) | Organization policies applied to this folder keyed by policy name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [name](variables.tf#L243) | Folder name. | <code>string</code> |  | <code>null</code> |
+| [org_policies](variables.tf#L249) | Organization policies applied to this folder keyed by policy name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [pam_entitlements](variables-pam.tf#L17) | Privileged Access Manager entitlements for this resource, keyed by entitlement ID. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [parent](variables.tf#L276) | Parent in folders/folder_id or organizations/org_id format. | <code>string</code> |  | <code>null</code> |
+| [parent](variables.tf#L277) | Parent in folders/folder_id or organizations/org_id format. | <code>string</code> |  | <code>null</code> |
 | [scc_mute_configs](variables-scc.tf#L17) | SCC mute configurations keyed by name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [scc_sha_custom_modules](variables-scc.tf#L27) | SCC custom modules keyed by module name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [service_agents_config](variables.tf#L290) | Service agents configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [tag_bindings](variables.tf#L300) | Tag bindings for this folder, in key => tag value id format. | <code>map&#40;string&#41;</code> |  | <code>null</code> |
+| [service_agents_config](variables.tf#L291) | Service agents configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [tag_bindings](variables.tf#L301) | Tag bindings for this folder, in key => tag value id format. | <code>map&#40;string&#41;</code> |  | <code>null</code> |
 
 ## Outputs
 

--- a/modules/folder/variables.tf
+++ b/modules/folder/variables.tf
@@ -78,7 +78,7 @@ variable "assured_workload_config" {
   })
   default = null
   validation {
-    condition = try(contains([
+    condition = var.assured_workload_config == null ? true : contains([
       "ASSURED_WORKLOADS_FOR_PARTNERS",
       "AU_REGIONS_AND_US_SUPPORT",
       "AUSTRALIA_DATA_BOUNDARY_AND_SUPPORT",
@@ -124,19 +124,20 @@ variable "assured_workload_config" {
       "US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES",
       "US_DATA_BOUNDARY_FOR_HEALTHCARE_AND_LIFE_SCIENCES_WITH_SUPPORT",
       "US_REGIONAL_ACCESS"
-    ], var.assured_workload_config.compliance_regime), true)
+    ], coalesce(var.assured_workload_config.compliance_regime, "-"))
     error_message = "Field assured_workload_config.compliance_regime must be one of the values listed in https://cloud.google.com/assured-workloads/docs/reference/rest/Shared.Types/ComplianceRegime"
   }
   validation {
-    condition = try(var.assured_workload_config.partner == null || contains([
-      "LOCAL_CONTROLS_BY_S3NS",
-      "PARTNER_UNSPECIFIED",
-      "SOVEREIGN_CONTROLS_BY_CNTXT_NO_EKM",
-      "SOVEREIGN_CONTROLS_BY_CNTXT",
-      "SOVEREIGN_CONTROLS_BY_PSN",
-      "SOVEREIGN_CONTROLS_BY_SIA_MINSAIT",
-      "SOVEREIGN_CONTROLS_BY_T_SYSTEMS",
-    ], var.assured_workload_config.partner), true)
+    condition = var.assured_workload_config == null ? true : (
+      var.assured_workload_config.partner == null || contains([
+        "LOCAL_CONTROLS_BY_S3NS",
+        "PARTNER_UNSPECIFIED",
+        "SOVEREIGN_CONTROLS_BY_CNTXT_NO_EKM",
+        "SOVEREIGN_CONTROLS_BY_CNTXT",
+        "SOVEREIGN_CONTROLS_BY_PSN",
+        "SOVEREIGN_CONTROLS_BY_SIA_MINSAIT",
+        "SOVEREIGN_CONTROLS_BY_T_SYSTEMS",
+    ], var.assured_workload_config.partner))
     error_message = "Field assured_workload_config.partner must be null or one of the values listed in https://cloud.google.com/assured-workloads/docs/reference/rest/Shared.Types/Partner"
   }
 }


### PR DESCRIPTION
> **TL;DR** — TF 1.16 made `contains()` return `false` for null instead of erroring, which silently flips `try(contains(l, null), true)` from pass to fail. #4125 fixed one instance; this audits all `.tf` files and fixes the remaining 2 (`modules/folder` `compliance_regime`, `simple-nva` `daemons_enabled`). Along the way I found the `modules/dns``load_balancer_type` validation has been dead code since it was written, and fixed that too. Verified identical behaviour on 1.15.8 and 1.16.0 across 18 cases; no impact in `fast/` or `blueprints/`.

Follow-up to #4125 

Terraform 1.16.0 changed `contains()` so it [can now test for null values](https://github.com/hashicorp/terraform/releases#release-v1.16.0):

```bash
$ echo 'contains(["a"], tostring(null))' | tf1.16.0 console
false
$ echo 'contains(["a"], tostring(null))' | tf1.15.3 console
│ Error: Invalid value for "value" parameter: argument must not be null.
```

The consequence for our validation blocks splits into two classes:

| pattern | TF ≤1.15 / OpenTofu | TF 1.16 |
|---|---|---|
| **A.** `try(contains(l, null), true)` | `contains` errors → `try` swallows → **silently PASSES** | returns `false` → **FAILS** |
| **B.** unguarded `contains(l, null)` | hard `Invalid function argument` crash | clean `error_message` |

Class B is strictly an improvement — those sites already crashed. **Class A is the regression**: valid configs that used to be accepted are now rejected.

### Audit

I scanned all git-tracked `.tf` files, classifying every `contains()` by whether its value argument can be null and whether it sits inside a `try()`. Class A has exactly **8 sites** repo-wide:

| site | verdict |
|---|---|
| `modules/folder/variables.tf` — `partner` | the original bug, fixed in #4125 |
| `modules/folder/variables.tf` — `compliance_regime` | **fixed here** — `compliance_regime = null` passed on 1.15, failed on 1.16 |
| `modules/cloud-config-container/simple-nva/variables.tf` — `daemons_enabled` | **fixed here** — a literal `null` element flipped pass→fail |
| `modules/ai-applications/variables.tf` ×2 | already guarded with `== null ? true :` inside the `try` — safe, untouched |
| `modules/cloud-config-container/simple-nva/main.tf` ×3 | null is the *collection* arg, which still errors in 1.16 — unaffected, untouched |

Nothing in `fast/` or `blueprints/` is affected.

### The compatible pattern

The obvious-looking guard is **not** sufficient. Verified against real 1.15.8 and
1.16.0 binaries:

| condition, with `o = {x = null}` | 1.15.8 | 1.16.0 |
|---|---|---|
| `var.o == null \|\| contains(l, var.o.x)` | **CRASH** | REJECT |
| `var.o == null ? true : contains(l, coalesce(var.o.x, "-"))` | REJECT | REJECT |

`||` short-circuits the *container* null but not the *value* null. So the rule applied throughout this PR is: **guard the container, and never let `contains()` receive null as its value** — an explicit `x == null ? true :` branch where null is legal, or `coalesce(x, "-")` where null must be rejected. `try()` is removed rather than relied upon, since swallowing the error is exactly what hid the version divergence.

### Changes

- **`modules/folder/variables.tf`** — dropped `try(..., true)` from both validations;
  container guarded explicitly, `compliance_regime` neutralised with `coalesce()`.
- **`modules/cloud-config-container/simple-nva/variables.tf`** — dropped
  `try(..., true)`; iterate `coalesce(try(...), [])`, element neutralised with
  `coalesce()`.
- **`modules/dns/variables.tf`** — this one was worse than the audit suggested.
  `geo_routing` is a `list(object)`, so `try(v.geo_routing.health_checked_targets, [])`
  was an attribute access **on a list**: it always errored, `try` always swallowed it to
  `[]`, and the loop body never executed. The validation has been dead code since it was
  written, which is also why nobody hit the `null`-in-allowed-list trick it relied on.
  Fixed the iteration and dropped the sentinel.
