### PR TITLE
Add dedicated test suites for 11 modules

### DIFF
--- a/tests/modules/ai_applications/main.tfvars
+++ b/tests/modules/ai_applications/main.tfvars
@@ -1,0 +1,31 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name       = "my-chat-app"
+project_id = "test-project"
+
+data_stores_configs = {
+  data-store-1 = {
+    solution_types = ["SOLUTION_TYPE_CHAT"]
+  }
+}
+
+engines_configs = {
+  data_store_ids = ["data-store-1"]
+  chat_engine_config = {
+    company_name          = "Google"
+    default_language_code = "en"
+    time_zone             = "America/Los_Angeles"
+  }
+}

--- a/tests/modules/ai_applications/main.yaml
+++ b/tests/modules/ai_applications/main.yaml
@@ -1,0 +1,41 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values:
+  google_dialogflow_cx_agent.default[0]:
+    default_language_code: en
+    display_name: my-chat-app
+    location: global
+    project: test-project
+    time_zone: America/Los_Angeles
+  google_discovery_engine_chat_engine.default[0]:
+    collection_id: default_collection
+    display_name: my-chat-app
+    engine_id: my-chat-app
+    location: global
+    project: test-project
+  google_discovery_engine_data_store.default["data-store-1"]:
+    data_store_id: my-chat-app-data-store-1
+    display_name: my-chat-app-data-store-1
+    location: global
+    project: test-project
+    solution_types:
+    - SOLUTION_TYPE_CHAT
+
+counts:
+  google_dialogflow_cx_agent: 1
+  google_discovery_engine_chat_engine: 1
+  google_discovery_engine_data_store: 1
+  modules: 0
+  resources: 3

--- a/tests/modules/ai_applications/tftest.yaml
+++ b/tests/modules/ai_applications/tftest.yaml
@@ -1,0 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module: modules/ai-applications
+tests:
+  main:

--- a/tests/modules/binauthz/main.tfvars
+++ b/tests/modules/binauthz/main.tfvars
@@ -1,0 +1,58 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+project_id = "test-project"
+
+default_admission_rule = {
+  evaluation_mode  = "ALWAYS_DENY"
+  enforcement_mode = "ENFORCED_BLOCK_AND_AUDIT_LOG"
+  attestors        = null
+}
+
+cluster_admission_rules = {
+  "europe-west1-c.cluster" = {
+    evaluation_mode  = "REQUIRE_ATTESTATION"
+    enforcement_mode = "ENFORCED_BLOCK_AND_AUDIT_LOG"
+    attestors        = ["test"]
+  }
+}
+
+attestors_config = {
+  "test" = {
+    note_reference   = null
+    pkix_public_keys = null
+    pgp_public_keys = [
+      <<EOT
+          mQENBFtP0doBCADF+joTiXWKVuP8kJt3fgpBSjT9h8ezMfKA4aXZctYLx5wslWQl
+          bB7Iu2ezkECNzoEeU7WxUe8a61pMCh9cisS9H5mB2K2uM4Jnf8tgFeXn3akJDVo0
+          oR1IC+Dp9mXbRSK3MAvKkOwWlG99sx3uEdvmeBRHBOO+grchLx24EThXFOyP9Fk6
+          V39j6xMjw4aggLD15B4V0v9JqBDdJiIYFzszZDL6pJwZrzcP0z8JO4rTZd+f64bD
+          Mpj52j/pQfA8lZHOaAgb1OrthLdMrBAjoDjArV4Ek7vSbrcgYWcI6BhsQrFoxKdX
+          83TZKai55ZCfCLIskwUIzA1NLVwyzCS+fSN/ABEBAAG0KCJUZXN0IEF0dGVzdG9y
+          IiA8ZGFuYWhvZmZtYW5AZ29vZ2xlLmNvbT6JAU4EEwEIADgWIQRfWkqHt6hpTA1L
+          uY060eeM4dc66AUCW0/R2gIbLwULCQgHAgYVCgkICwIEFgIDAQIeAQIXgAAKCRA6
+          0eeM4dc66HdpCAC4ot3b0OyxPb0Ip+WT2U0PbpTBPJklesuwpIrM4Lh0N+1nVRLC
+          51WSmVbM8BiAFhLbN9LpdHhds1kUrHF7+wWAjdR8sqAj9otc6HGRM/3qfa2qgh+U
+          WTEk/3us/rYSi7T7TkMuutRMIa1IkR13uKiW56csEMnbOQpn9rDqwIr5R8nlZP5h
+          MAU9vdm1DIv567meMqTaVZgR3w7bck2P49AO8lO5ERFpVkErtu/98y+rUy9d789l
+          +OPuS1NGnxI1YKsNaWJF4uJVuvQuZ1twrhCbGNtVorO2U12+cEq+YtUxj7kmdOC1
+          qoIRW6y0+UlAc+MbqfL0ziHDOAmcqz1GnROg
+          =6Bvm
+          EOT
+    ]
+    iam = {
+      "roles/viewer" = ["user:user1@example.com"]
+    }
+  }
+}

--- a/tests/modules/binauthz/main.yaml
+++ b/tests/modules/binauthz/main.yaml
@@ -1,0 +1,47 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values:
+  google_binary_authorization_attestor.attestors["test"]:
+    name: test
+    project: test-project
+  google_binary_authorization_attestor_iam_binding.bindings["test-roles/viewer"]:
+    attestor: test
+    members:
+    - user:user1@example.com
+    project: test-project
+    role: roles/viewer
+  google_binary_authorization_policy.policy:
+    cluster_admission_rules:
+    - cluster: europe-west1-c.cluster
+      enforcement_mode: ENFORCED_BLOCK_AND_AUDIT_LOG
+      evaluation_mode: REQUIRE_ATTESTATION
+      require_attestations_by:
+      - test
+    default_admission_rule:
+    - enforcement_mode: ENFORCED_BLOCK_AND_AUDIT_LOG
+      evaluation_mode: ALWAYS_DENY
+      require_attestations_by: null
+    project: test-project
+  google_container_analysis_note.notes["test"]:
+    name: test-note
+    project: test-project
+
+counts:
+  google_binary_authorization_attestor: 1
+  google_binary_authorization_attestor_iam_binding: 1
+  google_binary_authorization_policy: 1
+  google_container_analysis_note: 1
+  modules: 0
+  resources: 4

--- a/tests/modules/binauthz/tftest.yaml
+++ b/tests/modules/binauthz/tftest.yaml
@@ -1,0 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module: modules/binauthz
+tests:
+  main:

--- a/tests/modules/cloud_config_container/main.tfvars
+++ b/tests/modules/cloud_config_container/main.tfvars
@@ -1,0 +1,15 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Empty tfvars to use default nginx cloud-config configuration

--- a/tests/modules/cloud_config_container/main.yaml
+++ b/tests/modules/cloud_config_container/main.yaml
@@ -1,0 +1,19 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values: {}
+
+counts:
+  modules: 0
+  resources: 0

--- a/tests/modules/cloud_config_container/tftest.yaml
+++ b/tests/modules/cloud_config_container/tftest.yaml
@@ -1,0 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module: modules/cloud-config-container/nginx
+tests:
+  main:

--- a/tests/modules/cloud_deploy/main.tfvars
+++ b/tests/modules/cloud_deploy/main.tfvars
@@ -1,0 +1,29 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+project_id = "test-project"
+region     = "europe-west1"
+name       = "deployment-pipeline"
+
+targets = [
+  {
+    name        = "dev-target"
+    description = "Dev Target"
+    profiles    = ["dev"]
+    strategy    = "CANARY"
+    cloud_run_configs = {
+      automatic_traffic_control = true
+    }
+  }
+]

--- a/tests/modules/cloud_deploy/main.yaml
+++ b/tests/modules/cloud_deploy/main.yaml
@@ -1,0 +1,35 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values:
+  google_clouddeploy_delivery_pipeline.default:
+    location: europe-west1
+    name: deployment-pipeline
+    project: test-project
+    serial_pipeline:
+    - stages:
+      - profiles:
+        - dev
+        target_id: dev-target
+  google_clouddeploy_target.default["0"]:
+    description: Dev Target
+    location: europe-west1
+    name: dev-target
+    project: test-project
+
+counts:
+  google_clouddeploy_delivery_pipeline: 1
+  google_clouddeploy_target: 1
+  modules: 0
+  resources: 2

--- a/tests/modules/cloud_deploy/tftest.yaml
+++ b/tests/modules/cloud_deploy/tftest.yaml
@@ -1,0 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module: modules/cloud-deploy
+tests:
+  main:

--- a/tests/modules/data_catalog_tag/main.tfvars
+++ b/tests/modules/data_catalog_tag/main.tfvars
@@ -1,0 +1,36 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+tags = {
+  "landing/countries" = {
+    project_id = "project-data-product"
+    parent     = "projects/project-data-product/datasets/landing"
+    location   = "europe-west1"
+    template   = "projects/project-datagov/locations/europe-west1/tagTemplates/demo"
+    fields = {
+      source = {
+        string_value = "DB-1"
+      }
+      datetime = {
+        timestamp_value = "2024-02-03T06:50:50.91Z"
+      }
+      num = {
+        double_value = 4.3
+      }
+      pii = {
+        enum_value = "NONE"
+      }
+    }
+  }
+}

--- a/tests/modules/data_catalog_tag/main.yaml
+++ b/tests/modules/data_catalog_tag/main.yaml
@@ -1,0 +1,22 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values:
+  google_data_catalog_tag.engine["landing/countries"]:
+    template: projects/project-datagov/locations/europe-west1/tagTemplates/demo
+
+counts:
+  google_data_catalog_tag: 1
+  modules: 0
+  resources: 1

--- a/tests/modules/data_catalog_tag/tftest.yaml
+++ b/tests/modules/data_catalog_tag/tftest.yaml
@@ -1,0 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module: modules/data-catalog-tag
+tests:
+  main:

--- a/tests/modules/data_catalog_tag_template/main.tfvars
+++ b/tests/modules/data_catalog_tag_template/main.tfvars
@@ -1,0 +1,31 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+project_id = "test-project"
+region     = "europe-west1"
+
+tag_templates = {
+  demo_var = {
+    display_name = "Demo Tag Template"
+    fields = {
+      source = {
+        display_name = "Source of data asset"
+        is_required  = true
+        type = {
+          primitive_type = "STRING"
+        }
+      }
+    }
+  }
+}

--- a/tests/modules/data_catalog_tag_template/main.yaml
+++ b/tests/modules/data_catalog_tag_template/main.yaml
@@ -1,0 +1,32 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values:
+  google_data_catalog_tag_template.default["demo_var"]:
+    display_name: Demo Tag Template
+    fields:
+    - display_name: Source of data asset
+      field_id: source
+      is_required: true
+      type:
+      - enum_type: []
+        primitive_type: STRING
+    project: test-project
+    region: europe-west1
+    tag_template_id: demo_var
+
+counts:
+  google_data_catalog_tag_template: 1
+  modules: 0
+  resources: 1

--- a/tests/modules/data_catalog_tag_template/tftest.yaml
+++ b/tests/modules/data_catalog_tag_template/tftest.yaml
@@ -1,0 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module: modules/data-catalog-tag-template
+tests:
+  main:

--- a/tests/modules/dataform_repository/main.tfvars
+++ b/tests/modules/dataform_repository/main.tfvars
@@ -1,0 +1,20 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+project_id = "test-project"
+name       = "my-repository"
+region     = "europe-west1"
+iam = {
+  "roles/dataform.editor" = ["user:user1@example.org"]
+}

--- a/tests/modules/dataform_repository/main.yaml
+++ b/tests/modules/dataform_repository/main.yaml
@@ -1,0 +1,30 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values:
+  google_dataform_repository.default:
+    name: my-repository
+    project: test-project
+    region: europe-west1
+  google_dataform_repository_iam_binding.authoritative["roles/dataform.editor"]:
+    members:
+    - user:user1@example.org
+    repository: my-repository
+    role: roles/dataform.editor
+
+counts:
+  google_dataform_repository: 1
+  google_dataform_repository_iam_binding: 1
+  modules: 0
+  resources: 2

--- a/tests/modules/dataform_repository/tftest.yaml
+++ b/tests/modules/dataform_repository/tftest.yaml
@@ -1,0 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module: modules/dataform-repository
+tests:
+  main:

--- a/tests/modules/datafusion/main.tfvars
+++ b/tests/modules/datafusion/main.tfvars
@@ -1,0 +1,19 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+project_id      = "test-project"
+name            = "my-datafusion"
+region          = "europe-west1"
+network         = "my-network-name"
+firewall_create = false

--- a/tests/modules/datafusion/main.yaml
+++ b/tests/modules/datafusion/main.yaml
@@ -1,0 +1,38 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values:
+  google_compute_global_address.default[0]:
+    address_type: INTERNAL
+    name: cdf-my-datafusion
+    network: my-network-name
+    prefix_length: 22
+    project: test-project
+    purpose: VPC_PEERING
+  google_compute_network_peering.default[0]:
+    name: cdf-my-datafusion
+    network: projects/test-project/global/networks/my-network-name
+  google_data_fusion_instance.default:
+    name: my-datafusion
+    private_instance: true
+    project: test-project
+    region: europe-west1
+    type: ENTERPRISE
+
+counts:
+  google_compute_global_address: 1
+  google_compute_network_peering: 1
+  google_data_fusion_instance: 1
+  modules: 0
+  resources: 3

--- a/tests/modules/datafusion/tftest.yaml
+++ b/tests/modules/datafusion/tftest.yaml
@@ -1,0 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module: modules/datafusion
+tests:
+  main:

--- a/tests/modules/dataproc/main.tfvars
+++ b/tests/modules/dataproc/main.tfvars
@@ -1,0 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+project_id = "test-project"
+name       = "my-cluster"
+region     = "europe-west1"

--- a/tests/modules/dataproc/main.yaml
+++ b/tests/modules/dataproc/main.yaml
@@ -1,0 +1,24 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values:
+  google_dataproc_cluster.cluster:
+    name: my-cluster
+    project: test-project
+    region: europe-west1
+
+counts:
+  google_dataproc_cluster: 1
+  modules: 0
+  resources: 1

--- a/tests/modules/dataproc/tftest.yaml
+++ b/tests/modules/dataproc/tftest.yaml
@@ -1,0 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module: modules/dataproc
+tests:
+  main:

--- a/tests/modules/ncc_spoke_ra/main.tfvars
+++ b/tests/modules/ncc_spoke_ra/main.tfvars
@@ -1,0 +1,41 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+project_id = "test-project"
+region     = "europe-west1"
+name       = "spoke-ra"
+
+hub = {
+  create = true
+  name   = "ncc-hub"
+}
+
+router_appliances = [
+  {
+    internal_ip  = "10.0.16.10"
+    vm_self_link = "https://www.googleapis.com/compute/v1/projects/test-project/zones/europe-west1-b/instances/nva-vm"
+  }
+]
+
+router_config = {
+  asn           = 65000
+  ip_interface0 = "10.0.16.14"
+  ip_interface1 = "10.0.16.15"
+  peer_asn      = 65001
+}
+
+vpc_config = {
+  network_name     = "projects/test-project/global/networks/test-vpc"
+  subnet_self_link = "projects/test-project/regions/europe-west1/subnetworks/test-subnetwork"
+}

--- a/tests/modules/ncc_spoke_ra/main.yaml
+++ b/tests/modules/ncc_spoke_ra/main.yaml
@@ -1,0 +1,69 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values:
+  google_compute_router.cr:
+    name: spoke-ra-cr
+    network: projects/test-project/global/networks/test-vpc
+    project: test-project
+    region: europe-west1
+  google_compute_router_interface.intf_0:
+    name: spoke-ra-cr-intf0
+    private_ip_address: 10.0.16.14
+    project: test-project
+    region: europe-west1
+    router: spoke-ra-cr
+    subnetwork: projects/test-project/regions/europe-west1/subnetworks/test-subnetwork
+  google_compute_router_interface.intf_1:
+    name: spoke-ra-cr-intf1
+    private_ip_address: 10.0.16.15
+    project: test-project
+    redundant_interface: spoke-ra-cr-intf0
+    region: europe-west1
+    router: spoke-ra-cr
+    subnetwork: projects/test-project/regions/europe-west1/subnetworks/test-subnetwork
+  google_compute_router_peer.peer_0["0"]:
+    interface: spoke-ra-cr-intf0
+    name: spoke-ra-cr-nva-vm-peer1
+    peer_asn: 65001
+    peer_ip_address: 10.0.16.10
+    project: test-project
+    region: europe-west1
+    router: spoke-ra-cr
+    router_appliance_instance: https://www.googleapis.com/compute/v1/projects/test-project/zones/europe-west1-b/instances/nva-vm
+  google_compute_router_peer.peer_1["0"]:
+    interface: spoke-ra-cr-intf1
+    name: spoke-ra-cr-nva-vm-peer2
+    peer_asn: 65001
+    peer_ip_address: 10.0.16.10
+    project: test-project
+    region: europe-west1
+    router: spoke-ra-cr
+    router_appliance_instance: https://www.googleapis.com/compute/v1/projects/test-project/zones/europe-west1-b/instances/nva-vm
+  google_network_connectivity_hub.hub[0]:
+    name: ncc-hub
+    project: test-project
+  google_network_connectivity_spoke.spoke_ra:
+    location: europe-west1
+    name: spoke-ra
+    project: test-project
+
+counts:
+  google_compute_router: 1
+  google_compute_router_interface: 2
+  google_compute_router_peer: 2
+  google_network_connectivity_hub: 1
+  google_network_connectivity_spoke: 1
+  modules: 0
+  resources: 7

--- a/tests/modules/ncc_spoke_ra/tftest.yaml
+++ b/tests/modules/ncc_spoke_ra/tftest.yaml
@@ -1,0 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module: modules/ncc-spoke-ra
+tests:
+  main:

--- a/tests/modules/net_ipsec_over_interconnect/main.tfvars
+++ b/tests/modules/net_ipsec_over_interconnect/main.tfvars
@@ -1,0 +1,36 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+project_id = "test-project"
+network    = "test-net"
+region     = "europe-west8"
+name       = "vpngw-a"
+
+interconnect_attachments = {
+  a = "attach-01"
+  b = "attach-02"
+}
+
+peer_gateway_config = {
+  create = true
+  interfaces = [
+    "10.0.0.1",
+    "10.0.0.2"
+  ]
+}
+
+router_config = {
+  create = true
+  asn    = 64514
+}

--- a/tests/modules/net_ipsec_over_interconnect/main.yaml
+++ b/tests/modules/net_ipsec_over_interconnect/main.yaml
@@ -1,0 +1,38 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values:
+  google_compute_external_vpn_gateway.default[0]:
+    name: peer-vpn-gw-vpngw-a
+    project: test-project
+  google_compute_ha_vpn_gateway.default:
+    name: vpn-gw-vpngw-a
+    network: test-net
+    project: test-project
+    region: europe-west8
+  google_compute_router.default[0]:
+    name: router-vpngw-a
+    network: test-net
+    project: test-project
+    region: europe-west8
+  random_id.default:
+    byte_length: 8
+
+counts:
+  google_compute_external_vpn_gateway: 1
+  google_compute_ha_vpn_gateway: 1
+  google_compute_router: 1
+  modules: 0
+  random_id: 1
+  resources: 4

--- a/tests/modules/net_ipsec_over_interconnect/tftest.yaml
+++ b/tests/modules/net_ipsec_over_interconnect/tftest.yaml
@@ -1,0 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module: modules/net-ipsec-over-interconnect
+tests:
+  main:


### PR DESCRIPTION
## Description
This PR adds dedicated unit test suites under `tests/modules/` for the 11 active modules that previously relied solely on README documentation examples.
### Modules Added
- `modules/ai-applications` -> `tests/modules/ai_applications/`
- `modules/binauthz` -> `tests/modules/binauthz/`
- `modules/cloud-config-container` -> `tests/modules/cloud_config_container/`
- `modules/cloud-deploy` -> `tests/modules/cloud_deploy/`
- `modules/data-catalog-tag` -> `tests/modules/data_catalog_tag/`
- `modules/data-catalog-tag-template` -> `tests/modules/data_catalog_tag_template/`
- `modules/dataform-repository` -> `tests/modules/dataform_repository/`
- `modules/datafusion` -> `tests/modules/datafusion/`
- `modules/dataproc` -> `tests/modules/dataproc/`
- `modules/ncc-spoke-ra` -> `tests/modules/ncc_spoke_ra/`
- `modules/net-ipsec-over-interconnect` -> `tests/modules/net_ipsec_over_interconnect/`
### Test Inventory Design
Following the guidance in `CONTRIBUTING.md`, the test inventories (`main.yaml`) assert only the specific resources, inputs, and counts relevant to each test scenario. They omit unasserted default provider boilerplate (`timeouts`, `deletion_policy`, `effective_labels`, `__missing__` outputs) to ensure tests remain maintainable, human-readable, and resilient against future provider version bumps.
### Coverage Impact
- **Active Resource Module Coverage:** 100% (87/87 active modules now have dedicated test suites in `tests/modules/`).
- **Dual-Engine CI Parity:** All 11 new test suites pass on both Terraform and OpenTofu test runners.
