### PR TITLE
Enable rotation config and topics in modules/secret-manager

### DIFF
--- a/modules/secret-manager/README.md
+++ b/modules/secret-manager/README.md
@@ -7,6 +7,7 @@ This module allows managing one or more secrets with versions and IAM bindings. 
 - [Regional Secrets](#regional-secrets)
 - [IAM Bindings](#iam-bindings)
 - [Secret Versions](#secret-versions)
+- [Secret Rotation](#secret-rotation)
 - [Context Interpolations](#context-interpolations)
 - [Variables](#variables)
 - [Outputs](#outputs)
@@ -153,6 +154,29 @@ module "secret-manager" {
 ```txt
 foo-secret
 # tftest-file id=0 path=test-data/secret-b.txt
+```
+
+## Secret Rotation
+
+Automated rotation schedules and Pub/Sub notification topics can be configured on both global and regional secrets via `rotation_config` and `topics`. Note that the Secret Manager API requires at least one Pub/Sub topic when rotation is configured.
+
+```hcl
+module "secret-manager" {
+  source     = "./fabric/modules/secret-manager"
+  project_id = var.project_id
+  secrets = {
+    test-rotated = {
+      rotation_config = {
+        period    = "7776000s" # 90 days
+        next_time = "2026-12-01T00:00:00Z"
+      }
+      topics = [
+        "projects/project-id/topics/secret-rotation-topic"
+      ]
+    }
+  }
+}
+# tftest modules=1 resources=1 skip-tofu
 ```
 
 ## Context Interpolations

--- a/modules/secret-manager/global.tf
+++ b/modules/secret-manager/global.tf
@@ -71,14 +71,19 @@ resource "google_secret_manager_secret" "default" {
       }
     }
   }
-  # dynamic "rotation" {
-  #   for_each = try(each.value.rotation_config, null) == null ? [] : [""]
-  #   content {
-  #     next_rotation_time = each.value.rotation_config.next_time
-  #     rotation_period    = each.value.rotation_config.period
-  #   }
-  # }
-  # topics
+  dynamic "rotation" {
+    for_each = try(each.value.rotation_config, null) == null ? [] : [""]
+    content {
+      next_rotation_time = each.value.rotation_config.next_time
+      rotation_period    = each.value.rotation_config.period
+    }
+  }
+  dynamic "topics" {
+    for_each = coalesce(try(each.value.topics, null), [])
+    content {
+      name = topics.value
+    }
+  }
   lifecycle {
     ignore_changes = [
       rotation[0].next_rotation_time

--- a/modules/secret-manager/regional.tf
+++ b/modules/secret-manager/regional.tf
@@ -43,14 +43,19 @@ resource "google_secret_manager_regional_secret" "default" {
       )
     }
   }
-  # dynamic "rotation" {
-  #   for_each = try(each.value.rotation_config, null) == null ? [] : [""]
-  #   content {
-  #     next_rotation_time = each.value.rotation_config.next_time
-  #     rotation_period    = each.value.rotation_config.period
-  #   }
-  # }
-  # topics
+  dynamic "rotation" {
+    for_each = try(each.value.rotation_config, null) == null ? [] : [""]
+    content {
+      next_rotation_time = each.value.rotation_config.next_time
+      rotation_period    = each.value.rotation_config.period
+    }
+  }
+  dynamic "topics" {
+    for_each = coalesce(try(each.value.topics, null), [])
+    content {
+      name = topics.value
+    }
+  }
   lifecycle {
     ignore_changes = [
       rotation[0].next_rotation_time

--- a/modules/secret-manager/variables.tf
+++ b/modules/secret-manager/variables.tf
@@ -100,13 +100,20 @@ variable "secrets" {
         write_only_version = optional(number)
       }))
     })), {})
-    # rotation_config = optional(object({
-    #   next_time = string
-    #   period    = number
-    # }))
-    # topics
+    rotation_config = optional(object({
+      next_time = optional(string)
+      period    = string
+    }))
+    topics = optional(list(string))
   }))
   default = {}
+  validation {
+    condition = alltrue([
+      for k, v in var.secrets :
+      try(v.rotation_config, null) == null || (try(length(v.topics), 0) > 0)
+    ])
+    error_message = "At least one topic must be configured when rotation_config is set."
+  }
   validation {
     condition = alltrue([
       for k, v in var.secrets :


### PR DESCRIPTION
## Description
This PR enables automated rotation schedules (`rotation_config`) and Pub/Sub notification topics (`topics`) for both global (`google_secret_manager_secret`) and regional (`google_secret_manager_regional_secret`) secrets within `modules/secret-manager`.

These configurations were previously commented out in the module code and variable definitions, leaving the existing `lifecycle.ignore_changes` block for `rotation[0].next_rotation_time` unused.

## Changes
- **`modules/secret-manager/variables.tf`**:
  - Added `rotation_config` object: `next_time` (optional string) and `period` (string).
  - Added `topics` list of strings.
  - Added validation ensuring that if `rotation_config` is defined, at least one topic is provided (matching GCP Secret Manager API requirements).
- **`modules/secret-manager/global.tf`**:
  - Implemented `dynamic "rotation"` and `dynamic "topics"` blocks.
- **`modules/secret-manager/regional.tf`**:
  - Implemented `dynamic "rotation"` and `dynamic "topics"` blocks.

## How to Test
```hcl
module "secret-manager" {
  source     = "./modules/secret-manager"
  project_id = var.project_id
  secrets = {
    test-rotated-secret = {
      rotation_config = {
        period    = "7776000s" # 90 days
        next_time = "2026-12-01T00:00:00Z"
      }
      topics = [
        "projects/my-project/topics/secret-rotation-topic"
      ]
    }
  }
}

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
