### PR TITLE
fix: explicitly configure disabled IAP

### DIFF
--- a/modules/net-lb-app-ext-regional/backend-service.tf
+++ b/modules/net-lb-app-ext-regional/backend-service.tf
@@ -194,14 +194,11 @@ resource "google_compute_region_backend_service" "default" {
     }
   }
 
-  dynamic "iap" {
-    for_each = each.value.iap_config == null ? [] : [each.value.iap_config]
-    content {
-      enabled                     = true
-      oauth2_client_id            = try(iap.value.oauth2_client_id, null)
-      oauth2_client_secret        = try(iap.value.oauth2_client_secret, null)
-      oauth2_client_secret_sha256 = try(iap.value.oauth2_client_secret_sha256, null)
-    }
+  iap {
+    enabled                     = each.value.iap_config != null
+    oauth2_client_id            = try(each.value.iap_config.oauth2_client_id, null)
+    oauth2_client_secret        = try(each.value.iap_config.oauth2_client_secret, null)
+    oauth2_client_secret_sha256 = try(each.value.iap_config.oauth2_client_secret_sha256, null)
   }
 
   dynamic "log_config" {

--- a/modules/net-lb-app-ext/backend-service.tf
+++ b/modules/net-lb-app-ext/backend-service.tf
@@ -209,14 +209,11 @@ resource "google_compute_backend_service" "default" {
     }
   }
 
-  dynamic "iap" {
-    for_each = each.value.iap_config == null ? [] : [each.value.iap_config]
-    content {
-      enabled                     = true
-      oauth2_client_id            = try(iap.value.oauth2_client_id, null)
-      oauth2_client_secret        = try(iap.value.oauth2_client_secret, null)
-      oauth2_client_secret_sha256 = try(iap.value.oauth2_client_secret_sha256, null)
-    }
+  iap {
+    enabled                     = each.value.iap_config != null
+    oauth2_client_id            = try(each.value.iap_config.oauth2_client_id, null)
+    oauth2_client_secret        = try(each.value.iap_config.oauth2_client_secret, null)
+    oauth2_client_secret_sha256 = try(each.value.iap_config.oauth2_client_secret_sha256, null)
   }
 
   dynamic "log_config" {

--- a/modules/net-lb-app-int-cross-region/backend-service.tf
+++ b/modules/net-lb-app-int-cross-region/backend-service.tf
@@ -139,14 +139,11 @@ resource "google_compute_backend_service" "default" {
     }
   }
 
-  dynamic "iap" {
-    for_each = each.value.iap_config == null ? [] : [each.value.iap_config]
-    content {
-      enabled                     = true
-      oauth2_client_id            = try(iap.value.oauth2_client_id, null)
-      oauth2_client_secret        = try(iap.value.oauth2_client_secret, null)
-      oauth2_client_secret_sha256 = try(iap.value.oauth2_client_secret_sha256, null)
-    }
+  iap {
+    enabled                     = each.value.iap_config != null
+    oauth2_client_id            = try(each.value.iap_config.oauth2_client_id, null)
+    oauth2_client_secret        = try(each.value.iap_config.oauth2_client_secret, null)
+    oauth2_client_secret_sha256 = try(each.value.iap_config.oauth2_client_secret_sha256, null)
   }
 
   dynamic "log_config" {

--- a/modules/net-lb-app-int/backend-service.tf
+++ b/modules/net-lb-app-int/backend-service.tf
@@ -152,14 +152,11 @@ resource "google_compute_region_backend_service" "default" {
     }
   }
 
-  dynamic "iap" {
-    for_each = each.value.iap_config == null ? [] : [each.value.iap_config]
-    content {
-      enabled                     = true
-      oauth2_client_id            = try(iap.value.oauth2_client_id, null)
-      oauth2_client_secret        = try(iap.value.oauth2_client_secret, null)
-      oauth2_client_secret_sha256 = try(iap.value.oauth2_client_secret_sha256, null)
-    }
+  iap {
+    enabled                     = each.value.iap_config != null
+    oauth2_client_id            = try(each.value.iap_config.oauth2_client_id, null)
+    oauth2_client_secret        = try(each.value.iap_config.oauth2_client_secret, null)
+    oauth2_client_secret_sha256 = try(each.value.iap_config.oauth2_client_secret_sha256, null)
   }
 
   dynamic "log_config" {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here -->
This PR updates the IAP configuration in the backend service module to explicitly render the `iap` block with `enabled = false` when IAP is not configured.

### Changes
- Updated the dynamic `iap` block to always render when `iap_config` is `null`.
- Explicitly sets `enabled = false` when IAP is not configured.
- Prevents Terraform from continuously detecting the provider-returned `enabled = false` as a removal of the `iap` block.

### Impact
This resolves the recurring Terraform plan diff:

```text
- iap {
    - enabled = false -> null
  }
```
---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
