### PR TITLE
Fix custom role description handling for empty strings

### DIFF
--- a/modules/organization/iam.tf
+++ b/modules/organization/iam.tf
@@ -128,8 +128,10 @@ resource "google_organization_iam_custom_role" "roles" {
   title = coalesce(
     each.value.title, "Custom role ${each.value.name}"
   )
-  description = coalesce(
-    each.value.description, "Terraform-managed."
+  description = (
+    each.value.description == null
+    ? "Terraform-managed."
+    : each.value.description
   )
   stage       = each.value.stage
   permissions = each.value.permissions

--- a/modules/project/iam.tf
+++ b/modules/project/iam.tf
@@ -149,8 +149,10 @@ resource "google_project_iam_custom_role" "roles" {
   title = coalesce(
     each.value.title, "Custom role ${each.value.name}"
   )
-  description = coalesce(
-    each.value.description, "Terraform-managed."
+  description = (
+    each.value.description == null
+    ? "Terraform-managed."
+    : each.value.description
   )
   stage       = each.value.stage
   permissions = each.value.permissions

--- a/tests/modules/organization/custom_roles.tfvars
+++ b/tests/modules/organization/custom_roles.tfvars
@@ -1,0 +1,14 @@
+custom_roles = {
+  role_default_description = {
+    permissions = ["compute.instances.list"]
+  }
+  role_empty_description = {
+    description = ""
+    permissions = ["compute.instances.list"]
+  }
+  role_with_description = {
+    description = "Allows listing compute instances."
+    title       = "My custom role"
+    permissions = ["compute.instances.list"]
+  }
+}

--- a/tests/modules/organization/custom_roles.yaml
+++ b/tests/modules/organization/custom_roles.yaml
@@ -1,0 +1,47 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values:
+  google_organization_iam_custom_role.roles["role_default_description"]:
+    description: Terraform-managed.
+    org_id: '1234567890'
+    permissions:
+    - compute.instances.list
+    role_id: role_default_description
+    title: Custom role role_default_description
+  google_organization_iam_custom_role.roles["role_empty_description"]:
+    description: ''
+    org_id: '1234567890'
+    permissions:
+    - compute.instances.list
+    role_id: role_empty_description
+    title: Custom role role_empty_description
+  google_organization_iam_custom_role.roles["role_with_description"]:
+    description: Allows listing compute instances.
+    org_id: '1234567890'
+    permissions:
+    - compute.instances.list
+    role_id: role_with_description
+    title: My custom role
+
+counts:
+  google_organization_iam_custom_role: 3
+  modules: 0
+  resources: 3
+
+outputs:
+  custom_role_id:
+    role_default_description: organizations/1234567890/roles/role_default_description
+    role_empty_description: organizations/1234567890/roles/role_empty_description
+    role_with_description: organizations/1234567890/roles/role_with_description

--- a/tests/modules/organization/tftest.yaml
+++ b/tests/modules/organization/tftest.yaml
@@ -21,6 +21,7 @@ tests:
   context:
     extra_dirs:
       - ../../tests/modules/organization/factory-caa
+  custom_roles:
   iam_by_principals_additive:
   iam_by_principals_conditional:
   org_policies:

--- a/tests/modules/project/custom_roles.tfvars
+++ b/tests/modules/project/custom_roles.tfvars
@@ -1,0 +1,14 @@
+custom_roles = {
+  role_default_description = {
+    permissions = ["compute.instances.list"]
+  }
+  role_empty_description = {
+    description = ""
+    permissions = ["compute.instances.list"]
+  }
+  role_with_description = {
+    description = "Allows listing compute instances."
+    title       = "My custom role"
+    permissions = ["compute.instances.list"]
+  }
+}

--- a/tests/modules/project/custom_roles.yaml
+++ b/tests/modules/project/custom_roles.yaml
@@ -1,0 +1,48 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values:
+  google_project_iam_custom_role.roles["role_default_description"]:
+    description: Terraform-managed.
+    permissions:
+    - compute.instances.list
+    project: my-project
+    role_id: role_default_description
+    title: Custom role role_default_description
+  google_project_iam_custom_role.roles["role_empty_description"]:
+    description: ''
+    permissions:
+    - compute.instances.list
+    project: my-project
+    role_id: role_empty_description
+    title: Custom role role_empty_description
+  google_project_iam_custom_role.roles["role_with_description"]:
+    description: Allows listing compute instances.
+    permissions:
+    - compute.instances.list
+    project: my-project
+    role_id: role_with_description
+    title: My custom role
+
+counts:
+  google_project: 1
+  google_project_iam_custom_role: 3
+  modules: 0
+  resources: 4
+
+outputs:
+  custom_role_id:
+    role_default_description: projects/my-project/roles/role_default_description
+    role_empty_description: projects/my-project/roles/role_empty_description
+    role_with_description: projects/my-project/roles/role_with_description

--- a/tests/modules/project/tftest.yaml
+++ b/tests/modules/project/tftest.yaml
@@ -19,6 +19,7 @@ common_tfvars:
 
 tests:
   context:
+  custom_roles:
   iam_by_principals_additive:
   iam_by_principals_conditional:
   no_parent:


### PR DESCRIPTION
Custom roles with an explicitly empty description could not be expressed. This is the same bug class as #4134, in the one remaining place that still used `coalesce` for a generated description default.

## Problem

Both modules that create custom roles derived the role description with `coalesce`:

```hcl
description = coalesce(
  each.value.description, "Terraform-managed."
)
```

Terraform's `coalesce()` skips empty strings as well as nulls, so `description = ""` (or `description: ""` in a factory YAML) never reached the provider — it silently fell through to the `"Terraform-managed."` default.

As with log sinks, the practical consequence is that a pre-existing custom role with no description cannot be adopted: after `terraform import` every plan shows a permanent diff writing the default over the empty description, and there is no input that suppresses it. The factory JSON schema already declares `description` as a plain `string` with no default, so `""` was accepted as valid input and then discarded.

## Fix

Replaced `coalesce` with an explicit null check, so an unset (`null`) description still gets the default while an explicit empty string is passed through verbatim:

```hcl
description = (
  each.value.description == null
  ? "Terraform-managed."
  : each.value.description
)
```

Applied to the two modules that carried the identical expression:

- `modules/organization`
- `modules/project`

No variable, schema, or factory surface changed: `description` remains `optional(string)`, and the JSON schema already permitted `""`.

The adjacent `coalesce(each.value.title, "Custom role ${each.value.name}")` was deliberately left alone. An empty role title is not a meaningful configuration in the same way an empty description is, so changing it would be an interface decision rather than a bug fix.

## Verification

### Unit tests

Added a `custom_roles` scenario to `tests/modules/organization` and `tests/modules/project`, covering all three input paths in one plan: description omitted, `description = ""`, and a description explicitly set. The inventories assert the resolved values:

```yaml
google_organization_iam_custom_role.roles["role_default_description"]:
  description: Terraform-managed.
google_organization_iam_custom_role.roles["role_empty_description"]:
  description: ''
google_organization_iam_custom_role.roles["role_with_description"]:
  description: Allows listing compute instances.
```

No existing inventory changed, which is expected: the fix is a no-op for null and non-empty descriptions. Full `tests/modules/organization` and `tests/modules/project` suites pass (25 tests).

### Live E2E

Applied against a live sandbox organization and project, creating four roles — one empty-description and one default-description role at each of the org and project levels. The apply was clean, and `gcloud iam roles describe` confirms the intent at both levels:

```
name: organizations/123456789012/roles/e2eOrgEmptyDesc
stage: GA
title: E2E org empty description

description: Terraform-managed.
name: organizations/123456789012/roles/e2eOrgDefaultDesc
stage: GA
title: E2E org default description
```
