### PR TITLE
feat(fast/data-mongodb): add MongoDB Atlas database user resource

### DIFF
--- a/fast/project-templates/data-mongodb/README.md
+++ b/fast/project-templates/data-mongodb/README.md
@@ -15,7 +15,7 @@ This Terraform can of course be deployed using any pre-existing project. In that
 
 ## Variable Configuration
 
-Configuration is mostly done via the `atlas_config` and `vpc_config` variables. Note that:
+Configuration is mostly done via the `atlas_config`, `database_user`, and `vpc_config` variables. Note that:
 
 - VPC configuration can be set to reference a Shared VPC Host network like shown below, or an in-project network if that is preferred
 - the PSC CIDR block is used to allocate the required 50 endpoint addresses in the VPC, so it needs to be large enough to accommodate them
@@ -36,6 +36,10 @@ atlas_config = {
     private_key = "xxxxx-xxxx-xxxx-xxxx-xxxxxxxx"
   }
 }
+database_user = {
+  database_user_name     = "my-db-user"
+  database_user_password = "s3cr3t-p4ssw0rd"
+}
 project_id = "my-prod-shared-mongodb-0"
 vpc_config = {
   network_name   = "dev-spoke-0"
@@ -50,9 +54,10 @@ vpc_config = {
 | name | description | type | required | default |
 |---|---|:---:|:---:|:---:|
 | [atlas_config](variables.tf#L17) | MongoDB Atlas configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
-| [project_id](variables.tf#L40) | Project id where the registries will be created. | <code>string</code> | ✓ |  |
-| [vpc_config](variables.tf#L45) | VPC configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
-| [name](variables.tf#L33) | Prefix used for all resource names. | <code>string</code> |  | <code>&#34;mongodb&#34;</code> |
+| [database_user](variables.tf#L33) | MongoDB Atlas database user configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
+| [project_id](variables.tf#L48) | Project id where the registries will be created. | <code>string</code> | ✓ |  |
+| [vpc_config](variables.tf#L53) | VPC configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
+| [name](variables.tf#L41) | Prefix used for all resource names. | <code>string</code> |  | <code>&#34;mongodb&#34;</code> |
 
 ## Outputs
 
@@ -79,6 +84,10 @@ module "test" {
       private_key = "xxxxx-xxxx-xxxx-xxxx-xxxxxxxx"
     }
   }
+  database_user = {
+    database_user_name     = "my-db-user"
+    database_user_password = "s3cr3t-p4ssw0rd"
+  }
   project_id = "my-prod-shared-mongodb-0"
   vpc_config = {
     network_name   = "dev-spoke-0"
@@ -86,5 +95,5 @@ module "test" {
     psc_cidr_block = "10.8.11.192/26"
   }
 }
-# tftest modules=2 resources=6
+# tftest modules=2 resources=7
 ```

--- a/fast/project-templates/data-mongodb/README.md
+++ b/fast/project-templates/data-mongodb/README.md
@@ -37,8 +37,23 @@ atlas_config = {
   }
 }
 database_user = {
-  database_user_name     = "my-db-user"
-  database_user_password = "s3cr3t-p4ssw0rd"
+  username            = "my-db-user"
+  password_wo         = "s3cr3t-p4ssw0rd"
+  password_wo_version = 1
+  labels = {
+    environment = "test"
+  }
+  roles = {
+    app = {
+      database_name = "app"
+      role_name     = "readWrite"
+    }
+  }
+  scopes = {
+    test-0 = {
+      type = "CLUSTER"
+    }
+  }
 }
 project_id = "my-prod-shared-mongodb-0"
 vpc_config = {
@@ -55,9 +70,9 @@ vpc_config = {
 |---|---|:---:|:---:|:---:|
 | [atlas_config](variables.tf#L17) | MongoDB Atlas configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
 | [database_user](variables.tf#L33) | MongoDB Atlas database user configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
-| [project_id](variables.tf#L48) | Project id where the registries will be created. | <code>string</code> | ✓ |  |
-| [vpc_config](variables.tf#L53) | VPC configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
-| [name](variables.tf#L41) | Prefix used for all resource names. | <code>string</code> |  | <code>&#34;mongodb&#34;</code> |
+| [project_id](variables.tf#L89) | Project id where the registries will be created. | <code>string</code> | ✓ |  |
+| [vpc_config](variables.tf#L94) | VPC configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> | ✓ |  |
+| [name](variables.tf#L82) | Prefix used for all resource names. | <code>string</code> |  | <code>&#34;mongodb&#34;</code> |
 
 ## Outputs
 
@@ -85,8 +100,23 @@ module "test" {
     }
   }
   database_user = {
-    database_user_name     = "my-db-user"
-    database_user_password = "s3cr3t-p4ssw0rd"
+    username            = "my-db-user"
+    password_wo         = "s3cr3t-p4ssw0rd"
+    password_wo_version = 1
+    labels = {
+      environment = "test"
+    }
+    roles = {
+      app = {
+        database_name = "app"
+        role_name     = "readWrite"
+      }
+    }
+    scopes = {
+      test-0 = {
+        type = "CLUSTER"
+      }
+    }
   }
   project_id = "my-prod-shared-mongodb-0"
   vpc_config = {

--- a/fast/project-templates/data-mongodb/main.tf
+++ b/fast/project-templates/data-mongodb/main.tf
@@ -89,3 +89,15 @@ resource "mongodbatlas_privatelink_endpoint_service" "default" {
   private_endpoint_ip_address = module.addresses.psc[local.psc_endpoint_key].address.address
   gcp_project_id              = var.project_id
 }
+
+resource "mongodbatlas_database_user" "database_user" {
+  username           = var.database_user.database_user_name
+  password           = var.database_user.database_user_password
+  project_id         = mongodbatlas_project.default.id
+  auth_database_name = "admin"
+
+  roles {
+    role_name     = "readAnyDatabase"
+    database_name = "admin"
+  }
+}

--- a/fast/project-templates/data-mongodb/main.tf
+++ b/fast/project-templates/data-mongodb/main.tf
@@ -91,13 +91,43 @@ resource "mongodbatlas_privatelink_endpoint_service" "default" {
 }
 
 resource "mongodbatlas_database_user" "database_user" {
-  username           = var.database_user.database_user_name
-  password           = var.database_user.database_user_password
-  project_id         = mongodbatlas_project.default.id
-  auth_database_name = "admin"
+  username            = var.database_user.username
+  password            = var.database_user.password
+  password_wo         = var.database_user.password_wo
+  password_wo_version = var.database_user.password_wo_version
+  project_id          = mongodbatlas_project.default.id
+  auth_database_name  = var.database_user.auth_database_name
+  aws_iam_type        = var.database_user.aws_iam_type
+  description         = var.database_user.description
+  ldap_auth_type      = var.database_user.ldap_auth_type
+  oidc_auth_type      = var.database_user.oidc_auth_type
+  x509_type           = var.database_user.x509_type
 
-  roles {
-    role_name     = "readAnyDatabase"
-    database_name = "admin"
+  dynamic "labels" {
+    for_each = var.database_user.labels
+
+    content {
+      key   = labels.key
+      value = labels.value
+    }
+  }
+
+  dynamic "roles" {
+    for_each = var.database_user.roles
+
+    content {
+      role_name       = roles.value.role_name
+      database_name   = roles.value.database_name
+      collection_name = roles.value.collection_name
+    }
+  }
+
+  dynamic "scopes" {
+    for_each = var.database_user.scopes
+
+    content {
+      name = scopes.key
+      type = scopes.value.type
+    }
   }
 }

--- a/fast/project-templates/data-mongodb/providers_override.tf
+++ b/fast/project-templates/data-mongodb/providers_override.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     mongodbatlas = {
       source  = "mongodb/mongodbatlas"
-      version = "~> 2.7"
+      version = "~> 2.17"
     }
   }
 }

--- a/fast/project-templates/data-mongodb/variables.tf
+++ b/fast/project-templates/data-mongodb/variables.tf
@@ -30,6 +30,14 @@ variable "atlas_config" {
   })
 }
 
+variable "database_user" {
+  description = "MongoDB Atlas database user configuration."
+  type = object({
+    database_user_name     = string
+    database_user_password = string
+  })
+}
+
 variable "name" {
   description = "Prefix used for all resource names."
   type        = string

--- a/fast/project-templates/data-mongodb/variables.tf
+++ b/fast/project-templates/data-mongodb/variables.tf
@@ -48,12 +48,7 @@ variable "database_user" {
         database_name   = string
         role_name       = string
       })),
-      {
-        read_any_database = {
-          database_name = "admin"
-          role_name     = "readAnyDatabase"
-        }
-      }
+      {}
     )
     scopes = optional(map(object({
       type = string

--- a/fast/project-templates/data-mongodb/variables.tf
+++ b/fast/project-templates/data-mongodb/variables.tf
@@ -33,9 +33,50 @@ variable "atlas_config" {
 variable "database_user" {
   description = "MongoDB Atlas database user configuration."
   type = object({
-    database_user_name     = string
-    database_user_password = string
+    auth_database_name  = optional(string, "admin")
+    aws_iam_type        = optional(string)
+    description         = optional(string)
+    labels              = optional(map(string), {})
+    ldap_auth_type      = optional(string)
+    oidc_auth_type      = optional(string)
+    password            = optional(string)
+    password_wo         = optional(string)
+    password_wo_version = optional(number)
+    roles = optional(
+      map(object({
+        collection_name = optional(string)
+        database_name   = string
+        role_name       = string
+      })),
+      {
+        read_any_database = {
+          database_name = "admin"
+          role_name     = "readAnyDatabase"
+        }
+      }
+    )
+    scopes = optional(map(object({
+      type = string
+    })), {})
+    username  = string
+    x509_type = optional(string)
   })
+
+  validation {
+    condition = !(
+      var.database_user.password != null &&
+      var.database_user.password_wo != null
+    )
+    error_message = "Only one of password or password_wo can be set."
+  }
+
+  validation {
+    condition = (
+      var.database_user.password_wo == null ||
+      var.database_user.password_wo_version != null
+    )
+    error_message = "password_wo_version must be set when password_wo is set."
+  }
 }
 
 variable "name" {


### PR DESCRIPTION
## Summary

Adds MongoDB Atlas database user support to the FAST `data-mongodb` project template.

The new `database_user` variable configures a `mongodbatlas_database_user` resource and exposes the configurable fields supported by the underlying provider resource, including authentication settings, roles, scopes, labels, and password handling.

## Changes

- Add `mongodbatlas_database_user` to the `data-mongodb` template.
- Add a `database_user` input object with support for:
  - `username`
  - `password`
  - `password_wo`
  - `password_wo_version`
  - `auth_database_name`
  - `aws_iam_type`
  - `ldap_auth_type`
  - `oidc_auth_type`
  - `x509_type`
  - `description`
  - `labels`
  - `roles`
  - `scopes`
- Default database user role to `readAnyDatabase` on `admin`, preserving the template’s simple default behavior.
- Add validation to prevent setting both `password` and `password_wo`.
- Add validation requiring `password_wo_version` when `password_wo` is used.
- Update README examples and generated variable documentation.
- Bump the MongoDB Atlas provider constraint to `~> 2.17` so `password_wo` and `password_wo_version` are available.

## Compatibility

Compared the MongoDB Atlas provider schema for the resources used by this template between `2.7.0` and `2.17.0`. No arguments were removed and no new required arguments were added for the resources used here.

The relevant provider changes are additive. The main caveat is that `password_wo` requires Terraform `1.11+`.

## Validation

- `terraform fmt -check fast/project-templates/data-mongodb`
- `python3 tools/check_documentation.py fast/project-templates/data-mongodb`
- `python3 tools/check_boilerplate.py --scan-files fast/project-templates/data-mongodb/main.tf fast/project-templates/data-mongodb/variables.tf fast/project-templates/data-mongodb/providers_override.tf fast/project-templates/data-mongodb/README.md`
- `terraform -chdir=fast/project-templates/data-mongodb validate`


**Checklist**

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
