### PR TITLE
Adding folder-level log sinks destinations interpolation

### DIFF
--- a/modules/project-factory/folders.tf
+++ b/modules/project-factory/folders.tf
@@ -115,8 +115,10 @@ module "folder-1-iam" {
     }
     iam_principals  = local.ctx_iam_principals
     kms_keys        = merge(local.ctx.kms_keys, local.kms_keys)
+    log_buckets     = merge(local.ctx.log_buckets, local.log_buckets)
     project_ids     = local.ctx_project_ids
     project_numbers = local.ctx_project_numbers
+    pubsub_topics   = merge(local.ctx.pubsub_topics, local.pubsub_topics)
   })
 }
 
@@ -196,8 +198,10 @@ module "folder-2-iam" {
     }
     iam_principals  = local.ctx_iam_principals
     kms_keys        = merge(local.ctx.kms_keys, local.kms_keys)
+    log_buckets     = merge(local.ctx.log_buckets, local.log_buckets)
     project_ids     = local.ctx_project_ids
     project_numbers = local.ctx_project_numbers
+    pubsub_topics   = merge(local.ctx.pubsub_topics, local.pubsub_topics)
   })
 }
 
@@ -277,8 +281,10 @@ module "folder-3-iam" {
     }
     iam_principals  = local.ctx_iam_principals
     kms_keys        = merge(local.ctx.kms_keys, local.kms_keys)
+    log_buckets     = merge(local.ctx.log_buckets, local.log_buckets)
     project_ids     = local.ctx_project_ids
     project_numbers = local.ctx_project_numbers
+    pubsub_topics   = merge(local.ctx.pubsub_topics, local.pubsub_topics)
   })
 }
 
@@ -358,7 +364,9 @@ module "folder-4-iam" {
     }
     iam_principals  = local.ctx_iam_principals
     kms_keys        = merge(local.ctx.kms_keys, local.kms_keys)
+    log_buckets     = merge(local.ctx.log_buckets, local.log_buckets)
     project_ids     = local.ctx_project_ids
     project_numbers = local.ctx_project_numbers
+    pubsub_topics   = merge(local.ctx.pubsub_topics, local.pubsub_topics)
   })
 }

--- a/modules/project-factory/projects-log-buckets.tf
+++ b/modules/project-factory/projects-log-buckets.tf
@@ -34,6 +34,9 @@ locals {
       }
     ]
   ])
+  log_buckets = {
+    for k, v in module.log-buckets : k => v.id
+  }
 }
 
 module "log-buckets" {

--- a/modules/project-factory/projects-pubsub.tf
+++ b/modules/project-factory/projects-pubsub.tf
@@ -34,7 +34,7 @@ locals {
     ]
   ])
   pubsub_topics = {
-    for k, v in module.pubsub: k => v.id
+    for k, v in module.pubsub : k => v.id
   }
 }
 

--- a/modules/project-factory/projects-pubsub.tf
+++ b/modules/project-factory/projects-pubsub.tf
@@ -33,6 +33,9 @@ locals {
       }
     ]
   ])
+  pubsub_topics = {
+    for k, v in module.pubsub: k => v.id
+  }
 }
 
 module "pubsub" {


### PR DESCRIPTION
Adding folder-level log sinks destinations interpolation for:
-  log buckets
- pub/sub topics

<!-- Put a description of what this PR is for here -->

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
