### PR TITLE
`project-factory` - SA IAM declared (only) via iam_bindings was not applied

### DIFF
--- a/modules/project-factory/README.md
+++ b/modules/project-factory/README.md
@@ -993,7 +993,7 @@ module "project-factory" {
     basepath = "data"
   }
 }
-# tftest modules=12 resources=44 files=test-0,test-1,test-2 inventory=test-1.yaml
+# tftest modules=16 resources=49 files=test-0,test-1,test-2 inventory=test-1.yaml
 ```
 
 ```yaml
@@ -1105,5 +1105,23 @@ prefix: bar
 services:
   - iam.googleapis.com
   - storage.googleapis.com
+service_accounts:
+  # service account IAM is applied in a second pass, so bindings declared via
+  # iam_bindings/iam_bindings_additive alone also need to trigger it
+  bindings-only:
+    iam_bindings:
+      token-creator:
+        role: roles/iam.serviceAccountTokenCreator
+        members:
+          - user:user1@example.com
+  bindings-additive-only:
+    iam_bindings_additive:
+      key-admin:
+        role: roles/iam.serviceAccountKeyAdmin
+        member: user:user1@example.com
+      # cross-service account reference, only resolvable in the second pass
+      token-creator:
+        role: roles/iam.serviceAccountTokenCreator
+        member: $iam_principals:service_accounts/_self_/bindings-only
 # tftest-file id=test-2 path=data/projects/test-2.yaml
 ```

--- a/modules/project-factory/projects-service-accounts.tf
+++ b/modules/project-factory/projects-service-accounts.tf
@@ -128,7 +128,13 @@ module "service-accounts-iam" {
   for_each = {
     for k in local.projects_service_accounts :
     "${k.project_key}/${k.name}" => k
-    if k.iam_sa_roles != {} || k.iam_sa_bindings != {} || k.iam != {}
+    if(
+      k.iam != {} ||
+      k.iam_bindings != {} ||
+      k.iam_bindings_additive != {} ||
+      k.iam_sa_bindings != {} ||
+      k.iam_sa_roles != {}
+    )
   }
   project_id = (
     module.service-accounts[each.key].service_account.project

--- a/tests/modules/project_factory/examples/test-1.yaml
+++ b/tests/modules/project_factory/examples/test-1.yaml
@@ -348,6 +348,19 @@ values:
     project: bar-test-2
     service: storage.googleapis.com
     timeouts: null
+  ? module.project-factory.module.service-accounts-iam["test-2/bindings-additive-only"].google_service_account_iam_member.bindings["key-admin"]
+  : condition: []
+    member: user:user1@example.com
+    role: roles/iam.serviceAccountKeyAdmin
+  ? module.project-factory.module.service-accounts-iam["test-2/bindings-additive-only"].google_service_account_iam_member.bindings["token-creator"]
+  : condition: []
+    member: serviceAccount:bindings-only@bar-test-2.iam.gserviceaccount.com
+    role: roles/iam.serviceAccountTokenCreator
+  ? module.project-factory.module.service-accounts-iam["test-2/bindings-only"].google_service_account_iam_binding.bindings["token-creator"]
+  : condition: []
+    members:
+    - user:user1@example.com
+    role: roles/iam.serviceAccountTokenCreator
   module.project-factory.module.service-accounts["test-0/tag-test"].google_service_account.service_account[0]:
     account_id: tag-test
     create_ignore_already_exists: null
@@ -372,6 +385,28 @@ values:
     member: serviceAccount:tag-test@test-1.iam.gserviceaccount.com
     project: test-1
     timeouts: null
+  module.project-factory.module.service-accounts["test-2/bindings-additive-only"].google_service_account.service_account[0]:
+    account_id: bindings-additive-only
+    create_ignore_already_exists: null
+    deletion_policy: DELETE
+    description: null
+    disabled: false
+    display_name: Terraform-managed.
+    email: bindings-additive-only@bar-test-2.iam.gserviceaccount.com
+    member: serviceAccount:bindings-additive-only@bar-test-2.iam.gserviceaccount.com
+    project: bar-test-2
+    timeouts: null
+  module.project-factory.module.service-accounts["test-2/bindings-only"].google_service_account.service_account[0]:
+    account_id: bindings-only
+    create_ignore_already_exists: null
+    deletion_policy: DELETE
+    description: null
+    disabled: false
+    display_name: Terraform-managed.
+    email: bindings-only@bar-test-2.iam.gserviceaccount.com
+    member: serviceAccount:bindings-only@bar-test-2.iam.gserviceaccount.com
+    project: bar-test-2
+    timeouts: null
   module.project-factory.terraform_data.defaults_preconditions:
     input: null
     output: null
@@ -391,7 +426,9 @@ counts:
   google_project_service_identity: 3
   google_pubsub_topic: 1
   google_pubsub_topic_iam_binding: 1
-  google_service_account: 3
+  google_service_account: 5
+  google_service_account_iam_binding: 1
+  google_service_account_iam_member: 2
   google_storage_bucket: 2
   google_storage_notification: 1
   google_storage_project_service_account: 1
@@ -399,8 +436,8 @@ counts:
   google_tags_tag_key: 1
   google_tags_tag_value: 1
   google_tags_tag_value_iam_binding: 1
-  modules: 12
-  resources: 44
+  modules: 16
+  resources: 49
   terraform_data: 2
 
 outputs: {}


### PR DESCRIPTION
## Problem

In `modules/project-factory`, service accounts defined in YAML silently ignore IAM configuration if only `iam_bindings` or `iam_bindings_additive` are specified. 

The service account is created, but no IAM roles are assigned, with no plan warning or error:

```yaml
service_accounts:
  srv-example:
    display_name: srv-example
    iam_bindings_additive:
      grp-keyadmin:
        member: group:example@example.com
        role: roles/iam.serviceAccountKeyAdmin
```

Currently, these bindings only take effect if another SA-level IAM field (such as `iam`) is also set on the same service account. Furthermore, attempting to import such an unmanaged binding fails with `Configuration for import target does not exist`, which prevents Terraform from planning other resources.

## Root Cause & Solution

To support symbolic cross-references between service accounts (e.g., `$iam_principals:service_accounts/...`), `project-factory` creates service accounts first (`service-accounts`), and then applies IAM on them in a second pass (`service-accounts-iam`).

While the second pass forwards all five SA IAM inputs, the `for_each` condition filtering which accounts to process only checked three:

```hcl
# Before
if k.iam_sa_roles != {} || k.iam_sa_bindings != {} || k.iam != {}
```

Because `iam_bindings` and `iam_bindings_additive` were missing from this check, accounts that only set those fields were skipped entirely.

The condition in `service-accounts.tf` was updated to include all five inputs:

```hcl
# After
if(
  k.iam != {} ||
  k.iam_bindings != {} ||
  k.iam_bindings_additive != {} ||
  k.iam_sa_bindings != {} ||
  k.iam_sa_roles != {}
)
```

## Impact

- **Purely additive / No churn**: Since these bindings were previously omitted, they do not exist in existing state. Applying this change to existing projects only plans additions.
- **Automation service accounts unaffected**: `automation.tf` already forwards `iam_bindings` and `iam_bindings_additive` in its primary pass and is not affected.

## Verification & Testing Methodology

### Unit & Regression Tests
- Added test cases in the `project-factory` README:
  - `bindings-only`: Validates a service account using only `iam_bindings`.
  - `bindings-additive-only`: Validates a service account using only `iam_bindings_additive` with a cross-service-account symbolic reference to verify second-pass resolution.
- Regenerated test plan inventories with `tools/generate_plan_summary.py`.
- Reverted the fix locally to confirm the test fails as expected (`... is not a valid address in the plan`).
- Ran test suite: `pytest -k 'project-factory or project_factory'` and `tests/fast` pass.
- Verified linting and documentation: `tools/lint.sh`, `terraform fmt`, `check_documentation.py`, and `yamllint` all clean.

### Live E2E Sandbox Verification
- **Apply**: Deployed a test configuration to a live sandbox GCP project. Verified all service accounts and IAM bindings were created cleanly.
- **Read-Back Verification**: Inspected live IAM policies via `gcloud` to confirm the roles were assigned to the intended principals.
