### PR TITLE
Forward dropped bucket and log bucket attributes in project-factory

### DIFF
--- a/fast/project-templates/data-mongodb/project.yaml
+++ b/fast/project-templates/data-mongodb/project.yaml
@@ -38,7 +38,6 @@ automation:
     rw:
       description: Read/write automation service account for MongoDB.
   bucket:
-    description: Terraform state bucket for apt registries.
     # this reuses the existing stage state bucket and creates a folder in it
     name: iac-stage-state
     create: false

--- a/fast/project-templates/managed-kafka/project.yaml
+++ b/fast/project-templates/managed-kafka/project.yaml
@@ -40,7 +40,6 @@ automation:
     rw:
       description: Read/write automation service account for Managed Kafka.
   bucket:
-    description: Terraform state bucket for Managed Kafka.
     # this reuses the existing stage state bucket and creates a folder in it
     name: iac-stage-state
     create: false

--- a/fast/project-templates/secops-anonymization-pipeline/project.yaml
+++ b/fast/project-templates/secops-anonymization-pipeline/project.yaml
@@ -37,7 +37,6 @@ automation:
     rw:
       description: Read/write automation service account for secops pipeline.
   bucket:
-    description: Terraform state bucket for apt registries.
     # this reuses the existing stage state bucket and creates a folder in it
     name: iac-stage-state
     create: false

--- a/fast/stages/0-org-setup/datasets/classic-gcd/projects/core/iac-0.yaml
+++ b/fast/stages/0-org-setup/datasets/classic-gcd/projects/core/iac-0.yaml
@@ -94,7 +94,6 @@ data_access_logs:
 buckets:
   # Terraform state bucket for this stage
   iac-org-state:
-    description: Terraform state for the org-level automation.
     versioning: true
     iam:
       roles/storage.admin:
@@ -103,7 +102,6 @@ buckets:
         - $iam_principals:service_accounts/iac-0/iac-org-ro
   # Terraform state bucket for additional FAST stages
   iac-stage-state:
-    description: Terraform state for stage automation.
     versioning: true
     managed_folders:
       1-vpcsc:
@@ -132,7 +130,6 @@ buckets:
             - $iam_principals:service_accounts/iac-0/iac-pf-ro
   # Terraform state bucket for FAST outputs
   iac-outputs:
-    description: Terraform state for the org-level automation.
     versioning: true
     iam:
       roles/storage.admin:

--- a/fast/stages/0-org-setup/datasets/classic/projects/core/iac-0.yaml
+++ b/fast/stages/0-org-setup/datasets/classic/projects/core/iac-0.yaml
@@ -99,7 +99,6 @@ data_access_logs:
 buckets:
   # Terraform state bucket for this stage
   iac-org-state:
-    description: Terraform state for the org-level automation.
     versioning: true
     iam:
       roles/storage.admin:
@@ -108,7 +107,6 @@ buckets:
         - $iam_principals:service_accounts/iac-0/iac-org-ro
   # Terraform state bucket for additional FAST stages
   iac-stage-state:
-    description: Terraform state for stage automation.
     versioning: true
     managed_folders:
       1-vpcsc:
@@ -137,7 +135,6 @@ buckets:
             - $iam_principals:service_accounts/iac-0/iac-pf-ro
   # Terraform state bucket for FAST outputs
   iac-outputs:
-    description: Terraform state for the org-level automation.
     versioning: true
     iam:
       roles/storage.admin:

--- a/fast/stages/0-org-setup/datasets/hardened/projects/core/iac-0.yaml
+++ b/fast/stages/0-org-setup/datasets/hardened/projects/core/iac-0.yaml
@@ -132,7 +132,6 @@ org_policies:
 buckets:
   # Terraform state bucket for this stage
   iac-org-state:
-    description: Terraform state for the org-level automation.
     versioning: true
     encryption_key: $kms_keys:iac-0/ew1/storage
     lifecycle_rules:
@@ -167,7 +166,6 @@ buckets:
         - $iam_principals:service_accounts/iac-0/iac-org-ro
   # Terraform state bucket for additional FAST stages
   iac-stage-state:
-    description: Terraform state for stage automation.
     versioning: true
     encryption_key: $kms_keys:iac-0/ew1/storage
     lifecycle_rules:
@@ -222,7 +220,6 @@ buckets:
             - $iam_principals:service_accounts/iac-0/iac-pf-ro
   # Terraform state bucket for FAST outputs
   iac-outputs:
-    description: Terraform state for the org-level automation.
     versioning: true
     encryption_key: $kms_keys:iac-0/ew1/storage
     lifecycle_rules:

--- a/fast/stages/0-org-setup/datasets/starter-gcd/projects/iac-0.yaml
+++ b/fast/stages/0-org-setup/datasets/starter-gcd/projects/iac-0.yaml
@@ -47,13 +47,11 @@ services:
   - sts.googleapis.com
 buckets:
   iac-org-state:
-    description: Terraform state for the org-level automation.
     versioning: true
     iam:
       roles/storage.admin:
         - $iam_principals:service_accounts/iac-0/iac-org-rw
   iac-outputs:
-    description: Terraform state for the org-level automation.
     versioning: true
     iam:
       roles/storage.admin:

--- a/fast/stages/0-org-setup/schemas/folder.schema.json
+++ b/fast/stages/0-org-setup/schemas/folder.schema.json
@@ -666,9 +666,6 @@
         "name": {
           "type": "string"
         },
-        "description": {
-          "type": "string"
-        },
         "iam": {
           "$ref": "#/$defs/iam"
         },
@@ -713,6 +710,13 @@
         },
         "prefix": {
           "type": "string"
+        },
+        "public_access_prevention": {
+          "type": "string",
+          "enum": [
+            "enforced",
+            "inherited"
+          ]
         },
         "storage_class": {
           "type": "string"

--- a/fast/stages/0-org-setup/schemas/folder.schema.md
+++ b/fast/stages/0-org-setup/schemas/folder.schema.md
@@ -196,7 +196,6 @@
 - **bucket**<a name="refs-bucket"></a>: *object*
   <br>*additional properties: false*
   - **name**: *string*
-  - **description**: *string*
   - **iam**: *reference([iam](#refs-iam))*
   - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
   - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
@@ -212,6 +211,8 @@
       - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
       - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
   - **prefix**: *string*
+  - **public_access_prevention**: *string*
+    <br>*enum: ['enforced', 'inherited']*
   - **storage_class**: *string*
   - **uniform_bucket_level_access**: *boolean*
   - **versioning**: *boolean*

--- a/fast/stages/0-org-setup/schemas/project.schema.json
+++ b/fast/stages/0-org-setup/schemas/project.schema.json
@@ -1308,8 +1308,41 @@
           "type": "boolean",
           "default": true
         },
-        "description": {
-          "type": "string"
+        "autoclass": {
+          "type": "boolean"
+        },
+        "cors": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "origin": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "method": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "response_header": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "max_age_seconds": {
+              "type": "number"
+            }
+          }
+        },
+        "default_event_based_hold": {
+          "type": "boolean"
+        },
+        "enable_hierarchical_namespace": {
+          "type": "boolean"
         },
         "encryption_key": {
           "type": "string"
@@ -1323,8 +1356,38 @@
         "iam_bindings_additive": {
           "$ref": "#/$defs/iam_bindings_additive"
         },
+        "iam_by_principals": {
+          "$ref": "#/$defs/iam_by_principals"
+        },
         "force_destroy": {
           "type": "boolean"
+        },
+        "ip_filter": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "allow_cross_org_vpcs": {
+              "type": "boolean"
+            },
+            "allow_all_service_agent_access": {
+              "type": "boolean"
+            },
+            "public_network_sources": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "vpc_network_sources": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
         },
         "labels": {
           "$ref": "#/$defs/labels"
@@ -1469,8 +1532,81 @@
             }
           }
         },
+        "notification_config": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "enabled",
+            "payload_format",
+            "sa_email",
+            "topic_name"
+          ],
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "payload_format": {
+              "type": "string",
+              "enum": [
+                "JSON_API_V1",
+                "NONE"
+              ]
+            },
+            "sa_email": {
+              "type": "string"
+            },
+            "topic_name": {
+              "type": "string"
+            },
+            "create_topic": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "create": {
+                  "type": "boolean",
+                  "default": true
+                },
+                "kms_key_id": {
+                  "type": "string"
+                }
+              }
+            },
+            "event_types": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "custom_attributes": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "object_name_prefix": {
+              "type": "string"
+            }
+          }
+        },
         "prefix": {
           "type": "string"
+        },
+        "public_access_prevention": {
+          "type": "string",
+          "enum": [
+            "enforced",
+            "inherited"
+          ]
+        },
+        "requester_pays": {
+          "type": "boolean"
+        },
+        "rpo": {
+          "type": "string",
+          "enum": [
+            "ASYNC_TURBO",
+            "DEFAULT"
+          ]
         },
         "storage_class": {
           "type": "string"
@@ -1506,6 +1642,18 @@
           "type": "array",
           "items": {
             "type": "string"
+          }
+        },
+        "website": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "main_page_suffix": {
+              "type": "string"
+            },
+            "not_found_page": {
+              "type": "string"
+            }
           }
         }
       }
@@ -2005,6 +2153,9 @@
         "location": {
           "type": "string"
         },
+        "locked": {
+          "type": "boolean"
+        },
         "log_analytics": {
           "type": "object",
           "additionalProperties": false,
@@ -2023,6 +2174,42 @@
         },
         "retention": {
           "type": "number"
+        },
+        "tag_bindings": {
+          "$ref": "#/$defs/tag_bindings"
+        },
+        "views": {
+          "type": "object",
+          "additionalProperties": false,
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "filter"
+              ],
+              "properties": {
+                "filter": {
+                  "type": "string"
+                },
+                "location": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "iam": {
+                  "$ref": "#/$defs/iam"
+                },
+                "iam_bindings": {
+                  "$ref": "#/$defs/iam_bindings"
+                },
+                "iam_bindings_additive": {
+                  "$ref": "#/$defs/iam_bindings_additive"
+                }
+              }
+            }
+          }
         }
       }
     },

--- a/fast/stages/0-org-setup/schemas/project.schema.md
+++ b/fast/stages/0-org-setup/schemas/project.schema.md
@@ -365,12 +365,32 @@
   <br>*additional properties: false*
   - **name**: *string*
   - **create**: *boolean*
-  - **description**: *string*
+  - **autoclass**: *boolean*
+  - **cors**: *object*
+    <br>*additional properties: false*
+    - **origin**: *array*
+      - items: *string*
+    - **method**: *array*
+      - items: *string*
+    - **response_header**: *array*
+      - items: *string*
+    - **max_age_seconds**: *number*
+  - **default_event_based_hold**: *boolean*
+  - **enable_hierarchical_namespace**: *boolean*
   - **encryption_key**: *string*
   - **iam**: *reference([iam](#refs-iam))*
   - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
   - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
+  - **iam_by_principals**: *reference([iam_by_principals](#refs-iam_by_principals))*
   - **force_destroy**: *boolean*
+  - **ip_filter**: *object*
+    <br>*additional properties: false*
+    - **allow_cross_org_vpcs**: *boolean*
+    - **allow_all_service_agent_access**: *boolean*
+    - **public_network_sources**: *array*
+      - items: *string*
+    - **vpc_network_sources**: *object*
+      <br>*additional properties: array*
   - **labels**: *reference([labels](#refs-labels))*
   - **lifecycle_rules**: *object*
     <br>*additional properties: false*
@@ -412,7 +432,28 @@
       - **iam**: *reference([iam](#refs-iam))*
       - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
       - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
+  - **notification_config**: *object*
+    <br>*additional properties: false*
+    - ⁺**enabled**: *boolean*
+    - ⁺**payload_format**: *string*
+      <br>*enum: ['JSON_API_V1', 'NONE']*
+    - ⁺**sa_email**: *string*
+    - ⁺**topic_name**: *string*
+    - **create_topic**: *object*
+      <br>*additional properties: false*
+      - **create**: *boolean*
+      - **kms_key_id**: *string*
+    - **event_types**: *array*
+      - items: *string*
+    - **custom_attributes**: *object*
+      <br>*additional properties: string*
+    - **object_name_prefix**: *string*
   - **prefix**: *string*
+  - **public_access_prevention**: *string*
+    <br>*enum: ['enforced', 'inherited']*
+  - **requester_pays**: *boolean*
+  - **rpo**: *string*
+    <br>*enum: ['ASYNC_TURBO', 'DEFAULT']*
   - **storage_class**: *string*
   - **uniform_bucket_level_access**: *boolean*
   - **versioning**: *boolean*
@@ -425,6 +466,10 @@
   - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
   - **custom_placement_config**: *array*
     - items: *string*
+  - **website**: *object*
+    <br>*additional properties: false*
+    - **main_page_suffix**: *string*
+    - **not_found_page**: *string*
 - **buckets**<a name="refs-buckets"></a>: *object*
   <br>*additional properties: false*
   - **`^[a-z0-9-]+$`**: *reference([bucket](#refs-bucket))*
@@ -578,12 +623,24 @@
   - **description**: *string*
   - **kms_key_name**: *string*
   - **location**: *string*
+  - **locked**: *boolean*
   - **log_analytics**: *object*
     <br>*additional properties: false*
     - **enable**: *boolean*
     - **dataset_link_id**: *string*
     - **description**: *string*
   - **retention**: *number*
+  - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
+  - **views**: *object*
+    <br>*additional properties: false*
+    - **`^[a-zA-Z0-9_-]+$`**: *object*
+      <br>*additional properties: false*
+      - ⁺**filter**: *string*
+      - **location**: *string*
+      - **description**: *string*
+      - **iam**: *reference([iam](#refs-iam))*
+      - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
+      - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
 - **logging_sink**<a name="refs-logging_sink"></a>: *object*
   <br>*additional properties: false*
   - **bq_partitioned_table**: *boolean*

--- a/fast/stages/2-networking/schemas/folder.schema.json
+++ b/fast/stages/2-networking/schemas/folder.schema.json
@@ -666,9 +666,6 @@
         "name": {
           "type": "string"
         },
-        "description": {
-          "type": "string"
-        },
         "iam": {
           "$ref": "#/$defs/iam"
         },
@@ -713,6 +710,13 @@
         },
         "prefix": {
           "type": "string"
+        },
+        "public_access_prevention": {
+          "type": "string",
+          "enum": [
+            "enforced",
+            "inherited"
+          ]
         },
         "storage_class": {
           "type": "string"

--- a/fast/stages/2-networking/schemas/folder.schema.md
+++ b/fast/stages/2-networking/schemas/folder.schema.md
@@ -196,7 +196,6 @@
 - **bucket**<a name="refs-bucket"></a>: *object*
   <br>*additional properties: false*
   - **name**: *string*
-  - **description**: *string*
   - **iam**: *reference([iam](#refs-iam))*
   - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
   - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
@@ -212,6 +211,8 @@
       - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
       - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
   - **prefix**: *string*
+  - **public_access_prevention**: *string*
+    <br>*enum: ['enforced', 'inherited']*
   - **storage_class**: *string*
   - **uniform_bucket_level_access**: *boolean*
   - **versioning**: *boolean*

--- a/fast/stages/2-networking/schemas/project.schema.json
+++ b/fast/stages/2-networking/schemas/project.schema.json
@@ -1308,8 +1308,41 @@
           "type": "boolean",
           "default": true
         },
-        "description": {
-          "type": "string"
+        "autoclass": {
+          "type": "boolean"
+        },
+        "cors": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "origin": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "method": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "response_header": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "max_age_seconds": {
+              "type": "number"
+            }
+          }
+        },
+        "default_event_based_hold": {
+          "type": "boolean"
+        },
+        "enable_hierarchical_namespace": {
+          "type": "boolean"
         },
         "encryption_key": {
           "type": "string"
@@ -1323,8 +1356,38 @@
         "iam_bindings_additive": {
           "$ref": "#/$defs/iam_bindings_additive"
         },
+        "iam_by_principals": {
+          "$ref": "#/$defs/iam_by_principals"
+        },
         "force_destroy": {
           "type": "boolean"
+        },
+        "ip_filter": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "allow_cross_org_vpcs": {
+              "type": "boolean"
+            },
+            "allow_all_service_agent_access": {
+              "type": "boolean"
+            },
+            "public_network_sources": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "vpc_network_sources": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
         },
         "labels": {
           "$ref": "#/$defs/labels"
@@ -1469,8 +1532,81 @@
             }
           }
         },
+        "notification_config": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "enabled",
+            "payload_format",
+            "sa_email",
+            "topic_name"
+          ],
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "payload_format": {
+              "type": "string",
+              "enum": [
+                "JSON_API_V1",
+                "NONE"
+              ]
+            },
+            "sa_email": {
+              "type": "string"
+            },
+            "topic_name": {
+              "type": "string"
+            },
+            "create_topic": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "create": {
+                  "type": "boolean",
+                  "default": true
+                },
+                "kms_key_id": {
+                  "type": "string"
+                }
+              }
+            },
+            "event_types": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "custom_attributes": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "object_name_prefix": {
+              "type": "string"
+            }
+          }
+        },
         "prefix": {
           "type": "string"
+        },
+        "public_access_prevention": {
+          "type": "string",
+          "enum": [
+            "enforced",
+            "inherited"
+          ]
+        },
+        "requester_pays": {
+          "type": "boolean"
+        },
+        "rpo": {
+          "type": "string",
+          "enum": [
+            "ASYNC_TURBO",
+            "DEFAULT"
+          ]
         },
         "storage_class": {
           "type": "string"
@@ -1506,6 +1642,18 @@
           "type": "array",
           "items": {
             "type": "string"
+          }
+        },
+        "website": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "main_page_suffix": {
+              "type": "string"
+            },
+            "not_found_page": {
+              "type": "string"
+            }
           }
         }
       }
@@ -2005,6 +2153,9 @@
         "location": {
           "type": "string"
         },
+        "locked": {
+          "type": "boolean"
+        },
         "log_analytics": {
           "type": "object",
           "additionalProperties": false,
@@ -2023,6 +2174,42 @@
         },
         "retention": {
           "type": "number"
+        },
+        "tag_bindings": {
+          "$ref": "#/$defs/tag_bindings"
+        },
+        "views": {
+          "type": "object",
+          "additionalProperties": false,
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "filter"
+              ],
+              "properties": {
+                "filter": {
+                  "type": "string"
+                },
+                "location": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "iam": {
+                  "$ref": "#/$defs/iam"
+                },
+                "iam_bindings": {
+                  "$ref": "#/$defs/iam_bindings"
+                },
+                "iam_bindings_additive": {
+                  "$ref": "#/$defs/iam_bindings_additive"
+                }
+              }
+            }
+          }
         }
       }
     },

--- a/fast/stages/2-networking/schemas/project.schema.md
+++ b/fast/stages/2-networking/schemas/project.schema.md
@@ -365,12 +365,32 @@
   <br>*additional properties: false*
   - **name**: *string*
   - **create**: *boolean*
-  - **description**: *string*
+  - **autoclass**: *boolean*
+  - **cors**: *object*
+    <br>*additional properties: false*
+    - **origin**: *array*
+      - items: *string*
+    - **method**: *array*
+      - items: *string*
+    - **response_header**: *array*
+      - items: *string*
+    - **max_age_seconds**: *number*
+  - **default_event_based_hold**: *boolean*
+  - **enable_hierarchical_namespace**: *boolean*
   - **encryption_key**: *string*
   - **iam**: *reference([iam](#refs-iam))*
   - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
   - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
+  - **iam_by_principals**: *reference([iam_by_principals](#refs-iam_by_principals))*
   - **force_destroy**: *boolean*
+  - **ip_filter**: *object*
+    <br>*additional properties: false*
+    - **allow_cross_org_vpcs**: *boolean*
+    - **allow_all_service_agent_access**: *boolean*
+    - **public_network_sources**: *array*
+      - items: *string*
+    - **vpc_network_sources**: *object*
+      <br>*additional properties: array*
   - **labels**: *reference([labels](#refs-labels))*
   - **lifecycle_rules**: *object*
     <br>*additional properties: false*
@@ -412,7 +432,28 @@
       - **iam**: *reference([iam](#refs-iam))*
       - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
       - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
+  - **notification_config**: *object*
+    <br>*additional properties: false*
+    - ⁺**enabled**: *boolean*
+    - ⁺**payload_format**: *string*
+      <br>*enum: ['JSON_API_V1', 'NONE']*
+    - ⁺**sa_email**: *string*
+    - ⁺**topic_name**: *string*
+    - **create_topic**: *object*
+      <br>*additional properties: false*
+      - **create**: *boolean*
+      - **kms_key_id**: *string*
+    - **event_types**: *array*
+      - items: *string*
+    - **custom_attributes**: *object*
+      <br>*additional properties: string*
+    - **object_name_prefix**: *string*
   - **prefix**: *string*
+  - **public_access_prevention**: *string*
+    <br>*enum: ['enforced', 'inherited']*
+  - **requester_pays**: *boolean*
+  - **rpo**: *string*
+    <br>*enum: ['ASYNC_TURBO', 'DEFAULT']*
   - **storage_class**: *string*
   - **uniform_bucket_level_access**: *boolean*
   - **versioning**: *boolean*
@@ -425,6 +466,10 @@
   - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
   - **custom_placement_config**: *array*
     - items: *string*
+  - **website**: *object*
+    <br>*additional properties: false*
+    - **main_page_suffix**: *string*
+    - **not_found_page**: *string*
 - **buckets**<a name="refs-buckets"></a>: *object*
   <br>*additional properties: false*
   - **`^[a-z0-9-]+$`**: *reference([bucket](#refs-bucket))*
@@ -578,12 +623,24 @@
   - **description**: *string*
   - **kms_key_name**: *string*
   - **location**: *string*
+  - **locked**: *boolean*
   - **log_analytics**: *object*
     <br>*additional properties: false*
     - **enable**: *boolean*
     - **dataset_link_id**: *string*
     - **description**: *string*
   - **retention**: *number*
+  - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
+  - **views**: *object*
+    <br>*additional properties: false*
+    - **`^[a-zA-Z0-9_-]+$`**: *object*
+      <br>*additional properties: false*
+      - ⁺**filter**: *string*
+      - **location**: *string*
+      - **description**: *string*
+      - **iam**: *reference([iam](#refs-iam))*
+      - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
+      - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
 - **logging_sink**<a name="refs-logging_sink"></a>: *object*
   <br>*additional properties: false*
   - **bq_partitioned_table**: *boolean*

--- a/fast/stages/2-project-factory/schemas/folder.schema.json
+++ b/fast/stages/2-project-factory/schemas/folder.schema.json
@@ -666,9 +666,6 @@
         "name": {
           "type": "string"
         },
-        "description": {
-          "type": "string"
-        },
         "iam": {
           "$ref": "#/$defs/iam"
         },
@@ -713,6 +710,13 @@
         },
         "prefix": {
           "type": "string"
+        },
+        "public_access_prevention": {
+          "type": "string",
+          "enum": [
+            "enforced",
+            "inherited"
+          ]
         },
         "storage_class": {
           "type": "string"

--- a/fast/stages/2-project-factory/schemas/folder.schema.md
+++ b/fast/stages/2-project-factory/schemas/folder.schema.md
@@ -196,7 +196,6 @@
 - **bucket**<a name="refs-bucket"></a>: *object*
   <br>*additional properties: false*
   - **name**: *string*
-  - **description**: *string*
   - **iam**: *reference([iam](#refs-iam))*
   - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
   - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
@@ -212,6 +211,8 @@
       - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
       - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
   - **prefix**: *string*
+  - **public_access_prevention**: *string*
+    <br>*enum: ['enforced', 'inherited']*
   - **storage_class**: *string*
   - **uniform_bucket_level_access**: *boolean*
   - **versioning**: *boolean*

--- a/fast/stages/2-project-factory/schemas/project.schema.json
+++ b/fast/stages/2-project-factory/schemas/project.schema.json
@@ -1308,8 +1308,41 @@
           "type": "boolean",
           "default": true
         },
-        "description": {
-          "type": "string"
+        "autoclass": {
+          "type": "boolean"
+        },
+        "cors": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "origin": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "method": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "response_header": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "max_age_seconds": {
+              "type": "number"
+            }
+          }
+        },
+        "default_event_based_hold": {
+          "type": "boolean"
+        },
+        "enable_hierarchical_namespace": {
+          "type": "boolean"
         },
         "encryption_key": {
           "type": "string"
@@ -1323,8 +1356,38 @@
         "iam_bindings_additive": {
           "$ref": "#/$defs/iam_bindings_additive"
         },
+        "iam_by_principals": {
+          "$ref": "#/$defs/iam_by_principals"
+        },
         "force_destroy": {
           "type": "boolean"
+        },
+        "ip_filter": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "allow_cross_org_vpcs": {
+              "type": "boolean"
+            },
+            "allow_all_service_agent_access": {
+              "type": "boolean"
+            },
+            "public_network_sources": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "vpc_network_sources": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
         },
         "labels": {
           "$ref": "#/$defs/labels"
@@ -1469,8 +1532,81 @@
             }
           }
         },
+        "notification_config": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "enabled",
+            "payload_format",
+            "sa_email",
+            "topic_name"
+          ],
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "payload_format": {
+              "type": "string",
+              "enum": [
+                "JSON_API_V1",
+                "NONE"
+              ]
+            },
+            "sa_email": {
+              "type": "string"
+            },
+            "topic_name": {
+              "type": "string"
+            },
+            "create_topic": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "create": {
+                  "type": "boolean",
+                  "default": true
+                },
+                "kms_key_id": {
+                  "type": "string"
+                }
+              }
+            },
+            "event_types": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "custom_attributes": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "object_name_prefix": {
+              "type": "string"
+            }
+          }
+        },
         "prefix": {
           "type": "string"
+        },
+        "public_access_prevention": {
+          "type": "string",
+          "enum": [
+            "enforced",
+            "inherited"
+          ]
+        },
+        "requester_pays": {
+          "type": "boolean"
+        },
+        "rpo": {
+          "type": "string",
+          "enum": [
+            "ASYNC_TURBO",
+            "DEFAULT"
+          ]
         },
         "storage_class": {
           "type": "string"
@@ -1506,6 +1642,18 @@
           "type": "array",
           "items": {
             "type": "string"
+          }
+        },
+        "website": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "main_page_suffix": {
+              "type": "string"
+            },
+            "not_found_page": {
+              "type": "string"
+            }
           }
         }
       }
@@ -2005,6 +2153,9 @@
         "location": {
           "type": "string"
         },
+        "locked": {
+          "type": "boolean"
+        },
         "log_analytics": {
           "type": "object",
           "additionalProperties": false,
@@ -2023,6 +2174,42 @@
         },
         "retention": {
           "type": "number"
+        },
+        "tag_bindings": {
+          "$ref": "#/$defs/tag_bindings"
+        },
+        "views": {
+          "type": "object",
+          "additionalProperties": false,
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "filter"
+              ],
+              "properties": {
+                "filter": {
+                  "type": "string"
+                },
+                "location": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "iam": {
+                  "$ref": "#/$defs/iam"
+                },
+                "iam_bindings": {
+                  "$ref": "#/$defs/iam_bindings"
+                },
+                "iam_bindings_additive": {
+                  "$ref": "#/$defs/iam_bindings_additive"
+                }
+              }
+            }
+          }
         }
       }
     },

--- a/fast/stages/2-project-factory/schemas/project.schema.md
+++ b/fast/stages/2-project-factory/schemas/project.schema.md
@@ -365,12 +365,32 @@
   <br>*additional properties: false*
   - **name**: *string*
   - **create**: *boolean*
-  - **description**: *string*
+  - **autoclass**: *boolean*
+  - **cors**: *object*
+    <br>*additional properties: false*
+    - **origin**: *array*
+      - items: *string*
+    - **method**: *array*
+      - items: *string*
+    - **response_header**: *array*
+      - items: *string*
+    - **max_age_seconds**: *number*
+  - **default_event_based_hold**: *boolean*
+  - **enable_hierarchical_namespace**: *boolean*
   - **encryption_key**: *string*
   - **iam**: *reference([iam](#refs-iam))*
   - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
   - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
+  - **iam_by_principals**: *reference([iam_by_principals](#refs-iam_by_principals))*
   - **force_destroy**: *boolean*
+  - **ip_filter**: *object*
+    <br>*additional properties: false*
+    - **allow_cross_org_vpcs**: *boolean*
+    - **allow_all_service_agent_access**: *boolean*
+    - **public_network_sources**: *array*
+      - items: *string*
+    - **vpc_network_sources**: *object*
+      <br>*additional properties: array*
   - **labels**: *reference([labels](#refs-labels))*
   - **lifecycle_rules**: *object*
     <br>*additional properties: false*
@@ -412,7 +432,28 @@
       - **iam**: *reference([iam](#refs-iam))*
       - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
       - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
+  - **notification_config**: *object*
+    <br>*additional properties: false*
+    - ⁺**enabled**: *boolean*
+    - ⁺**payload_format**: *string*
+      <br>*enum: ['JSON_API_V1', 'NONE']*
+    - ⁺**sa_email**: *string*
+    - ⁺**topic_name**: *string*
+    - **create_topic**: *object*
+      <br>*additional properties: false*
+      - **create**: *boolean*
+      - **kms_key_id**: *string*
+    - **event_types**: *array*
+      - items: *string*
+    - **custom_attributes**: *object*
+      <br>*additional properties: string*
+    - **object_name_prefix**: *string*
   - **prefix**: *string*
+  - **public_access_prevention**: *string*
+    <br>*enum: ['enforced', 'inherited']*
+  - **requester_pays**: *boolean*
+  - **rpo**: *string*
+    <br>*enum: ['ASYNC_TURBO', 'DEFAULT']*
   - **storage_class**: *string*
   - **uniform_bucket_level_access**: *boolean*
   - **versioning**: *boolean*
@@ -425,6 +466,10 @@
   - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
   - **custom_placement_config**: *array*
     - items: *string*
+  - **website**: *object*
+    <br>*additional properties: false*
+    - **main_page_suffix**: *string*
+    - **not_found_page**: *string*
 - **buckets**<a name="refs-buckets"></a>: *object*
   <br>*additional properties: false*
   - **`^[a-z0-9-]+$`**: *reference([bucket](#refs-bucket))*
@@ -578,12 +623,24 @@
   - **description**: *string*
   - **kms_key_name**: *string*
   - **location**: *string*
+  - **locked**: *boolean*
   - **log_analytics**: *object*
     <br>*additional properties: false*
     - **enable**: *boolean*
     - **dataset_link_id**: *string*
     - **description**: *string*
   - **retention**: *number*
+  - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
+  - **views**: *object*
+    <br>*additional properties: false*
+    - **`^[a-zA-Z0-9_-]+$`**: *object*
+      <br>*additional properties: false*
+      - ⁺**filter**: *string*
+      - **location**: *string*
+      - **description**: *string*
+      - **iam**: *reference([iam](#refs-iam))*
+      - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
+      - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
 - **logging_sink**<a name="refs-logging_sink"></a>: *object*
   <br>*additional properties: false*
   - **bq_partitioned_table**: *boolean*

--- a/fast/stages/2-security/schemas/folder.schema.json
+++ b/fast/stages/2-security/schemas/folder.schema.json
@@ -666,9 +666,6 @@
         "name": {
           "type": "string"
         },
-        "description": {
-          "type": "string"
-        },
         "iam": {
           "$ref": "#/$defs/iam"
         },
@@ -713,6 +710,13 @@
         },
         "prefix": {
           "type": "string"
+        },
+        "public_access_prevention": {
+          "type": "string",
+          "enum": [
+            "enforced",
+            "inherited"
+          ]
         },
         "storage_class": {
           "type": "string"

--- a/fast/stages/2-security/schemas/folder.schema.md
+++ b/fast/stages/2-security/schemas/folder.schema.md
@@ -196,7 +196,6 @@
 - **bucket**<a name="refs-bucket"></a>: *object*
   <br>*additional properties: false*
   - **name**: *string*
-  - **description**: *string*
   - **iam**: *reference([iam](#refs-iam))*
   - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
   - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
@@ -212,6 +211,8 @@
       - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
       - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
   - **prefix**: *string*
+  - **public_access_prevention**: *string*
+    <br>*enum: ['enforced', 'inherited']*
   - **storage_class**: *string*
   - **uniform_bucket_level_access**: *boolean*
   - **versioning**: *boolean*

--- a/fast/stages/2-security/schemas/project.schema.json
+++ b/fast/stages/2-security/schemas/project.schema.json
@@ -1308,8 +1308,41 @@
           "type": "boolean",
           "default": true
         },
-        "description": {
-          "type": "string"
+        "autoclass": {
+          "type": "boolean"
+        },
+        "cors": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "origin": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "method": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "response_header": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "max_age_seconds": {
+              "type": "number"
+            }
+          }
+        },
+        "default_event_based_hold": {
+          "type": "boolean"
+        },
+        "enable_hierarchical_namespace": {
+          "type": "boolean"
         },
         "encryption_key": {
           "type": "string"
@@ -1323,8 +1356,38 @@
         "iam_bindings_additive": {
           "$ref": "#/$defs/iam_bindings_additive"
         },
+        "iam_by_principals": {
+          "$ref": "#/$defs/iam_by_principals"
+        },
         "force_destroy": {
           "type": "boolean"
+        },
+        "ip_filter": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "allow_cross_org_vpcs": {
+              "type": "boolean"
+            },
+            "allow_all_service_agent_access": {
+              "type": "boolean"
+            },
+            "public_network_sources": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "vpc_network_sources": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
         },
         "labels": {
           "$ref": "#/$defs/labels"
@@ -1469,8 +1532,81 @@
             }
           }
         },
+        "notification_config": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "enabled",
+            "payload_format",
+            "sa_email",
+            "topic_name"
+          ],
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "payload_format": {
+              "type": "string",
+              "enum": [
+                "JSON_API_V1",
+                "NONE"
+              ]
+            },
+            "sa_email": {
+              "type": "string"
+            },
+            "topic_name": {
+              "type": "string"
+            },
+            "create_topic": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "create": {
+                  "type": "boolean",
+                  "default": true
+                },
+                "kms_key_id": {
+                  "type": "string"
+                }
+              }
+            },
+            "event_types": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "custom_attributes": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "object_name_prefix": {
+              "type": "string"
+            }
+          }
+        },
         "prefix": {
           "type": "string"
+        },
+        "public_access_prevention": {
+          "type": "string",
+          "enum": [
+            "enforced",
+            "inherited"
+          ]
+        },
+        "requester_pays": {
+          "type": "boolean"
+        },
+        "rpo": {
+          "type": "string",
+          "enum": [
+            "ASYNC_TURBO",
+            "DEFAULT"
+          ]
         },
         "storage_class": {
           "type": "string"
@@ -1506,6 +1642,18 @@
           "type": "array",
           "items": {
             "type": "string"
+          }
+        },
+        "website": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "main_page_suffix": {
+              "type": "string"
+            },
+            "not_found_page": {
+              "type": "string"
+            }
           }
         }
       }
@@ -2005,6 +2153,9 @@
         "location": {
           "type": "string"
         },
+        "locked": {
+          "type": "boolean"
+        },
         "log_analytics": {
           "type": "object",
           "additionalProperties": false,
@@ -2023,6 +2174,42 @@
         },
         "retention": {
           "type": "number"
+        },
+        "tag_bindings": {
+          "$ref": "#/$defs/tag_bindings"
+        },
+        "views": {
+          "type": "object",
+          "additionalProperties": false,
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "filter"
+              ],
+              "properties": {
+                "filter": {
+                  "type": "string"
+                },
+                "location": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "iam": {
+                  "$ref": "#/$defs/iam"
+                },
+                "iam_bindings": {
+                  "$ref": "#/$defs/iam_bindings"
+                },
+                "iam_bindings_additive": {
+                  "$ref": "#/$defs/iam_bindings_additive"
+                }
+              }
+            }
+          }
         }
       }
     },

--- a/fast/stages/2-security/schemas/project.schema.md
+++ b/fast/stages/2-security/schemas/project.schema.md
@@ -365,12 +365,32 @@
   <br>*additional properties: false*
   - **name**: *string*
   - **create**: *boolean*
-  - **description**: *string*
+  - **autoclass**: *boolean*
+  - **cors**: *object*
+    <br>*additional properties: false*
+    - **origin**: *array*
+      - items: *string*
+    - **method**: *array*
+      - items: *string*
+    - **response_header**: *array*
+      - items: *string*
+    - **max_age_seconds**: *number*
+  - **default_event_based_hold**: *boolean*
+  - **enable_hierarchical_namespace**: *boolean*
   - **encryption_key**: *string*
   - **iam**: *reference([iam](#refs-iam))*
   - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
   - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
+  - **iam_by_principals**: *reference([iam_by_principals](#refs-iam_by_principals))*
   - **force_destroy**: *boolean*
+  - **ip_filter**: *object*
+    <br>*additional properties: false*
+    - **allow_cross_org_vpcs**: *boolean*
+    - **allow_all_service_agent_access**: *boolean*
+    - **public_network_sources**: *array*
+      - items: *string*
+    - **vpc_network_sources**: *object*
+      <br>*additional properties: array*
   - **labels**: *reference([labels](#refs-labels))*
   - **lifecycle_rules**: *object*
     <br>*additional properties: false*
@@ -412,7 +432,28 @@
       - **iam**: *reference([iam](#refs-iam))*
       - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
       - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
+  - **notification_config**: *object*
+    <br>*additional properties: false*
+    - ⁺**enabled**: *boolean*
+    - ⁺**payload_format**: *string*
+      <br>*enum: ['JSON_API_V1', 'NONE']*
+    - ⁺**sa_email**: *string*
+    - ⁺**topic_name**: *string*
+    - **create_topic**: *object*
+      <br>*additional properties: false*
+      - **create**: *boolean*
+      - **kms_key_id**: *string*
+    - **event_types**: *array*
+      - items: *string*
+    - **custom_attributes**: *object*
+      <br>*additional properties: string*
+    - **object_name_prefix**: *string*
   - **prefix**: *string*
+  - **public_access_prevention**: *string*
+    <br>*enum: ['enforced', 'inherited']*
+  - **requester_pays**: *boolean*
+  - **rpo**: *string*
+    <br>*enum: ['ASYNC_TURBO', 'DEFAULT']*
   - **storage_class**: *string*
   - **uniform_bucket_level_access**: *boolean*
   - **versioning**: *boolean*
@@ -425,6 +466,10 @@
   - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
   - **custom_placement_config**: *array*
     - items: *string*
+  - **website**: *object*
+    <br>*additional properties: false*
+    - **main_page_suffix**: *string*
+    - **not_found_page**: *string*
 - **buckets**<a name="refs-buckets"></a>: *object*
   <br>*additional properties: false*
   - **`^[a-z0-9-]+$`**: *reference([bucket](#refs-bucket))*
@@ -578,12 +623,24 @@
   - **description**: *string*
   - **kms_key_name**: *string*
   - **location**: *string*
+  - **locked**: *boolean*
   - **log_analytics**: *object*
     <br>*additional properties: false*
     - **enable**: *boolean*
     - **dataset_link_id**: *string*
     - **description**: *string*
   - **retention**: *number*
+  - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
+  - **views**: *object*
+    <br>*additional properties: false*
+    - **`^[a-zA-Z0-9_-]+$`**: *object*
+      <br>*additional properties: false*
+      - ⁺**filter**: *string*
+      - **location**: *string*
+      - **description**: *string*
+      - **iam**: *reference([iam](#refs-iam))*
+      - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
+      - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
 - **logging_sink**<a name="refs-logging_sink"></a>: *object*
   <br>*additional properties: false*
   - **bq_partitioned_table**: *boolean*

--- a/modules/project-factory/README.md
+++ b/modules/project-factory/README.md
@@ -206,7 +206,6 @@ automation:
       description: Read-only automation sa for app example 0.
   bucket:
     # bucket name: foo-prod-app-example-0-tf-state
-    description: Terraform state bucket for app example 0.
     iam:
       roles/storage.objectCreator:
         - $iam_principals:service_accounts/iac-core-0/rw
@@ -263,7 +262,6 @@ automation:
       description: Read/write automation sa for team a app 0.
   buckets:
     state:
-      description: Terraform state bucket for team a app 0.
       iam:
         roles/storage.objectCreator:
           - $iam_principals:service_accounts/my-project/rw
@@ -811,7 +809,6 @@ automation:
     ro:
       description: Team B app 0 read-only automation sa.
   bucket:
-    description: Team B app 0 Terraform state bucket.
     iam:
       roles/storage.objectCreator:
         - $iam_principals:service_accounts/dev-tb-app0-0/automation/rw
@@ -995,7 +992,7 @@ module "project-factory" {
     basepath = "data"
   }
 }
-# tftest modules=10 resources=36 files=test-0,test-1,test-2 inventory=test-1.yaml
+# tftest modules=12 resources=44 files=test-0,test-1,test-2 inventory=test-1.yaml
 ```
 
 ```yaml
@@ -1032,6 +1029,55 @@ automation:
     auto-tag-test:
       tag_bindings:
         project-level: $tag_values:test-0/context/project-factory
+# test forwarding of the full gcs bucket attribute surface
+buckets:
+  attrs-test:
+    autoclass: false
+    default_event_based_hold: true
+    enable_hierarchical_namespace: false
+    public_access_prevention: enforced
+    requester_pays: true
+    # rpo is only accepted on dual-region buckets
+    location: EU
+    custom_placement_config:
+      - europe-west1
+      - europe-west4
+    rpo: DEFAULT
+    cors:
+      origin:
+        - https://example.com
+      method:
+        - GET
+      response_header:
+        - Content-Type
+      max_age_seconds: 3600
+    ip_filter:
+      allow_all_service_agent_access: true
+      public_network_sources:
+        - 192.0.2.0/24
+    notification_config:
+      enabled: true
+      payload_format: JSON_API_V1
+      sa_email: service-1234567890@gs-project-accounts.iam.gserviceaccount.com
+      topic_name: attrs-test-notifications
+    website:
+      main_page_suffix: index.html
+      not_found_page: 404.html
+# test forwarding of the full logging-bucket attribute surface
+log_buckets:
+  audit-logs:
+    description: Test log bucket description.
+    locked: false
+    retention: 365
+    tag_bindings:
+      project-level: $tag_values:test-0/context/project-factory
+    views:
+      audit-view:
+        description: Test log view.
+        filter: 'LOG_ID("cloudaudit.googleapis.com/activity")'
+        iam:
+          roles/logging.viewAccessor:
+            - $iam_principals:tag-test
 # tftest-file id=test-0 path=data/projects/test-0.yaml
 ```
 

--- a/modules/project-factory/automation.tf
+++ b/modules/project-factory/automation.tf
@@ -111,6 +111,9 @@ module "automation-bucket" {
     lookup(each.value, "location", null),
     local.data_defaults.defaults.locations.storage
   )
+  public_access_prevention = lookup(
+    each.value, "public_access_prevention", null
+  )
   storage_class = lookup(
     each.value, "storage_class", "STANDARD"
   )

--- a/modules/project-factory/projects-buckets.tf
+++ b/modules/project-factory/projects-buckets.tf
@@ -18,12 +18,19 @@ locals {
   projects_buckets = flatten([
     for k, v in local.projects_input : [
       for name, opts in lookup(v, "buckets", {}) : {
-        key            = "${k}/${name}"
-        project_key    = k
-        project_name   = v.name
-        name           = lookup(opts, "name", "${v.name}-${name}")
-        create         = lookup(opts, "create", true)
-        description    = lookup(opts, "description", "Terraform-managed.")
+        key          = "${k}/${name}"
+        project_key  = k
+        project_name = v.name
+        name         = lookup(opts, "name", "${v.name}-${name}")
+        create       = lookup(opts, "create", true)
+        autoclass    = lookup(opts, "autoclass", null)
+        cors         = lookup(opts, "cors", null)
+        default_event_based_hold = lookup(
+          opts, "default_event_based_hold", null
+        )
+        enable_hierarchical_namespace = lookup(
+          opts, "enable_hierarchical_namespace", null
+        )
         encryption_key = lookup(opts, "encryption_key", null)
         force_destroy = try(coalesce(
           local.data_defaults.overrides.bucket.force_destroy,
@@ -34,14 +41,21 @@ locals {
         iam_bindings          = lookup(opts, "iam_bindings", {})
         iam_bindings_additive = lookup(opts, "iam_bindings_additive", {})
         iam_by_principals     = lookup(opts, "iam_by_principals", {})
+        ip_filter             = lookup(opts, "ip_filter", null)
         labels                = lookup(opts, "labels", {})
         location              = lookup(opts, "location", null)
         managed_folders       = lookup(opts, "managed_folders", {})
+        notification_config   = lookup(opts, "notification_config", null)
         prefix = try(coalesce(
           local.data_defaults.overrides.prefix,
           try(v.prefix, null),
           local.data_defaults.defaults.prefix
         ), null)
+        public_access_prevention = lookup(
+          opts, "public_access_prevention", null
+        )
+        requester_pays = lookup(opts, "requester_pays", null)
+        rpo            = lookup(opts, "rpo", null)
         storage_class = lookup(
           opts, "storage_class", "STANDARD"
         )
@@ -58,20 +72,25 @@ locals {
         enable_object_retention = lookup(opts, "enable_object_retention", null)
         tag_bindings            = lookup(opts, "tag_bindings", {})
         custom_placement_config = lookup(opts, "custom_placement_config", null)
+        website                 = lookup(opts, "website", null)
       }
     ]
   ])
 }
 
 module "buckets" {
-  source         = "../gcs"
-  for_each       = { for k in local.projects_buckets : k.key => k }
-  project_id     = module.projects-iam[each.value.project_key].project_id
-  prefix         = each.value.prefix
-  name           = each.value.name
-  bucket_create  = each.value.create
-  encryption_key = each.value.encryption_key
-  force_destroy  = each.value.force_destroy
+  source                        = "../gcs"
+  for_each                      = { for k in local.projects_buckets : k.key => k }
+  project_id                    = module.projects-iam[each.value.project_key].project_id
+  prefix                        = each.value.prefix
+  name                          = each.value.name
+  autoclass                     = each.value.autoclass
+  bucket_create                 = each.value.create
+  cors                          = each.value.cors
+  default_event_based_hold      = each.value.default_event_based_hold
+  enable_hierarchical_namespace = each.value.enable_hierarchical_namespace
+  encryption_key                = each.value.encryption_key
+  force_destroy                 = each.value.force_destroy
   context = merge(local.ctx, {
     tag_vars = {
       projects     = merge(try(local.ctx.tag_vars.projects, {}), local.tag_vars_projects)
@@ -96,6 +115,7 @@ module "buckets" {
   iam_bindings          = each.value.iam_bindings
   iam_bindings_additive = each.value.iam_bindings_additive
   iam_by_principals     = each.value.iam_by_principals
+  ip_filter             = each.value.ip_filter
   labels                = each.value.labels
   lifecycle_rules       = each.value.lifecycle_rules
   location = coalesce(
@@ -104,6 +124,10 @@ module "buckets" {
     local.data_defaults.defaults.locations.storage
   )
   managed_folders             = each.value.managed_folders
+  notification_config         = each.value.notification_config
+  public_access_prevention    = each.value.public_access_prevention
+  requester_pays              = each.value.requester_pays
+  rpo                         = each.value.rpo
   storage_class               = each.value.storage_class
   uniform_bucket_level_access = each.value.uniform_bucket_level_access
   versioning                  = each.value.versioning
@@ -113,4 +137,5 @@ module "buckets" {
   enable_object_retention     = each.value.enable_object_retention
   tag_bindings                = each.value.tag_bindings
   custom_placement_config     = each.value.custom_placement_config
+  website                     = each.value.website
 }

--- a/modules/project-factory/projects-buckets.tf
+++ b/modules/project-factory/projects-buckets.tf
@@ -21,10 +21,13 @@ locals {
         key          = "${k}/${name}"
         project_key  = k
         project_name = v.name
-        name         = lookup(opts, "name", "${v.name}-${name}")
-        create       = lookup(opts, "create", true)
-        autoclass    = lookup(opts, "autoclass", null)
-        cors         = lookup(opts, "cors", null)
+        # coalesce as typed var entries return null from lookup
+        name = coalesce(
+          lookup(opts, "name", null), "${v.name}-${name}"
+        )
+        create    = lookup(opts, "create", true)
+        autoclass = lookup(opts, "autoclass", null)
+        cors      = lookup(opts, "cors", null)
         default_event_based_hold = lookup(
           opts, "default_event_based_hold", null
         )

--- a/modules/project-factory/projects-log-buckets.tf
+++ b/modules/project-factory/projects-log-buckets.tf
@@ -21,7 +21,7 @@ locals {
         project_key  = k
         project_name = v.name
         name         = name
-        description  = lookup(opts, "description", "Terraform-managed.")
+        description  = lookup(opts, "description", null)
         kms_key_name = lookup(opts, "kms_key_name", null)
         location = coalesce(
           local.data_defaults.overrides.locations.logging,
@@ -29,8 +29,11 @@ locals {
           local.data_defaults.defaults.locations.logging,
           "global"
         )
+        locked        = lookup(opts, "locked", null)
         retention     = lookup(opts, "retention", null)
         log_analytics = lookup(opts, "log_analytics", {})
+        tag_bindings  = lookup(opts, "tag_bindings", {})
+        views         = lookup(opts, "views", {})
       }
     ]
   ])
@@ -46,10 +49,15 @@ module "log-buckets" {
   }
   parent       = module.projects-iam[each.value.project_key].project_id
   name         = each.value.name
+  description  = each.value.description
   location     = each.value.location
   kms_key_name = each.value.kms_key_name
   context = merge(local.ctx, {
     folder_ids = local.ctx_folder_ids
+    tag_vars = {
+      projects     = merge(try(local.ctx.tag_vars.projects, {}), local.tag_vars_projects)
+      organization = try(local.ctx.tag_vars.organization, {})
+    }
     iam_principals = merge(
       local.ctx.iam_principals,
       local.projects_sas_iam_emails,
@@ -61,7 +69,11 @@ module "log-buckets" {
     kms_keys    = merge(local.ctx.kms_keys, local.kms_keys, local.kms_autokeys)
     locations   = local.ctx.locations
     project_ids = local.ctx_project_ids
+    tag_values  = local.ctx_tag_values
   })
+  locked        = each.value.locked
   retention     = each.value.retention
   log_analytics = each.value.log_analytics
+  tag_bindings  = each.value.tag_bindings
+  views         = each.value.views
 }

--- a/modules/project-factory/sample-data-1/folders/prod-iac-core-0.yaml
+++ b/modules/project-factory/sample-data-1/folders/prod-iac-core-0.yaml
@@ -33,14 +33,12 @@ iam_by_principals:
     - roles/storage.admin
 buckets:
   iac-bootstrap-state:
-    description: Terraform state for the org-level automation.
     iam:
       roles/storage.admin:
         - $iam_principals:service_accounts/prod-iac-core-0/iac-bootstrap-rw
       $custom_roles:storage_viewer:
         - $iam_principals:service_accounts/prod-iac-core-0/iac-bootstrap-ro
   iac-outputs:
-    description: Terraform state for the org-level automation.
     iam:
       roles/storage.admin:
         - $iam_principals:service_accounts/prod-iac-core-0/iac-bootstrap-rw

--- a/modules/project-factory/schemas/folder.schema.json
+++ b/modules/project-factory/schemas/folder.schema.json
@@ -666,9 +666,6 @@
         "name": {
           "type": "string"
         },
-        "description": {
-          "type": "string"
-        },
         "iam": {
           "$ref": "#/$defs/iam"
         },
@@ -713,6 +710,13 @@
         },
         "prefix": {
           "type": "string"
+        },
+        "public_access_prevention": {
+          "type": "string",
+          "enum": [
+            "enforced",
+            "inherited"
+          ]
         },
         "storage_class": {
           "type": "string"

--- a/modules/project-factory/schemas/folder.schema.md
+++ b/modules/project-factory/schemas/folder.schema.md
@@ -196,7 +196,6 @@
 - **bucket**<a name="refs-bucket"></a>: *object*
   <br>*additional properties: false*
   - **name**: *string*
-  - **description**: *string*
   - **iam**: *reference([iam](#refs-iam))*
   - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
   - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
@@ -212,6 +211,8 @@
       - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
       - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
   - **prefix**: *string*
+  - **public_access_prevention**: *string*
+    <br>*enum: ['enforced', 'inherited']*
   - **storage_class**: *string*
   - **uniform_bucket_level_access**: *boolean*
   - **versioning**: *boolean*

--- a/modules/project-factory/schemas/project.schema.json
+++ b/modules/project-factory/schemas/project.schema.json
@@ -1308,8 +1308,41 @@
           "type": "boolean",
           "default": true
         },
-        "description": {
-          "type": "string"
+        "autoclass": {
+          "type": "boolean"
+        },
+        "cors": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "origin": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "method": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "response_header": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "max_age_seconds": {
+              "type": "number"
+            }
+          }
+        },
+        "default_event_based_hold": {
+          "type": "boolean"
+        },
+        "enable_hierarchical_namespace": {
+          "type": "boolean"
         },
         "encryption_key": {
           "type": "string"
@@ -1323,8 +1356,38 @@
         "iam_bindings_additive": {
           "$ref": "#/$defs/iam_bindings_additive"
         },
+        "iam_by_principals": {
+          "$ref": "#/$defs/iam_by_principals"
+        },
         "force_destroy": {
           "type": "boolean"
+        },
+        "ip_filter": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "allow_cross_org_vpcs": {
+              "type": "boolean"
+            },
+            "allow_all_service_agent_access": {
+              "type": "boolean"
+            },
+            "public_network_sources": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "vpc_network_sources": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
         },
         "labels": {
           "$ref": "#/$defs/labels"
@@ -1469,8 +1532,81 @@
             }
           }
         },
+        "notification_config": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "enabled",
+            "payload_format",
+            "sa_email",
+            "topic_name"
+          ],
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "payload_format": {
+              "type": "string",
+              "enum": [
+                "JSON_API_V1",
+                "NONE"
+              ]
+            },
+            "sa_email": {
+              "type": "string"
+            },
+            "topic_name": {
+              "type": "string"
+            },
+            "create_topic": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "create": {
+                  "type": "boolean",
+                  "default": true
+                },
+                "kms_key_id": {
+                  "type": "string"
+                }
+              }
+            },
+            "event_types": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "custom_attributes": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "object_name_prefix": {
+              "type": "string"
+            }
+          }
+        },
         "prefix": {
           "type": "string"
+        },
+        "public_access_prevention": {
+          "type": "string",
+          "enum": [
+            "enforced",
+            "inherited"
+          ]
+        },
+        "requester_pays": {
+          "type": "boolean"
+        },
+        "rpo": {
+          "type": "string",
+          "enum": [
+            "ASYNC_TURBO",
+            "DEFAULT"
+          ]
         },
         "storage_class": {
           "type": "string"
@@ -1506,6 +1642,18 @@
           "type": "array",
           "items": {
             "type": "string"
+          }
+        },
+        "website": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "main_page_suffix": {
+              "type": "string"
+            },
+            "not_found_page": {
+              "type": "string"
+            }
           }
         }
       }
@@ -2005,6 +2153,9 @@
         "location": {
           "type": "string"
         },
+        "locked": {
+          "type": "boolean"
+        },
         "log_analytics": {
           "type": "object",
           "additionalProperties": false,
@@ -2023,6 +2174,42 @@
         },
         "retention": {
           "type": "number"
+        },
+        "tag_bindings": {
+          "$ref": "#/$defs/tag_bindings"
+        },
+        "views": {
+          "type": "object",
+          "additionalProperties": false,
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "filter"
+              ],
+              "properties": {
+                "filter": {
+                  "type": "string"
+                },
+                "location": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "iam": {
+                  "$ref": "#/$defs/iam"
+                },
+                "iam_bindings": {
+                  "$ref": "#/$defs/iam_bindings"
+                },
+                "iam_bindings_additive": {
+                  "$ref": "#/$defs/iam_bindings_additive"
+                }
+              }
+            }
+          }
         }
       }
     },

--- a/modules/project-factory/schemas/project.schema.md
+++ b/modules/project-factory/schemas/project.schema.md
@@ -365,12 +365,32 @@
   <br>*additional properties: false*
   - **name**: *string*
   - **create**: *boolean*
-  - **description**: *string*
+  - **autoclass**: *boolean*
+  - **cors**: *object*
+    <br>*additional properties: false*
+    - **origin**: *array*
+      - items: *string*
+    - **method**: *array*
+      - items: *string*
+    - **response_header**: *array*
+      - items: *string*
+    - **max_age_seconds**: *number*
+  - **default_event_based_hold**: *boolean*
+  - **enable_hierarchical_namespace**: *boolean*
   - **encryption_key**: *string*
   - **iam**: *reference([iam](#refs-iam))*
   - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
   - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
+  - **iam_by_principals**: *reference([iam_by_principals](#refs-iam_by_principals))*
   - **force_destroy**: *boolean*
+  - **ip_filter**: *object*
+    <br>*additional properties: false*
+    - **allow_cross_org_vpcs**: *boolean*
+    - **allow_all_service_agent_access**: *boolean*
+    - **public_network_sources**: *array*
+      - items: *string*
+    - **vpc_network_sources**: *object*
+      <br>*additional properties: array*
   - **labels**: *reference([labels](#refs-labels))*
   - **lifecycle_rules**: *object*
     <br>*additional properties: false*
@@ -412,7 +432,28 @@
       - **iam**: *reference([iam](#refs-iam))*
       - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
       - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
+  - **notification_config**: *object*
+    <br>*additional properties: false*
+    - ⁺**enabled**: *boolean*
+    - ⁺**payload_format**: *string*
+      <br>*enum: ['JSON_API_V1', 'NONE']*
+    - ⁺**sa_email**: *string*
+    - ⁺**topic_name**: *string*
+    - **create_topic**: *object*
+      <br>*additional properties: false*
+      - **create**: *boolean*
+      - **kms_key_id**: *string*
+    - **event_types**: *array*
+      - items: *string*
+    - **custom_attributes**: *object*
+      <br>*additional properties: string*
+    - **object_name_prefix**: *string*
   - **prefix**: *string*
+  - **public_access_prevention**: *string*
+    <br>*enum: ['enforced', 'inherited']*
+  - **requester_pays**: *boolean*
+  - **rpo**: *string*
+    <br>*enum: ['ASYNC_TURBO', 'DEFAULT']*
   - **storage_class**: *string*
   - **uniform_bucket_level_access**: *boolean*
   - **versioning**: *boolean*
@@ -425,6 +466,10 @@
   - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
   - **custom_placement_config**: *array*
     - items: *string*
+  - **website**: *object*
+    <br>*additional properties: false*
+    - **main_page_suffix**: *string*
+    - **not_found_page**: *string*
 - **buckets**<a name="refs-buckets"></a>: *object*
   <br>*additional properties: false*
   - **`^[a-z0-9-]+$`**: *reference([bucket](#refs-bucket))*
@@ -578,12 +623,24 @@
   - **description**: *string*
   - **kms_key_name**: *string*
   - **location**: *string*
+  - **locked**: *boolean*
   - **log_analytics**: *object*
     <br>*additional properties: false*
     - **enable**: *boolean*
     - **dataset_link_id**: *string*
     - **description**: *string*
   - **retention**: *number*
+  - **tag_bindings**: *reference([tag_bindings](#refs-tag_bindings))*
+  - **views**: *object*
+    <br>*additional properties: false*
+    - **`^[a-zA-Z0-9_-]+$`**: *object*
+      <br>*additional properties: false*
+      - ⁺**filter**: *string*
+      - **location**: *string*
+      - **description**: *string*
+      - **iam**: *reference([iam](#refs-iam))*
+      - **iam_bindings**: *reference([iam_bindings](#refs-iam_bindings))*
+      - **iam_bindings_additive**: *reference([iam_bindings_additive](#refs-iam_bindings_additive))*
 - **logging_sink**<a name="refs-logging_sink"></a>: *object*
   <br>*additional properties: false*
   - **bq_partitioned_table**: *boolean*

--- a/modules/project-factory/variables-projects.tf
+++ b/modules/project-factory/variables-projects.tf
@@ -38,9 +38,12 @@ variable "projects" {
       project = string
       bucket = optional(object({
         location                    = string
-        description                 = optional(string)
+        create                      = optional(bool, true)
+        encryption_key              = optional(string)
         force_destroy               = optional(bool)
+        name                        = optional(string, "tf-state")
         prefix                      = optional(string)
+        public_access_prevention    = optional(string)
         storage_class               = optional(string, "STANDARD")
         uniform_bucket_level_access = optional(bool, true)
         versioning                  = optional(bool)
@@ -201,49 +204,22 @@ variable "projects" {
     billing_account = optional(string)
     billing_budgets = optional(list(string), [])
     buckets = optional(map(object({
-      location                    = string
-      description                 = optional(string)
-      force_destroy               = optional(bool)
-      prefix                      = optional(string)
-      storage_class               = optional(string, "STANDARD")
-      uniform_bucket_level_access = optional(bool, true)
-      versioning                  = optional(bool)
-      autoclass                   = optional(bool)
+      location  = string
+      autoclass = optional(bool)
       cors = optional(object({
         origin          = optional(list(string))
         method          = optional(list(string))
         response_header = optional(list(string))
         max_age_seconds = optional(number)
       }))
+      create                        = optional(bool, true)
+      custom_placement_config       = optional(list(string))
       default_event_based_hold      = optional(bool)
       enable_hierarchical_namespace = optional(bool)
-      ip_filter = optional(object({
-        allow_cross_org_vpcs           = optional(bool)
-        allow_all_service_agent_access = optional(bool)
-        public_network_sources         = optional(list(string))
-        vpc_network_sources            = optional(map(list(string)), {})
-      }))
-      notification_config = optional(object({
-        enabled        = bool
-        payload_format = string
-        sa_email       = string
-        topic_name     = string
-        create_topic = optional(object({
-          create     = optional(bool, true)
-          kms_key_id = optional(string)
-        }), {})
-        event_types        = optional(list(string))
-        custom_attributes  = optional(map(string))
-        object_name_prefix = optional(string)
-      }))
-      public_access_prevention = optional(string)
-      requester_pays           = optional(bool)
-      rpo                      = optional(string)
-      website = optional(object({
-        main_page_suffix = optional(string)
-        not_found_page   = optional(string)
-      }))
-      iam = optional(map(list(string)), {})
+      enable_object_retention       = optional(bool)
+      encryption_key                = optional(string)
+      force_destroy                 = optional(bool)
+      iam                           = optional(map(list(string)), {})
       iam_bindings = optional(map(object({
         members = list(string)
         role    = string
@@ -262,29 +238,14 @@ variable "projects" {
           description = optional(string)
         }))
       })), {})
+      iam_by_principals = optional(map(list(string)), {})
+      ip_filter = optional(object({
+        allow_cross_org_vpcs           = optional(bool)
+        allow_all_service_agent_access = optional(bool)
+        public_network_sources         = optional(list(string))
+        vpc_network_sources            = optional(map(list(string)), {})
+      }))
       labels = optional(map(string), {})
-      managed_folders = optional(map(object({
-        force_destroy = optional(bool)
-        iam           = optional(map(list(string)), {})
-        iam_bindings = optional(map(object({
-          members = list(string)
-          role    = string
-          condition = optional(object({
-            expression  = string
-            title       = string
-            description = optional(string)
-          }))
-        })), {})
-        iam_bindings_additive = optional(map(object({
-          member = string
-          role   = string
-          condition = optional(object({
-            expression  = string
-            title       = string
-            description = optional(string)
-          }))
-        })), {})
-      })), {})
       lifecycle_rules = optional(map(object({
         action = object({
           type          = string
@@ -308,11 +269,59 @@ variable "projects" {
         log_bucket        = string
         log_object_prefix = optional(string)
       }), null)
+      managed_folders = optional(map(object({
+        force_destroy = optional(bool)
+        iam           = optional(map(list(string)), {})
+        iam_bindings = optional(map(object({
+          members = list(string)
+          role    = string
+          condition = optional(object({
+            expression  = string
+            title       = string
+            description = optional(string)
+          }))
+        })), {})
+        iam_bindings_additive = optional(map(object({
+          member = string
+          role   = string
+          condition = optional(object({
+            expression  = string
+            title       = string
+            description = optional(string)
+          }))
+        })), {})
+      })), {})
+      name = optional(string)
+      notification_config = optional(object({
+        enabled        = bool
+        payload_format = string
+        sa_email       = string
+        topic_name     = string
+        create_topic = optional(object({
+          create     = optional(bool, true)
+          kms_key_id = optional(string)
+        }), {})
+        event_types        = optional(list(string))
+        custom_attributes  = optional(map(string))
+        object_name_prefix = optional(string)
+      }))
+      prefix                   = optional(string)
+      public_access_prevention = optional(string)
+      requester_pays           = optional(bool)
       retention_policy = optional(object({
         retention_period = string
         is_locked        = optional(bool)
       }))
-      soft_delete_retention = optional(number)
+      rpo                         = optional(string)
+      soft_delete_retention       = optional(number)
+      storage_class               = optional(string, "STANDARD")
+      tag_bindings                = optional(map(string), {})
+      uniform_bucket_level_access = optional(bool, true)
+      versioning                  = optional(bool)
+      website = optional(object({
+        main_page_suffix = optional(string)
+        not_found_page   = optional(string)
+      }))
     })), {})
     contacts = optional(map(list(string)), {})
     custom_roles = optional(map(object({
@@ -431,7 +440,43 @@ variable "projects" {
         })), {})
       })), {})
     }), {})
-    labels        = optional(map(string), {})
+    labels = optional(map(string), {})
+    log_buckets = optional(map(object({
+      description  = optional(string)
+      kms_key_name = optional(string)
+      location     = optional(string)
+      locked       = optional(bool)
+      log_analytics = optional(object({
+        enable          = optional(bool, false)
+        dataset_link_id = optional(string)
+        description     = optional(string)
+      }))
+      retention    = optional(number)
+      tag_bindings = optional(map(string), {})
+      views = optional(map(object({
+        filter      = string
+        location    = optional(string)
+        description = optional(string)
+        iam         = optional(map(list(string)), {})
+        iam_bindings = optional(map(object({
+          members = list(string)
+          condition = optional(object({
+            expression  = string
+            title       = string
+            description = optional(string)
+          }))
+        })), {})
+        iam_bindings_additive = optional(map(object({
+          member = string
+          role   = string
+          condition = optional(object({
+            expression  = string
+            title       = string
+            description = optional(string)
+          }))
+        })), {})
+      })), {})
+    })), {})
     metric_scopes = optional(list(string), [])
     pam_entitlements = optional(map(object({
       max_request_duration = string

--- a/modules/project-factory/variables-projects.tf
+++ b/modules/project-factory/variables-projects.tf
@@ -208,7 +208,42 @@ variable "projects" {
       storage_class               = optional(string, "STANDARD")
       uniform_bucket_level_access = optional(bool, true)
       versioning                  = optional(bool)
-      iam                         = optional(map(list(string)), {})
+      autoclass                   = optional(bool)
+      cors = optional(object({
+        origin          = optional(list(string))
+        method          = optional(list(string))
+        response_header = optional(list(string))
+        max_age_seconds = optional(number)
+      }))
+      default_event_based_hold      = optional(bool)
+      enable_hierarchical_namespace = optional(bool)
+      ip_filter = optional(object({
+        allow_cross_org_vpcs           = optional(bool)
+        allow_all_service_agent_access = optional(bool)
+        public_network_sources         = optional(list(string))
+        vpc_network_sources            = optional(map(list(string)), {})
+      }))
+      notification_config = optional(object({
+        enabled        = bool
+        payload_format = string
+        sa_email       = string
+        topic_name     = string
+        create_topic = optional(object({
+          create     = optional(bool, true)
+          kms_key_id = optional(string)
+        }), {})
+        event_types        = optional(list(string))
+        custom_attributes  = optional(map(string))
+        object_name_prefix = optional(string)
+      }))
+      public_access_prevention = optional(string)
+      requester_pays           = optional(bool)
+      rpo                      = optional(string)
+      website = optional(object({
+        main_page_suffix = optional(string)
+        not_found_page   = optional(string)
+      }))
+      iam = optional(map(list(string)), {})
       iam_bindings = optional(map(object({
         members = list(string)
         role    = string

--- a/tests/fast/stages/s0_org_setup/data-customizations/projects/iac-0.yaml
+++ b/tests/fast/stages/s0_org_setup/data-customizations/projects/iac-0.yaml
@@ -47,7 +47,6 @@ services:
   - sts.googleapis.com
 buckets:
   iac-org-state:
-    description: Terraform state for the org-level automation.
     versioning: true
     iam:
       roles/storage.admin:
@@ -55,7 +54,6 @@ buckets:
       $custom_roles:storage_viewer:
         - $iam_principals:service_accounts/iac-0/iac-org-ro
   iac-outputs:
-    description: Terraform state for the org-level automation.
     versioning: true
     iam:
       roles/storage.admin:

--- a/tests/modules/project_factory/examples/test-1.yaml
+++ b/tests/modules/project_factory/examples/test-1.yaml
@@ -54,6 +54,110 @@ values:
     timeouts: null
   ? module.project-factory.module.automation-service-accounts["test-0/automation/auto-tag-test"].google_tags_tag_binding.binding["project-level"]
   : timeouts: null
+  module.project-factory.module.buckets["test-0/attrs-test"].google_pubsub_topic.topic[0]:
+    deletion_policy: DELETE
+    effective_labels:
+      goog-terraform-provisioned: 'true'
+    ingestion_data_source_settings: []
+    kms_key_name: null
+    labels: null
+    message_retention_duration: null
+    message_transforms: []
+    name: attrs-test-notifications
+    project: foo-test-0
+    schema_settings: []
+    tags: null
+    terraform_labels:
+      goog-terraform-provisioned: 'true'
+    timeouts: null
+  module.project-factory.module.buckets["test-0/attrs-test"].google_pubsub_topic_iam_binding.binding[0]:
+    condition: []
+    members:
+    - serviceAccount:service-1234567890@gs-project-accounts.iam.gserviceaccount.com
+    role: roles/pubsub.publisher
+  module.project-factory.module.buckets["test-0/attrs-test"].google_storage_bucket.bucket[0]:
+    autoclass:
+    - enabled: false
+    cors:
+    - max_age_seconds: 3600
+      method:
+      - GET
+      origin:
+      - https://example.com
+      response_header:
+      - Content-Type
+    custom_placement_config:
+    - data_locations:
+      - EUROPE-WEST1
+      - EUROPE-WEST4
+    default_event_based_hold: true
+    deletion_policy: DELETE
+    effective_labels:
+      goog-terraform-provisioned: 'true'
+    enable_object_retention: null
+    encryption: []
+    force_destroy: false
+    hierarchical_namespace:
+    - enabled: false
+    ip_filter:
+    - allow_all_service_agent_access: true
+      allow_cross_org_vpcs: null
+      mode: Enabled
+      public_network_source:
+      - allowed_ip_cidr_ranges:
+        - 192.0.2.0/24
+      vpc_network_sources: []
+    labels: null
+    lifecycle_rule: []
+    location: EU
+    logging: []
+    name: foo-test-0-attrs-test
+    project: foo-test-0
+    public_access_prevention: enforced
+    requester_pays: true
+    retention_policy: []
+    rpo: DEFAULT
+    storage_class: STANDARD
+    terraform_labels:
+      goog-terraform-provisioned: 'true'
+    timeouts: null
+    uniform_bucket_level_access: true
+    versioning:
+    - enabled: false
+    website:
+    - main_page_suffix: index.html
+      not_found_page: 404.html
+  module.project-factory.module.buckets["test-0/attrs-test"].google_storage_notification.notification[0]:
+    bucket: foo-test-0-attrs-test
+    custom_attributes: null
+    event_types: null
+    object_name_prefix: null
+    payload_format: JSON_API_V1
+  module.project-factory.module.log-buckets["test-0/audit-logs"].google_logging_log_view.views["audit-view"]:
+    description: Test log view.
+    filter: LOG_ID("cloudaudit.googleapis.com/activity")
+    location: global
+    name: audit-view
+    timeouts: null
+  ? module.project-factory.module.log-buckets["test-0/audit-logs"].google_logging_log_view_iam_binding.authoritative["audit-view.roles/logging.viewAccessor"]
+  : condition: []
+    location: global
+    members:
+    - user:user1@example.com
+    name: audit-view
+    role: roles/logging.viewAccessor
+  module.project-factory.module.log-buckets["test-0/audit-logs"].google_logging_project_bucket_config.bucket[0]:
+    bucket_id: audit-logs
+    cmek_settings: []
+    description: Test log bucket description.
+    enable_analytics: false
+    index_configs: []
+    location: global
+    locked: false
+    project: foo-test-0
+    retention_days: 365
+  module.project-factory.module.log-buckets["test-0/audit-logs"].google_tags_tag_binding.binding["project-level"]:
+    timeouts: null
   module.project-factory.module.projects-iam["test-0"].google_project_iam_member.bindings["test_context"]:
     condition:
     - description: null
@@ -278,19 +382,25 @@ values:
     triggers_replace: null
 
 counts:
+  google_logging_log_view: 1
+  google_logging_log_view_iam_binding: 1
+  google_logging_project_bucket_config: 1
   google_project: 3
   google_project_iam_member: 6
   google_project_service: 10
   google_project_service_identity: 3
+  google_pubsub_topic: 1
+  google_pubsub_topic_iam_binding: 1
   google_service_account: 3
-  google_storage_bucket: 1
+  google_storage_bucket: 2
+  google_storage_notification: 1
   google_storage_project_service_account: 1
-  google_tags_tag_binding: 4
+  google_tags_tag_binding: 5
   google_tags_tag_key: 1
   google_tags_tag_value: 1
   google_tags_tag_value_iam_binding: 1
-  modules: 10
-  resources: 36
+  modules: 12
+  resources: 44
   terraform_data: 2
 
 outputs: {}


### PR DESCRIPTION
Fixes #4147, fixes #4149.

### Context & Problem

In `modules/project-factory`, the input lists passed to `modules/gcs` and `modules/logging-bucket`have drifted from the interfaces of the wrapped modules. Several attributes advertised in the project schema and validated by the glue code were being silently discarded instead of forwarded to the underlying resources.

---

### Root Cause: Discarded Attributes

* **GCS Buckets:**
  * **Dropped attributes:** `autoclass`, `cors`, `default_event_based_hold`, `enable_hierarchical_namespace`, `ip_filter`, `notification_config`, `public_access_prevention`, `requester_pays`, `rpo`, and `website`.
  * **Impact:** Existing buckets with an explicit `public_access_prevention` could not be represented in project YAML, causing permanent plan drift upon import.
* **Log Buckets:**
  * **Dropped `description`:** Evaluated at `projects-log-buckets.tf:24` but never passed to the module. Setting a description in project YAML validated without errors but had no effect.
  * **Other missing attributes:** `locked`, `tag_bindings`, and `views`.

---

### Changes

#### 1. Input Forwarding & Variable Parity
* **Forward missing inputs:** Updated `projects-buckets.tf` and `projects-log-buckets.tf` to pass all missing arguments to the wrapped modules.
* **Variable parity:** Added these attributes to the typed `projects` variable so they are accessible directly without using factory YAML files.
* **Log bucket context:** Added `tag_values` and `tag_vars` to the log bucket context merge so newly added `tag_bindings` resolve symbolically.
* **Safe description default:** Changed log bucket `description` default from `"Terraform-managed."` to `null`. Forwarding the previous default would have forced a description onto every existing factory-managed log bucket that currently lacks one.

#### 2. Schema Adjustments
* **Bucket schema (`$defs.bucket`):** Added `iam_by_principals` (the glue code already forwarded it, but schema validation was rejecting it via `additionalProperties: false`).
* **Automation buckets:** Kept their intentionally narrow surface, adding only `public_access_prevention` (also added to the folder schema for folder-level automation buckets).

---

### Verification

#### Plan-Level Testing
* The `Tests` README fixture now exercises every newly supported attribute.
* The regenerated test inventory asserts these attributes on planned resources.
* The inventory diff is strictly additive (no pre-existing resources were modified).
* Full test suites pass: `project-factory` (19 tests) and `tests/fast` (25 tests).

#### Live End-to-End (E2E) Testing
Resource configuration was verified via direct GCP service API read-back (bypassing Terraform state):
* **GCS read-back verified:** `publicAccessPrevention: enforced`, `requesterPays: true`, `rpo: DEFAULT`, `defaultEventBasedHold: true`, `hierarchicalNamespace.enabled: false`, plus nested structures for `ipFilter`, `cors`, `website`, and `customPlacementConfig`.
* **Logging read-back verified:** `gcloud logging buckets describe` returned `description: E2E log bucket description.`, with log views and `retentionDays: 365`.

**API Validation Feedback Loop:**
Two apply failures confirmed attributes were successfully delivered to GCP APIs:
1. GCP rejected `rpo: DEFAULT` on a `REGION` bucket (fixed in fixture by switching to a dual-region bucket, making the README example apply-valid rather than merely plan-valid).
2. `ip_filter` locked out the operator IP during read-back (recovered via temporary `storage.buckets.exemptFromIpFilter` custom role, which has since been removed).

> *Note:* Behavioral verification beyond API read-back was not performed. All sandbox test resources were destroyed.

---

### Breaking Changes

```upgrade-note
`modules/project-factory`: the `description` attribute is removed from bucket definitions (`buckets` and `automation.bucket`, in both the project and folder schemas). It never had any effect, because `google_storage_bucket` has no description field, so the schema was advertising an attribute the GCS API cannot store.

No plan or apply breaks and no resource changes: the factory does no runtime schema validation, so a leftover `description` key in project YAML is simply ignored (verified against a real plan). The key is only rejected by schema validation in editors and in CI, so drop it when convenient. Eighteen in-repo datasets set one and are cleaned up in this PR.

Separately, log bucket `description` is now actually applied. A `log_buckets` entry that already sets one will show a one-time in-place update adding it to `google_logging_project_bucket_config`.
```
