### PR TITLE
Adds optional prefix to workload and workforce identity pool ids

### DIFF
--- a/fast/stages/0-org-setup/organization.tf
+++ b/fast/stages/0-org-setup/organization.tf
@@ -93,6 +93,7 @@ module "organization" {
     locations       = local.ctx.locations
   }
   contacts              = lookup(local.organization, "contacts", {})
+  prefix                = lookup(local.organization, "prefix", null)
   service_agents_config = lookup(local.organization, "service_agents_config", {})
   factories_config = {
     access_levels          = "${local.paths.organization}/access-levels"

--- a/fast/stages/0-org-setup/schemas/organization.schema.json
+++ b/fast/stages/0-org-setup/schemas/organization.schema.json
@@ -390,6 +390,9 @@
     "pam_entitlements": {
       "$ref": "#/$defs/pam_entitlements"
     },
+    "prefix": {
+      "type": "string"
+    },
     "service_agents_config": {
       "type": "object",
       "additionalProperties": false,
@@ -469,6 +472,9 @@
             },
             "disabled": {
               "type": "boolean"
+            },
+            "pool_id": {
+              "type": "string"
             },
             "session_duration": {
               "type": "string"

--- a/fast/stages/0-org-setup/schemas/organization.schema.md
+++ b/fast/stages/0-org-setup/schemas/organization.schema.md
@@ -121,6 +121,7 @@
           - **location**: *string*
           - **title**: *string*
 - **pam_entitlements**: *reference([pam_entitlements](#refs-pam_entitlements))*
+- **prefix**: *string*
 - **service_agents_config**: *object*
   <br>*additional properties: false*
   - **create_agents**: *boolean*
@@ -135,6 +136,7 @@
     - **display_name**: *string*
     - **description**: *string*
     - **disabled**: *boolean*
+    - **pool_id**: *string*
     - **session_duration**: *string*
     - **access_restrictions**: *object*
       <br>*additional properties: false*

--- a/fast/stages/0-org-setup/schemas/project.schema.json
+++ b/fast/stages/0-org-setup/schemas/project.schema.json
@@ -1171,6 +1171,9 @@
             "disabled": {
               "type": "boolean"
             },
+            "pool_id": {
+              "type": "string"
+            },
             "providers": {
               "type": "object",
               "additionalProperties": false,

--- a/fast/stages/0-org-setup/schemas/project.schema.md
+++ b/fast/stages/0-org-setup/schemas/project.schema.md
@@ -343,6 +343,7 @@
     - **description**: *string*
     - **display_name**: *string*
     - **disabled**: *boolean*
+    - **pool_id**: *string*
     - **providers**: *object*
       <br>*additional properties: false*
       - **`^[a-z][a-z0-9-]+[a-z0-9]$`**: *object*

--- a/fast/stages/2-networking/schemas/project.schema.json
+++ b/fast/stages/2-networking/schemas/project.schema.json
@@ -1171,6 +1171,9 @@
             "disabled": {
               "type": "boolean"
             },
+            "pool_id": {
+              "type": "string"
+            },
             "providers": {
               "type": "object",
               "additionalProperties": false,

--- a/fast/stages/2-networking/schemas/project.schema.md
+++ b/fast/stages/2-networking/schemas/project.schema.md
@@ -343,6 +343,7 @@
     - **description**: *string*
     - **display_name**: *string*
     - **disabled**: *boolean*
+    - **pool_id**: *string*
     - **providers**: *object*
       <br>*additional properties: false*
       - **`^[a-z][a-z0-9-]+[a-z0-9]$`**: *object*

--- a/fast/stages/2-project-factory/schemas/project.schema.json
+++ b/fast/stages/2-project-factory/schemas/project.schema.json
@@ -1171,6 +1171,9 @@
             "disabled": {
               "type": "boolean"
             },
+            "pool_id": {
+              "type": "string"
+            },
             "providers": {
               "type": "object",
               "additionalProperties": false,

--- a/fast/stages/2-project-factory/schemas/project.schema.md
+++ b/fast/stages/2-project-factory/schemas/project.schema.md
@@ -343,6 +343,7 @@
     - **description**: *string*
     - **display_name**: *string*
     - **disabled**: *boolean*
+    - **pool_id**: *string*
     - **providers**: *object*
       <br>*additional properties: false*
       - **`^[a-z][a-z0-9-]+[a-z0-9]$`**: *object*

--- a/fast/stages/2-security/schemas/project.schema.json
+++ b/fast/stages/2-security/schemas/project.schema.json
@@ -1171,6 +1171,9 @@
             "disabled": {
               "type": "boolean"
             },
+            "pool_id": {
+              "type": "string"
+            },
             "providers": {
               "type": "object",
               "additionalProperties": false,

--- a/fast/stages/2-security/schemas/project.schema.md
+++ b/fast/stages/2-security/schemas/project.schema.md
@@ -343,6 +343,7 @@
     - **description**: *string*
     - **display_name**: *string*
     - **disabled**: *boolean*
+    - **pool_id**: *string*
     - **providers**: *object*
       <br>*additional properties: false*
       - **`^[a-z][a-z0-9-]+[a-z0-9]$`**: *object*

--- a/modules/organization/README.md
+++ b/modules/organization/README.md
@@ -962,10 +962,13 @@ A Workforce Identity pool and providers can be created via the `workforce_identi
 
 Auto-population of provider attributes is supported via the `attribute_mapping_template` provider attribute. Currently only `azuread` and `okta` are supported.
 
+Workforce pool ids need to be globally unique. Pool ids default to their map keys optionally prepended with the module `prefix` variable, so that the same configuration can be deployed more than once. A pool id can also be set explicitly via the pool-level `pool_id` attribute, which ignores the module prefix.
+
 ```hcl
 module "org" {
   source          = "./fabric/modules/organization"
   organization_id = var.organization_id
+  prefix          = var.prefix
   workforce_identity_pools = {
     "test-pool" = {
       display_name = "Test Pool"
@@ -1174,9 +1177,10 @@ module "org" {
 | [org_policies](variables.tf#L275) | Organization policies applied to this organization keyed by policy name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [org_policy_custom_constraints](variables.tf#L303) | Organization policy custom constraints keyed by constraint name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [pam_entitlements](variables-pam.tf#L17) | Privileged Access Manager entitlements for this resource, keyed by entitlement ID. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [prefix](variables.tf#L326) | Optional prefix used to generate workforce identity pool ids. | <code>string</code> |  | <code>null</code> |
 | [scc_mute_configs](variables-scc.tf#L17) | SCC mute configurations keyed by name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [scc_sha_custom_modules](variables-scc.tf#L28) | SCC custom modules keyed by module name. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [service_agents_config](variables.tf#L326) | Service agents configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
+| [service_agents_config](variables.tf#L336) | Service agents configuration. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [tag_bindings](variables-tags.tf#L89) | Tag bindings for this organization, in key => tag value id format. | <code>map&#40;string&#41;</code> |  | <code>&#123;&#125;</code> |
 | [tags](variables-tags.tf#L96) | Tags by key name. If `id` is provided, key or value creation is skipped. The `iam` attribute behaves like the similarly named one at module level. | <code>map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
 | [tags_config](variables-tags.tf#L171) | Fine-grained control on tag resource and IAM creation. | <code>object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |

--- a/modules/organization/identity-providers.tf
+++ b/modules/organization/identity-providers.tf
@@ -55,14 +55,16 @@ locals {
 }
 
 resource "google_iam_workforce_pool" "default" {
-  for_each          = var.workforce_identity_pools
-  parent            = var.organization_id
-  location          = "global"
-  workforce_pool_id = each.key
-  description       = each.value.description
-  disabled          = each.value.disabled
-  display_name      = each.value.display_name
-  session_duration  = each.value.session_duration
+  for_each = var.workforce_identity_pools
+  parent   = var.organization_id
+  location = "global"
+  workforce_pool_id = coalesce(
+    each.value.pool_id, "${local.prefix}${each.key}"
+  )
+  description      = each.value.description
+  disabled         = each.value.disabled
+  display_name     = each.value.display_name
+  session_duration = each.value.session_duration
   dynamic "access_restrictions" {
     for_each = each.value.access_restrictions != null ? [""] : []
     content {

--- a/modules/organization/main.tf
+++ b/modules/organization/main.tf
@@ -35,6 +35,7 @@ locals {
   })
   ctx_p                   = "$"
   organization_id_numeric = split("/", var.organization_id)[1]
+  prefix                  = var.prefix == null ? "" : "${var.prefix}-"
 }
 
 resource "google_essential_contacts_contact" "contact" {

--- a/modules/organization/variables-identity-providers.tf
+++ b/modules/organization/variables-identity-providers.tf
@@ -20,6 +20,7 @@ variable "workforce_identity_pools" {
     description      = optional(string)
     disabled         = optional(bool)
     display_name     = optional(string)
+    pool_id          = optional(string)
     session_duration = optional(string)
     access_restrictions = optional(object({
       disable_programmatic_signin = optional(bool)

--- a/modules/organization/variables.tf
+++ b/modules/organization/variables.tf
@@ -323,6 +323,16 @@ variable "organization_id" {
   }
 }
 
+variable "prefix" {
+  description = "Optional prefix used to generate workforce identity pool ids."
+  type        = string
+  default     = null
+  validation {
+    condition     = var.prefix != ""
+    error_message = "Prefix cannot be empty, please use null instead."
+  }
+}
+
 variable "service_agents_config" {
   description = "Service agents configuration."
   type = object({

--- a/modules/project-factory/README.md
+++ b/modules/project-factory/README.md
@@ -601,6 +601,7 @@ org_policies:
 workload_identity_pools:
   test-0:
     display_name: Test pool.
+    pool_id: test-0-explicit-id
     providers:
       github-test:
         display_name: GitHub test provider.

--- a/modules/project-factory/projects-defaults.tf
+++ b/modules/project-factory/projects-defaults.tf
@@ -258,6 +258,7 @@ locals {
           display_name = lookup(wv, "display_name", null)
           description  = lookup(wv, "description", null)
           disabled     = lookup(wv, "disabled", null)
+          pool_id      = lookup(wv, "pool_id", null)
           providers = {
             for pk, pv in try(wv.providers, {}) : pk => {
               display_name        = lookup(pv, "display_name", null)

--- a/modules/project-factory/schemas/project.schema.json
+++ b/modules/project-factory/schemas/project.schema.json
@@ -1171,6 +1171,9 @@
             "disabled": {
               "type": "boolean"
             },
+            "pool_id": {
+              "type": "string"
+            },
             "providers": {
               "type": "object",
               "additionalProperties": false,

--- a/modules/project-factory/schemas/project.schema.md
+++ b/modules/project-factory/schemas/project.schema.md
@@ -343,6 +343,7 @@
     - **description**: *string*
     - **display_name**: *string*
     - **disabled**: *boolean*
+    - **pool_id**: *string*
     - **providers**: *object*
       <br>*additional properties: false*
       - **`^[a-z][a-z0-9-]+[a-z0-9]$`**: *object*

--- a/modules/project-factory/variables-projects.tf
+++ b/modules/project-factory/variables-projects.tf
@@ -744,6 +744,7 @@ variable "projects" {
       display_name = optional(string)
       description  = optional(string)
       disabled     = optional(bool)
+      pool_id      = optional(string)
       providers = optional(map(object({
         display_name        = optional(string)
         description         = optional(string)

--- a/modules/project/README.md
+++ b/modules/project/README.md
@@ -2251,6 +2251,8 @@ Workload Identity federation pools and providers can be created via the `workloa
 
 Auto-population of provider attributes and issuer are supported for OIDC providers via the `provider_template` attribute. Currently `github`, `gitlab`, `okta` and `terraform` provider types are supported.
 
+Pool ids default to their map keys, and can be set explicitly via the optional `pool_id` attribute. This is useful when the same configuration is deployed more than once and pool ids need to differ, or to preserve an existing pool id when renaming its key.
+
 ```hcl
 module "project" {
   source          = "./fabric/modules/project"
@@ -2261,6 +2263,7 @@ module "project" {
   workload_identity_pools = {
     test-oidc = {
       display_name = "Test pool (OIDC)."
+      pool_id      = "test-oidc-explicit-id"
       providers = {
         github-test = {
           attribute_condition = "attribute.repository_owner=='my_org'"

--- a/modules/project/identity-providers.tf
+++ b/modules/project/identity-providers.tf
@@ -34,7 +34,7 @@ locals {
 resource "google_iam_workload_identity_pool" "default" {
   for_each                  = var.workload_identity_pools
   project                   = local.project.project_id
-  workload_identity_pool_id = each.key
+  workload_identity_pool_id = coalesce(each.value.pool_id, each.key)
   display_name              = each.value.display_name
   description               = each.value.description
   disabled                  = each.value.disabled

--- a/modules/project/variables-identity-providers.tf
+++ b/modules/project/variables-identity-providers.tf
@@ -20,6 +20,7 @@ variable "workload_identity_pools" {
     display_name = optional(string)
     description  = optional(string)
     disabled     = optional(bool)
+    pool_id      = optional(string)
     providers = optional(map(object({
       description         = optional(string)
       display_name        = optional(string)

--- a/tests/fast/stages/s0_org_setup/customizations.yaml
+++ b/tests/fast/stages/s0_org_setup/customizations.yaml
@@ -1010,6 +1010,14 @@ values:
     condition:
     - title: audit-logs bucket writer
     role: roles/logging.bucketWriter
+  module.organization[0].google_iam_workforce_pool.default["wf-0"]:
+    display_name: Test workforce pool.
+    parent: organizations/1234567890
+    workforce_pool_id: test-wf-0
+  module.organization[0].google_iam_workforce_pool.default["wf-1"]:
+    display_name: Test workforce pool with explicit id.
+    parent: organizations/1234567890
+    workforce_pool_id: wf-1-explicit-id
   module.organization[0].google_logging_organization_settings.default[0]:
     organization: '1234567890'
     timeouts: null
@@ -1346,6 +1354,7 @@ counts:
   google_compute_shared_vpc_service_project: 2
   google_compute_subnetwork: 2
   google_folder: 2
+  google_iam_workforce_pool: 2
   google_logging_organization_settings: 1
   google_logging_organization_sink: 1
   google_logging_project_bucket_config: 1
@@ -1367,7 +1376,7 @@ counts:
   google_tags_tag_value: 2
   local_file: 3
   modules: 27
-  resources: 169
+  resources: 171
   terraform_data: 4
 
 outputs:

--- a/tests/fast/stages/s0_org_setup/data-customizations/organization/.config.yaml
+++ b/tests/fast/stages/s0_org_setup/data-customizations/organization/.config.yaml
@@ -17,9 +17,16 @@
 # yaml-language-server: $schema=../../../schemas/organization.schema.json
 
 id: $defaults:organization/id
+prefix: test
 service_agents_config:
   services:
     - privilegedaccessmanager.googleapis.com
+workforce_identity_pools:
+  wf-0:
+    display_name: Test workforce pool.
+  wf-1:
+    display_name: Test workforce pool with explicit id.
+    pool_id: wf-1-explicit-id
 
 iam_by_principals:
   $iam_principals:gcp-organization-admins:

--- a/tests/modules/organization/examples/wfif.yaml
+++ b/tests/modules/organization/examples/wfif.yaml
@@ -22,7 +22,7 @@ values:
     parent: organizations/1122334455
     session_duration: 3600s
     timeouts: null
-    workforce_pool_id: test-pool
+    workforce_pool_id: test-test-pool
   module.org.google_iam_workforce_pool_provider.default["test-pool/oidc-full"]:
     attribute_condition: null
     attribute_mapping:
@@ -56,7 +56,7 @@ values:
     saml: []
     scim_usage: ENABLED_FOR_GROUPS
     timeouts: null
-    workforce_pool_id: test-pool
+    workforce_pool_id: test-test-pool
   module.org.google_iam_workforce_pool_provider.default["test-pool/saml-basic"]:
     attribute_condition: null
     attribute_mapping:
@@ -79,7 +79,7 @@ values:
     - idp_metadata_xml: <?xml version="1.0" encoding="utf-8"?>...
     scim_usage: null
     timeouts: null
-    workforce_pool_id: test-pool
+    workforce_pool_id: test-test-pool
   module.org.google_iam_workforce_pool_provider.default["test-pool/saml-full"]:
     attribute_condition: null
     attribute_mapping:
@@ -105,7 +105,7 @@ values:
     - idp_metadata_xml: <?xml version="1.0" encoding="utf-8"?>...
     scim_usage: null
     timeouts: null
-    workforce_pool_id: test-pool
+    workforce_pool_id: test-test-pool
   module.org.google_iam_workforce_pool_provider_scim_tenant.default["test-pool/oidc-full"]:
     claim_mapping:
       google.group: group.externalId
@@ -117,7 +117,7 @@ values:
     provider_id: oidc-full
     scim_tenant_id: my-scim-tenant
     timeouts: null
-    workforce_pool_id: test-pool
+    workforce_pool_id: test-test-pool
 
 counts:
   google_iam_workforce_pool: 1

--- a/tests/modules/organization/tftest.yaml
+++ b/tests/modules/organization/tftest.yaml
@@ -32,3 +32,4 @@ tests:
   tags:
   tags_force_context:
   tags_skip_iam:
+  workforce_identity_pools:

--- a/tests/modules/organization/workforce_identity_pools.tfvars
+++ b/tests/modules/organization/workforce_identity_pools.tfvars
@@ -1,0 +1,20 @@
+prefix = "test"
+workforce_identity_pools = {
+  prefixed-pool = {
+    display_name = "Prefixed pool."
+    providers = {
+      saml-test = {
+        attribute_mapping_template = "azuread"
+        identity_provider = {
+          saml = {
+            idp_metadata_xml = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+          }
+        }
+      }
+    }
+  }
+  explicit-pool = {
+    display_name = "Pool with explicit id."
+    pool_id      = "explicit-pool-id"
+  }
+}

--- a/tests/modules/organization/workforce_identity_pools.yaml
+++ b/tests/modules/organization/workforce_identity_pools.yaml
@@ -1,0 +1,32 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values:
+  google_iam_workforce_pool.default["explicit-pool"]:
+    display_name: Pool with explicit id.
+    parent: organizations/1234567890
+    workforce_pool_id: explicit-pool-id
+  google_iam_workforce_pool.default["prefixed-pool"]:
+    display_name: Prefixed pool.
+    parent: organizations/1234567890
+    workforce_pool_id: test-prefixed-pool
+  google_iam_workforce_pool_provider.default["prefixed-pool/saml-test"]:
+    provider_id: saml-test
+    workforce_pool_id: test-prefixed-pool
+
+counts:
+  google_iam_workforce_pool: 2
+  google_iam_workforce_pool_provider: 1
+  modules: 0
+  resources: 3

--- a/tests/modules/project/examples/wif.yaml
+++ b/tests/modules/project/examples/wif.yaml
@@ -26,7 +26,7 @@ values:
     display_name: Test pool (OIDC).
     project: test-project
     timeouts: null
-    workload_identity_pool_id: test-oidc
+    workload_identity_pool_id: test-oidc-explicit-id
   module.project.google_iam_workload_identity_pool_provider.default["test-non-oidc/aws-test"]:
     attribute_condition: attribute.aws_role=="arn:aws:sts::999999999999:assumed-role/stack-eu-central-1-lambdaRole"
     attribute_mapping:
@@ -86,7 +86,7 @@ values:
     project: test-project
     saml: []
     timeouts: null
-    workload_identity_pool_id: test-oidc
+    workload_identity_pool_id: test-oidc-explicit-id
     workload_identity_pool_provider_id: github-test
     x509: []
   module.project.google_iam_workload_identity_pool_provider.default["test-oidc/gitlab-test"]:
@@ -113,7 +113,7 @@ values:
     project: test-project
     saml: []
     timeouts: null
-    workload_identity_pool_id: test-oidc
+    workload_identity_pool_id: test-oidc-explicit-id
     workload_identity_pool_provider_id: gitlab-test
     x509: []
   module.project.google_project.project[0]:

--- a/tests/modules/project_factory/examples/example.yaml
+++ b/tests/modules/project_factory/examples/example.yaml
@@ -801,7 +801,7 @@ values:
     inline_trust_config: []
     project: test-pf-teams-iac-0
     timeouts: null
-    workload_identity_pool_id: test-0
+    workload_identity_pool_id: test-0-explicit-id
   ? module.project-factory.module.projects["teams-iac-0"].google_iam_workload_identity_pool_provider.default["test-0/github-test"]
   : attribute_condition: attribute.repository_owner=="my_org"
     attribute_mapping:
@@ -828,7 +828,7 @@ values:
     project: test-pf-teams-iac-0
     saml: []
     timeouts: null
-    workload_identity_pool_id: test-0
+    workload_identity_pool_id: test-0-explicit-id
     workload_identity_pool_provider_id: github-test
     x509: []
   module.project-factory.module.projects["teams-iac-0"].google_project.project[0]:


### PR DESCRIPTION
Fixes #4154.

Pools are declared as maps in workload_identity_pools (project module) and workforce_identity_pools (organization module), and each entry's key was used directly as the pool id created in GCP:

```
workforce_identity_pools = {
  # key "landing" becomes workforce_pool_id = "landing"
  landing = {
    display_name = "Landing pool."
  }
}
```

That key is also the internal handle: providers nest under it, outputs are keyed by it, and FAST context references point at it ($workload_identity_pools:iac-0/default). So the id could not be varied without renaming the key and updating every reference to it.

This matters for workforce pools, whose ids are globally unique — the provider requires "a globally unique string of 6 to 63 lowercase letters, digits, or hyphens". Deploying the same configuration twice, for two environments that differ only by prefix, collides on the pool id. Workload identity pool ids are project-scoped and don't collide, but they were pinned to the key in the same way.

### Changes

- `modules/organization`: new optional prefix variable, prepended to workforce pool ids.
- `modules/organization`, `modules/project`: new optional per-pool pool_id attribute, which sets the pool id explicitly and ignores the module prefix.
- `modules/project-factory`: `pool_id` plumbed through the project interface and project.schema.json (with its FAST copies).
- fast/stages/0-org-setup: new optional prefix key in the organization dataset config, forwarded to the organization module.

The change is entirely additive. Both prefix and pool_id default to null, so pool ids continue to be the map key unless a value is set — no existing pool is renamed or recreated.

### Verification

Local: 10 organization, 14 project/project-factory and 5 FAST 0-org-setup module tests, plus README example tests. A new workforce_identity_pools tftest scenario covers both paths (prefixed id and explicit id), and the FAST customizations fixture exercises the stage wiring end to end.

E2E, workload identity, in a sandbox project: applied two pools, one keyed and one with pool_id, and read them back with gcloud iam workload-identity-pools list. Both ids matched the intended values; destroyed and confirmed clean. Providers were left out of the applied config because the sandbox enforces constraints/iam.workloadIdentityPoolProviders, which rejects the GitHub issuer; the pool id is the surface this change touches.

E2E, workforce identity, in a test organization: applied a keyed pool and one with pool_id, read back with gcloud iam workforce-pools list as e2e4154-key-pool and e2e4154-override-explicit-id, both ACTIVE. Destroyed and confirmed removed.
