### PR TITLE
fix: conditionally configure GKE backup schedule

### DIFF
--- a/modules/gke-cluster-autopilot/main.tf
+++ b/modules/gke-cluster-autopilot/main.tf
@@ -429,8 +429,11 @@ resource "google_gke_backup_backup_plan" "backup_plan" {
     backup_retain_days      = try(each.value.retention_policy_days)
     locked                  = try(each.value.retention_policy_lock)
   }
-  backup_schedule {
-    cron_schedule = each.value.schedule
+  dynamic "backup_schedule" {
+    for_each = each.value.schedule != null ? [""] : []
+    content {
+      cron_schedule = each.value.schedule
+    }
   }
 
   backup_config {

--- a/modules/gke-cluster-standard/main.tf
+++ b/modules/gke-cluster-standard/main.tf
@@ -649,9 +649,13 @@ resource "google_gke_backup_backup_plan" "backup_plan" {
     backup_retain_days      = try(each.value.retention_policy_days)
     locked                  = try(each.value.retention_policy_lock)
   }
-  backup_schedule {
-    cron_schedule = each.value.schedule
+  dynamic "backup_schedule" {
+    for_each = each.value.schedule != null ? [""] : []
+    content {
+      cron_schedule = each.value.schedule
+    }
   }
+
   backup_config {
     include_volume_data = each.value.include_volume_data
     include_secrets     = each.value.include_secrets


### PR DESCRIPTION
<!-- Put a description of what this PR is for here -->
This PR updates the GKE backup plan configuration for both Standard and Autopilot clusters.

### Changes

- Updated `google_gke_backup_backup_plan` to conditionally create the `backup_schedule` block only when a schedule is configured.
- Prevents `cron_schedule` from being set when `schedule` is `null`.
- Applied the same change to:
  - `modules/gke-cluster-standard`
  - `modules/gke-cluster-autopilot`

### Impact

Backup plans without a configured schedule will no longer generate an empty `backup_schedule` block, while existing scheduled backup plans will continue to work as before.

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
