### PR TITLE
Allow contact_email to be passed from context block

### DIFF
--- a/modules/project/quotas.tf
+++ b/modules/project/quotas.tf
@@ -41,7 +41,7 @@ resource "google_cloud_quotas_quota_preference" "default" {
   service       = each.value.service
   dimensions    = each.value.dimensions
   quota_id      = each.value.quota_id
-  contact_email = each.value.contact_email
+  contact_email = try(local.ctx.email_addresses[each.value.contact_email], each.value.contact_email)
   justification = each.value.justification
   quota_config {
     preferred_value = each.value.preferred_value


### PR DESCRIPTION
Updated quotas `contact_email` field to resolve against `local.ctx.email_addresses` using `try()`, falling back to the raw value if no matching alias key is found.

---
**Checklist**
<!--
Replace each [ ] with [X] to check it. These steps will speed up the review process, and we appreciate you spending time on them before sending your code to be reviewed.
-->

I applicable, I acknowledge that I have:
- [X] Read the [contributing guide](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md)
- [X] Ran `terraform fmt` on all modified files
- [ ] Regenerated the relevant README.md files using [`tools/tfdoc.py`](https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/blob/master/CONTRIBUTING.md#fabric-tools)
- [ ] Made sure all relevant tests pass

<!--
If your code introduces any breaking changes, uncomment and complete the section below, following the examples provided.
-->

<!--
**Breaking Changes**

```upgrade-note
`fast/stages/0-boostrap`: example upgrade note 1.
```
```upgrade-note
`modules/project`: example upgrade note 2.
```
```upgrade-note
`terraform-google-provider`: version updated to X.XX, because ...
```

-->
