### PR TITLE
Fix log sink description handling for empty strings

### DIFF
--- a/modules/billing-account/logging.tf
+++ b/modules/billing-account/logging.tf
@@ -49,9 +49,13 @@ locals {
 }
 
 resource "google_logging_billing_account_sink" "sink" {
-  for_each        = local.logging_sinks
-  name            = each.key
-  description     = coalesce(each.value.description, "${each.key} (Terraform-managed).")
+  for_each = local.logging_sinks
+  name     = each.key
+  description = (
+    each.value.description == null
+    ? "${each.key} (Terraform-managed)."
+    : each.value.description
+  )
   billing_account = var.id
   destination     = "${each.value.type}.googleapis.com/${each.value.destination}"
   filter          = each.value.filter

--- a/modules/folder/logging.tf
+++ b/modules/folder/logging.tf
@@ -89,9 +89,13 @@ resource "google_folder_iam_audit_config" "default" {
 }
 
 resource "google_logging_folder_sink" "sink" {
-  for_each           = local.logging_sinks
-  name               = each.key
-  description        = coalesce(each.value.description, "${each.key} (Terraform-managed).")
+  for_each = local.logging_sinks
+  name     = each.key
+  description = (
+    each.value.description == null
+    ? "${each.key} (Terraform-managed)."
+    : each.value.description
+  )
   folder             = local.folder_id
   destination        = "${lookup(each.value, "api", each.value.type)}.googleapis.com/${each.value.destination}"
   filter             = each.value.filter

--- a/modules/organization/logging.tf
+++ b/modules/organization/logging.tf
@@ -93,9 +93,13 @@ resource "google_organization_iam_audit_config" "default" {
 }
 
 resource "google_logging_organization_sink" "sink" {
-  for_each           = local.logging_sinks
-  name               = each.key
-  description        = coalesce(each.value.description, "${each.key} (Terraform-managed).")
+  for_each = local.logging_sinks
+  name     = each.key
+  description = (
+    each.value.description == null
+    ? "${each.key} (Terraform-managed)."
+    : each.value.description
+  )
   org_id             = local.organization_id_numeric
   destination        = "${lookup(each.value, "api", each.value.type)}.googleapis.com/${each.value.destination}"
   filter             = each.value.filter

--- a/modules/project/logging.tf
+++ b/modules/project/logging.tf
@@ -88,9 +88,13 @@ resource "google_project_iam_audit_config" "default" {
 }
 
 resource "google_logging_project_sink" "sink" {
-  for_each               = local.logging_sinks
-  name                   = each.key
-  description            = coalesce(each.value.description, "${each.key} (Terraform-managed).")
+  for_each = local.logging_sinks
+  name     = each.key
+  description = (
+    each.value.description == null
+    ? "${each.key} (Terraform-managed)."
+    : each.value.description
+  )
   project                = local.project.project_id
   destination            = "${lookup(each.value, "api", each.value.type)}.googleapis.com/${each.value.destination}"
   filter                 = each.value.filter

--- a/tests/modules/folder/context.tfvars
+++ b/tests/modules/folder/context.tfvars
@@ -110,6 +110,7 @@ logging_settings = {
 }
 logging_sinks = {
   test-pubsub = {
+    description = ""
     destination = "$pubsub_topics:test"
     filter      = "log_id('cloudaudit.googleapis.com/activity')"
     type        = "pubsub"

--- a/tests/modules/folder/context.yaml
+++ b/tests/modules/folder/context.yaml
@@ -119,7 +119,7 @@ values:
     kms_key_name: projects/test-kms-0/locations/europe-west8/keyRings/test/cryptoKeys/test
     timeouts: null
   google_logging_folder_sink.sink["test-pubsub"]:
-    description: test-pubsub (Terraform-managed).
+    description: ''
     destination: pubsub.googleapis.com/projects/test-prod-audit-logs-0/topics/audit-logs
     disabled: false
     exclusions: []

--- a/tests/modules/organization/context.tfvars
+++ b/tests/modules/organization/context.tfvars
@@ -132,6 +132,7 @@ logging_sinks = {
     type        = "project"
   }
   test-pubsub = {
+    description = ""
     destination = "$pubsub_topics:test"
     filter      = "log_id('cloudaudit.googleapis.com/activity')"
     type        = "pubsub"

--- a/tests/modules/organization/context.yaml
+++ b/tests/modules/organization/context.yaml
@@ -143,7 +143,7 @@ values:
     org_id: '1234567890'
   google_logging_organization_sink.sink["test-pubsub"]:
     deletion_policy: DELETE
-    description: test-pubsub (Terraform-managed).
+    description: ''
     destination: pubsub.googleapis.com/projects/test-prod-audit-logs-0/topics/audit-logs
     disabled: false
     exclusions: []

--- a/tests/modules/project/context.tfvars
+++ b/tests/modules/project/context.tfvars
@@ -145,6 +145,7 @@ logging_data_access = {
 }
 logging_sinks = {
   test-pubsub = {
+    description = ""
     destination = "$pubsub_topics:test"
     filter      = "log_id('cloudaudit.googleapis.com/activity')"
     type        = "pubsub"

--- a/tests/modules/project/context.yaml
+++ b/tests/modules/project/context.yaml
@@ -76,7 +76,7 @@ values:
     value_extractor: null
   google_logging_project_sink.sink["test-pubsub"]:
     custom_writer_identity: null
-    description: test-pubsub (Terraform-managed).
+    description: ''
     destination: pubsub.googleapis.com/projects/test-prod-audit-logs-0/topics/audit-logs
     disabled: false
     exclusions: []


### PR DESCRIPTION
Log sinks with an explicitly empty description could not be expressed, which made importing pre-existing sinks impossible.

## Problem

All four modules supporting log-sinks derived the sink description with `coalesce`:

```hcl
description = coalesce(each.value.description, "${each.key} (Terraform-managed).")
```

Terraform's `coalesce()` skips empty strings as well as nulls, so `description = ""` (or `description: ""` in a factory YAML) never reached the provider — it silently fell through to the generated `"<sink-name> (Terraform-managed)."` default.

The practical consequence is that a pre-existing log sink with no description cannot be adopted: after `terraform import` every plan shows a permanent, unavoidable diff writing the generated default over the empty description, and there is no input that suppresses it. The factory JSON schema already declares `description` as a plain `string` with no default, so `""` was accepted as valid input and then discarded.

## Fix

Replaced `coalesce` with an explicit null check, so an unset (`null`) description still gets the generated default while an explicit empty string is passed through verbatim:

```hcl
description = (
  each.value.description == null
  ? "${each.key} (Terraform-managed)."
  : each.value.description
)
```

Applied to the four modules that carried the identical expression:

- `modules/organization`
- `modules/folder`
- `modules/project`
- `modules/billing-account`

No variable, schema, or factory surface changed: `description` remains `optional(string)`, and the JSON schema already permitted `""`.

The `coalesce(each.value.description, var.description)` occurrences in `modules/net-lb-*` and `modules/net-swp` were deliberately left alone. Those fall back to a module-level default rather than a generated string, so whether an empty per-item description should override that default is a separate interface question rather than an unambiguous bug.

## Verification

### Live E2E

Verified end to end against a live sandbox project using `modules/project`.

A log sink was created out of band with `gcloud` and no `--description`, to reproduce a genuine brownfield resource, then imported into the module with `description = ""`. The post-import plan is clean:

```
No changes. Your infrastructure matches the configuration.
```

`terraform plan -detailed-exitcode` returned 0.

To confirm the clean plan is actually attributable to this fix, `modules/project/logging.tf` was reverted to the `coalesce` version and the same import re-planned, reproducing the permanent diff (exit code 2):

```
  # module.project.google_logging_project_sink.sink["e2e-empty-desc"] will be updated in-place
  ~ resource "google_logging_project_sink" "sink" {
      + description            = "e2e-empty-desc (Terraform-managed)."
        id                     = "projects/my-project/sinks/e2e-empty-desc"
        name                   = "e2e-empty-desc"
        # (7 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```
The other two input paths were checked for regressions against the same live sink:

- `description = "custom text"` reads back as exactly `custom text`.
- omitting `description` entirely reads back as `e2e-empty-desc (Terraform-managed).`, so the generated default still works.

## Behavior change

This does not require any user action and no configuration becomes invalid, so no `upgrade-note` is included. One narrow behavior change is worth recording for reviewers: a user who explicitly set `description = ""` previously received `"<sink-name> (Terraform-managed)."` and will now get an empty description. Configurations that leave `description` unset are unaffected.

