### PR TITLE
Shard examples-modules test job across 4 runners

### DIFF
--- a/.github/workflows/daily-tag.yml
+++ b/.github/workflows/daily-tag.yml
@@ -29,7 +29,7 @@ jobs:
     name: "Create tag on master if there was activity in last 24 hours"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -32,7 +32,7 @@ jobs:
   linting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           terraform_version: 1.11.4
 
-      - uses: terraform-linters/setup-tflint@6e87008f9dd1fe3e34e66aca6c97b4a69f72a7f4 # v4
+      - uses: terraform-linters/setup-tflint@90f302c255ef959cbfb4bd10581afecdb7ece3e6 # v4.1.1
         name: Setup TFLint
         with:
           tflint_version: v0.59.1

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0  # Need full history for diffing
           persist-credentials: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
     name: "Release new version"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -143,9 +143,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - flavour: terraform
-          - flavour: tofu
+        flavour: [terraform, tofu]
+        shard: [0, 1, 2, 3]
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -173,14 +172,15 @@ jobs:
         env:
           TERRAFORM: ${{ matrix.flavour }}
         run: |
-          pytest -vv ${{ matrix.flavour == 'terraform' && '-n4' || '-n4' }} --tb=line \
+          pytest -vv -n4 --tb=line \
+            --shard-id ${{ matrix.shard }} --shard-count 4 \
             --junit-xml=test-results-raw.xml -k "terraform and modules/" tests/examples
 
       - name: Create report
         uses: ./.github/actions/post-fabric-tests
         if: always()
         with:
-          MODULE: Module Examples
+          MODULE: Module Examples (${{ matrix.flavour }} shard ${{ matrix.shard }})
 
   modules:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
           - flavour: terraform
           - flavour: tofu
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - name: Set Terraform versions
@@ -116,7 +116,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup-tf-providers
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
@@ -147,7 +147,7 @@ jobs:
         shard: [0, 1, 2, 3]
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - name: Set Terraform versions
@@ -194,7 +194,7 @@ jobs:
           - flavour: tofu
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - name: Set Terraform versions
@@ -240,7 +240,7 @@ jobs:
           - flavour: terraform
           # - flavour: tofu # tofu fails to find the terraform binary for FAST tests
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - name: Set Terraform versions
@@ -274,7 +274,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup-tf-providers
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 'Pytest configuration.'
 
+import hashlib
 import itertools
 import pytest
 
@@ -20,6 +21,39 @@ pytest_plugins = (
     'tests.fixtures',
     'tests.collectors',
 )
+
+
+def pytest_addoption(parser):
+  group = parser.getgroup('sharding')
+  group.addoption('--shard-id', type=int, default=0, metavar='N',
+                  help='Zero-based index of this shard.')
+  group.addoption('--shard-count', type=int, default=1, metavar='N',
+                  help='Total number of shards (1 disables sharding).')
+
+
+def pytest_collection_modifyitems(config, items):
+  """Keep only the tests belonging to the current shard.
+
+  Tests are assigned to shards by hashing their node id, so every shard
+  computes the same partition without talking to the others. hashlib is
+  used instead of hash() because Python randomizes string hashing per
+  process, which would make shards disagree and silently drop tests.
+  """
+  count = config.getoption('shard_count')
+  if count <= 1:
+    return
+  shard_id = config.getoption('shard_id')
+  if not 0 <= shard_id < count:
+    raise pytest.UsageError(f'--shard-id must be in [0, {count}), '
+                            f'got {shard_id}')
+  selected, deselected = [], []
+  for item in items:
+    digest = hashlib.sha256(item.nodeid.encode()).digest()
+    bucket = int.from_bytes(digest[:8], 'big') % count
+    (selected if bucket == shard_id else deselected).append(item)
+  if deselected:
+    config.hook.pytest_deselected(items=deselected)
+  items[:] = selected
 
 
 def pytest_terminal_summary(terminalreporter, exitstatus, config):


### PR DESCRIPTION
`examples-modules (terraform)` has a 19m07s median runtime and accounts for
almost all of the workflow's wall clock. This splits it across 4 runners per
flavour.

## Changes

- `tests/conftest.py`: adds `--shard-id` / `--shard-count`. Tests are assigned
  to shards by hashing their node id, so every shard computes the same
  partition without coordination. Inert unless `--shard-count > 1`, so local
  runs, `tests/examples_e2e`, and any other invocation are unaffected.
- `.github/workflows/tests.yml`: `examples-modules` matrix becomes
  `flavour × shard`.

No new dependencies.

## Timings

Before: median of the last 5 `master` runs.
After: run 34584401504 on this branch.

| job                            | before     | after     |
| ------------------------------ | ---------- | --------- |
| **workflow total**             | **19m42s** | **6m00s** |
| examples-modules (terraform)   | 19m07s     | 5m27s     |
| examples-modules (tofu)        | 16m17s     | 4m20s     |
| modules (terraform)            | 4m36s      | 4m39s     |
| fast (terraform)               | 3m03s      | 2m32s     |

Sharded jobs show the slowest of the 4 shards. Jobs go from 9 to 15.

`modules (terraform)` at 4m39s is now the next bottleneck, so raising the
shard count on this job alone will not help. A follow-up can shard `modules`
in 2 and `examples-modules` in 6, which brings the workflow to ~4m19s.

## Requires a branch protection update before merge

The matrix change renames the status checks:

| before                         | after                               |
| ------------------------------ | ----------------------------------- |
| `examples-modules (terraform)` | `examples-modules (terraform, 0…3)` |
| `examples-modules (tofu)`      | `examples-modules (tofu, 0…3)`      |

The two old names must be replaced by these 8, confirmed from run 34584401504:

```
examples-modules (terraform, 0)
examples-modules (terraform, 1)
examples-modules (terraform, 2)
examples-modules (terraform, 3)
examples-modules (tofu, 0)
examples-modules (tofu, 1)
examples-modules (tofu, 2)
examples-modules (tofu, 3)
```

Otherwise every PR blocks waiting on checks that will never report again —
including this one.
