### PR TITLE
Add deletion_policy support to modules/pubsub subscriptions

### DIFF
--- a/fast/stages/0-org-setup/schemas/project.schema.json
+++ b/fast/stages/0-org-setup/schemas/project.schema.json
@@ -2531,6 +2531,14 @@
                 "ack_deadline_seconds": {
                   "type": "number"
                 },
+                "deletion_policy": {
+                  "type": "string",
+                  "enum": [
+                    "ABANDON",
+                    "DELETE",
+                    "PREVENT"
+                  ]
+                },
                 "enable_exactly_once_delivery": {
                   "type": "boolean"
                 },

--- a/fast/stages/0-org-setup/schemas/project.schema.md
+++ b/fast/stages/0-org-setup/schemas/project.schema.md
@@ -734,6 +734,8 @@
     - **`^[a-zA-Z0-9_-]+$`**: *object*
       <br>*additional properties: false*
       - **ack_deadline_seconds**: *number*
+      - **deletion_policy**: *string*
+        <br>*enum: ['ABANDON', 'DELETE', 'PREVENT']*
       - **enable_exactly_once_delivery**: *boolean*
       - **enable_message_ordering**: *boolean*
       - **expiration_policy_ttl**: *string*

--- a/fast/stages/2-networking/schemas/project.schema.json
+++ b/fast/stages/2-networking/schemas/project.schema.json
@@ -2531,6 +2531,14 @@
                 "ack_deadline_seconds": {
                   "type": "number"
                 },
+                "deletion_policy": {
+                  "type": "string",
+                  "enum": [
+                    "ABANDON",
+                    "DELETE",
+                    "PREVENT"
+                  ]
+                },
                 "enable_exactly_once_delivery": {
                   "type": "boolean"
                 },

--- a/fast/stages/2-networking/schemas/project.schema.md
+++ b/fast/stages/2-networking/schemas/project.schema.md
@@ -734,6 +734,8 @@
     - **`^[a-zA-Z0-9_-]+$`**: *object*
       <br>*additional properties: false*
       - **ack_deadline_seconds**: *number*
+      - **deletion_policy**: *string*
+        <br>*enum: ['ABANDON', 'DELETE', 'PREVENT']*
       - **enable_exactly_once_delivery**: *boolean*
       - **enable_message_ordering**: *boolean*
       - **expiration_policy_ttl**: *string*

--- a/fast/stages/2-project-factory/schemas/project.schema.json
+++ b/fast/stages/2-project-factory/schemas/project.schema.json
@@ -2531,6 +2531,14 @@
                 "ack_deadline_seconds": {
                   "type": "number"
                 },
+                "deletion_policy": {
+                  "type": "string",
+                  "enum": [
+                    "ABANDON",
+                    "DELETE",
+                    "PREVENT"
+                  ]
+                },
                 "enable_exactly_once_delivery": {
                   "type": "boolean"
                 },

--- a/fast/stages/2-project-factory/schemas/project.schema.md
+++ b/fast/stages/2-project-factory/schemas/project.schema.md
@@ -734,6 +734,8 @@
     - **`^[a-zA-Z0-9_-]+$`**: *object*
       <br>*additional properties: false*
       - **ack_deadline_seconds**: *number*
+      - **deletion_policy**: *string*
+        <br>*enum: ['ABANDON', 'DELETE', 'PREVENT']*
       - **enable_exactly_once_delivery**: *boolean*
       - **enable_message_ordering**: *boolean*
       - **expiration_policy_ttl**: *string*

--- a/fast/stages/2-security/schemas/project.schema.json
+++ b/fast/stages/2-security/schemas/project.schema.json
@@ -2531,6 +2531,14 @@
                 "ack_deadline_seconds": {
                   "type": "number"
                 },
+                "deletion_policy": {
+                  "type": "string",
+                  "enum": [
+                    "ABANDON",
+                    "DELETE",
+                    "PREVENT"
+                  ]
+                },
                 "enable_exactly_once_delivery": {
                   "type": "boolean"
                 },

--- a/fast/stages/2-security/schemas/project.schema.md
+++ b/fast/stages/2-security/schemas/project.schema.md
@@ -734,6 +734,8 @@
     - **`^[a-zA-Z0-9_-]+$`**: *object*
       <br>*additional properties: false*
       - **ack_deadline_seconds**: *number*
+      - **deletion_policy**: *string*
+        <br>*enum: ['ABANDON', 'DELETE', 'PREVENT']*
       - **enable_exactly_once_delivery**: *boolean*
       - **enable_message_ordering**: *boolean*
       - **expiration_policy_ttl**: *string*

--- a/modules/project-factory/schemas/project.schema.json
+++ b/modules/project-factory/schemas/project.schema.json
@@ -2531,6 +2531,14 @@
                 "ack_deadline_seconds": {
                   "type": "number"
                 },
+                "deletion_policy": {
+                  "type": "string",
+                  "enum": [
+                    "ABANDON",
+                    "DELETE",
+                    "PREVENT"
+                  ]
+                },
                 "enable_exactly_once_delivery": {
                   "type": "boolean"
                 },

--- a/modules/project-factory/schemas/project.schema.md
+++ b/modules/project-factory/schemas/project.schema.md
@@ -734,6 +734,8 @@
     - **`^[a-zA-Z0-9_-]+$`**: *object*
       <br>*additional properties: false*
       - **ack_deadline_seconds**: *number*
+      - **deletion_policy**: *string*
+        <br>*enum: ['ABANDON', 'DELETE', 'PREVENT']*
       - **enable_exactly_once_delivery**: *boolean*
       - **enable_message_ordering**: *boolean*
       - **expiration_policy_ttl**: *string*

--- a/modules/project-factory/variables-projects.tf
+++ b/modules/project-factory/variables-projects.tf
@@ -560,6 +560,7 @@ variable "projects" {
       }))
       subscriptions = optional(map(object({
         ack_deadline_seconds         = optional(number)
+        deletion_policy              = optional(string)
         enable_exactly_once_delivery = optional(bool, false)
         enable_message_ordering      = optional(bool, false)
         expiration_policy_ttl        = optional(string)

--- a/modules/pubsub/README.md
+++ b/modules/pubsub/README.md
@@ -6,6 +6,7 @@ This module allows managing a single Pub/Sub topic, including multiple subscript
 - [Simple topic with IAM](#simple-topic-with-iam)
 - [Topic with schema](#topic-with-schema)
 - [Subscriptions](#subscriptions)
+- [Subscription deletion protection](#subscription-deletion-protection)
 - [Push subscriptions](#push-subscriptions)
 - [BigQuery subscriptions](#bigquery-subscriptions)
 - [BigQuery Subscription with service account email](#bigquery-subscription-with-service-account-email)
@@ -97,6 +98,24 @@ module "pubsub" {
   }
 }
 # tftest modules=1 resources=3 inventory=subscriptions.yaml e2e
+```
+
+## Subscription deletion protection
+
+Subscription filters are immutable, so changing one destroys and recreates the subscription. Since a subscription's IAM policy is a property of the subscription itself, GCP removes the policy with it, and this module's IAM bindings are not re-created: they identify the subscription by a name that a filter edit leaves unchanged. Set `deletion_policy` to `PREVENT` where that destroy should fail loudly instead. `ABANDON` removes the subscription from state without deleting it.
+
+```hcl
+module "pubsub" {
+  source     = "./fabric/modules/pubsub"
+  project_id = var.project_id
+  name       = "my-topic"
+  subscriptions = {
+    test-protected = {
+      deletion_policy = "PREVENT"
+    }
+  }
+}
+# tftest modules=1 resources=2 inventory=subscription-deletion-policy.yaml
 ```
 
 ## Push subscriptions

--- a/modules/pubsub/main.tf
+++ b/modules/pubsub/main.tf
@@ -73,6 +73,7 @@ resource "google_pubsub_subscription" "default" {
   filter                       = each.value.filter
   enable_message_ordering      = each.value.enable_message_ordering
   enable_exactly_once_delivery = each.value.enable_exactly_once_delivery
+  deletion_policy              = each.value.deletion_policy
   dynamic "bigquery_config" {
     for_each = each.value.bigquery == null ? [] : [""]
     content {

--- a/modules/pubsub/variables.tf
+++ b/modules/pubsub/variables.tf
@@ -83,6 +83,7 @@ variable "subscriptions" {
   description = "Topic subscriptions. Also define push configs for push subscriptions. If options is set to null subscription defaults will be used. Labels default to topic labels if set to null."
   type = map(object({
     ack_deadline_seconds         = optional(number)
+    deletion_policy              = optional(string)
     enable_exactly_once_delivery = optional(bool, false)
     enable_message_ordering      = optional(bool, false)
     expiration_policy_ttl        = optional(string)

--- a/modules/pubsub/variables.tf
+++ b/modules/pubsub/variables.tf
@@ -150,4 +150,12 @@ variable "subscriptions" {
   }))
   default  = {}
   nullable = false
+  validation {
+    condition = alltrue([
+      for k, v in var.subscriptions : contains(
+        ["ABANDON", "DELETE", "PREVENT"], coalesce(v.deletion_policy, "DELETE")
+      )
+    ])
+    error_message = "Subscription deletion policy must be one of 'ABANDON', 'DELETE' or 'PREVENT'."
+  }
 }

--- a/tests/modules/pubsub/examples/subscription-deletion-policy.yaml
+++ b/tests/modules/pubsub/examples/subscription-deletion-policy.yaml
@@ -1,0 +1,61 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+values:
+  module.pubsub.google_pubsub_subscription.default["test-protected"]:
+    bigquery_config: []
+    cloud_storage_config: []
+    dead_letter_policy: []
+    deletion_policy: PREVENT
+    effective_labels:
+      goog-terraform-provisioned: 'true'
+    enable_exactly_once_delivery: false
+    enable_message_ordering: false
+    filter: null
+    labels: null
+    message_retention_duration: 604800s
+    message_transforms: []
+    name: test-protected
+    project: project-id
+    push_config: []
+    retain_acked_messages: false
+    retry_policy: []
+    tags: null
+    terraform_labels:
+      goog-terraform-provisioned: 'true'
+    timeouts: null
+  module.pubsub.google_pubsub_topic.default:
+    deletion_policy: DELETE
+    effective_labels:
+      goog-terraform-provisioned: 'true'
+    ingestion_data_source_settings: []
+    kms_key_name: null
+    labels: null
+    message_retention_duration: null
+    message_transforms: []
+    name: my-topic
+    project: project-id
+    schema_settings: []
+    tags: null
+    terraform_labels:
+      goog-terraform-provisioned: 'true'
+    timeouts: null
+
+counts:
+  google_pubsub_subscription: 1
+  google_pubsub_topic: 1
+  modules: 1
+  resources: 2
+
+outputs: {}


### PR DESCRIPTION
## What

Exposes the `google_pubsub_subscription` `deletion_policy` argument (`DELETE` / `PREVENT` / `ABANDON`) as an optional field on the `subscriptions` variable, and passes it through to the resource.

## Why

Subscription `filter` is immutable in GCP, so editing one forces a destroy/create. Because a subscription's IAM policy is a property *of* the subscription, GCP deletes the policy along with it — while Terraform plans no change to this module's IAM bindings, since they identify the subscription by a config-deterministic name that a filter edit doesn't change.

The net effect is a subscription that comes back with an empty IAM policy, no error surfaced, and state still asserting the bindings are healthy. Convergence needs a second apply. We hit this in production: a one-line filter change silently removed a subscriber's `roles/pubsub.subscriber` binding and the consumer crash-looped on `PERMISSION_DENIED`.

`deletion_policy = "PREVENT"` lets callers make that destroy fail loudly instead of silently succeeding.

A `lifecycle` block would also address it, but `deletion_policy` is preferable as a module interface: it's a resource *argument*, so it can be set per subscription by the caller, whereas `prevent_destroy` and `replace_triggered_by` are meta-arguments that can only be hardcoded inside the module.

## Notes

- Purely additive and optional; defaults to `null`, so existing behaviour is unchanged.
- `deletion_policy` is available from provider `v7.40.0`, satisfying this module's `>= 7.40.0, < 8.0.0` constraint.
- `tools/tfdoc.py modules/pubsub` produces no diff — `subscriptions` is the last variable in the file so its line anchor is unchanged, and complex types render collapsed.
- `pytest tests/modules/pubsub` passes.
- I deliberately did **not** add `PREVENT` to a README example: the Subscriptions example is tagged `e2e`, and a `PREVENT` subscription would leave the e2e run unable to tear itself down. Happy to add an example using `DELETE`, or a non-e2e example, if you'd prefer one for documentation.