### PR TITLE
Fix module source in gke-cluster-standard PSC example

### DIFF
--- a/modules/gke-cluster-standard/README.md
+++ b/modules/gke-cluster-standard/README.md
@@ -492,7 +492,7 @@ To disable IP access to the GKE control plane and prevent PSC endpoint creation,
 
 ```hcl
 module "cluster-1" {
-  source     = "./fabric/modules/gke-cluster-autopilot"
+  source     = "./fabric/modules/gke-cluster-standard"
   project_id = "myproject"
   name       = "cluster-1"
   location   = "europe-west1"

--- a/modules/gke-cluster-standard/README.md
+++ b/modules/gke-cluster-standard/README.md
@@ -486,7 +486,7 @@ module "cluster-1" {
 # tftest modules=1 resources=1
 ```
 
-### Disable PSC endpoint creation
+### Disable PSC endpoint creation 
 
 To disable IP access to the GKE control plane and prevent PSC endpoint creation, set `var.access_config.ip_access` to `null` or omit the variable.
 

--- a/tests/modules/gke_cluster_standard/examples/no-ip-access.yaml
+++ b/tests/modules/gke_cluster_standard/examples/no-ip-access.yaml
@@ -20,28 +20,31 @@ values:
         load_balancer_type: null
       config_connector_config:
       - enabled: false
+      dns_cache_config:
+      - enabled: true
+      gce_persistent_disk_csi_driver_config:
+      - enabled: true
+      gcp_filestore_csi_driver_config:
+      - enabled: true
+      gcs_fuse_csi_driver_config:
+      - enabled: true
       gke_backup_agent_config:
       - enabled: false
       horizontal_pod_autoscaling:
       - disabled: false
       http_load_balancing:
       - disabled: false
+      istio_config:
+      - auth: null
+        disabled: true
       kalm_config:
       - enabled: false
-    allow_net_admin: false
+      network_policy_config:
+      - disabled: true
+      stateful_ha_config:
+      - enabled: false
+    allow_net_admin: null
     binary_authorization: []
-    cluster_autoscaling:
-    - auto_provisioning_defaults:
-      - boot_disk_kms_key: null
-        disk_size: null
-        disk_type: null
-        image_type: null
-        min_cpu_platform: null
-        service_account: default
-        shielded_instance_config: []
-      autoscaling_profile: null
-      default_compute_class_enabled: null
-      resource_limits: []
     control_plane_endpoints_config:
     - dns_endpoint_config:
       - allow_external_traffic: true
@@ -51,7 +54,9 @@ values:
       - enabled: false
     cost_management_config:
     - enabled: true
+    datapath_provider: ADVANCED_DATAPATH
     dataplane_optimization_mode: null
+    default_max_pods_per_node: 110
     deletion_policy: DELETE
     deletion_protection: true
     description: null
@@ -61,16 +66,16 @@ values:
     effective_labels:
       environment: dev
       goog-terraform-provisioned: 'true'
-    enable_autopilot: true
+    enable_autopilot: null
     enable_cilium_clusterwide_network_policy: false
-    enable_fqdn_network_policy: false
-    enable_intranode_visibility: true
+    enable_fqdn_network_policy: true
+    enable_intranode_visibility: false
     enable_k8s_beta_apis: []
     enable_kubernetes_alpha: false
     enable_l4_ilb_subsetting: false
     enable_legacy_abac: false
     enable_multi_networking: false
-    enable_shielded_nodes: true
+    enable_shielded_nodes: false
     enable_tpu: false
     fleet: []
     ignore_node_count_changes: null
@@ -86,7 +91,6 @@ values:
     logging_config:
     - enable_components:
       - SYSTEM_COMPONENTS
-      - WORKLOADS
     maintenance_policy:
     - daily_maintenance_window:
       - start_time: 03:00
@@ -107,22 +111,43 @@ values:
     network: https://www.googleapis.com/compute/v1/projects/xxx/global/networks/aaa
     network_performance_config: []
     network_policy: []
-    networking_mode: VPC_NATIVE
-    node_pool_auto_config:
-    - linux_node_config: []
-      network_tags: []
-      node_kubelet_config:
-      - {}
+    node_config:
+    - advanced_machine_features: []
+      boot_disk_kms_key: null
+      enable_confidential_storage: null
+      ephemeral_storage_config: []
+      ephemeral_storage_local_ssd_config: []
+      fast_socket: []
+      flex_start: null
+      gvnic: []
+      host_maintenance_policy: []
+      local_nvme_ssd_block_config: []
+      local_ssd_encryption_mode: null
+      max_run_duration: null
+      node_group: null
+      preemptible: false
+      reservation_affinity: []
+      resource_labels: null
       resource_manager_tags: null
+      sandbox_config: []
+      secondary_boot_disks: []
+      sole_tenant_config: []
+      spot: false
+      storage_pools: null
+      tags: null
+      taint: []
+      taint_config: []
+    node_pool_defaults:
+    - node_config_defaults:
+      - gcfs_config:
+        - enabled: false
     pod_security_policy_config: []
     private_cluster_config:
     - enable_private_endpoint: null
       enable_private_nodes: true
       private_endpoint_subnetwork: null
     project: myproject
-    release_channel:
-    - channel: REGULAR
-    remove_default_node_pool: null
+    remove_default_node_pool: true
     resource_labels:
       environment: dev
     resource_usage_export_config: []
@@ -136,6 +161,8 @@ values:
       goog-terraform-provisioned: 'true'
     timeouts: null
     user_managed_keys_config: []
+    workload_identity_config:
+    - workload_pool: myproject.svc.id.goog
 
 counts:
   google_container_cluster: 1


### PR DESCRIPTION
The "Disable PSC endpoint creation" example in `modules/gke-cluster-standard/README.md`
sources `./fabric/modules/gke-cluster-autopilot` instead of `./fabric/modules/gke-cluster-standard`.
The section is a verbatim copy of the equivalent one in the autopilot module's README,
including the `source` line and the `inventory=no-ip-access.yaml` filename.

The wrong source was introduced in #2997 (2025-04-02).
