### PR TITLE
Add net-cloud-armor module

### DIFF
--- a/modules/net-cloud-armor/README.md
+++ b/modules/net-cloud-armor/README.md
@@ -1,0 +1,151 @@
+# Google Cloud Armor Security Policy Module
+
+This module manages a Google Cloud Armor security policy, including preconfigured WAF (OWASP) rules, IP allow/deny rules, rate limiting, and Layer 7 DDoS Adaptive Protection.
+
+<!-- BEGIN TOC -->
+- [Basic Usage](#basic-usage)
+- [Rate Limiting and Adaptive Protection](#rate-limiting-and-adaptive-protection)
+- [Rules Factory](#rules-factory)
+- [Variables](#variables)
+- [Outputs](#outputs)
+<!-- END TOC -->
+
+## Basic Usage
+
+```hcl
+module "cloud_armor" {
+  source     = "./fabric/modules/net-cloud-armor"
+  project_id = var.project_id
+  name       = "my-security-policy"
+  rules = {
+    owasp-sqli = {
+      action            = "deny(403)"
+      priority          = 1000
+      description       = "OWASP SQL Injection protection"
+      preconfigured_waf = "sqli-v33-stable"
+    }
+    allow-trusted-ips = {
+      action        = "allow"
+      priority      = 2000
+      description   = "Allow corporate IPs"
+      src_ip_ranges = ["192.0.2.0/24"]
+    }
+  }
+}
+# tftest modules=1 resources=1
+```
+
+## Rate Limiting and Adaptive Protection
+
+```hcl
+module "cloud_armor" {
+  source     = "./fabric/modules/net-cloud-armor"
+  project_id = var.project_id
+  name       = "advanced-security-policy"
+  adaptive_protection_config = {
+    layer_7_ddos_defense = {
+      enable          = true
+      rule_visibility = "STANDARD"
+    }
+  }
+  rules = {
+    rate-limit = {
+      action        = "throttle"
+      priority      = 5000
+      description   = "Rate limit traffic"
+      src_ip_ranges = ["*"]
+      rate_limit_options = {
+        conform_action = "allow"
+        exceed_action  = "deny(429)"
+        enforce_on_key = "IP"
+        rate_limit_threshold = {
+          count        = 100
+          interval_sec = 60
+        }
+      }
+    }
+  }
+}
+# tftest modules=1 resources=1
+```
+
+## Rules Factory
+
+The module includes a rules factory for massive creation of rules leveraging YAML configuration files. Each configuration file can contain rules conforming to the schema defined in [`schemas/rules.schema.json`](schemas/rules.schema.json).
+
+```hcl
+module "cloud_armor" {
+  source     = "./fabric/modules/net-cloud-armor"
+  project_id = var.project_id
+  name       = "waf-security-policy"
+  factories_config = {
+    rules_file_path = "rules/owasp.yaml"
+  }
+}
+# tftest modules=1 resources=1 files=waf_rules
+```
+
+```yaml
+# yaml-language-server: $schema=../schemas/rules.schema.json
+
+owasp-sqli:
+  action: deny(403)
+  priority: 1000
+  description: OWASP SQL injection protection
+  preconfigured_waf: sqli-v33-stable
+
+owasp-xss:
+  action: deny(403)
+  priority: 1001
+  description: OWASP XSS protection
+  preconfigured_waf: xss-v33-stable
+
+threat-intel-tor:
+  action: deny(403)
+  priority: 1050
+  description: Block Tor exit nodes
+  threat_intel_feed: iplist-tor-exit-nodes
+
+geo-block-non-us:
+  action: deny(403)
+  priority: 1100
+  description: Deny non-US traffic
+  expression: origin.region_code != 'US'
+
+allow-gcp-health-checks:
+  action: allow
+  priority: 10
+  description: Allow GCP health check probes
+  src_ip_ranges:
+    - 130.211.0.0/22
+    - 35.191.0.0/16
+# tftest-file id=waf_rules path=rules/owasp.yaml schema=rules.schema.json
+```
+<!-- BEGIN TFDOC -->
+## Variables
+
+| name | description | type | required | default |
+|---|---|:---:|:---:|:---:|
+| [name](variables.tf#L92) | The name of the security policy. | <code>string</code> | ✓ |  |
+| [project_id](variables.tf#L97) | The project in which the security policy belongs. | <code>string</code> | ✓ |  |
+| [adaptive_protection_config](variables.tf#L15) | Adaptive Protection configuration for this security policy. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [advanced_options_config](variables.tf#L41) | Advanced options configuration for this security policy. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [default_rule_action](variables.tf#L55) | Action for the default rule (priority 2147483647). | <code>string</code> |  | <code>&#34;allow&#34;</code> |
+| [default_rule_description](variables.tf#L65) | Description for the default rule (priority 2147483647). | <code>string</code> |  | <code>&#34;Default rule.&#34;</code> |
+| [description](variables.tf#L71) | An optional description of this security policy. | <code>string</code> |  | <code>&#34;Managed by Terraform.&#34;</code> |
+| [factories_config](variables.tf#L77) | Paths to rule data definitions. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [labels](variables.tf#L86) | Labels to apply to the security policy. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
+| [recaptcha_options_config](variables.tf#L102) | reCAPTCHA configuration options for this security policy. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+| [rules](variables.tf#L110) | Security policy rules. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [type](variables.tf#L150) | The type indicates the intended use of the security policy (CLOUD_ARMOR or CLOUD_ARMOR_EDGE). | <code>string</code> |  | <code>&#34;CLOUD_ARMOR&#34;</code> |
+
+## Outputs
+
+| name | description | sensitive |
+|---|---|:---:|
+| [fingerprint](outputs.tf#L15) | Fingerprint of the security policy. |  |
+| [id](outputs.tf#L20) | The security policy ID. |  |
+| [name](outputs.tf#L25) | The security policy name. |  |
+| [security_policy](outputs.tf#L30) | The security policy resource. |  |
+| [self_link](outputs.tf#L35) | The URI of the created security policy. |  |
+<!-- END TFDOC -->

--- a/modules/net-cloud-armor/factory.tf
+++ b/modules/net-cloud-armor/factory.tf
@@ -1,0 +1,55 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+locals {
+  _factory_rules_folder = try(pathexpand(var.factories_config.rules_folder), null)
+  _factory_rule_files = local._factory_rules_folder == null ? [] : [
+    for f in try(fileset(local._factory_rules_folder, "**/*.yaml"), []) :
+    "${local._factory_rules_folder}/${f}"
+  ]
+  _factory_file_data = (
+    var.factories_config.rules_file_path != null
+    ? file(pathexpand(var.factories_config.rules_file_path))
+    : "{}"
+  )
+  _factory_file_rules = yamldecode(local._factory_file_data)
+  _factory_folder_rules = merge(
+    {},
+    [
+      for f in local._factory_rule_files :
+      yamldecode(file(f))
+    ]...
+  )
+  _factory_raw_rules = merge(local._factory_file_rules, local._factory_folder_rules)
+
+  factory_rules = {
+    for k, v in local._factory_raw_rules : k => {
+      action      = v.action
+      priority    = v.priority
+      description = lookup(v, "description", null)
+      preview     = lookup(v, "preview", false)
+      expression = (
+        lookup(v, "preconfigured_waf", null) != null
+        ? "evaluatePreconfiguredWaf('${v.preconfigured_waf}')"
+        : lookup(v, "threat_intel_feed", null) != null
+        ? "evaluateThreatIntelligence('${v.threat_intel_feed}')"
+        : lookup(v, "expression", null)
+      )
+      src_ip_ranges      = lookup(v, "src_ip_ranges", null)
+      header_action      = lookup(v, "header_action", null)
+      rate_limit_options = lookup(v, "rate_limit_options", null)
+      redirect_options   = lookup(v, "redirect_options", null)
+    }
+  }
+}

--- a/modules/net-cloud-armor/main.tf
+++ b/modules/net-cloud-armor/main.tf
@@ -1,0 +1,197 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+locals {
+  has_default_rule = anytrue([for k, v in local.all_rules : v.priority == 2147483647])
+  default_rule = local.has_default_rule ? {} : {
+    default = {
+      action             = var.default_rule_action
+      priority           = 2147483647
+      description        = var.default_rule_description
+      preview            = false
+      src_ip_ranges      = ["*"]
+      expression         = null
+      header_action      = null
+      rate_limit_options = null
+      redirect_options   = null
+    }
+  }
+  normalized_rules = {
+    for k, v in var.rules : k => {
+      action      = v.action
+      priority    = v.priority
+      description = v.description
+      preview     = v.preview
+      expression = (
+        v.preconfigured_waf != null
+        ? "evaluatePreconfiguredWaf('${v.preconfigured_waf}')"
+        : v.threat_intel_feed != null
+        ? "evaluateThreatIntelligence('${v.threat_intel_feed}')"
+        : v.expression
+      )
+      src_ip_ranges      = v.src_ip_ranges
+      header_action      = v.header_action
+      rate_limit_options = v.rate_limit_options
+      redirect_options   = v.redirect_options
+    }
+  }
+  all_rules = merge(local.factory_rules, local.normalized_rules)
+  rules     = merge(local.default_rule, local.all_rules)
+}
+
+resource "google_compute_security_policy" "default" {
+  provider    = google
+  project     = var.project_id
+  name        = var.name
+  description = var.description
+  type        = var.type
+  labels      = var.labels
+
+  dynamic "adaptive_protection_config" {
+    for_each = var.adaptive_protection_config != null ? [var.adaptive_protection_config] : []
+    content {
+      dynamic "layer_7_ddos_defense_config" {
+        for_each = adaptive_protection_config.value.layer_7_ddos_defense != null ? [adaptive_protection_config.value.layer_7_ddos_defense] : []
+        content {
+          enable          = layer_7_ddos_defense_config.value.enable
+          rule_visibility = layer_7_ddos_defense_config.value.rule_visibility
+
+          dynamic "threshold_configs" {
+            for_each = layer_7_ddos_defense_config.value.threshold_configs != null ? layer_7_ddos_defense_config.value.threshold_configs : []
+            content {
+              name                                    = threshold_configs.value.name
+              auto_deploy_load_threshold              = threshold_configs.value.auto_deploy_load_threshold
+              auto_deploy_confidence_threshold        = threshold_configs.value.auto_deploy_confidence_threshold
+              auto_deploy_impacted_baseline_threshold = threshold_configs.value.auto_deploy_impacted_baseline_threshold
+              auto_deploy_expiration_sec              = threshold_configs.value.auto_deploy_expiration_sec
+              detection_load_threshold                = threshold_configs.value.detection_load_threshold
+              detection_absolute_qps                  = threshold_configs.value.detection_absolute_qps
+              detection_relative_to_baseline_qps      = threshold_configs.value.detection_relative_to_baseline_qps
+
+              dynamic "traffic_granularity_configs" {
+                for_each = threshold_configs.value.traffic_granularity_configs != null ? threshold_configs.value.traffic_granularity_configs : []
+                content {
+                  type                     = traffic_granularity_configs.value.type
+                  value                    = traffic_granularity_configs.value.value
+                  enable_each_unique_value = traffic_granularity_configs.value.enable_each_unique_value
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  dynamic "advanced_options_config" {
+    for_each = var.advanced_options_config != null ? [var.advanced_options_config] : []
+    content {
+      json_parsing                 = advanced_options_config.value.json_parsing
+      log_level                    = advanced_options_config.value.log_level
+      request_body_inspection_size = advanced_options_config.value.request_body_inspection_size
+      user_ip_request_headers      = advanced_options_config.value.user_ip_request_headers
+
+      dynamic "json_custom_config" {
+        for_each = advanced_options_config.value.json_custom_config != null ? [advanced_options_config.value.json_custom_config] : []
+        content {
+          content_types = json_custom_config.value.content_types
+        }
+      }
+    }
+  }
+
+  dynamic "recaptcha_options_config" {
+    for_each = var.recaptcha_options_config != null ? [var.recaptcha_options_config] : []
+    content {
+      redirect_site_key = recaptcha_options_config.value.redirect_site_key
+    }
+  }
+
+  dynamic "rule" {
+    for_each = local.rules
+    content {
+      action      = rule.value.action
+      priority    = rule.value.priority
+      description = rule.value.description
+      preview     = rule.value.preview
+
+      dynamic "header_action" {
+        for_each = rule.value.header_action != null ? [1] : []
+        content {
+          dynamic "request_headers_to_adds" {
+            for_each = rule.value.header_action
+            content {
+              header_name  = request_headers_to_adds.value.header_name
+              header_value = request_headers_to_adds.value.header_value
+            }
+          }
+        }
+      }
+
+      dynamic "match" {
+        for_each = (rule.value.src_ip_ranges != null || rule.value.expression != null) ? [1] : []
+        content {
+          versioned_expr = rule.value.src_ip_ranges != null ? "SRC_IPS_V1" : null
+          dynamic "config" {
+            for_each = rule.value.src_ip_ranges != null ? [1] : []
+            content {
+              src_ip_ranges = rule.value.src_ip_ranges
+            }
+          }
+          dynamic "expr" {
+            for_each = rule.value.expression != null ? [1] : []
+            content {
+              expression = rule.value.expression
+            }
+          }
+        }
+      }
+
+      dynamic "rate_limit_options" {
+        for_each = rule.value.rate_limit_options != null ? [rule.value.rate_limit_options] : []
+        content {
+          ban_duration_sec    = rate_limit_options.value.ban_duration_sec
+          conform_action      = rate_limit_options.value.conform_action
+          enforce_on_key      = rate_limit_options.value.enforce_on_key
+          enforce_on_key_name = rate_limit_options.value.enforce_on_key_name
+          exceed_action       = rate_limit_options.value.exceed_action
+
+          dynamic "ban_threshold" {
+            for_each = rate_limit_options.value.ban_threshold != null ? [rate_limit_options.value.ban_threshold] : []
+            content {
+              count        = ban_threshold.value.count
+              interval_sec = ban_threshold.value.interval_sec
+            }
+          }
+
+          dynamic "rate_limit_threshold" {
+            for_each = [rate_limit_options.value.rate_limit_threshold]
+            content {
+              count        = rate_limit_threshold.value.count
+              interval_sec = rate_limit_threshold.value.interval_sec
+            }
+          }
+        }
+      }
+
+      dynamic "redirect_options" {
+        for_each = rule.value.redirect_options != null ? [rule.value.redirect_options] : []
+        content {
+          target = redirect_options.value.target
+          type   = redirect_options.value.type
+        }
+      }
+    }
+  }
+}

--- a/modules/net-cloud-armor/outputs.tf
+++ b/modules/net-cloud-armor/outputs.tf
@@ -1,0 +1,38 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "fingerprint" {
+  description = "Fingerprint of the security policy."
+  value       = google_compute_security_policy.default.fingerprint
+}
+
+output "id" {
+  description = "The security policy ID."
+  value       = google_compute_security_policy.default.id
+}
+
+output "name" {
+  description = "The security policy name."
+  value       = google_compute_security_policy.default.name
+}
+
+output "security_policy" {
+  description = "The security policy resource."
+  value       = google_compute_security_policy.default
+}
+
+output "self_link" {
+  description = "The URI of the created security policy."
+  value       = google_compute_security_policy.default.self_link
+}

--- a/modules/net-cloud-armor/schemas/rules.schema.json
+++ b/modules/net-cloud-armor/schemas/rules.schema.json
@@ -1,0 +1,153 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Cloud Armor Rules",
+  "type": "object",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^[a-z0-9_-]+$": {
+      "$ref": "#/$defs/rule"
+    }
+  },
+  "$defs": {
+    "rule": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "priority",
+        "action"
+      ],
+      "properties": {
+        "priority": {
+          "type": "number"
+        },
+        "action": {
+          "type": "string",
+          "enum": [
+            "allow",
+            "deny(403)",
+            "deny(404)",
+            "deny(502)",
+            "throttle",
+            "rate_based_ban",
+            "redirect"
+          ]
+        },
+        "description": {
+          "type": "string"
+        },
+        "preview": {
+          "type": "boolean"
+        },
+        "preconfigured_waf": {
+          "type": "string"
+        },
+        "threat_intel_feed": {
+          "type": "string"
+        },
+        "expression": {
+          "type": "string"
+        },
+        "src_ip_ranges": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "header_action": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/header_action"
+          }
+        },
+        "rate_limit_options": {
+          "$ref": "#/$defs/rate_limit_options"
+        },
+        "redirect_options": {
+          "$ref": "#/$defs/redirect_options"
+        }
+      }
+    },
+    "header_action": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "header_name",
+        "header_value"
+      ],
+      "properties": {
+        "header_name": {
+          "type": "string"
+        },
+        "header_value": {
+          "type": "string"
+        }
+      }
+    },
+    "rate_limit_options": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "exceed_action",
+        "rate_limit_threshold"
+      ],
+      "properties": {
+        "conform_action": {
+          "type": "string"
+        },
+        "exceed_action": {
+          "type": "string"
+        },
+        "enforce_on_key": {
+          "type": "string"
+        },
+        "enforce_on_key_name": {
+          "type": "string"
+        },
+        "ban_duration_sec": {
+          "type": "number"
+        },
+        "rate_limit_threshold": {
+          "$ref": "#/$defs/threshold"
+        },
+        "ban_threshold": {
+          "$ref": "#/$defs/threshold"
+        }
+      }
+    },
+    "threshold": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "count",
+        "interval_sec"
+      ],
+      "properties": {
+        "count": {
+          "type": "number"
+        },
+        "interval_sec": {
+          "type": "number"
+        }
+      }
+    },
+    "redirect_options": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "GOOGLE_RECAPTCHA",
+            "EXTERNAL_302"
+          ]
+        },
+        "target": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/modules/net-cloud-armor/schemas/rules.schema.md
+++ b/modules/net-cloud-armor/schemas/rules.schema.md
@@ -1,0 +1,50 @@
+# Cloud Armor Rules
+
+<!-- markdownlint-disable MD036 -->
+
+## Properties
+
+*additional properties: false*
+
+- **`^[a-z0-9_-]+$`**: *reference([rule](#refs-rule))*
+
+## Definitions
+
+- **rule**<a name="refs-rule"></a>: *object*
+  <br>*additional properties: false*
+  - ⁺**priority**: *number*
+  - ⁺**action**: *string*
+    <br>*enum: ['allow', 'deny(403)', 'deny(404)', 'deny(502)', 'throttle', 'rate_based_ban', 'redirect']*
+  - **description**: *string*
+  - **preview**: *boolean*
+  - **preconfigured_waf**: *string*
+  - **threat_intel_feed**: *string*
+  - **expression**: *string*
+  - **src_ip_ranges**: *array*
+    - items: *string*
+  - **header_action**: *array*
+    - items: *reference([header_action](#refs-header_action))*
+  - **rate_limit_options**: *reference([rate_limit_options](#refs-rate_limit_options))*
+  - **redirect_options**: *reference([redirect_options](#refs-redirect_options))*
+- **header_action**<a name="refs-header_action"></a>: *object*
+  <br>*additional properties: false*
+  - ⁺**header_name**: *string*
+  - ⁺**header_value**: *string*
+- **rate_limit_options**<a name="refs-rate_limit_options"></a>: *object*
+  <br>*additional properties: false*
+  - **conform_action**: *string*
+  - ⁺**exceed_action**: *string*
+  - **enforce_on_key**: *string*
+  - **enforce_on_key_name**: *string*
+  - **ban_duration_sec**: *number*
+  - **rate_limit_threshold**: *reference([threshold](#refs-threshold))*
+  - **ban_threshold**: *reference([threshold](#refs-threshold))*
+- **threshold**<a name="refs-threshold"></a>: *object*
+  <br>*additional properties: false*
+  - ⁺**count**: *number*
+  - ⁺**interval_sec**: *number*
+- **redirect_options**<a name="refs-redirect_options"></a>: *object*
+  <br>*additional properties: false*
+  - ⁺**type**: *string*
+    <br>*enum: ['GOOGLE_RECAPTCHA', 'EXTERNAL_302']*
+  - **target**: *string*

--- a/modules/net-cloud-armor/variables.tf
+++ b/modules/net-cloud-armor/variables.tf
@@ -1,0 +1,158 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "adaptive_protection_config" {
+  description = "Adaptive Protection configuration for this security policy."
+  type = object({
+    layer_7_ddos_defense = optional(object({
+      enable          = optional(bool, true)
+      rule_visibility = optional(string, "STANDARD")
+      threshold_configs = optional(list(object({
+        name                                    = string
+        auto_deploy_load_threshold              = optional(number)
+        auto_deploy_confidence_threshold        = optional(number)
+        auto_deploy_impacted_baseline_threshold = optional(number)
+        auto_deploy_expiration_sec              = optional(number)
+        detection_load_threshold                = optional(number)
+        detection_absolute_qps                  = optional(number)
+        detection_relative_to_baseline_qps      = optional(number)
+        traffic_granularity_configs = optional(list(object({
+          type                     = string
+          value                    = optional(string)
+          enable_each_unique_value = optional(bool)
+        })))
+      })))
+    }))
+  })
+  default = null
+}
+
+variable "advanced_options_config" {
+  description = "Advanced options configuration for this security policy."
+  type = object({
+    json_parsing                 = optional(string)
+    log_level                    = optional(string)
+    request_body_inspection_size = optional(string)
+    user_ip_request_headers      = optional(list(string))
+    json_custom_config = optional(object({
+      content_types = list(string)
+    }))
+  })
+  default = null
+}
+
+variable "default_rule_action" {
+  description = "Action for the default rule (priority 2147483647)."
+  type        = string
+  default     = "allow"
+  validation {
+    condition     = contains(["allow", "deny(403)", "deny(404)", "deny(502)"], var.default_rule_action)
+    error_message = "Default rule action must be one of allow, deny(403), deny(404), or deny(502)."
+  }
+}
+
+variable "default_rule_description" {
+  description = "Description for the default rule (priority 2147483647)."
+  type        = string
+  default     = "Default rule."
+}
+
+variable "description" {
+  description = "An optional description of this security policy."
+  type        = string
+  default     = "Managed by Terraform."
+}
+
+variable "factories_config" {
+  description = "Paths to rule data definitions."
+  type = object({
+    rules_file_path = optional(string)
+    rules_folder    = optional(string)
+  })
+  default = {}
+}
+
+variable "labels" {
+  description = "Labels to apply to the security policy."
+  type        = map(string)
+  default     = {}
+}
+
+variable "name" {
+  description = "The name of the security policy."
+  type        = string
+}
+
+variable "project_id" {
+  description = "The project in which the security policy belongs."
+  type        = string
+}
+
+variable "recaptcha_options_config" {
+  description = "reCAPTCHA configuration options for this security policy."
+  type = object({
+    redirect_site_key = string
+  })
+  default = null
+}
+
+variable "rules" {
+  description = "Security policy rules."
+  type = map(object({
+    action            = string
+    priority          = number
+    description       = optional(string)
+    preview           = optional(bool, false)
+    preconfigured_waf = optional(string)
+    threat_intel_feed = optional(string)
+    # Match criteria
+    src_ip_ranges = optional(list(string))
+    expression    = optional(string)
+    # Advanced rule options
+    header_action = optional(list(object({
+      header_name  = string
+      header_value = string
+    })))
+    rate_limit_options = optional(object({
+      conform_action      = optional(string, "allow")
+      exceed_action       = string
+      enforce_on_key      = optional(string)
+      enforce_on_key_name = optional(string)
+      rate_limit_threshold = object({
+        count        = number
+        interval_sec = number
+      })
+      ban_duration_sec = optional(number)
+      ban_threshold = optional(object({
+        count        = number
+        interval_sec = number
+      }))
+    }))
+    redirect_options = optional(object({
+      type   = string
+      target = optional(string)
+    }))
+  }))
+  default = {}
+}
+
+variable "type" {
+  description = "The type indicates the intended use of the security policy (CLOUD_ARMOR or CLOUD_ARMOR_EDGE)."
+  type        = string
+  default     = "CLOUD_ARMOR"
+  validation {
+    condition     = contains(["CLOUD_ARMOR", "CLOUD_ARMOR_EDGE"], var.type)
+    error_message = "Type must be either CLOUD_ARMOR or CLOUD_ARMOR_EDGE."
+  }
+}

--- a/modules/net-cloud-armor/versions.tf
+++ b/modules/net-cloud-armor/versions.tf
@@ -1,0 +1,35 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Fabric release: v58.0.0
+
+terraform {
+  required_version = ">= 1.12.2"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 7.40.0, < 8.0.0" # tftest
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 7.40.0, < 8.0.0" # tftest
+    }
+  }
+  provider_meta "google" {
+    module_name = "google-pso-tool/cloud-foundation-fabric/modules/net-cloud-armor:v58.0.0-tf"
+  }
+  provider_meta "google-beta" {
+    module_name = "google-pso-tool/cloud-foundation-fabric/modules/net-cloud-armor:v58.0.0-tf"
+  }
+}

--- a/modules/net-cloud-armor/versions.tofu
+++ b/modules/net-cloud-armor/versions.tofu
@@ -1,0 +1,35 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Fabric release: v58.0.0
+
+terraform {
+  required_version = ">= 1.11.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 7.40.0, < 8.0.0" # tftest
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 7.40.0, < 8.0.0" # tftest
+    }
+  }
+  provider_meta "google" {
+    module_name = "google-pso-tool/cloud-foundation-fabric/modules/net-cloud-armor:v58.0.0-tofu"
+  }
+  provider_meta "google-beta" {
+    module_name = "google-pso-tool/cloud-foundation-fabric/modules/net-cloud-armor:v58.0.0-tofu"
+  }
+}

--- a/tests/modules/net_cloud_armor/main.tfvars
+++ b/tests/modules/net_cloud_armor/main.tfvars
@@ -1,0 +1,32 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+project_id          = "test-project"
+name                = "test-policy"
+description         = "Test security policy"
+default_rule_action = "deny(403)"
+adaptive_protection_config = {
+  layer_7_ddos_defense = {
+    enable          = true
+    rule_visibility = "STANDARD"
+  }
+}
+rules = {
+  rule-owasp = {
+    action      = "deny(403)"
+    priority    = 1000
+    description = "OWASP rule"
+    expression  = "evaluatePreconfiguredWaf('sqli-v33-stable')"
+  }
+}

--- a/tests/modules/net_cloud_armor/main.yaml
+++ b/tests/modules/net_cloud_armor/main.yaml
@@ -1,0 +1,66 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values:
+  google_compute_security_policy.default:
+    adaptive_protection_config:
+      - layer_7_ddos_defense_config:
+          - enable: true
+            rule_visibility: STANDARD
+            threshold_configs: []
+    description: Test security policy
+    effective_labels:
+      goog-terraform-provisioned: 'true'
+    labels: null
+    name: test-policy
+    project: test-project
+    recaptcha_options_config: []
+    rule:
+      - action: deny(403)
+        description: Default rule.
+        header_action: []
+        match:
+          - config:
+              - src_ip_ranges:
+                  - '*'
+            expr: []
+            expr_options: []
+            versioned_expr: SRC_IPS_V1
+        preconfigured_waf_config: []
+        preview: false
+        priority: 2147483647
+        rate_limit_options: []
+        redirect_options: []
+      - action: deny(403)
+        description: OWASP rule
+        header_action: []
+        match:
+          - config: []
+            expr:
+              - expression: evaluatePreconfiguredWaf('sqli-v33-stable')
+            expr_options: []
+            versioned_expr: ''
+        preconfigured_waf_config: []
+        preview: false
+        priority: 1000
+        rate_limit_options: []
+        redirect_options: []
+    terraform_labels:
+      goog-terraform-provisioned: 'true'
+    type: CLOUD_ARMOR
+
+counts:
+  google_compute_security_policy: 1
+  modules: 0
+  resources: 1

--- a/tests/modules/net_cloud_armor/tftest.yaml
+++ b/tests/modules/net_cloud_armor/tftest.yaml
@@ -1,0 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module: modules/net-cloud-armor
+tests:
+  main:


### PR DESCRIPTION
This PR introduces the `modules/net-cloud-armor` module for provisioning and managing Google Cloud Armor security policies.

### Overview & Key Features

- **Preconfigured WAF & Threat Intelligence**:
  - Direct rule convenience helpers for OWASP Core Rule Set (`sqli-v33-stable`, `xss-v33-stable`, `rce-v33-stable`, etc.) via `preconfigured_waf`.
  - Native support for Google Threat Intelligence feeds (`iplist-tor-exit-nodes`, `iplist-known-malicious-ips`, `iplist-vpn-providers`, etc.) via `threat_intel_feed`.
- **IP & Custom Expression Rules**:
  - Source IP CIDR allow/deny matching (such as GCP load balancer health check probe allowlists `130.211.0.0/22`, `35.191.0.0/16`).
  - Custom CEL expression matching (such as geo-blocking via `origin.region_code != 'US'`).
- **Rate Limiting & Throttling**:
  - IP-based and session-based (`HTTP_COOKIE`, `HTTP_HEADER`) rate limiting with configurable thresholds, conform/exceed actions (`throttle`, `deny(429)`), and ban duration.
- **Layer 7 DDoS Defense & Advanced Inspection**:
  - Adaptive Protection configuration for Layer 7 DDoS defense.
  - JSON body parsing (`STANDARD`) and custom content-type inspection.
- **Rules Factory**:
  - Data-driven configuration allowing users to inject rules from YAML files or folders via `factories_config`.
  - JSON Schema (Draft-07) defined in `schemas/rules.schema.json` with companion documentation generated by `tools/schema_docs.py` in `schemas/rules.schema.md`.
- **Dual-Engine CI Parity**:
  - Tested and verified under both Terraform and OpenTofu.

---

**Checklist**

I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [X] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [X] Made sure all relevant tests pass (all 11 CFF verification steps passed)
