### PR TITLE
Add binary authorization and default URI disabling to modules/cloud-run-v2

### DIFF
--- a/modules/cloud-run-v2/README.md
+++ b/modules/cloud-run-v2/README.md
@@ -23,6 +23,7 @@ Cloud Run Services and Jobs, with support for IAM roles and Eventarc trigger cre
 - [Adding GPUs](#adding-gpus)
 - [Multi-Region Service](#multi-region-service)
 - [Traffic Splitting and Revision Tagging](#traffic-splitting-and-revision-tagging)
+- [Security Configurations](#security-configurations)
 - [Variables](#variables)
 - [Outputs](#outputs)
 - [Fixtures](#fixtures)
@@ -1035,31 +1036,58 @@ module "cloud_run" {
 }
 # tftest inventory=traffic.yaml
 ```
+
+## Security Configurations
+
+You can enable Binary Authorization to verify container image signatures and disable the default `*.a.run.app` URL when routing traffic exclusively through internal networks or Application Load Balancers:
+
+```hcl
+module "cloud_run" {
+  source     = "./fabric/modules/cloud-run-v2"
+  project_id = var.project_id
+  region     = var.region
+  name       = "example-security"
+  containers = {
+    hello = {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+    }
+  }
+  binary_authorization = {
+    use_default = true
+  }
+  service_config = {
+    default_uri_disabled = true
+  }
+  deletion_protection = false
+}
+# tftest inventory=security.yaml
+```
 <!-- BEGIN TFDOC -->
 ## Variables
 
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
-| [name](variables.tf#L182) | Name used for Cloud Run service. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L187) | Project id used for all resources. | <code>string</code> | ✓ |  |
-| [region](variables.tf#L192) | Region used for all resources. | <code>string</code> | ✓ |  |
-| [containers](variables.tf#L17) | Containers in name => attributes format. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [context](variables.tf#L97) | Context-specific interpolations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [deletion_protection](variables.tf#L119) | Deletion protection setting for this Cloud Run service. | <code>string</code> |  | <code>null</code> |
-| [encryption_key](variables.tf#L125) | The full resource name of the Cloud KMS CryptoKey. | <code>string</code> |  | <code>null</code> |
-| [iam](variables.tf#L131) | IAM bindings for Cloud Run service in {ROLE => [MEMBERS]} format. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [job_config](variables.tf#L137) | Cloud Run Job specific configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [labels](variables.tf#L152) | Resource labels. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
-| [launch_stage](variables.tf#L158) | The launch stage as defined by Google Cloud Platform Launch Stages. | <code>string</code> |  | <code>null</code> |
-| [managed_revision](variables.tf#L175) | Whether the Terraform module should control the deployment of revisions. | <code>bool</code> |  | <code>true</code> |
-| [revision](variables.tf#L197) | Revision template configurations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [name](variables.tf#L192) | Name used for Cloud Run service. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L197) | Project id used for all resources. | <code>string</code> | ✓ |  |
+| [region](variables.tf#L202) | Region used for all resources. | <code>string</code> | ✓ |  |
+| [binary_authorization](variables.tf#L17) | Binary Authorization configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [containers](variables.tf#L27) | Containers in name => attributes format. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [context](variables.tf#L107) | Context-specific interpolations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [deletion_protection](variables.tf#L129) | Deletion protection setting for this Cloud Run service. | <code>string</code> |  | <code>null</code> |
+| [encryption_key](variables.tf#L135) | The full resource name of the Cloud KMS CryptoKey. | <code>string</code> |  | <code>null</code> |
+| [iam](variables.tf#L141) | IAM bindings for Cloud Run service in {ROLE => [MEMBERS]} format. | <code>map&#40;list&#40;string&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [job_config](variables.tf#L147) | Cloud Run Job specific configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [labels](variables.tf#L162) | Resource labels. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [launch_stage](variables.tf#L168) | The launch stage as defined by Google Cloud Platform Launch Stages. | <code>string</code> |  | <code>null</code> |
+| [managed_revision](variables.tf#L185) | Whether the Terraform module should control the deployment of revisions. | <code>bool</code> |  | <code>true</code> |
+| [revision](variables.tf#L207) | Revision template configurations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [service_account_config](variables-serviceaccount.tf#L17) | Service account configurations. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [service_config](variables.tf#L264) | Cloud Run service specific configuration options. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [tag_bindings](variables.tf#L363) | Tag bindings for this service, in key => tag value id format. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
-| [type](variables.tf#L370) | Type of Cloud Run resource to deploy: JOB, SERVICE or WORKERPOOL. | <code>string</code> |  | <code>&#34;SERVICE&#34;</code> |
-| [volumes](variables.tf#L380) | Named volumes in containers in name => attributes format. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [service_config](variables.tf#L274) | Cloud Run service specific configuration options. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [tag_bindings](variables.tf#L374) | Tag bindings for this service, in key => tag value id format. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [type](variables.tf#L381) | Type of Cloud Run resource to deploy: JOB, SERVICE or WORKERPOOL. | <code>string</code> |  | <code>&#34;SERVICE&#34;</code> |
+| [volumes](variables.tf#L391) | Named volumes in containers in name => attributes format. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [vpc_connector_create](variables-vpcconnector.tf#L17) | VPC connector network configuration. Must be provided if new VPC connector is being created. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [workerpool_config](variables.tf#L414) | Cloud Run Worker Pool specific configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [workerpool_config](variables.tf#L425) | Cloud Run Worker Pool specific configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 
 ## Outputs
 

--- a/modules/cloud-run-v2/job-managed.tf
+++ b/modules/cloud-run-v2/job-managed.tf
@@ -23,6 +23,15 @@ resource "google_cloud_run_v2_job" "job" {
   labels              = var.labels
   launch_stage        = var.launch_stage
   deletion_protection = var.deletion_protection
+
+  dynamic "binary_authorization" {
+    for_each = var.binary_authorization == null ? [] : [""]
+    content {
+      breakglass_justification = var.binary_authorization.breakglass_justification
+      policy                   = var.binary_authorization.policy
+      use_default              = var.binary_authorization.use_default
+    }
+  }
   template {
     labels     = var.revision.labels
     task_count = var.job_config.task_count

--- a/modules/cloud-run-v2/job-unmanaged.tf
+++ b/modules/cloud-run-v2/job-unmanaged.tf
@@ -23,6 +23,15 @@ resource "google_cloud_run_v2_job" "job_unmanaged" {
   labels              = var.labels
   launch_stage        = var.launch_stage
   deletion_protection = var.deletion_protection
+
+  dynamic "binary_authorization" {
+    for_each = var.binary_authorization == null ? [] : [""]
+    content {
+      breakglass_justification = var.binary_authorization.breakglass_justification
+      policy                   = var.binary_authorization.policy
+      use_default              = var.binary_authorization.use_default
+    }
+  }
   template {
     labels     = var.revision.labels
     task_count = var.job_config.task_count

--- a/modules/cloud-run-v2/service-managed.tf
+++ b/modules/cloud-run-v2/service-managed.tf
@@ -20,6 +20,7 @@ resource "google_cloud_run_v2_service" "service" {
   project              = local.project_id
   location             = local.location
   name                 = var.name
+  default_uri_disabled = var.service_config.default_uri_disabled
   ingress              = var.service_config.ingress
   invoker_iam_disabled = var.service_config.invoker_iam_disabled
   labels               = var.labels
@@ -27,6 +28,15 @@ resource "google_cloud_run_v2_service" "service" {
   custom_audiences     = var.service_config.custom_audiences
   deletion_protection  = var.deletion_protection
   iap_enabled          = var.service_config.iap_config != null
+
+  dynamic "binary_authorization" {
+    for_each = var.binary_authorization == null ? [] : [""]
+    content {
+      breakglass_justification = var.binary_authorization.breakglass_justification
+      policy                   = var.binary_authorization.policy
+      use_default              = var.binary_authorization.use_default
+    }
+  }
 
   dynamic "multi_region_settings" {
     for_each = local.multi_region_regions == null ? [] : [""]

--- a/modules/cloud-run-v2/service-unmanaged.tf
+++ b/modules/cloud-run-v2/service-unmanaged.tf
@@ -20,6 +20,7 @@ resource "google_cloud_run_v2_service" "service_unmanaged" {
   project              = local.project_id
   location             = local.location
   name                 = var.name
+  default_uri_disabled = var.service_config.default_uri_disabled
   ingress              = var.service_config.ingress
   invoker_iam_disabled = var.service_config.invoker_iam_disabled
   labels               = var.labels
@@ -27,6 +28,15 @@ resource "google_cloud_run_v2_service" "service_unmanaged" {
   custom_audiences     = var.service_config.custom_audiences
   deletion_protection  = var.deletion_protection
   iap_enabled          = var.service_config.iap_config != null
+
+  dynamic "binary_authorization" {
+    for_each = var.binary_authorization == null ? [] : [""]
+    content {
+      breakglass_justification = var.binary_authorization.breakglass_justification
+      policy                   = var.binary_authorization.policy
+      use_default              = var.binary_authorization.use_default
+    }
+  }
 
   dynamic "multi_region_settings" {
     for_each = local.multi_region_regions == null ? [] : [""]

--- a/modules/cloud-run-v2/variables.tf
+++ b/modules/cloud-run-v2/variables.tf
@@ -14,6 +14,16 @@
  * limitations under the License.
  */
 
+variable "binary_authorization" {
+  description = "Binary Authorization configuration."
+  type = object({
+    breakglass_justification = optional(string)
+    policy                   = optional(string)
+    use_default              = optional(bool)
+  })
+  default = null
+}
+
 variable "containers" {
   description = "Containers in name => attributes format."
   type = map(object({
@@ -264,7 +274,8 @@ variable "revision" {
 variable "service_config" {
   description = "Cloud Run service specific configuration options."
   type = object({
-    custom_audiences = optional(list(string), null)
+    custom_audiences     = optional(list(string), null)
+    default_uri_disabled = optional(bool)
     eventarc_triggers = optional(
       object({
         audit_log = optional(map(object({

--- a/modules/cloud-run-v2/workerpool-managed.tf
+++ b/modules/cloud-run-v2/workerpool-managed.tf
@@ -24,6 +24,15 @@ resource "google_cloud_run_v2_worker_pool" "default_managed" {
   launch_stage        = var.launch_stage
   deletion_protection = var.deletion_protection
 
+  dynamic "binary_authorization" {
+    for_each = var.binary_authorization == null ? [] : [""]
+    content {
+      breakglass_justification = var.binary_authorization.breakglass_justification
+      policy                   = var.binary_authorization.policy
+      use_default              = var.binary_authorization.use_default
+    }
+  }
+
   dynamic "scaling" {
     for_each = var.workerpool_config.scaling == null ? [] : [""]
     content {

--- a/modules/cloud-run-v2/workerpool-unmanaged.tf
+++ b/modules/cloud-run-v2/workerpool-unmanaged.tf
@@ -24,6 +24,15 @@ resource "google_cloud_run_v2_worker_pool" "default_unmanaged" {
   launch_stage        = var.launch_stage
   deletion_protection = var.deletion_protection
 
+  dynamic "binary_authorization" {
+    for_each = var.binary_authorization == null ? [] : [""]
+    content {
+      breakglass_justification = var.binary_authorization.breakglass_justification
+      policy                   = var.binary_authorization.policy
+      use_default              = var.binary_authorization.use_default
+    }
+  }
+
   dynamic "scaling" {
     for_each = var.workerpool_config.scaling == null ? [] : [""]
     content {

--- a/tests/modules/cloud_run_v2/examples/security.yaml
+++ b/tests/modules/cloud_run_v2/examples/security.yaml
@@ -1,10 +1,10 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,13 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-module: modules/cloud-run-v2
-tests:
-  context:
-  context-subnet:
-  context-subnet-project:
-  vpcconnector:
-  multiregion:
-  traffic:
-  security:
+values:
+  module.cloud_run.google_cloud_run_v2_service.service[0]:
+    location: europe-west8
+    name: example-security
+    project: project-id
+    default_uri_disabled: true
+    binary_authorization:
+    - breakglass_justification: null
+      policy: null
+      use_default: true
 
+counts:
+  google_cloud_run_v2_service: 1
+  google_project_iam_member: 2
+  google_service_account: 1
+  modules: 1
+  resources: 4

--- a/tests/modules/cloud_run_v2/security.tfvars
+++ b/tests/modules/cloud_run_v2/security.tfvars
@@ -1,10 +1,10 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,13 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-module: modules/cloud-run-v2
-tests:
-  context:
-  context-subnet:
-  context-subnet-project:
-  vpcconnector:
-  multiregion:
-  traffic:
-  security:
+name       = "test-run-security"
+project_id = "test-project"
+region     = "europe-west8"
 
+containers = {
+  first = {
+    image = "gcr.io/cloudrun/hello"
+  }
+}
+
+binary_authorization = {
+  use_default = true
+}
+
+service_config = {
+  default_uri_disabled = true
+}

--- a/tests/modules/cloud_run_v2/security.yaml
+++ b/tests/modules/cloud_run_v2/security.yaml
@@ -1,10 +1,10 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,13 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-module: modules/cloud-run-v2
-tests:
-  context:
-  context-subnet:
-  context-subnet-project:
-  vpcconnector:
-  multiregion:
-  traffic:
-  security:
+values:
+  google_cloud_run_v2_service.service[0]:
+    location: europe-west8
+    name: test-run-security
+    project: test-project
+    default_uri_disabled: true
+    binary_authorization:
+    - breakglass_justification: null
+      policy: null
+      use_default: true
 
+counts:
+  google_cloud_run_v2_service: 1
+  google_project_iam_member: 2
+  google_service_account: 1
+  modules: 0
+  resources: 4


### PR DESCRIPTION
### Description
This PR enhances the `modules/cloud-run-v2` module with two key security capabilities:
- **Binary Authorization:** Exposes a top-level `binary_authorization` object (`policy`, `breakglass_justification`, `use_default`) supported across Cloud Run Services, Jobs, and Worker Pools.
- **Default URI Disabling:** Exposes `service_config.default_uri_disabled` (`bool`) to allow disabling the default `*.a.run.app` URL when services should only be reachable via internal networks or Application Load Balancers.
### Verification
- Added documentation example in `modules/cloud-run-v2/README.md` and regenerated tables with `tfdoc.py`.
- Added test fixtures and pruned test inventories under `tests/modules/cloud_run_v2/`.
- Verified 100% locally with all 11 CI checks passing:
  - License boilerplate, `terraform fmt`, `tflint`, `codespell`, `check_yaml_schema.py`
  - Dual-engine test execution with `terraform` and `tofu` (7/7 passed)
  - Documentation example tests (26/26 passed)